### PR TITLE
Improve back navigation fallback

### DIFF
--- a/nextjs/src/components/BackButton.tsx
+++ b/nextjs/src/components/BackButton.tsx
@@ -1,32 +1,92 @@
 // nextjs/src/components/BackButton.tsx
 'use client';
+
 import { Button } from "@/components/ui/button";
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import { ArrowLeft } from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useCallback } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
+
+const HISTORY_KEY = "appPageLayout:history";
+
+function readHistory(): string[] {
+  if (typeof window === "undefined") return [];
+
+  try {
+    const raw = window.sessionStorage.getItem(HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    console.error("Failed to read back history", error);
+    return [];
+  }
+}
+
+function writeHistory(history: string[]) {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.sessionStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+  } catch (error) {
+    console.error("Failed to persist back history", error);
+  }
+}
 
 export default function BackButton() {
-    const { t } = useI18n();
-    const router = useRouter();
+  const { t } = useI18n();
+  const router = useRouter();
+  const pathname = usePathname();
 
-    const handleBack = useCallback(() => {
-        if (typeof window !== "undefined" && window.history.length > 1) {
-            router.back();
-            return;
-        }
-        setTimeout(() => {
-            router.refresh();
-        }, 200);
-        return;
-    }, [router]);
-    return (<Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={handleBack}
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const history = readHistory();
+    const lastEntry = history[history.length - 1];
+    if (lastEntry !== pathname) {
+      const updated = [...history, pathname].slice(-50);
+      writeHistory(updated);
+    }
+  }, [pathname]);
+
+  const handleBack = useCallback(() => {
+    const history = readHistory();
+    const trimmedHistory = history.filter((entry) => !!entry);
+
+    if (trimmedHistory.length === 0) {
+      router.push("/app/dashboard");
+      return;
+    }
+
+    // Remove current page
+    if (trimmedHistory[trimmedHistory.length - 1] === pathname) {
+      trimmedHistory.pop();
+    }
+
+    const isFormPath = (path: string) => /\/(edit|new)(\/|$)/.test(path);
+
+    let target = "/app/dashboard";
+    while (trimmedHistory.length > 0) {
+      const candidate = trimmedHistory.pop()!;
+      if (candidate === pathname) continue;
+      if (isFormPath(candidate)) continue;
+      target = candidate;
+      break;
+    }
+
+    writeHistory(trimmedHistory);
+    router.push(target);
+  }, [pathname, router]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      onClick={handleBack}
     >
-        <ArrowLeft className="h-5 w-5" />
-        <span className="sr-only">{t("common.back")}</span>
-    </Button>)
+      <ArrowLeft className="h-5 w-5" />
+      <span className="sr-only">{t("common.back")}</span>
+    </Button>
+  );
 }


### PR DESCRIPTION
## Summary
- track navigation history for the app layout back button
- skip edit/new routes and duplicates so back navigation returns to the previous meaningful page
- default to dashboard when no prior history is available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273bac88e48323ade66f5f40357673)