### PR TITLE
feat: add dashboard data hook

### DIFF
--- a/nextjs/src/features/dashboard/hooks/useDashboardData.ts
+++ b/nextjs/src/features/dashboard/hooks/useDashboardData.ts
@@ -1,0 +1,366 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { useI18n } from "@/lib/i18n/I18nProvider";
+import { useGlobal } from "@/lib/context/GlobalContext";
+import { createSPASassClientAuthenticated as createSPASassClient } from "@/lib/supabase/client";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { computeProjectFlags } from "@projects/utils/projectFlags";
+import type { Project, ProjectMetrics, ProjectWithMetrics } from "@projects/types";
+import type { SupabaseDocumentRow } from "@documents/types";
+import { normalizeDocuments } from "@documents/utils/normalizeDocuments";
+
+import type {
+  DashboardDocumentItem,
+  DashboardResult,
+  DashboardState,
+  DashboardSummaryMetric,
+  DashboardTodoItem,
+} from "../types";
+import { createInitialDashboardState } from "../utils/state";
+
+const TODO_STATUS_FILTER = ["pending", "in_progress"] as const;
+const TODO_DUE_SOON_THRESHOLD_DAYS = 3;
+
+const MS_IN_DAY = 1000 * 60 * 60 * 24;
+
+type SupabaseInteractionSummary = {
+  id: string;
+  subject: string | null;
+  content: string | null;
+  occurred_at: string | null;
+  created_at: string;
+  type: string | null;
+};
+
+type SupabaseTodoRow = {
+  id: string;
+  subject: string | null;
+  status: string | null;
+  occurred_at: string | null;
+  created_at: string;
+};
+
+type SupabaseDocumentLinkCountRow = {
+  id: string;
+  interaction_documents: { interaction_id: string }[] | null;
+};
+
+type SummaryResult = {
+  metrics: DashboardSummaryMetric[];
+  recentInteractions: DashboardState["recentInteractions"];
+};
+
+type ProjectResult = ProjectWithMetrics[];
+
+type DocumentsResult = DashboardState["documents"];
+
+const createTodoFlags = (occurredAt: string | null): Pick<DashboardTodoItem, "isDueSoon" | "isOverdue"> => {
+  if (!occurredAt) {
+    return {
+      isDueSoon: false,
+      isOverdue: false,
+    };
+  }
+
+  const due = new Date(occurredAt);
+  const today = new Date();
+  due.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+
+  if (due < today) {
+    return {
+      isDueSoon: false,
+      isOverdue: true,
+    };
+  }
+
+  const deltaDays = (due.getTime() - today.getTime()) / MS_IN_DAY;
+
+  return {
+    isOverdue: false,
+    isDueSoon: deltaDays >= 0 && deltaDays <= TODO_DUE_SOON_THRESHOLD_DAYS,
+  };
+};
+
+const fetchSummary = async (
+  client: SupabaseClient,
+  householdId: string
+): Promise<SummaryResult> => {
+  const [{ data: interactionsData, count: interactionCount, error: interactionsError }, { count: zoneCount, error: zoneError }, { count: contactCount, error: contactError }] =
+    await Promise.all([
+      client
+        .from("interactions")
+        .select(
+          "id, subject, content, occurred_at, created_at, type",
+          { count: "exact" }
+        )
+        .eq("household_id", householdId)
+        .order("occurred_at", { ascending: false, nullsLast: false })
+        .order("created_at", { ascending: false })
+        .limit(5),
+      client
+        .from("zones")
+        .select("id", { count: "exact", head: true })
+        .eq("household_id", householdId),
+      client
+        .from("contacts")
+        .select("id", { count: "exact", head: true })
+        .eq("household_id", householdId),
+    ]);
+
+  if (interactionsError) throw interactionsError;
+  if (zoneError) throw zoneError;
+  if (contactError) throw contactError;
+
+  const interactions = (interactionsData ?? []) as SupabaseInteractionSummary[];
+  const recentInteractions = {
+    total: interactionCount ?? 0,
+    items: interactions.map((interaction) => ({
+      id: interaction.id,
+      subject: interaction.subject,
+      content: interaction.content,
+      occurredAt: interaction.occurred_at,
+      createdAt: interaction.created_at,
+      type: interaction.type,
+    })),
+  };
+
+  const metrics: DashboardSummaryMetric[] = [
+    {
+      key: "interactions",
+      total: interactionCount ?? 0,
+      labelKey: "dashboard.interactions",
+      descriptionKey: "dashboard.totalInHousehold",
+    },
+    {
+      key: "contacts",
+      total: contactCount ?? 0,
+      labelKey: "dashboard.contacts",
+      descriptionKey: "dashboard.peopleAndVendors",
+    },
+    {
+      key: "zones",
+      total: zoneCount ?? 0,
+      labelKey: "dashboard.zones",
+      descriptionKey: "dashboard.roomsAndAreas",
+    },
+  ];
+
+  return {
+    metrics,
+    recentInteractions,
+  };
+};
+
+const fetchTodos = async (
+  client: SupabaseClient,
+  householdId: string
+): Promise<DashboardTodoItem[]> => {
+  const { data, error } = await client
+    .from("interactions")
+    .select("id, subject, status, occurred_at, created_at")
+    .eq("household_id", householdId)
+    .eq("type", "todo")
+    .in("status", [...TODO_STATUS_FILTER])
+    .order("occurred_at", { ascending: true, nullsLast: false })
+    .order("created_at", { ascending: true })
+    .limit(15);
+
+  if (error) throw error;
+
+  const rows = (data ?? []) as SupabaseTodoRow[];
+  return rows.map((row) => {
+    const flags = createTodoFlags(row.occurred_at);
+    return {
+      id: row.id,
+      subject: row.subject,
+      status: row.status,
+      occurredAt: row.occurred_at,
+      createdAt: row.created_at,
+      ...flags,
+    };
+  });
+};
+
+const fetchProjects = async (
+  client: SupabaseClient,
+  householdId: string
+): Promise<ProjectResult> => {
+  const { data, error } = await client
+    .from("projects")
+    .select(
+      `
+        id,
+        household_id,
+        title,
+        description,
+        status,
+        priority,
+        start_date,
+        due_date,
+        closed_at,
+        tags,
+        planned_budget,
+        actual_cost_cached,
+        cover_interaction_id,
+        created_at,
+        updated_at,
+        created_by,
+        updated_by
+      `
+    )
+    .eq("household_id", householdId)
+    .in("status", ["active", "draft"])
+    .order("updated_at", { ascending: false })
+    .limit(5);
+
+  if (error) throw error;
+
+  const typedProjects = (data ?? []) as Project[];
+  const ids = typedProjects.map((item) => item.id);
+
+  let metricsByProject = new Map<string, ProjectMetrics>();
+  if (ids.length) {
+    const { data: metricsRows, error: metricsError } = await client
+      .from("project_metrics")
+      .select("project_id, open_todos, done_todos, documents_count, actual_cost")
+      .in("project_id", ids);
+    if (metricsError) throw metricsError;
+    metricsByProject = new Map(
+      (metricsRows ?? []).map((item) => [item.project_id, item as ProjectMetrics])
+    );
+  }
+
+  return typedProjects.map((project) => {
+    const metrics = metricsByProject.get(project.id) ?? null;
+    const flags = computeProjectFlags(project, metrics);
+    return {
+      ...project,
+      metrics,
+      ...flags,
+    };
+  });
+};
+
+const fetchDocuments = async (
+  client: SupabaseClient,
+  householdId: string
+): Promise<DocumentsResult> => {
+  const [{ data, error }, { data: linkRows, error: linkError }] = await Promise.all([
+    client
+      .from("documents")
+      .select(
+        `
+          id,
+          household_id,
+          file_path,
+          name,
+          notes,
+          mime_type,
+          type,
+          metadata,
+          created_at,
+          created_by,
+          interaction_documents (
+            interaction_id,
+            interaction:interactions (
+              id,
+              subject
+            )
+          )
+        `
+      )
+      .eq("household_id", householdId)
+      .order("created_at", { ascending: false })
+      .limit(5),
+    client
+      .from("documents")
+      .select(
+        `
+          id,
+          interaction_documents (
+            interaction_id
+          )
+        `
+      )
+      .eq("household_id", householdId),
+  ]);
+
+  if (error) throw error;
+  if (linkError) throw linkError;
+
+  const normalized = normalizeDocuments(data as SupabaseDocumentRow[] | null);
+  const items: DashboardDocumentItem[] = normalized.map((doc) => ({
+    ...doc,
+    hasLinks: doc.links.length > 0,
+  }));
+
+  const linkRowsSafe = (linkRows ?? []) as SupabaseDocumentLinkCountRow[];
+  const unlinkedCount = linkRowsSafe.reduce((count, row) => {
+    const links = row.interaction_documents ?? [];
+    return links.length === 0 ? count + 1 : count;
+  }, 0);
+
+  return {
+    items,
+    unlinkedCount,
+  };
+};
+
+export function useDashboardData(): DashboardResult {
+  const { selectedHouseholdId: householdId } = useGlobal();
+  const { t } = useI18n();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<DashboardState>(() => createInitialDashboardState());
+
+  const load = useCallback(async () => {
+    if (!householdId) {
+      setData(createInitialDashboardState());
+      setError(null);
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const supa = await createSPASassClient();
+      const client = supa.getSupabaseClient();
+
+      const [summary, todos, projects, documents] = await Promise.all([
+        fetchSummary(client, householdId),
+        fetchTodos(client, householdId),
+        fetchProjects(client, householdId),
+        fetchDocuments(client, householdId),
+      ]);
+
+      setData({
+        summary: summary.metrics,
+        recentInteractions: summary.recentInteractions,
+        todos,
+        projects,
+        documents,
+      });
+    } catch (err: unknown) {
+      console.error(err);
+      const message = err instanceof Error ? err.message : t("common.unexpectedError");
+      setError(message);
+      setData(createInitialDashboardState());
+    } finally {
+      setLoading(false);
+    }
+  }, [householdId, t]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return {
+    loading,
+    error,
+    ...data,
+  };
+}

--- a/nextjs/src/features/dashboard/mocks/dashboardData.mock.ts
+++ b/nextjs/src/features/dashboard/mocks/dashboardData.mock.ts
@@ -1,0 +1,147 @@
+import { createInitialDashboardState } from "../utils/state";
+import type { DashboardDocumentItem, DashboardState } from "../types";
+
+const base = createInitialDashboardState();
+
+const mockDocuments: DashboardDocumentItem[] = [
+  {
+    id: "document-1",
+    household_id: "household-1",
+    file_path: "household-1/interaction-1/invoice.pdf",
+    name: "Roof Inspection Invoice",
+    notes: "Paid in full",
+    mime_type: "application/pdf",
+    type: "invoice",
+    metadata: { amount: 250 },
+    created_at: new Date().toISOString(),
+    created_by: "user-1",
+    interaction_id: "interaction-1",
+    link_role: null,
+    link_note: null,
+    link_created_at: null,
+    links: [
+      {
+        interactionId: "interaction-1",
+        subject: "Inspect roof leak",
+      },
+    ],
+    hasLinks: true,
+  },
+  {
+    id: "document-2",
+    household_id: "household-1",
+    file_path: "household-1/misc/manual.pdf",
+    name: "Boiler Manual",
+    notes: "",
+    mime_type: "application/pdf",
+    type: "document",
+    metadata: {},
+    created_at: new Date().toISOString(),
+    created_by: "user-1",
+    interaction_id: null,
+    link_role: null,
+    link_note: null,
+    link_created_at: null,
+    links: [],
+    hasLinks: false,
+  },
+];
+
+export const dashboardDataMock: DashboardState = {
+  ...base,
+  summary: [
+    {
+      key: "interactions",
+      total: 42,
+      labelKey: "dashboard.interactions",
+      descriptionKey: "dashboard.totalInHousehold",
+    },
+    {
+      key: "contacts",
+      total: 18,
+      labelKey: "dashboard.contacts",
+      descriptionKey: "dashboard.peopleAndVendors",
+    },
+    {
+      key: "zones",
+      total: 9,
+      labelKey: "dashboard.zones",
+      descriptionKey: "dashboard.roomsAndAreas",
+    },
+  ],
+  recentInteractions: {
+    total: 42,
+    items: [
+      {
+        id: "interaction-1",
+        subject: "Inspect roof leak",
+        content: "Called ACME Roofing to schedule inspection.",
+        occurredAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        type: "call",
+      },
+      {
+        id: "interaction-2",
+        subject: "Delivered new dishwasher",
+        content: "Appliance delivered and installed successfully.",
+        occurredAt: new Date().toISOString(),
+        createdAt: new Date().toISOString(),
+        type: "note",
+      },
+    ],
+  },
+  todos: [
+    {
+      id: "todo-1",
+      subject: "Schedule annual HVAC maintenance",
+      status: "pending",
+      occurredAt: new Date(Date.now() + 2 * 24 * 60 * 60 * 1000).toISOString(),
+      createdAt: new Date().toISOString(),
+      isOverdue: false,
+      isDueSoon: true,
+    },
+    {
+      id: "todo-2",
+      subject: "Renew home insurance policy",
+      status: "in_progress",
+      occurredAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      createdAt: new Date().toISOString(),
+      isOverdue: true,
+      isDueSoon: false,
+    },
+  ],
+  projects: [
+    {
+      id: "project-1",
+      household_id: "household-1",
+      title: "Kitchen refresh",
+      description: "Paint cabinets and replace backsplash.",
+      status: "active",
+      priority: 3,
+      start_date: new Date().toISOString(),
+      due_date: new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString(),
+      closed_at: null,
+      tags: ["kitchen"],
+      planned_budget: 12000,
+      actual_cost_cached: 2500,
+      cover_interaction_id: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      created_by: "user-1",
+      updated_by: "user-1",
+      metrics: {
+        project_id: "project-1",
+        open_todos: 2,
+        done_todos: 1,
+        documents_count: 4,
+        actual_cost: 2500,
+      },
+      isOverdue: false,
+      isDueSoon: true,
+    },
+  ],
+  documents: {
+    items: mockDocuments,
+    unlinkedCount: mockDocuments.filter((doc) => !doc.hasLinks).length,
+  },
+};

--- a/nextjs/src/features/dashboard/types.ts
+++ b/nextjs/src/features/dashboard/types.ts
@@ -1,0 +1,63 @@
+import type { DocumentWithLinks } from "@documents/types";
+import type { ProjectWithMetrics } from "@projects/types";
+
+export type DashboardSummaryMetricKey = "interactions" | "contacts" | "zones";
+
+export type DashboardSummaryMetric = {
+  key: DashboardSummaryMetricKey;
+  total: number;
+  labelKey: string;
+  descriptionKey?: string;
+};
+
+export type DashboardRecentInteraction = {
+  id: string;
+  subject: string | null;
+  content: string | null;
+  occurredAt: string | null;
+  createdAt: string;
+  type: string | null;
+};
+
+export type DashboardRecentInteractions = {
+  total: number;
+  items: DashboardRecentInteraction[];
+};
+
+export type DashboardTodoItem = {
+  id: string;
+  subject: string | null;
+  status: string | null;
+  occurredAt: string | null;
+  createdAt: string;
+  isOverdue: boolean;
+  isDueSoon: boolean;
+};
+
+export type DashboardDocuments<TDocument> = {
+  items: TDocument[];
+  unlinkedCount: number;
+};
+
+export type DashboardData<TDocument, TProject> = {
+  summary: DashboardSummaryMetric[];
+  recentInteractions: DashboardRecentInteractions;
+  todos: DashboardTodoItem[];
+  projects: TProject[];
+  documents: DashboardDocuments<TDocument>;
+};
+
+export type DashboardHookResult<TDocument, TProject> = DashboardData<TDocument, TProject> & {
+  loading: boolean;
+  error: string | null;
+};
+
+export type DashboardDocumentItem = DocumentWithLinks & {
+  hasLinks: boolean;
+};
+
+export type DashboardProjectSummary = ProjectWithMetrics;
+
+export type DashboardState = DashboardData<DashboardDocumentItem, DashboardProjectSummary>;
+
+export type DashboardResult = DashboardHookResult<DashboardDocumentItem, DashboardProjectSummary>;

--- a/nextjs/src/features/dashboard/utils/state.ts
+++ b/nextjs/src/features/dashboard/utils/state.ts
@@ -1,0 +1,15 @@
+import type { DashboardState } from "../types";
+
+export const createInitialDashboardState = (): DashboardState => ({
+  summary: [],
+  recentInteractions: {
+    total: 0,
+    items: [],
+  },
+  todos: [],
+  projects: [],
+  documents: {
+    items: [],
+    unlinkedCount: 0,
+  },
+});

--- a/nextjs/src/features/documents/hooks/useDocuments.ts
+++ b/nextjs/src/features/documents/hooks/useDocuments.ts
@@ -4,29 +4,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { createSPASassClientAuthenticated as createSPASassClient } from "@/lib/supabase/client";
-import type { Document } from "@interactions/types";
 import { useGlobal } from "@/lib/context/GlobalContext";
-
-export type DocumentLink = {
-  interactionId: string;
-  subject: string | null;
-};
-
-export type DocumentWithLinks = Document & {
-  links: DocumentLink[];
-};
-
-type SupabaseInteractionLink = {
-  interaction_id: string;
-  interaction?: {
-    id: string;
-    subject: string | null;
-  } | null;
-};
-
-type SupabaseDocumentRow = Document & {
-  interaction_documents?: SupabaseInteractionLink[] | null;
-};
+import type { DocumentWithLinks, SupabaseDocumentRow } from "@documents/types";
+import { normalizeDocuments } from "@documents/utils/normalizeDocuments";
 
 export function useDocuments() {
   const { selectedHouseholdId: householdId } = useGlobal();
@@ -75,17 +55,7 @@ export function useDocuments() {
 
       if (supabaseError) throw supabaseError;
 
-      const normalized: DocumentWithLinks[] = (data as SupabaseDocumentRow[] | null)?.map((row) => {
-        const linksRaw = row.interaction_documents ?? [];
-        const links: DocumentLink[] = linksRaw.map((link) => ({
-          interactionId: link.interaction_id,
-          subject: link.interaction?.subject ?? null,
-        }));
-        return {
-          ...row,
-          links,
-        };
-      }) ?? [];
+      const normalized: DocumentWithLinks[] = normalizeDocuments(data as SupabaseDocumentRow[] | null);
 
       setDocuments(normalized);
     } catch (fetchError: unknown) {

--- a/nextjs/src/features/documents/types.ts
+++ b/nextjs/src/features/documents/types.ts
@@ -1,0 +1,22 @@
+import type { Document } from "@interactions/types";
+
+type SupabaseInteractionLink = {
+  interaction_id: string;
+  interaction?: {
+    id: string;
+    subject: string | null;
+  } | null;
+};
+
+export type DocumentLink = {
+  interactionId: string;
+  subject: string | null;
+};
+
+export type DocumentWithLinks = Document & {
+  links: DocumentLink[];
+};
+
+export type SupabaseDocumentRow = Document & {
+  interaction_documents?: SupabaseInteractionLink[] | null;
+};

--- a/nextjs/src/features/documents/utils/normalizeDocuments.ts
+++ b/nextjs/src/features/documents/utils/normalizeDocuments.ts
@@ -1,0 +1,20 @@
+import type { DocumentLink, DocumentWithLinks, SupabaseDocumentRow } from "@documents/types";
+
+export function normalizeDocuments(rows: SupabaseDocumentRow[] | null | undefined): DocumentWithLinks[] {
+  if (!rows || rows.length === 0) {
+    return [];
+  }
+
+  return rows.map((row) => {
+    const { interaction_documents: interactionDocuments, ...document } = row;
+    const links: DocumentLink[] = (interactionDocuments ?? []).map((link) => ({
+      interactionId: link.interaction_id,
+      subject: link.interaction?.subject ?? null,
+    }));
+
+    return {
+      ...document,
+      links,
+    };
+  });
+}

--- a/nextjs/src/features/projects/hooks/useProject.ts
+++ b/nextjs/src/features/projects/hooks/useProject.ts
@@ -6,30 +6,7 @@ import { createSPASassClientAuthenticated as createSPASassClient } from "@/lib/s
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import type { Project, ProjectMetrics, ProjectWithMetrics } from "@projects/types";
 import { useGlobal } from "@/lib/context/GlobalContext";
-
-const computeFlags = (project: Project, metrics: ProjectMetrics | null) => {
-  const base: Pick<ProjectWithMetrics, "isDueSoon" | "isOverdue"> = {
-    isDueSoon: false,
-    isOverdue: false,
-  };
-  if (!project.due_date || project.status === "completed" || project.status === "cancelled") {
-    return base;
-  }
-
-  const due = new Date(project.due_date);
-  const today = new Date();
-  due.setHours(0, 0, 0, 0);
-  today.setHours(0, 0, 0, 0);
-  const openTodos = metrics?.open_todos ?? 0;
-
-  const diffMs = due.getTime() - today.getTime();
-  const diffDays = diffMs / (1000 * 60 * 60 * 24);
-
-  return {
-    isOverdue: due < today && openTodos > 0,
-    isDueSoon: diffDays >= 0 && diffDays <= 7 && openTodos > 0,
-  };
-};
+import { computeProjectFlags } from "@projects/utils/projectFlags";
 
 export function useProject(projectId?: string) {
   const { selectedHouseholdId: householdId } = useGlobal();
@@ -89,7 +66,7 @@ export function useProject(projectId?: string) {
       if (metricsError) throw metricsError;
 
       const metrics = (metricsRow as ProjectMetrics | null) ?? null;
-      const flags = computeFlags(projectData, metrics);
+      const flags = computeProjectFlags(projectData, metrics);
 
       setProject({
         ...projectData,

--- a/nextjs/src/features/projects/hooks/useProjects.ts
+++ b/nextjs/src/features/projects/hooks/useProjects.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import { useGlobal } from "@/lib/context/GlobalContext";
 import { createSPASassClientAuthenticated as createSPASassClient } from "@/lib/supabase/client";
+import { computeProjectFlags } from "@projects/utils/projectFlags";
 import type {
   Project,
   ProjectListFilters,
@@ -18,29 +19,6 @@ export const DEFAULT_PROJECT_FILTERS: ProjectListFilters = {
   statuses: ["active", "draft"],
 };
 
-const MS_IN_DAY = 1000 * 60 * 60 * 24;
-
-const computeIsOverdue = (project: Project, metrics: ProjectMetrics | null) => {
-  if (!project.due_date || project.status === "completed" || project.status === "cancelled") return false;
-  const due = new Date(project.due_date);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  due.setHours(0, 0, 0, 0);
-  const openTodos = metrics?.open_todos ?? 0;
-  return due < today && openTodos > 0;
-};
-
-const computeIsDueSoon = (project: Project, metrics: ProjectMetrics | null) => {
-  if (!project.due_date || project.status === "completed" || project.status === "cancelled") return false;
-  const due = new Date(project.due_date);
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  due.setHours(0, 0, 0, 0);
-  const delta = (due.getTime() - today.getTime()) / MS_IN_DAY;
-  const openTodos = metrics?.open_todos ?? 0;
-  return delta >= 0 && delta <= 7 && openTodos > 0;
-};
-
 export function useProjects(initialFilters: ProjectListFilters = DEFAULT_PROJECT_FILTERS) {
   const { t } = useI18n();
   const { selectedHouseholdId: householdId } = useGlobal();
@@ -48,7 +26,6 @@ export function useProjects(initialFilters: ProjectListFilters = DEFAULT_PROJECT
   const [projects, setProjects] = useState<ProjectWithMetrics[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>("");
-  console.log(filters)
 
   const load = useCallback(async () => {
     if (!householdId) return;
@@ -125,11 +102,11 @@ export function useProjects(initialFilters: ProjectListFilters = DEFAULT_PROJECT
 
       const enriched: ProjectWithMetrics[] = typedProjects.map((project) => {
         const metrics = metricsByProject.get(project.id) ?? null;
+        const flags = computeProjectFlags(project, metrics);
         return {
           ...project,
           metrics,
-          isOverdue: computeIsOverdue(project, metrics),
-          isDueSoon: computeIsDueSoon(project, metrics),
+          ...flags,
         };
       });
 

--- a/nextjs/src/features/projects/utils/projectFlags.ts
+++ b/nextjs/src/features/projects/utils/projectFlags.ts
@@ -1,0 +1,33 @@
+import type { Project, ProjectMetrics, ProjectWithMetrics } from "@projects/types";
+
+const MS_IN_DAY = 1000 * 60 * 60 * 24;
+
+export type ProjectFlagResult = Pick<ProjectWithMetrics, "isDueSoon" | "isOverdue">;
+
+export function computeProjectFlags(project: Project, metrics: ProjectMetrics | null): ProjectFlagResult {
+  const base: ProjectFlagResult = {
+    isDueSoon: false,
+    isOverdue: false,
+  };
+
+  if (!project.due_date || project.status === "completed" || project.status === "cancelled") {
+    return base;
+  }
+
+  const due = new Date(project.due_date);
+  const today = new Date();
+  due.setHours(0, 0, 0, 0);
+  today.setHours(0, 0, 0, 0);
+
+  const openTodos = metrics?.open_todos ?? 0;
+  if (openTodos <= 0) {
+    return base;
+  }
+
+  const delta = (due.getTime() - today.getTime()) / MS_IN_DAY;
+
+  return {
+    isOverdue: due < today,
+    isDueSoon: delta >= 0 && delta <= 7,
+  };
+}

--- a/nextjs/tsconfig.json
+++ b/nextjs/tsconfig.json
@@ -44,6 +44,9 @@
       ],
       "@projects/*": [
         "features/projects/*"
+      ],
+      "@dashboard/*": [
+        "features/dashboard/*"
       ]
     }
   },


### PR DESCRIPTION
## Summary
- add a dashboard data hook that aggregates summary metrics, todos, projects, documents, and recent interactions
- refactor documents and projects hooks to share normalization and status flag utilities
- define dashboard types, initial state helper, and mock data to validate the returned structure

## Testing
- yarn lint *(fails: existing unused variable errors in layout components and context)*

------
https://chatgpt.com/codex/tasks/task_e_68fded6e5b1083238b72d02de057c54e