### PR TITLE
Use shared sheet action for list filters

### DIFF
--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -53,6 +53,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@playwright/test": "^1.50.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@testing-library/user-event": "^14.6.1",

--- a/nextjs/src/app/app/(pages)/interactions/page.tsx
+++ b/nextjs/src/app/app/(pages)/interactions/page.tsx
@@ -14,6 +14,7 @@ import { useInteractions } from "@interactions/hooks/useInteractions";
 import { DEFAULT_INTERACTION_FILTERS } from "@interactions/constants";
 import ListPageLayout from "@shared/layout/ListPageLayout";
 import EmptyState from "@shared/components/EmptyState";
+import FiltersActionSheet from "@shared/components/FiltersActionSheet";
 import { Button } from "@/components/ui/button";
 
 export default function InteractionsPage() {
@@ -44,21 +45,30 @@ export default function InteractionsPage() {
     router.replace(next, { scroll: false });
   }, [contactIdFilter, router, searchParams]);
 
+  const resetFilters = useCallback(
+    () => setFilters({ ...DEFAULT_INTERACTION_FILTERS }),
+    [setFilters]
+  );
+
   const actions = useMemo(
     () => [
+      {
+        element: (
+          <FiltersActionSheet
+            title={t("interactions.filters.title")}
+            ariaLabel={t("common.filter")}
+          >
+            <InteractionFilters filters={filters} onChange={setFilters} onReset={resetFilters} />
+          </FiltersActionSheet>
+        ),
+      },
       {
         icon: Plus,
         href: "/app/interactions/new",
         variant: "default" as const,
       },
     ],
-    [t]
-  );
-
-  const resetFilters = () => setFilters({ ...DEFAULT_INTERACTION_FILTERS });
-
-  const toolbar = (
-    <InteractionFilters filters={filters} onChange={setFilters} onReset={resetFilters} />
+    [filters, resetFilters, setFilters, t]
   );
 
   useEffect(() => {
@@ -86,7 +96,6 @@ export default function InteractionsPage() {
       title={t("interactionstitle")}
       hideBackButton
       actions={actions}
-      toolbar={toolbar}
       loading={loading}
       isEmpty={!loading && displayedInteractions.length === 0}
       emptyState={

--- a/nextjs/src/app/app/(pages)/interactions/page.tsx
+++ b/nextjs/src/app/app/(pages)/interactions/page.tsx
@@ -11,7 +11,6 @@ import LinkWithOverlay from "@/components/layout/LinkWithOverlay";
 import InteractionList from "@interactions/components/InteractionList";
 import InteractionFilters from "@interactions/components/InteractionFilters";
 import { useInteractions } from "@interactions/hooks/useInteractions";
-import { DEFAULT_INTERACTION_FILTERS } from "@interactions/constants";
 import ListPageLayout from "@shared/layout/ListPageLayout";
 import EmptyState from "@shared/components/EmptyState";
 import FiltersActionSheet from "@shared/components/FiltersActionSheet";
@@ -22,7 +21,7 @@ export default function InteractionsPage() {
   const { show } = useToast();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { interactions, documentCounts, loading, error, filters, setFilters } = useInteractions();
+  const { interactions, documentCounts, loading, error, filters, setFilters, resetFilters } = useInteractions();
 
   const contactIdFilter = searchParams?.get("contactId") ?? null;
   const contactNameParam = searchParams?.get("contactName") ?? null;
@@ -44,11 +43,6 @@ export default function InteractionsPage() {
     const next = `/app/interactions${nextParams.toString() ? `?${nextParams.toString()}` : ""}`;
     router.replace(next, { scroll: false });
   }, [contactIdFilter, router, searchParams]);
-
-  const resetFilters = useCallback(
-    () => setFilters({ ...DEFAULT_INTERACTION_FILTERS }),
-    [setFilters]
-  );
 
   const hasActiveFilters = useMemo(
     () =>

--- a/nextjs/src/app/app/(pages)/interactions/page.tsx
+++ b/nextjs/src/app/app/(pages)/interactions/page.tsx
@@ -50,6 +50,18 @@ export default function InteractionsPage() {
     [setFilters]
   );
 
+  const hasActiveFilters = useMemo(
+    () =>
+      Boolean(
+        filters.search?.trim() ||
+          filters.types.length ||
+          filters.statuses.length ||
+          filters.occurredFrom ||
+          filters.occurredTo
+      ),
+    [filters]
+  );
+
   const actions = useMemo(
     () => [
       {
@@ -57,6 +69,7 @@ export default function InteractionsPage() {
           <FiltersActionSheet
             title={t("interactions.filters.title")}
             ariaLabel={t("common.filter")}
+            isActive={hasActiveFilters}
           >
             <InteractionFilters filters={filters} onChange={setFilters} onReset={resetFilters} />
           </FiltersActionSheet>
@@ -68,7 +81,7 @@ export default function InteractionsPage() {
         variant: "default" as const,
       },
     ],
-    [filters, resetFilters, setFilters, t]
+    [filters, hasActiveFilters, resetFilters, setFilters, t]
   );
 
   useEffect(() => {

--- a/nextjs/src/app/app/(pages)/projects/page.tsx
+++ b/nextjs/src/app/app/(pages)/projects/page.tsx
@@ -1,7 +1,7 @@
 // nextjs/src/app/app/projects/page.tsx
 "use client";
 
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import { Plus } from "lucide-react";
 
 import ProjectFilters from "@projects/components/ProjectFilters";
@@ -17,12 +17,7 @@ import LinkWithOverlay from "@/components/layout/LinkWithOverlay";
 
 export default function ProjectsPage() {
   const { t } = useI18n();
-  const { projects, loading, error, filters, setFilters } = useProjects();
-
-  const resetFilters = useCallback(
-    () => setFilters({ ...DEFAULT_PROJECT_FILTERS }),
-    [setFilters]
-  );
+  const { projects, loading, error, filters, setFilters, resetFilters } = useProjects();
 
   const hasActiveFilters = useMemo(() => {
     const defaultStatuses = DEFAULT_PROJECT_FILTERS.statuses ?? [];

--- a/nextjs/src/app/app/(pages)/projects/page.tsx
+++ b/nextjs/src/app/app/(pages)/projects/page.tsx
@@ -24,6 +24,23 @@ export default function ProjectsPage() {
     [setFilters]
   );
 
+  const hasActiveFilters = useMemo(() => {
+    const defaultStatuses = DEFAULT_PROJECT_FILTERS.statuses ?? [];
+    const currentStatuses = filters.statuses ?? [];
+    const statusesChanged =
+      defaultStatuses.length !== currentStatuses.length ||
+      currentStatuses.some((status) => !defaultStatuses.includes(status));
+
+    return Boolean(
+      statusesChanged ||
+        filters.search?.trim() ||
+        (filters.tags?.length ?? 0) > 0 ||
+        filters.startDateFrom ||
+        filters.dueDateTo ||
+        filters.projectGroupId
+    );
+  }, [filters]);
+
   const actions = useMemo(
     () => [
       {
@@ -31,6 +48,7 @@ export default function ProjectsPage() {
           <FiltersActionSheet
             title={t("projects.filters.title")}
             ariaLabel={t("common.filter")}
+            isActive={hasActiveFilters}
           >
             <ProjectFilters filters={filters} onChange={setFilters} onReset={resetFilters} />
           </FiltersActionSheet>
@@ -42,7 +60,7 @@ export default function ProjectsPage() {
         variant: "default" as const,
       },
     ],
-    [filters, resetFilters, setFilters, t]
+    [filters, hasActiveFilters, resetFilters, setFilters, t]
   );
 
   const toolbar = (

--- a/nextjs/src/app/app/(pages)/projects/page.tsx
+++ b/nextjs/src/app/app/(pages)/projects/page.tsx
@@ -1,9 +1,8 @@
 // nextjs/src/app/app/projects/page.tsx
 "use client";
 
-import { useMemo } from "react";
-import { Filter, Plus } from "lucide-react";
-import { SheetDialog } from "@/components/ui/sheet-dialog";
+import { useCallback, useMemo } from "react";
+import { Plus } from "lucide-react";
 
 import ProjectFilters from "@projects/components/ProjectFilters";
 import TextSearch from "@projects/components/TextSearch";
@@ -12,6 +11,7 @@ import { DEFAULT_PROJECT_FILTERS, useProjects } from "@projects/hooks/useProject
 import { useI18n } from "@/lib/i18n/I18nProvider";
 import ListPageLayout from "@shared/layout/ListPageLayout";
 import EmptyState from "@shared/components/EmptyState";
+import FiltersActionSheet from "@shared/components/FiltersActionSheet";
 import { Button } from "@/components/ui/button";
 import LinkWithOverlay from "@/components/layout/LinkWithOverlay";
 
@@ -19,18 +19,21 @@ export default function ProjectsPage() {
   const { t } = useI18n();
   const { projects, loading, error, filters, setFilters } = useProjects();
 
-  const resetFilters = () => setFilters({ ...DEFAULT_PROJECT_FILTERS });
+  const resetFilters = useCallback(
+    () => setFilters({ ...DEFAULT_PROJECT_FILTERS }),
+    [setFilters]
+  );
 
   const actions = useMemo(
     () => [
       {
-        // Custom element action: open filters in a SheetDialog
         element: (
-          <SheetDialog
-            trigger={<Button variant="outline" size="sm"><Filter /></Button>}
+          <FiltersActionSheet
+            title={t("projects.filters.title")}
+            ariaLabel={t("common.filter")}
           >
             <ProjectFilters filters={filters} onChange={setFilters} onReset={resetFilters} />
-          </SheetDialog>
+          </FiltersActionSheet>
         ),
       },
       {
@@ -39,7 +42,7 @@ export default function ProjectsPage() {
         variant: "default" as const,
       },
     ],
-    [filters, setFilters, resetFilters]
+    [filters, resetFilters, setFilters, t]
   );
 
   const toolbar = (

--- a/nextjs/src/features/_shared/components/FiltersActionSheet.tsx
+++ b/nextjs/src/features/_shared/components/FiltersActionSheet.tsx
@@ -1,0 +1,47 @@
+// nextjs/src/features/_shared/components/FiltersActionSheet.tsx
+"use client";
+
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Filter } from "lucide-react";
+
+import { Button, type ButtonProps } from "@/components/ui/button";
+import { SheetDialog } from "@/components/ui/sheet-dialog";
+
+interface FiltersActionSheetProps {
+  children: ReactNode;
+  title?: string;
+  description?: string;
+  icon?: LucideIcon;
+  buttonVariant?: ButtonProps["variant"];
+  buttonSize?: ButtonProps["size"];
+  ariaLabel?: string;
+}
+
+export default function FiltersActionSheet({
+  children,
+  title,
+  description,
+  icon: Icon = Filter,
+  buttonVariant = "outline",
+  buttonSize = "sm",
+  ariaLabel,
+}: FiltersActionSheetProps) {
+  return (
+    <SheetDialog
+      title={title}
+      description={description}
+      trigger={(
+        <Button
+          variant={buttonVariant}
+          size={buttonSize}
+          aria-label={ariaLabel ?? title ?? "Filters"}
+        >
+          <Icon />
+        </Button>
+      )}
+    >
+      {children}
+    </SheetDialog>
+  );
+}

--- a/nextjs/src/features/_shared/components/FiltersActionSheet.tsx
+++ b/nextjs/src/features/_shared/components/FiltersActionSheet.tsx
@@ -16,6 +16,7 @@ interface FiltersActionSheetProps {
   buttonVariant?: ButtonProps["variant"];
   buttonSize?: ButtonProps["size"];
   ariaLabel?: string;
+  isActive?: boolean;
 }
 
 export default function FiltersActionSheet({
@@ -26,6 +27,7 @@ export default function FiltersActionSheet({
   buttonVariant = "outline",
   buttonSize = "sm",
   ariaLabel,
+  isActive = false,
 }: FiltersActionSheetProps) {
   return (
     <SheetDialog
@@ -36,8 +38,15 @@ export default function FiltersActionSheet({
           variant={buttonVariant}
           size={buttonSize}
           aria-label={ariaLabel ?? title ?? "Filters"}
+          className="relative"
         >
           <Icon />
+          {isActive ? (
+            <span
+              aria-hidden
+              className="absolute -right-0.5 -top-0.5 block h-2 w-2 rounded-full bg-primary ring-2 ring-background"
+            />
+          ) : null}
         </Button>
       )}
     >

--- a/nextjs/src/features/_shared/hooks/__tests__/usePersistentFilters.test.ts
+++ b/nextjs/src/features/_shared/hooks/__tests__/usePersistentFilters.test.ts
@@ -36,8 +36,7 @@ describe("usePersistentFilters", () => {
 
   beforeEach(() => {
     localStorageMock = createMockStorage();
-    vi.stubGlobal("window", { localStorage: localStorageMock.localStorage } as unknown as Window &
-      typeof globalThis);
+    vi.stubGlobal("localStorage", localStorageMock.localStorage);
   });
 
   afterEach(() => {

--- a/nextjs/src/features/_shared/hooks/__tests__/usePersistentFilters.test.ts
+++ b/nextjs/src/features/_shared/hooks/__tests__/usePersistentFilters.test.ts
@@ -1,0 +1,106 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePersistentFilters } from "@shared/hooks/usePersistentFilters";
+
+type TestFilters = {
+  status: string;
+  search: string;
+};
+
+const STORAGE_KEY = "test-filters";
+const fallbackFilters: TestFilters = { status: "open", search: "" };
+
+const createMockStorage = () => {
+  const store = new Map<string, string>();
+
+  return {
+    store,
+    localStorage: {
+      getItem: vi.fn((key: string) => store.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        store.set(key, value);
+      }),
+      removeItem: vi.fn((key: string) => {
+        store.delete(key);
+      }),
+      clear: vi.fn(() => store.clear()),
+      key: vi.fn(),
+      length: 0,
+    },
+  };
+};
+
+describe("usePersistentFilters", () => {
+  let localStorageMock: ReturnType<typeof createMockStorage>;
+
+  beforeEach(() => {
+    localStorageMock = createMockStorage();
+    vi.stubGlobal("window", { localStorage: localStorageMock.localStorage } as unknown as Window &
+      typeof globalThis);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("initializes with fallback values when storage is empty", () => {
+    const { result } = renderHook(() =>
+      usePersistentFilters<TestFilters>({ key: STORAGE_KEY, fallback: fallbackFilters })
+    );
+
+    expect(result.current.filters).toEqual(fallbackFilters);
+  });
+
+  it("restores saved filters and merges with fallback defaults", () => {
+    const storageKey = `${STORAGE_KEY}:global`;
+    localStorageMock.store.set(storageKey, JSON.stringify({ search: "query" }));
+
+    const { result } = renderHook(() =>
+      usePersistentFilters<TestFilters>({ key: STORAGE_KEY, fallback: fallbackFilters })
+    );
+
+    expect(result.current.filters).toEqual({ status: "open", search: "query" });
+    expect(localStorageMock.localStorage.getItem).toHaveBeenCalledWith(storageKey);
+  });
+
+  it("persists updates and can reset to fallback values", async () => {
+    const { result } = renderHook(() =>
+      usePersistentFilters<TestFilters>({ key: STORAGE_KEY, fallback: fallbackFilters })
+    );
+
+    await act(async () => {
+      result.current.setFilters({ status: "closed", search: "leak" });
+    });
+
+    const storageKey = `${STORAGE_KEY}:global`;
+    await waitFor(() =>
+      expect(localStorageMock.localStorage.setItem).toHaveBeenCalledWith(
+        storageKey,
+        JSON.stringify({ status: "closed", search: "leak" })
+      )
+    );
+
+    await act(async () => {
+      result.current.resetFilters();
+    });
+
+    expect(result.current.filters).toEqual(fallbackFilters);
+  });
+
+  it("scopes persisted values by the provided storage scope", () => {
+    const scopedKey = `${STORAGE_KEY}:household-123`;
+    localStorageMock.store.set(scopedKey, JSON.stringify({ status: "scheduled", search: "" }));
+
+    const { result } = renderHook(() =>
+      usePersistentFilters<TestFilters>({
+        key: STORAGE_KEY,
+        fallback: fallbackFilters,
+        scope: "household-123",
+      })
+    );
+
+    expect(result.current.filters).toEqual({ status: "scheduled", search: "" });
+    expect(localStorageMock.localStorage.getItem).toHaveBeenCalledWith(scopedKey);
+  });
+});

--- a/nextjs/src/features/_shared/hooks/usePersistentFilters.ts
+++ b/nextjs/src/features/_shared/hooks/usePersistentFilters.ts
@@ -1,0 +1,55 @@
+// nextjs/src/features/_shared/hooks/usePersistentFilters.ts
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+const DEFAULT_STORAGE_SCOPE = "global";
+
+const readFromStorage = <T,>(storageKey: string, fallback: T) => {
+  if (typeof window === "undefined") return fallback;
+
+  try {
+    const raw = window.localStorage.getItem(storageKey);
+    if (!raw) return fallback;
+
+    const parsed = JSON.parse(raw) as T;
+    return { ...fallback, ...parsed };
+  } catch (err) {
+    console.error("Failed to read filters from storage", err);
+    return fallback;
+  }
+};
+
+export function usePersistentFilters<T extends Record<string, unknown>>({
+  key,
+  fallback,
+  scope,
+}: {
+  key: string;
+  fallback: T;
+  scope?: string | null;
+}) {
+  const storageKey = useMemo(
+    () => `${key}:${scope || DEFAULT_STORAGE_SCOPE}`,
+    [key, scope]
+  );
+
+  const [filters, setFilters] = useState<T>(() => readFromStorage(storageKey, fallback));
+
+  useEffect(() => {
+    setFilters(readFromStorage(storageKey, fallback));
+  }, [fallback, storageKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(filters));
+    } catch (err) {
+      console.error("Failed to store filters", err);
+    }
+  }, [filters, storageKey]);
+
+  const resetFilters = useCallback(() => setFilters({ ...fallback }), [fallback]);
+
+  return { filters, setFilters, resetFilters } as const;
+}

--- a/nextjs/src/features/interactions/components/InteractionFilters.tsx
+++ b/nextjs/src/features/interactions/components/InteractionFilters.tsx
@@ -76,7 +76,6 @@ export default function InteractionFilters({ filters, onChange, onReset }: Inter
         title={t("common.filter")}
         onReset={onReset}
         resetAriaLabel={t("interactions.filters.reset")}
-        defaultCollapsed
       >
         <Input
           className="w-full md:w-64"

--- a/nextjs/src/features/interactions/hooks/useInteractions.ts
+++ b/nextjs/src/features/interactions/hooks/useInteractions.ts
@@ -15,6 +15,7 @@ import type {
 } from "@interactions/types";
 import { DEFAULT_INTERACTION_FILTERS } from "@interactions/constants";
 import { useGlobal } from "@/lib/context/GlobalContext";
+import { usePersistentFilters } from "@shared/hooks/usePersistentFilters";
 
 type DocumentsByInteraction = Record<string, Document[]>;
 type RawInteraction = {
@@ -160,7 +161,11 @@ export function useInteractions() {
   const [documentCounts, setDocumentCounts] = useState<Record<string, number>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [filters, setFilters] = useState<InteractionListFilters>({ ...DEFAULT_INTERACTION_FILTERS });
+  const { filters, setFilters, resetFilters } = usePersistentFilters<InteractionListFilters>({
+    key: "interaction-filters",
+    fallback: DEFAULT_INTERACTION_FILTERS,
+    scope: householdId,
+  });
 
   const interactions = useMemo(() => {
     const searchTerm = filters.search?.trim().toLowerCase() || null;
@@ -437,5 +442,15 @@ export function useInteractions() {
     load();
   }, [householdId, t]);
 
-  return { interactions, documentsByInteraction, documentCounts, loading, error, setError, filters, setFilters };
+  return {
+    interactions,
+    documentsByInteraction,
+    documentCounts,
+    loading,
+    error,
+    setError,
+    filters,
+    setFilters,
+    resetFilters,
+  };
 }

--- a/nextjs/src/features/projects/hooks/useProjects.ts
+++ b/nextjs/src/features/projects/hooks/useProjects.ts
@@ -7,6 +7,7 @@ import { useI18n } from "@/lib/i18n/I18nProvider";
 import { useGlobal } from "@/lib/context/GlobalContext";
 import { createSPASassClientAuthenticated as createSPASassClient } from "@/lib/supabase/client";
 import { computeProjectFlags } from "@projects/utils/projectFlags";
+import { usePersistentFilters } from "@shared/hooks/usePersistentFilters";
 import type {
   Project,
   ProjectListFilters,
@@ -23,7 +24,11 @@ export const DEFAULT_PROJECT_FILTERS: ProjectListFilters = {
 export function useProjects(initialFilters: ProjectListFilters = DEFAULT_PROJECT_FILTERS) {
   const { t } = useI18n();
   const { selectedHouseholdId: householdId } = useGlobal();
-  const [filters, setFilters] = useState<ProjectListFilters>(initialFilters);
+  const { filters, setFilters, resetFilters } = usePersistentFilters<ProjectListFilters>({
+    key: "project-filters",
+    fallback: initialFilters,
+    scope: householdId,
+  });
   const [projects, setProjects] = useState<ProjectWithMetrics[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>("");
@@ -169,6 +174,7 @@ export function useProjects(initialFilters: ProjectListFilters = DEFAULT_PROJECT
     error,
     filters: activeFilters,
     setFilters,
+    resetFilters,
     reload: load,
   };
 }

--- a/nextjs/vitest.config.ts
+++ b/nextjs/vitest.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
-import path from "path";
+import path from "node:path";
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   plugins: [react()],
@@ -8,12 +8,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
-import path from "node:path";
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  test: {
-    environment: "node",
     include: ["src/**/*.test.{ts,tsx}"],
     coverage: {
       reporter: ["text", "lcov"],
@@ -30,6 +24,7 @@ export default defineConfig({
       "@documents": path.resolve(__dirname, "./src/features/documents"),
       "@structures": path.resolve(__dirname, "./src/features/structures"),
       "@projects": path.resolve(__dirname, "./src/features/projects"),
+      "@shared": path.resolve(__dirname, "./src/features/_shared"),
     },
   },
 });

--- a/nextjs/vitest.setup.ts
+++ b/nextjs/vitest.setup.ts
@@ -3,11 +3,8 @@ import React from "react";
 import { vi } from "vitest";
 
 vi.mock("next/link", () => {
-  const Link = ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
-    <a href={href} {...rest}>
-      {children}
-    </a>
-  );
+  const Link = ({ children, href, ...rest }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href, ...rest }, children);
   Link.displayName = "NextLinkMock";
   return { __esModule: true, default: Link };
 });

--- a/nextjs/yarn.lock
+++ b/nextjs/yarn.lock
@@ -23,7 +23,7 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@babel/code-frame@^7.27.1":
+"@babel/code-frame@^7.10.4", "@babel/code-frame@^7.27.1":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -1529,6 +1529,20 @@
   dependencies:
     tslib "^2.8.0"
 
+"@testing-library/dom@^10.4.1":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
 "@testing-library/jest-dom@^6.6.3":
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz#7613a04e146dd2976d24ddf019730d57a89d56c2"
@@ -1552,6 +1566,11 @@
   version "14.6.1"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
   integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/babel__core@^7.20.5":
   version "7.20.5"
@@ -1959,6 +1978,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
@@ -1993,6 +2017,13 @@ aria-hidden@^1.2.4:
   integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
   dependencies:
     tslib "^2.0.0"
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 aria-query@^5.0.0, aria-query@^5.3.2:
   version "5.3.2"
@@ -2609,7 +2640,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-dequal@^2.0.0:
+dequal@^2.0.0, dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
@@ -2647,6 +2678,11 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dom-accessibility-api@^0.6.3:
   version "0.6.3"
@@ -4012,6 +4048,11 @@ lucide-react@^0.469.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.469.0.tgz#f16936ca6521482fef754a7eabb310e6c68e1482"
   integrity sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.30.12:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
@@ -4674,7 +4715,7 @@ pdf-parse@^1.1.1:
     debug "^3.1.0"
     node-ensure "^0.0.0"
 
-picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -4794,6 +4835,15 @@ prettier@^3.6.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
 
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 prop-types@^15.6.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -4846,6 +4896,11 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-is@^18.3.1:
   version "18.3.1"


### PR DESCRIPTION
## Summary
- add a shared FiltersActionSheet helper for sheet-based action buttons
- switch project and interaction list pages to open filters from the action bar
- keep interaction filters expanded when opened in the sheet

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69274c0c9634832392a0bdbefb201603)