### PR TITLE
Fix zone parent selection in detail view

### DIFF
--- a/nextjs/src/features/zones/hooks/useZoneDetail.ts
+++ b/nextjs/src/features/zones/hooks/useZoneDetail.ts
@@ -116,7 +116,7 @@ export function useZoneDetail(zoneId?: string) {
             parent_id,
             created_at,
             created_by,
-            zones(
+            parent:zones!zones_parent_id_fkey(
               id,
               name,
               color


### PR DESCRIPTION
## Summary
- fetch the zone parent via the self-referential relation so the parent section shows the correct value in zone detail

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69274b70d9b483238cf0ecf094467e86)