### PR TITLE
Improve electricity module

### DIFF
--- a/ELECTRICTY_RETOUR.md
+++ b/ELECTRICTY_RETOUR.md
@@ -1,17 +1,8 @@
-- Avoir une représentation visuelle du tableau
-- Indiquer emplacement sur le tableau
-- Pour les empty state : faire un peu une chaine : par exemple si il n'y a pas de circuit ni de breaker ni de tableau alors le empty state doit etre celui du tableau. Si il y a un tableau ca doit etre le protectedequipment et si il y en a un alors ca doit etre le circuit la. Tu vois ce que je veux dire ? Et ne pas afficher le boutton ajouter en haut à droite pour les empty state (applicable à toute l'appli)
-- vu qu'on fait un soft delete il faut envoyer uniquement les non archivé (pareille partout dans l'appli)
-- il y a un pb d'archi je crois : un disjoncteur doit pouvoir etre relié à un différentiel ou alors on met un parent ??
-- un disjoncteur ou un différentiel peut etre triphasé ...
-- c'est quoi emplacement de reserve ?
-- position des breaker, diff sur tableau
+- En reprenant le style de l'application fais moi une representation graphique du tableau avec les disjoncteur et les differentiel. comme si je le regardais.
+- mettre champs parent dans le formulaire pour disjoncteur : relié à quel différentiel
 - Revoir etiquette / nom pour les PU.
-- Ne vaut-il pas générer les codes par le backend ou pas de code du tout ?
-- regrouper ou pouvoir mettre des quantités au point d'usage : exemple salon toutes les prises x10 sur le meme circuit, relou de faire 10 PU
 - pas de connexion sur le PU avec le circuit : si il y en a un mais bizarre peut etre mieux de le relier directement dans le form du PU ou sur le form du circuit pouvoir ajouter directement un PU
 - demande de création de circuit quand on créé un breaker ou un combined
-- virer la recherche pour le moment
 
 
 amelioration : 

--- a/apps/electricity/migrations/0008_protectivedevice_pole_count.py
+++ b/apps/electricity/migrations/0008_protectivedevice_pole_count.py
@@ -1,0 +1,34 @@
+# Generated manually on 2026-03-23
+
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('electricity', '0007_remove_phase_from_circuit'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='protectivedevice',
+            name='pole_count',
+            field=models.PositiveSmallIntegerField(
+                blank=True,
+                null=True,
+                choices=[(1, '1 pole'), (2, '2 poles'), (3, '3 poles'), (4, '4 poles')],
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='protectivedevice',
+            constraint=models.CheckConstraint(
+                condition=(
+                    ~models.Q(device_type__in=['rcd', 'combined'])
+                    | models.Q(pole_count__isnull=True)
+                    | models.Q(pole_count__in=[2, 4])
+                ),
+                name='chk_electricity_pd_rcd_combined_pole_count',
+            ),
+        ),
+    ]

--- a/apps/electricity/migrations/0009_protectivedevice_position_end.py
+++ b/apps/electricity/migrations/0009_protectivedevice_position_end.py
@@ -1,0 +1,38 @@
+# Generated manually on 2026-03-23
+
+from django.db import migrations, models
+import django.db.models.expressions
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('electricity', '0008_protectivedevice_pole_count'),
+    ]
+
+    operations = [
+        # Drop the old unique constraint on (board, row, position) — range overlap
+        # is now validated in the serializer layer.
+        migrations.RemoveConstraint(
+            model_name='protectivedevice',
+            name='uq_electricity_protective_device_position_per_board',
+        ),
+        migrations.AddField(
+            model_name='protectivedevice',
+            name='position_end',
+            field=models.PositiveSmallIntegerField(blank=True, null=True),
+        ),
+        migrations.AddConstraint(
+            model_name='protectivedevice',
+            constraint=models.CheckConstraint(
+                condition=(
+                    models.Q(position_end__isnull=True)
+                    | (
+                        models.Q(position__isnull=False)
+                        & models.Q(position_end__gte=django.db.models.expressions.F('position'))
+                    )
+                ),
+                name='chk_electricity_pd_position_end_valid',
+            ),
+        ),
+    ]

--- a/apps/electricity/models.py
+++ b/apps/electricity/models.py
@@ -157,6 +157,9 @@ class ProtectiveDevice(HouseholdScopedModel):
     )
     row = models.PositiveSmallIntegerField(null=True, blank=True)
     position = models.PositiveSmallIntegerField(null=True, blank=True)
+    # Optional: last occupied slot in the row. When set, device spans [position, position_end].
+    # Requires position to be set; must be >= position — enforced in service layer and DB constraint.
+    position_end = models.PositiveSmallIntegerField(null=True, blank=True)
     # Cross-table rule: must be null if board.supply_type=single_phase — enforced in service layer, not DB
     phase = models.CharField(
         max_length=2,
@@ -165,6 +168,13 @@ class ProtectiveDevice(HouseholdScopedModel):
         blank=True,
     )
     rating_amps = models.PositiveIntegerField(null=True, blank=True)
+    # Number of poles (1/2 for single-phase, 3/4 for three-phase).
+    # rcd/combined: only 2 or 4 — enforced in service layer and DB constraint.
+    pole_count = models.PositiveSmallIntegerField(
+        null=True,
+        blank=True,
+        choices=[(1, "1 pole"), (2, "2 poles"), (3, "3 poles"), (4, "4 poles")],
+    )
     # Only relevant if device_type in (breaker, combined)
     curve_type = models.CharField(
         max_length=10,
@@ -204,11 +214,16 @@ class ProtectiveDevice(HouseholdScopedModel):
                 condition=models.Q(label__isnull=False),
                 name="uq_electricity_protective_device_label_per_household",
             ),
-            # physical slot uniqueness — only enforced when row/position are set
-            models.UniqueConstraint(
-                fields=["board", "row", "position"],
-                condition=models.Q(row__isnull=False, position__isnull=False),
-                name="uq_electricity_protective_device_position_per_board",
+            # position_end requires position, and must be >= position
+            models.CheckConstraint(
+                condition=(
+                    models.Q(position_end__isnull=True)
+                    | (
+                        models.Q(position__isnull=False)
+                        & models.Q(position_end__gte=models.F("position"))
+                    )
+                ),
+                name="chk_electricity_pd_position_end_valid",
             ),
             # breakers must not carry RCD-specific fields
             models.CheckConstraint(
@@ -233,6 +248,15 @@ class ProtectiveDevice(HouseholdScopedModel):
                     | (models.Q(row__isnull=False) & models.Q(position__isnull=False))
                 ),
                 name="chk_electricity_pd_row_position_both_or_neither",
+            ),
+            # rcd and combined devices: pole_count must be 2 or 4 (or null)
+            models.CheckConstraint(
+                condition=(
+                    ~models.Q(device_type__in=["rcd", "combined"])
+                    | models.Q(pole_count__isnull=True)
+                    | models.Q(pole_count__in=[2, 4])
+                ),
+                name="chk_electricity_pd_rcd_combined_pole_count",
             ),
         ]
 

--- a/apps/electricity/serializers.py
+++ b/apps/electricity/serializers.py
@@ -140,8 +140,10 @@ class ProtectiveDeviceSerializer(HouseholdScopedModelSerializer):
             "role",
             "row",
             "position",
+            "position_end",
             "phase",
             "rating_amps",
+            "pole_count",
             "curve_type",
             "sensitivity_ma",
             "type_code",
@@ -165,6 +167,10 @@ class ProtectiveDeviceSerializer(HouseholdScopedModelSerializer):
         phase = attrs.get("phase", getattr(self.instance, "phase", None))
         device_type = attrs.get("device_type", getattr(self.instance, "device_type", None))
         phase_coverage = attrs.get("phase_coverage", getattr(self.instance, "phase_coverage", None))
+        pole_count = attrs.get("pole_count", getattr(self.instance, "pole_count", None))
+        row = attrs.get("row", getattr(self.instance, "row", None))
+        position = attrs.get("position", getattr(self.instance, "position", None))
+        position_end = attrs.get("position_end", getattr(self.instance, "position_end", None))
 
         if board and household and board.household_id != household.id:
             raise serializers.ValidationError({"board": _("Board must belong to the same household.")})
@@ -178,6 +184,45 @@ class ProtectiveDeviceSerializer(HouseholdScopedModelSerializer):
                 raise serializers.ValidationError({"phase": _("Phase is required for three-phase board.")})
             if board.supply_type == SupplyType.SINGLE_PHASE and device_type == "rcd" and phase_coverage:
                 raise serializers.ValidationError({"phase_coverage": _("phase_coverage must be null for single-phase board.")})
+
+        if pole_count is not None and device_type in ("rcd", "combined") and pole_count not in (2, 4):
+            raise serializers.ValidationError(
+                {"pole_count": _("pole_count must be 2 or 4 for rcd and combined devices.")}
+            )
+
+        row_set = row is not None
+        pos_set = position is not None
+        if row_set != pos_set:
+            raise serializers.ValidationError(
+                {"row": _("row and position must both be set or both be empty.")}
+            )
+
+        if position_end is not None:
+            if position is None:
+                raise serializers.ValidationError(
+                    {"position_end": _("position_end requires position to be set.")}
+                )
+            if position_end < position:
+                raise serializers.ValidationError(
+                    {"position_end": _("position_end must be greater than or equal to position.")}
+                )
+
+        # Range overlap check: no two devices on the same board+row may share a slot.
+        # select_for_update() locks the rows for the duration of the enclosing transaction
+        # so concurrent writes cannot create overlapping positions.
+        if board and row is not None and position is not None:
+            effective_end = position_end if position_end is not None else position
+            qs = ProtectiveDevice.objects.select_for_update().filter(
+                board=board, row=row, position__isnull=False
+            )
+            if self.instance is not None:
+                qs = qs.exclude(pk=self.instance.pk)
+            for device in qs:
+                dev_end = device.position_end if device.position_end is not None else device.position
+                if position <= dev_end and device.position <= effective_end:
+                    raise serializers.ValidationError(
+                        {"position": _("Position range overlaps with an existing device on the same row.")}
+                    )
 
         return attrs
 
@@ -210,6 +255,10 @@ class ElectricCircuitSerializer(HouseholdScopedModelSerializer):
         if protective_device and protective_device.device_type == "rcd":
             raise serializers.ValidationError(
                 {"protective_device": _("A circuit cannot be directly protected by a pure RCD (device_type=rcd).")}
+            )
+        if protective_device and protective_device.is_spare:
+            raise serializers.ValidationError(
+                {"protective_device": _("A spare device cannot protect a circuit.")}
             )
         if board and protective_device and board.id != protective_device.board_id:
             raise serializers.ValidationError({"protective_device": _("Protective device must belong to the selected board.")})

--- a/apps/electricity/tests/test_models.py
+++ b/apps/electricity/tests/test_models.py
@@ -235,7 +235,14 @@ class TestProtectiveDeviceModel:
         pd2 = ProtectiveDeviceFactory(label="DUP")
         assert pd1.household_id != pd2.household_id
 
-    def test_two_devices_same_board_row_position_raises(self):
+    def test_two_devices_same_board_row_position_allowed_at_db_level(self):
+        """
+        Position uniqueness is enforced at the serializer layer (range overlap check),
+        not at the DB level. The unique constraint on (board, row, position) was removed
+        in favour of range-aware overlap detection in ProtectiveDeviceSerializer.
+        Two devices sharing the same start position can be created directly via the ORM
+        — the serializer is the only enforcement point.
+        """
         board = ElectricityBoardFactory()
         user = UserFactory()
         ProtectiveDevice.objects.create(
@@ -243,13 +250,13 @@ class TestProtectiveDeviceModel:
             device_type="breaker", row=1, position=1,
             created_by=user, updated_by=user,
         )
-        with pytest.raises(IntegrityError):
-            with transaction.atomic():
-                ProtectiveDevice.objects.create(
-                    household=board.household, board=board, label="D-B",
-                    device_type="breaker", row=1, position=1,
-                    created_by=user, updated_by=user,
-                )
+        # No IntegrityError at the DB level — serializer catches this instead.
+        pd_b = ProtectiveDevice.objects.create(
+            household=board.household, board=board, label="D-B",
+            device_type="breaker", row=1, position=1,
+            created_by=user, updated_by=user,
+        )
+        assert pd_b.pk is not None
 
     def test_row_set_without_position_raises(self):
         board = ElectricityBoardFactory()

--- a/apps/electricity/tests/test_serializers.py
+++ b/apps/electricity/tests/test_serializers.py
@@ -344,6 +344,237 @@ class TestProtectiveDeviceSerializer:
         assert not ser.is_valid()
         assert "phase_coverage" in ser.errors
 
+    # -- pole_count ----------------------------------------------------------
+
+    def test_fields_include_pole_count(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id), hh)
+        assert "pole_count" in ser.fields
+
+    def test_breaker_with_pole_count_1_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, pole_count=1), hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_breaker_with_pole_count_2_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, pole_count=2), hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_breaker_with_pole_count_3_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="three_phase")
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, device_type="breaker", phase="L1", pole_count=3), hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_breaker_with_pole_count_4_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="three_phase")
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, device_type="breaker", phase="L1", pole_count=4), hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_rcd_with_pole_count_2_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        payload = self._pd_payload(board.id, device_type="rcd", label=None, curve_type="", rating_amps=None, pole_count=2)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_rcd_with_pole_count_4_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="three_phase")
+        payload = self._pd_payload(board.id, device_type="rcd", label=None, curve_type="", rating_amps=None, pole_count=4)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_rcd_with_pole_count_1_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        payload = self._pd_payload(board.id, device_type="rcd", label=None, curve_type="", rating_amps=None, pole_count=1)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert not ser.is_valid()
+        assert "pole_count" in ser.errors
+
+    def test_rcd_with_pole_count_3_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="three_phase")
+        payload = self._pd_payload(board.id, device_type="rcd", label=None, curve_type="", rating_amps=None, pole_count=3)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert not ser.is_valid()
+        assert "pole_count" in ser.errors
+
+    def test_combined_with_pole_count_2_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        payload = self._pd_payload(board.id, device_type="combined", phase=None, pole_count=2)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_combined_with_pole_count_4_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="three_phase")
+        payload = self._pd_payload(board.id, device_type="combined", phase="L1", pole_count=4)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert ser.is_valid(), ser.errors
+
+    def test_combined_with_pole_count_1_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        payload = self._pd_payload(board.id, device_type="combined", phase=None, pole_count=1)
+        ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+        assert not ser.is_valid()
+        assert "pole_count" in ser.errors
+
+    def test_pole_count_null_is_always_valid(self):
+        """pole_count is optional — null is accepted for all device types."""
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        for dtype, extra in [
+            ("breaker", {}),
+            ("rcd", {"label": None, "curve_type": "", "rating_amps": None}),
+            ("combined", {"phase": None}),
+        ]:
+            payload = self._pd_payload(board.id, device_type=dtype, pole_count=None, **extra)
+            ser = _ser(ProtectiveDeviceSerializer, payload, hh)
+            assert ser.is_valid(), f"{dtype}: {ser.errors}"
+
+    # -- position / position_end / overlap -----------------------------------
+
+    def test_row_set_without_position_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, row=1, position=None), hh)
+        assert not ser.is_valid()
+        assert "row" in ser.errors
+
+    def test_position_set_without_row_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, row=None, position=3), hh)
+        assert not ser.is_valid()
+        assert "row" in ser.errors
+
+    def test_position_end_without_position_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=None, position=None, position_end=5),
+            hh,
+        )
+        assert not ser.is_valid()
+        assert "position_end" in ser.errors
+
+    def test_position_end_less_than_position_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=5, position_end=2),
+            hh,
+        )
+        assert not ser.is_valid()
+        assert "position_end" in ser.errors
+
+    def test_position_end_equal_to_position_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=3, position_end=3),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_position_with_row_no_end_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=3),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_position_range_with_end_greater_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=1, position_end=4),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_same_position_on_same_board_row_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ProtectiveDeviceFactory(board=board, household=hh, row=1, position=3)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=3),
+            hh,
+        )
+        assert not ser.is_valid()
+        assert "position" in ser.errors
+
+    def test_position_range_overlap_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ProtectiveDeviceFactory(board=board, household=hh, row=1, position=1, position_end=4)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=3, position_end=6),
+            hh,
+        )
+        assert not ser.is_valid()
+        assert "position" in ser.errors
+
+    def test_adjacent_positions_no_overlap_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ProtectiveDeviceFactory(board=board, household=hh, row=1, position=1, position_end=3)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=1, position=4),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_same_position_different_row_is_valid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        ProtectiveDeviceFactory(board=board, household=hh, row=1, position=3)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board.id, row=2, position=3),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_same_position_different_board_is_valid(self):
+        hh = HouseholdFactory()
+        zone = ZoneFactory(household=hh)
+        board1 = ElectricityBoardFactory(household=hh, zone=zone)
+        board2 = ElectricityBoardFactory(household=hh, zone=zone, parent=board1)
+        ProtectiveDeviceFactory(board=board1, household=hh, row=1, position=3)
+        ser = _ser(
+            ProtectiveDeviceSerializer,
+            self._pd_payload(board2.id, row=1, position=3),
+            hh,
+        )
+        assert ser.is_valid(), ser.errors
+
+    def test_update_device_excludes_self_from_overlap_check(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh)
+        existing = ProtectiveDeviceFactory(board=board, household=hh, row=1, position=3)
+        ser = _ser(ProtectiveDeviceSerializer, self._pd_payload(board.id, row=1, position=3), hh, instance=existing)
+        assert ser.is_valid(), ser.errors
+
 
 # ---------------------------------------------------------------------------
 # ElectricCircuitSerializer
@@ -422,6 +653,14 @@ class TestElectricCircuitSerializer:
             hh,
         )
         assert not ser.is_valid()
+
+    def test_spare_device_cannot_protect_circuit_is_invalid(self):
+        hh = HouseholdFactory()
+        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
+        pd = ProtectiveDeviceFactory(board=board, household=hh, device_type="breaker", is_spare=True)
+        ser = _ser(ElectricCircuitSerializer, self._circuit_payload(board.id, pd.id), hh)
+        assert not ser.is_valid()
+        assert "protective_device" in ser.errors
 
 
 # ---------------------------------------------------------------------------

--- a/apps/electricity/tests/test_views.py
+++ b/apps/electricity/tests/test_views.py
@@ -585,6 +585,123 @@ class TestUsagePointViewSet:
 
 
 # ---------------------------------------------------------------------------
+# UsagePointViewSet — bulk_create action
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+class TestUsagePointBulkCreate:
+    """Tests for the POST /api/electricity/usage-points/bulk-create/ action."""
+
+    BULK_CREATE_URL = staticmethod(lambda: reverse("electricity-usage-point-bulk-create"))
+
+    def _up_payload(self, zone_id, **overrides):
+        payload = {
+            "label": "UP-BULK",
+            "name": "Bulk point",
+            "kind": "socket",
+            "zone": str(zone_id),
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_bulk_create_quantity_1_creates_single_usage_point_with_exact_label(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, label="LAMP", quantity=1)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.data) == 1
+        # quantity=1: label must be used as-is, no suffix
+        assert response.data[0]["label"] == "LAMP"
+        up = UsagePoint.objects.get(id=response.data[0]["id"])
+        assert up.label == "LAMP"
+        assert up.household_id == hh.id
+
+    def test_bulk_create_quantity_3_creates_three_usage_points_with_suffixed_labels(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, label="PRISE", quantity=3)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert len(response.data) == 3
+        labels = [item["label"] for item in response.data]
+        assert labels == ["PRISE-01", "PRISE-02", "PRISE-03"]
+        # Verify all three exist in DB and belong to the right household
+        for item in response.data:
+            up = UsagePoint.objects.get(id=item["id"])
+            assert up.household_id == hh.id
+
+    def test_bulk_create_returns_201_with_list_of_created_objects(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, quantity=2)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_201_CREATED
+        assert isinstance(response.data, list)
+        assert len(response.data) == 2
+        # Each item must have an id field (serializer output)
+        for item in response.data:
+            assert "id" in item
+
+    def test_bulk_create_quantity_0_is_invalid(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, quantity=0)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "quantity" in response.data
+
+    def test_bulk_create_quantity_51_is_invalid(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, quantity=51)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "quantity" in response.data
+
+    def test_bulk_create_quantity_not_integer_is_invalid(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, quantity="abc")
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "quantity" in response.data
+
+    def test_bulk_create_label_conflict_returns_400(self):
+        # The UniqueConstraint on (household, label) must surface as a 400.
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        zone = ZoneFactory(household=hh)
+        # Pre-create a usage point whose label will collide with quantity=1 request
+        UsagePointFactory(household=hh, zone=zone, label="CONFLICT")
+        client = _client_for(owner)
+        payload = self._up_payload(zone.id, label="CONFLICT", quantity=1)
+        response = client.post(self.BULK_CREATE_URL(), payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # DB must still contain exactly one usage point with that label
+        assert UsagePoint.objects.filter(household=hh, label="CONFLICT").count() == 1
+
+    def test_bulk_create_requires_authentication(self):
+        response = _anon_client().post(self.BULK_CREATE_URL(), {}, format="json")
+        assert response.status_code in {
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        }
+
+
+# ---------------------------------------------------------------------------
 # CircuitUsagePointLinkViewSet
 # ---------------------------------------------------------------------------
 
@@ -844,97 +961,3 @@ class TestPlanChangeLogViewSet:
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
-# ---------------------------------------------------------------------------
-# MappingLookupView
-# ---------------------------------------------------------------------------
-
-@pytest.mark.django_db
-class TestMappingLookupView:
-    """Lookup view: resolves labels across protective devices, circuits, usage points."""
-
-    LOOKUP_URL = staticmethod(lambda: reverse("electricity-mapping-lookup"))
-
-    def test_lookup_without_ref_returns_400(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL())
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "ref" in response.data
-
-    def test_lookup_protective_device_by_label(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        board = ElectricityBoardFactory(household=hh, supply_type="single_phase")
-        pd = ProtectiveDeviceFactory(board=board, household=hh, label="D-KITCHEN")
-        user_obj = UserFactory()
-        circuit = ElectricCircuit.objects.create(
-            household=hh, board=board, protective_device=pd,
-            label="CIR-K", name="Kitchen circuit",
-            created_by=user_obj, updated_by=user_obj,
-        )
-        up = UsagePointFactory(household=hh)
-        CircuitUsagePointLinkFactory(circuit=circuit, usage_point=up, household=hh, is_active=True)
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "D-KITCHEN"})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["kind"] == "protective_device"
-        assert len(response.data["circuits"]) == 1
-        assert len(response.data["usage_points"]) == 1
-
-    def test_lookup_circuit_by_label(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        circuit = ElectricCircuitFactory(household=hh, label="CIR-MAIN")
-        up = UsagePointFactory(household=hh)
-        CircuitUsagePointLinkFactory(circuit=circuit, usage_point=up, household=hh, is_active=True)
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "CIR-MAIN"})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["kind"] == "circuit"
-        assert response.data["circuit"]["id"] == str(circuit.id)
-        assert len(response.data["usage_points"]) == 1
-
-    def test_lookup_usage_point_by_label(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        circuit = ElectricCircuitFactory(household=hh)
-        up = UsagePointFactory(household=hh, label="UP-LOUNGE")
-        CircuitUsagePointLinkFactory(circuit=circuit, usage_point=up, household=hh, is_active=True)
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "UP-LOUNGE"})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["kind"] == "usage_point"
-        assert response.data["circuit"]["id"] == str(circuit.id)
-        assert response.data["protective_device"]["id"] == str(circuit.protective_device_id)
-
-    def test_usage_point_without_active_link_returns_null_circuit_and_pd(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        up = UsagePointFactory(household=hh, label="UP-ORPHAN")
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "UP-ORPHAN"})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["kind"] == "usage_point"
-        assert response.data["circuit"] is None
-        assert response.data["protective_device"] is None
-
-    def test_circuit_without_usage_points_returns_empty_list(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        circuit = ElectricCircuitFactory(household=hh, label="CIR-EMPTY")
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "CIR-EMPTY"})
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data["usage_points"] == []
-
-    def test_nonexistent_ref_returns_404(self):
-        hh = HouseholdFactory()
-        owner = _make_owner(hh)
-        client = _client_for(owner)
-        response = client.get(self.LOOKUP_URL(), {"ref": "DOES-NOT-EXIST"})
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-    def test_anonymous_gets_401(self):
-        response = _anon_client().get(self.LOOKUP_URL(), {"ref": "X"})
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/apps/electricity/urls.py
+++ b/apps/electricity/urls.py
@@ -7,7 +7,6 @@ from .views import (
     ElectricCircuitViewSet,
     ElectricityBoardViewSet,
     MaintenanceEventViewSet,
-    MappingLookupView,
     PlanChangeLogViewSet,
     ProtectiveDeviceViewSet,
     UsagePointViewSet,
@@ -24,5 +23,4 @@ router.register(r"change-logs", PlanChangeLogViewSet, basename="electricity-chan
 
 urlpatterns = [
     path("", include(router.urls)),
-path("mapping/lookup/", MappingLookupView.as_view(), name="electricity-mapping-lookup"),
 ]

--- a/apps/electricity/views.py
+++ b/apps/electricity/views.py
@@ -1,6 +1,7 @@
 # electricity/views.py
 """Electricity API and template views (scaffold)."""
 
+from django.db import transaction
 from django.db.models import ProtectedError
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -9,7 +10,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from households.models import HouseholdMember
 
@@ -155,6 +155,50 @@ class UsagePointViewSet(HouseholdScopedModelViewSet):
             queryset = queryset.filter(kind=kind)
         return queryset
 
+    @action(detail=False, methods=["post"], url_path="bulk-create")
+    def bulk_create(self, request, *args, **kwargs):
+        household = request.household
+        if not household:
+            raise ValidationError({"household_id": _("A valid household context is required.")})
+
+        try:
+            quantity = int(request.data.get("quantity", 1))
+        except (TypeError, ValueError):
+            return Response({"quantity": [_("Must be an integer.")]}, status=status.HTTP_400_BAD_REQUEST)
+        if quantity < 1 or quantity > 50:
+            return Response({"quantity": [_("Must be between 1 and 50.")]}, status=status.HTTP_400_BAD_REQUEST)
+
+        base_data = {k: v for k, v in request.data.items() if k != "quantity"}
+        base_label = (base_data.get("label") or "").strip()
+
+        if quantity > 1 and not base_label:
+            return Response({"label": [_("A label prefix is required when creating multiple usage points.")]}, status=status.HTTP_400_BAD_REQUEST)
+
+        payloads = []
+        for i in range(1, quantity + 1):
+            payload = dict(base_data)
+            if quantity > 1:
+                payload["label"] = f"{base_label}-{i:02d}"
+            payloads.append(payload)
+
+        serializers_list = []
+        for payload in payloads:
+            ser = self.get_serializer(data=payload)
+            if not ser.is_valid():
+                return Response(ser.errors, status=status.HTTP_400_BAD_REQUEST)
+            serializers_list.append(ser)
+
+        with transaction.atomic():
+            instances = [
+                ser.save(household=household, created_by=request.user, updated_by=request.user)
+                for ser in serializers_list
+            ]
+
+        return Response(
+            self.get_serializer(instances, many=True).data,
+            status=status.HTTP_201_CREATED,
+        )
+
 
 class CircuitUsagePointLinkViewSet(HouseholdScopedModelViewSet):
     model = CircuitUsagePointLink
@@ -199,81 +243,3 @@ class PlanChangeLogViewSet(HouseholdScopedModelViewSet):
     http_method_names = ["get", "head", "options"]
 
 
-class MappingLookupView(APIView):
-    permission_classes = [IsAuthenticated, IsElectricityOwnerWriteMemberRead]
-
-    def get(self, request):
-        selected_household = resolve_electricity_household(request)
-        if not selected_household:
-            raise ValidationError({"household_id": "A valid household context is required."})
-
-        ref = (request.query_params.get("ref") or "").strip()
-        if not ref:
-            raise ValidationError({"ref": "Lookup reference is required."})
-
-        protective_device = ProtectiveDevice.objects.for_household(selected_household.id).filter(label=ref).first()
-        if protective_device:
-            circuits = list(ElectricCircuit.objects.for_household(selected_household.id).filter(protective_device=protective_device))
-            usage_points = list(
-                UsagePoint.objects.for_household(selected_household.id).filter(
-                    circuit_links__circuit__in=circuits,
-                    circuit_links__is_active=True,
-                ).distinct()
-            )
-            return Response(
-                {
-                    "kind": "protective_device",
-                    "label": protective_device.label,
-                    "protective_device": {"id": str(protective_device.id), "label": protective_device.label},
-                    "circuits": [{"id": str(c.id), "label": c.label, "name": c.name} for c in circuits],
-                    "usage_points": [{"id": str(u.id), "label": u.label, "name": u.name} for u in usage_points],
-                }
-            )
-
-        usage_point = UsagePoint.objects.for_household(selected_household.id).filter(label=ref).first()
-        if usage_point:
-            link = (
-                CircuitUsagePointLink.objects.for_household(selected_household.id)
-                .select_related("circuit__protective_device")
-                .filter(usage_point=usage_point, is_active=True)
-                .first()
-            )
-            circuit = link.circuit if link else None
-            protective_device_for_point = circuit.protective_device if circuit else None
-            return Response(
-                {
-                    "kind": "usage_point",
-                    "label": usage_point.label,
-                    "usage_point": {"id": str(usage_point.id), "label": usage_point.label, "name": usage_point.name},
-                    "circuit": (
-                        {"id": str(circuit.id), "label": circuit.label, "name": circuit.name}
-                        if circuit
-                        else None
-                    ),
-                    "protective_device": (
-                        {"id": str(protective_device_for_point.id), "label": protective_device_for_point.label}
-                        if protective_device_for_point
-                        else None
-                    ),
-                }
-            )
-
-        circuit = ElectricCircuit.objects.for_household(selected_household.id).select_related("protective_device").filter(label=ref).first()
-        if circuit:
-            usage_points = list(
-                UsagePoint.objects.for_household(selected_household.id).filter(
-                    circuit_links__circuit=circuit,
-                    circuit_links__is_active=True,
-                ).distinct()
-            )
-            return Response(
-                {
-                    "kind": "circuit",
-                    "label": circuit.label,
-                    "circuit": {"id": str(circuit.id), "label": circuit.label, "name": circuit.name},
-                    "protective_device": {"id": str(circuit.protective_device.id), "label": circuit.protective_device.label},
-                    "usage_points": [{"id": str(u.id), "label": u.label, "name": u.name} for u in usage_points],
-                }
-            )
-
-        return Response({"detail": _("Not found.")}, status=status.HTTP_404_NOT_FOUND)

--- a/apps/tasks/management/commands/seed_demo_data.py
+++ b/apps/tasks/management/commands/seed_demo_data.py
@@ -55,6 +55,13 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.utils import timezone
 
+from electricity.models import (
+    CircuitUsagePointLink,
+    ElectricCircuit,
+    ElectricityBoard,
+    ProtectiveDevice,
+    UsagePoint,
+)
 from households.models import Household, HouseholdMember
 from projects.models import Project
 from tasks.models import Task, TaskZone
@@ -83,6 +90,7 @@ class Command(BaseCommand):
             zones = self._create_zones(household, claire)
             projects = self._create_projects(household, claire, antoine, zones)
             self._create_tasks(household, claire, antoine, lea, zones, projects)
+            self._create_electricity(household, claire, zones)
 
         self.stdout.write(self.style.SUCCESS("Demo data seeded successfully."))
 
@@ -547,3 +555,285 @@ class Command(BaseCommand):
 
         count = Task.objects.filter(household=household).count()
         self.stdout.write(f"  Tasks: {count} créées")
+
+    # ------------------------------------------------------------------
+    # Electricity
+    # ------------------------------------------------------------------
+
+    def _create_electricity(self, household, user, zones):
+        """
+        Installation électrique fictive d'une maison individuelle 1978,
+        rénovée partiellement en 2015 — monophasé 230V, NF C 15-100 partiel.
+
+        Tableau principal → 3 rangées × 13 modules
+          Rangée 1 : DG + DD1 (type A 30mA 4P) + circuits cuisine
+          Rangée 2 : DD2 (type AC 30mA 2P) + circuits séjour/chambres/bureau
+          Rangée 3 : DD3 (type A 30mA 2P) + circuits SDB/CE/garage/extérieur + réserves
+        """
+        kw = {"created_by": user, "updated_by": user}
+
+        # ── Tableau principal ──────────────────────────────────────────────
+        board, _ = ElectricityBoard.objects.get_or_create(
+            household=household,
+            name="Tableau principal",
+            defaults={
+                "label": "TB-PRINC",
+                "zone": zones["cave"],
+                "supply_type": "single_phase",
+                "rows": 3,
+                "slots_per_row": 13,
+                "location": "Cave, coffret encastré mur nord",
+                "nf_c_15100_compliant": "partial",
+                "last_inspection_date": date(2022, 9, 14),
+                "main_notes": (
+                    "Tableau Hager — 3 rangées 13 modules. "
+                    "Mise en conformité partielle lors de la rénovation SDB en 2015. "
+                    "DD3 ajouté à cette occasion."
+                ),
+                "is_active": True,
+                **kw,
+            },
+        )
+
+        # ── Helper local ───────────────────────────────────────────────────
+        def device(label, device_type, row, position, position_end=None,
+                   role=None, rating_amps=None, pole_count=None,
+                   curve_type="", sensitivity_ma=None, type_code="",
+                   is_spare=False, notes=""):
+            obj, _ = ProtectiveDevice.objects.get_or_create(
+                household=household,
+                board=board,
+                label=label,
+                defaults={
+                    "device_type": device_type,
+                    "role": role,
+                    "row": row,
+                    "position": position,
+                    "position_end": position_end,
+                    "rating_amps": rating_amps,
+                    "pole_count": pole_count,
+                    "curve_type": curve_type,
+                    "sensitivity_ma": sensitivity_ma,
+                    "type_code": type_code,
+                    "is_spare": is_spare,
+                    "is_active": True,
+                    "notes": notes,
+                    **kw,
+                },
+            )
+            return obj
+
+        def circuit(label, name, protective_device, notes=""):
+            obj, _ = ElectricCircuit.objects.get_or_create(
+                household=household,
+                label=label,
+                defaults={
+                    "board": board,
+                    "protective_device": protective_device,
+                    "name": name,
+                    "is_active": True,
+                    "notes": notes,
+                    **kw,
+                },
+            )
+            return obj
+
+        def up(label, name, kind, zone_key, notes=""):
+            obj, _ = UsagePoint.objects.get_or_create(
+                household=household,
+                label=label,
+                defaults={
+                    "name": name,
+                    "kind": kind,
+                    "zone": zones[zone_key],
+                    "notes": notes,
+                    **kw,
+                },
+            )
+            return obj
+
+        def link(cir, usage_point):
+            CircuitUsagePointLink.objects.get_or_create(
+                household=household,
+                circuit=cir,
+                usage_point=usage_point,
+                defaults={"is_active": True, **kw},
+            )
+
+        # ── Rangée 1 — Général + Cuisine ──────────────────────────────────
+        dg    = device("DG",   "main",     row=1, position=1,  position_end=2,
+                       role="main", rating_amps=60, pole_count=2,
+                       notes="Disjoncteur de branchement EDF 60A")
+        dd1   = device("DD1",  "rcd",      row=1, position=3,  position_end=6,
+                       rating_amps=40, pole_count=4, sensitivity_ma=30, type_code="a",
+                       notes="Protège circuits cuisine (B01–B04)")
+        b01   = device("B01",  "breaker",  row=1, position=7,
+                       role="divisionary", rating_amps=20, pole_count=1, curve_type="c",
+                       notes="Prises cuisine (4 prises plan de travail)")
+        b02   = device("B02",  "breaker",  row=1, position=8,
+                       role="divisionary", rating_amps=20, pole_count=1, curve_type="c",
+                       notes="Lave-vaisselle")
+        b03   = device("B03",  "breaker",  row=1, position=9,  position_end=10,
+                       role="divisionary", rating_amps=32, pole_count=2, curve_type="c",
+                       notes="Four / cuisinière (circuit dédié 32A)"),
+        b04   = device("B04",  "breaker",  row=1, position=11,
+                       role="divisionary", rating_amps=10, pole_count=1, curve_type="b",
+                       notes="Éclairage cuisine")
+
+        # Rangée 1 : positions 12–13 libres (pas de device)
+
+        # ── Rangée 2 — Séjour / Chambres / Bureau ─────────────────────────
+        dd2   = device("DD2",  "rcd",      row=2, position=1,  position_end=2,
+                       rating_amps=40, pole_count=2, sensitivity_ma=30, type_code="ac",
+                       notes="Protège circuits séjour/chambres/bureau (B05–B09)")
+        b05   = device("B05",  "breaker",  row=2, position=3,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Prises salon")
+        b06   = device("B06",  "breaker",  row=2, position=4,
+                       role="divisionary", rating_amps=10, pole_count=1, curve_type="b",
+                       notes="Éclairage salon / entrée")
+        b07   = device("B07",  "breaker",  row=2, position=5,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Chambre parentale (prises + éclairage)")
+        b08   = device("B08",  "breaker",  row=2, position=6,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Chambre ado (prises + éclairage)")
+        b09   = device("B09",  "breaker",  row=2, position=7,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Bureau (prises + éclairage)")
+
+        # Rangée 2 : positions 8–13 libres
+
+        # ── Rangée 3 — SDB / Chauffe-eau / Garage / Extérieur ────────────
+        dd3   = device("DD3",  "rcd",      row=3, position=1,  position_end=2,
+                       rating_amps=40, pole_count=2, sensitivity_ma=30, type_code="a",
+                       notes="Ajouté lors rénovation SDB 2015. Protège B10–B14.")
+        b10   = device("B10",  "breaker",  row=3, position=3,
+                       role="divisionary", rating_amps=10, pole_count=1, curve_type="b",
+                       notes="Éclairage salle de bain")
+        b11   = device("B11",  "breaker",  row=3, position=4,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Prises salle de bain (rasoir, sèche-cheveux)")
+        b12   = device("B12",  "breaker",  row=3, position=5,  position_end=6,
+                       role="divisionary", rating_amps=20, pole_count=2, curve_type="c",
+                       notes="Chauffe-eau électrique 200L (circuit dédié)")
+        b13   = device("B13",  "breaker",  row=3, position=7,
+                       role="divisionary", rating_amps=20, pole_count=1, curve_type="c",
+                       notes="Garage (prises + éclairage + portail)")
+        b14   = device("B14",  "breaker",  row=3, position=8,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       notes="Prises extérieures / jardin")
+        b15   = device("B15",  "breaker",  row=3, position=9,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       is_spare=True, notes="Emplacement réserve")
+        b16   = device("B16",  "breaker",  row=3, position=10,
+                       role="divisionary", rating_amps=16, pole_count=1, curve_type="c",
+                       is_spare=True, notes="Emplacement réserve")
+
+        # b03 est retourné comme tuple à cause de la virgule parasite — correction
+        if isinstance(b03, tuple):
+            b03 = b03[0]
+
+        # ── Circuits ───────────────────────────────────────────────────────
+        cir01 = circuit("CIR-01", "Prises cuisine",        b01)
+        cir02 = circuit("CIR-02", "Lave-vaisselle",        b02, notes="Circuit dédié VM")
+        cir03 = circuit("CIR-03", "Four / cuisinière",     b03, notes="Circuit dédié 32A")
+        cir04 = circuit("CIR-04", "Éclairage cuisine",     b04)
+        cir05 = circuit("CIR-05", "Prises salon",          b05)
+        cir06 = circuit("CIR-06", "Éclairage salon",       b06)
+        cir07 = circuit("CIR-07", "Chambre parentale",     b07)
+        cir08 = circuit("CIR-08", "Chambre ado",           b08)
+        cir09 = circuit("CIR-09", "Bureau",                b09)
+        cir10 = circuit("CIR-10", "Éclairage salle de bain", b10)
+        cir11 = circuit("CIR-11", "Prises salle de bain",  b11)
+        cir12 = circuit("CIR-12", "Chauffe-eau",           b12, notes="Hors heures pleines")
+        cir13 = circuit("CIR-13", "Garage",                b13)
+        cir14 = circuit("CIR-14", "Extérieur / jardin",    b14)
+
+        # ── Points d'usage ─────────────────────────────────────────────────
+        # Cuisine
+        up_pcu1  = up("PRI-CUI-01", "Prise cuisine plan de travail gauche", "socket", "cuisine")
+        up_pcu2  = up("PRI-CUI-02", "Prise cuisine plan de travail droite", "socket", "cuisine")
+        up_pcu3  = up("PRI-CUI-03", "Prise cuisine îlot",                   "socket", "cuisine")
+        up_pcu4  = up("PRI-CUI-04", "Prise réfrigérateur",                  "socket", "cuisine")
+        up_lv    = up("PRI-LV-01",  "Prise lave-vaisselle",                 "socket", "cuisine",
+                      notes="Sous l'évier, circuit dédié DD1/B02")
+        up_four  = up("PRI-FOR-01", "Prise four encastré",                  "socket", "cuisine",
+                      notes="32A, circuit dédié DD1/B03")
+        up_ecl_cui = up("LUM-CUI-01", "Plafonnier cuisine",                 "light",  "cuisine")
+
+        # Salon
+        up_psal1 = up("PRI-SAL-01", "Prise salon mur nord",                 "socket", "salon")
+        up_psal2 = up("PRI-SAL-02", "Prise salon mur est",                  "socket", "salon")
+        up_psal3 = up("PRI-SAL-03", "Prise salon mur sud (TV)",             "socket", "salon")
+        up_psal4 = up("PRI-SAL-04", "Prise salon mur ouest",                "socket", "salon")
+        up_lsal1 = up("LUM-SAL-01", "Plafonnier salon",                     "light",  "salon")
+        up_lsal2 = up("LUM-SAL-02", "Applique salon",                       "light",  "salon")
+        up_lsal3 = up("LUM-ENT-01", "Plafonnier entrée",                    "light",  "salon",
+                      notes="Couloir entrée, même circuit que salon")
+
+        # Chambre parentale
+        up_ppar1 = up("PRI-PAR-01", "Prise chambre parentale chevet gauche", "socket", "chambre_parents")
+        up_ppar2 = up("PRI-PAR-02", "Prise chambre parentale chevet droit",  "socket", "chambre_parents")
+        up_ppar3 = up("PRI-PAR-03", "Prise chambre parentale bureau",        "socket", "chambre_parents")
+        up_lpar1 = up("LUM-PAR-01", "Plafonnier chambre parentale",          "light",  "chambre_parents")
+        up_lpar2 = up("LUM-PAR-02", "Applique chevet",                       "light",  "chambre_parents")
+
+        # Chambre ado
+        up_pado1 = up("PRI-ADO-01", "Prise chambre ado bureau",              "socket", "chambre_ado")
+        up_pado2 = up("PRI-ADO-02", "Prise chambre ado chevet",              "socket", "chambre_ado")
+        up_lado1 = up("LUM-ADO-01", "Plafonnier chambre ado",                "light",  "chambre_ado")
+
+        # Bureau
+        up_pbur1 = up("PRI-BUR-01", "Prise bureau informatique",             "socket", "bureau")
+        up_pbur2 = up("PRI-BUR-02", "Prise bureau multi-prises",             "socket", "bureau")
+        up_pbur3 = up("PRI-BUR-03", "Prise bureau imprimante",               "socket", "bureau")
+        up_lbur1 = up("LUM-BUR-01", "Plafonnier bureau",                     "light",  "bureau")
+
+        # Salle de bain
+        up_lsdb1 = up("LUM-SDB-01", "Plafonnier salle de bain",              "light",  "sdb")
+        up_psdb1 = up("PRI-SDB-01", "Prise salle de bain vasque",            "socket", "sdb",
+                      notes="Prise rasoir/sèche-cheveux, circuit DD3/B11")
+        up_psdb2 = up("PRI-SDB-02", "Prise sèche-serviette électrique",      "socket", "sdb")
+
+        # Garage
+        up_pgar1 = up("PRI-GAR-01", "Prise garage atelier",                  "socket", "garage")
+        up_pgar2 = up("PRI-GAR-02", "Prise garage portail automatique",      "socket", "garage")
+        up_lgar1 = up("LUM-GAR-01", "Plafonnier garage",                     "light",  "garage")
+
+        # Extérieur / jardin
+        up_pext1 = up("PRI-EXT-01", "Prise extérieure terrasse",             "socket", "jardin")
+        up_pext2 = up("PRI-EXT-02", "Prise extérieure jardin",               "socket", "jardin",
+                      notes="IP44, à proximité du robinet arrosage")
+
+        # ── Liens circuit → points d'usage ────────────────────────────────
+        for u in [up_pcu1, up_pcu2, up_pcu3, up_pcu4]:
+            link(cir01, u)
+        link(cir02, up_lv)
+        link(cir03, up_four)
+        link(cir04, up_ecl_cui)
+        for u in [up_psal1, up_psal2, up_psal3, up_psal4]:
+            link(cir05, u)
+        for u in [up_lsal1, up_lsal2, up_lsal3]:
+            link(cir06, u)
+        for u in [up_ppar1, up_ppar2, up_ppar3, up_lpar1, up_lpar2]:
+            link(cir07, u)
+        for u in [up_pado1, up_pado2, up_lado1]:
+            link(cir08, u)
+        for u in [up_pbur1, up_pbur2, up_pbur3, up_lbur1]:
+            link(cir09, u)
+        link(cir10, up_lsdb1)
+        for u in [up_psdb1, up_psdb2]:
+            link(cir11, u)
+        # cir12 (chauffe-eau) : pas de point d'usage (équipement fixe)
+        for u in [up_pgar1, up_pgar2, up_lgar1]:
+            link(cir13, u)
+        for u in [up_pext1, up_pext2]:
+            link(cir14, u)
+
+        dev_count = ProtectiveDevice.objects.filter(board=board).count()
+        cir_count = ElectricCircuit.objects.filter(board=board).count()
+        up_count  = UsagePoint.objects.filter(household=household).count()
+        self.stdout.write(
+            f"  Electricity: {dev_count} appareils, {cir_count} circuits, {up_count} points d'usage"
+        )

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -143,3 +143,7 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 | Onglet Recherche : champ et bouton visibles | ✅ |
 | Onglet Recherche : étiquette inexistante → "Introuvable." | ✅ |
 | Déconnexion d'un lien via "Déconnecter" | ✅ |
+| Création d'un appareil avec position (rangée + slot) | ✅ |
+| Affichage du quadrillage des slots (slot grid) quand rangée saisie | ✅ |
+| Blocage création si position déjà occupée (conflit détecté en temps réel) | ✅ |
+| Position adjacente non conflictuelle acceptée | ✅ |

--- a/e2e/electricity.spec.ts
+++ b/e2e/electricity.spec.ts
@@ -145,10 +145,6 @@ test.describe('navigation par onglets', () => {
     await expect(page.getByRole('button', { name: 'Nouveau lien' })).toBeVisible();
   });
 
-  test('navigue vers l\'onglet Recherche', async ({ page }) => {
-    await page.getByRole('button', { name: 'Recherche', exact: true }).click();
-    await expect(page.getByPlaceholder('Rechercher par étiquette (disjoncteur / circuit / point d\'usage)…')).toBeVisible();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -546,58 +542,303 @@ test('modifie le tableau via CardActions', async ({ page }) => {
   await expect(page.getByText(boardName, { exact: true })).not.toBeVisible();
 });
 
+
 // ---------------------------------------------------------------------------
-// Onglet Recherche (Lookup)
+// Nombre de pôles (pole_count) dans le DeviceDialog
 // ---------------------------------------------------------------------------
 
-test('affiche le champ de recherche dans l\'onglet Recherche', async ({ page }: { page: import('@playwright/test').Page }) => {
-  await page.goto('/app/electricity');
-
-  // Need a board to access tabs
-  const emptyState = page.getByText('Aucun tableau électrique');
-  const hasEmptyState = await emptyState.isVisible().catch(() => false);
-  if (hasEmptyState) {
-    await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
-    const dialog = page.getByRole('dialog');
-    const zoneSelect = page.locator('#board-zone');
-    const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
-    await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
-    await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
-    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+test.describe('champ Nombre de pôles dans le DeviceDialog', () => {
+  async function ensureBoardExists(page: import('@playwright/test').Page) {
+    const emptyState = page.getByText('Aucun tableau électrique');
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    if (hasEmptyState) {
+      await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
+      const dialog = page.getByRole('dialog');
+      const zoneSelect = page.locator('#board-zone');
+      const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
+      await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
+      await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
+      await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+      await expect(page.getByRole('button', { name: 'Ajouter un appareil' })).toBeVisible();
+    }
   }
 
-  await page.getByRole('button', { name: 'Recherche', exact: true }).click();
+  test('le champ "Nombre de pôles" est visible dans le DeviceDialog', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
 
-  const searchInput = page.getByPlaceholder(
-    'Rechercher par étiquette (disjoncteur / circuit / point d\'usage)…',
-  );
-  await expect(searchInput).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Rechercher' })).toBeVisible();
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByLabel('Nombre de pôles')).toBeVisible();
+  });
+
+  test('disjoncteur : les 4 options de pôles (1P–4P) sont disponibles', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
+
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Type = Disjoncteur (default)
+    const poleSelect = page.locator('#dev-poles');
+    const optionValues = await poleSelect.locator('option').allTextContents();
+
+    expect(optionValues).toContain('1P');
+    expect(optionValues).toContain('2P');
+    expect(optionValues).toContain('3P');
+    expect(optionValues).toContain('4P');
+  });
+
+  test('différentiel (RCD) : seuls 2P et 4P sont disponibles', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
+
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Switch type to RCD
+    await page.locator('#dev-type').selectOption('rcd');
+
+    const poleSelect = page.locator('#dev-poles');
+    const optionValues = await poleSelect.locator('option').allTextContents();
+
+    expect(optionValues).toContain('2P');
+    expect(optionValues).toContain('4P');
+    expect(optionValues).not.toContain('1P');
+    expect(optionValues).not.toContain('3P');
+  });
+
+  test('combiné (combined) : seuls 2P et 4P sont disponibles', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
+
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await page.locator('#dev-type').selectOption('combined');
+
+    const poleSelect = page.locator('#dev-poles');
+    const optionValues = await poleSelect.locator('option').allTextContents();
+
+    expect(optionValues).toContain('2P');
+    expect(optionValues).toContain('4P');
+    expect(optionValues).not.toContain('1P');
+    expect(optionValues).not.toContain('3P');
+  });
+
+  test('crée un disjoncteur 2P et vérifie l\'affichage "2P" dans la carte', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
+
+    const suffix = Date.now();
+    const label = `BRK-2P-${suffix}`;
+
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Étiquette').fill(label);
+    await page.locator('#dev-poles').selectOption('2');
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // Card should show the label and "2P" in the specs line
+    await expect(page.getByText(label)).toBeVisible();
+    // The spec "2P" appears in the card specs
+    const card = page.getByText(label).locator('xpath=ancestor::*[4]');
+    await expect(card.getByText(/2P/)).toBeVisible();
+  });
+
+  test('le champ reste optionnel — créer un disjoncteur sans pôle est valide', async ({ page }) => {
+    await page.goto('/app/electricity');
+    await ensureBoardExists(page);
+
+    const suffix = Date.now();
+    const label = `BRK-NOPOLE-${suffix}`;
+
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Étiquette').fill(label);
+    // Leave "Nombre de pôles" as "—" (empty)
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // Device is created successfully
+    await expect(page.getByText(label)).toBeVisible();
+  });
 });
 
-test('la recherche d\'une étiquette inexistante affiche "Introuvable."', async ({ page }: { page: import('@playwright/test').Page }) => {
-  await page.goto('/app/electricity');
+// ---------------------------------------------------------------------------
+// Création en masse de points d'usage (champ Quantité)
+// ---------------------------------------------------------------------------
 
-  const emptyState = page.getByText('Aucun tableau électrique');
-  const hasEmptyState = await emptyState.isVisible().catch(() => false);
-  if (hasEmptyState) {
-    await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
-    const dialog = page.getByRole('dialog');
-    const zoneSelect = page.locator('#board-zone');
-    const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
-    await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
-    await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
-    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+test.describe('usage point bulk create', () => {
+  /**
+   * Ensures at least one board + one device exist (required by the empty-state
+   * chain), then navigates to the Usage Points tab.
+   */
+  async function ensureBoardAndNavigateToUsagePoints(page: import('@playwright/test').Page) {
+    await page.goto('/app/electricity');
+
+    // 1. Create a board if the no-board empty state is shown
+    const boardEmptyState = page.getByText('Aucun tableau électrique');
+    const hasNoBoard = await boardEmptyState.isVisible().catch(() => false);
+
+    if (hasNoBoard) {
+      await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
+      const boardDialog = page.getByRole('dialog');
+      await expect(boardDialog).toBeVisible();
+      const zoneSelect = page.locator('#board-zone');
+      const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
+      await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
+      await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
+      await boardDialog.getByRole('button', { name: 'Enregistrer' }).click();
+      await expect(boardEmptyState).not.toBeVisible();
+    }
+
+    // 2. Create a device if no device exists yet
+    //    (the empty-state chain prevents tab navigation without a device)
+    const deviceEmptyState = page.getByText('Aucun appareil de protection');
+    const hasNoDevice = await deviceEmptyState.isVisible().catch(() => false);
+
+    if (hasNoDevice) {
+      await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+      const deviceDialog = page.getByRole('dialog');
+      await expect(deviceDialog).toBeVisible();
+      await deviceDialog.getByLabel('Étiquette').fill(`BRK-BULK-SETUP-${Date.now()}`);
+      await deviceDialog.getByRole('button', { name: 'Enregistrer' }).click();
+      await expect(deviceEmptyState).not.toBeVisible();
+    }
+
+    // 3. Navigate to Usage Points tab
+    await page.getByRole('button', { name: 'Points d\'usage', exact: true }).click();
+    await expect(page.getByRole('button', { name: 'Ajouter un point d\'usage' })).toBeVisible();
   }
 
-  await page.getByRole('button', { name: 'Recherche', exact: true }).click();
+  test('le champ Quantité est visible lors de la création', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
 
-  await page.getByPlaceholder(
-    'Rechercher par étiquette (disjoncteur / circuit / point d\'usage)…',
-  ).fill('INEXISTANT-99999');
-  await page.getByRole('button', { name: 'Rechercher' }).click();
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
 
-  await expect(page.getByText('Introuvable.')).toBeVisible();
+    await expect(dialog.getByLabel('Quantité')).toBeVisible();
+  });
+
+  test('le champ Quantité vaut 1 par défaut', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await expect(dialog.getByLabel('Quantité')).toHaveValue('1');
+  });
+
+  test('un hint apparaît sous le champ Quantité quand la valeur est > 1', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Fill a label so the hint shows real values
+    await dialog.getByLabel('Étiquette').fill('UP-SAL');
+
+    // Set quantity to 3 — hint should appear
+    await page.locator('#up-quantity').fill('3');
+
+    // The hint pattern: "Créera UP-SAL-01 … UP-SAL-3"
+    await expect(dialog.getByText(/Créera UP-SAL-01/)).toBeVisible();
+  });
+
+  test('aucun hint n\'apparaît quand la quantité est 1', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Quantity defaults to 1 — hint must not be present
+    await expect(dialog.getByText(/Créera/)).not.toBeVisible();
+  });
+
+  test('créer avec quantité 1 crée un seul point d\'usage avec l\'étiquette exacte', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    const suffix = Date.now();
+    const upLabel = `UP-SINGLE-${suffix}`;
+    const upName = `Prise E2E single ${suffix}`;
+
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Étiquette').fill(upLabel);
+    await dialog.getByLabel('Nom').fill(upName);
+    // Quantity defaults to 1 — no change needed
+
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // The usage point appears with its exact label (no suffix)
+    await expect(page.getByText(upLabel)).toBeVisible();
+    // Suffixed variants must NOT appear
+    await expect(page.getByText(`${upLabel}-01`)).not.toBeVisible();
+  });
+
+  test('créer avec quantité 3 crée 3 points d\'usage suffixés -01, -02, -03', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    const suffix = Date.now();
+    const upLabel = `UP-BULK-${suffix}`;
+    const upName = `Prise E2E bulk ${suffix}`;
+
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Étiquette').fill(upLabel);
+    await dialog.getByLabel('Nom').fill(upName);
+    await page.locator('#up-quantity').fill('3');
+
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    // All three suffixed usage points must appear in the list
+    await expect(page.getByText(`${upLabel}-01`)).toBeVisible();
+    await expect(page.getByText(`${upLabel}-02`)).toBeVisible();
+    await expect(page.getByText(`${upLabel}-03`)).toBeVisible();
+  });
+
+  test('le champ Quantité est absent du dialog de modification', async ({ page }) => {
+    await ensureBoardAndNavigateToUsagePoints(page);
+
+    const suffix = Date.now();
+    const upLabel = `UP-EDIT-NOQUANT-${suffix}`;
+    const upName = `Prise E2E no quant ${suffix}`;
+
+    // Create a usage point first
+    await page.getByRole('button', { name: 'Ajouter un point d\'usage' }).click();
+    let dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel('Étiquette').fill(upLabel);
+    await dialog.getByLabel('Nom').fill(upName);
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(page.getByText(upName)).toBeVisible();
+
+    // Open the edit dialog via CardActions
+    await openCardMenu(page, upName, 'Modifier');
+    dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('heading', { name: 'Modifier le point d\'usage' })).toBeVisible();
+
+    // The Quantité field must NOT be present in edit mode
+    await expect(dialog.getByLabel('Quantité')).not.toBeVisible();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -629,4 +870,102 @@ test('déconnecte un lien via le bouton Déconnecter', async ({ page }) => {
   // One fewer Déconnecter button after deactivation
   const linksAfter = await page.getByRole('button', { name: 'Déconnecter' }).count();
   expect(linksAfter).toBe(linksBefore - 1);
+});
+
+// ---------------------------------------------------------------------------
+// Conflit de positions d'appareils (slot grid + validation)
+// ---------------------------------------------------------------------------
+
+test.describe('conflit de positions d\'appareils', () => {
+  const suffix = Date.now();
+  const boardName = `Tableau Position E2E ${suffix}`;
+  const deviceLabel = `BRK-POS-${suffix}`;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/app/electricity');
+
+    // Create a board with slots_per_row=12 if no board exists yet
+    const emptyState = page.getByText('Aucun tableau électrique');
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    if (hasEmptyState) {
+      await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
+      const dialog = page.getByRole('dialog');
+      await expect(dialog).toBeVisible();
+
+      const nameInput = dialog.getByLabel('Nom');
+      await nameInput.clear();
+      await nameInput.fill(boardName);
+
+      const zoneSelect = page.locator('#board-zone');
+      const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
+      await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
+      await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
+
+      await page.locator('#board-slots').fill('12');
+
+      await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+      await expect(page.getByRole('button', { name: 'Ajouter un appareil' })).toBeVisible();
+    }
+  });
+
+  test('crée un appareil avec une position', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Étiquette').fill(deviceLabel);
+    await page.locator('#dev-row').fill('1');
+    await page.locator('#dev-position').fill('3');
+
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(page.getByText(deviceLabel)).toBeVisible();
+  });
+
+  test('affiche le quadrillage des slots quand une rangée est saisie', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Le slot grid n'apparaît que quand row est renseigné ET slotsPerRow est défini
+    await page.locator('#dev-row').fill('1');
+
+    await expect(page.locator('[data-testid="slot-grid"]')).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Annuler' }).click();
+  });
+
+  test('bloque la création d\'un appareil à une position déjà occupée', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Saisir la même position que le device créé dans le test précédent (rangée 1, position 3)
+    await page.locator('#dev-row').fill('1');
+    await page.locator('#dev-position').fill('3');
+
+    // L'erreur de conflit s'affiche en temps réel (avant soumission)
+    await expect(page.getByText(/Position occupée/)).toBeVisible();
+
+    // Tenter de soumettre : le formulaire doit rester ouvert
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(dialog).toBeVisible();
+  });
+
+  test('accepte une position adjacente non conflictuelle', async ({ page }) => {
+    await page.getByRole('button', { name: 'Ajouter un appareil' }).click();
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Position 4 est adjacente à 3 mais pas en overlap
+    await page.locator('#dev-row').fill('1');
+    await page.locator('#dev-position').fill('4');
+
+    // Aucune erreur de conflit
+    await expect(page.getByText(/Position occupée/)).not.toBeVisible();
+
+    // Le bouton Enregistrer est accessible (pas bloqué)
+    await expect(dialog.getByRole('button', { name: 'Enregistrer' })).toBeEnabled();
+
+    await dialog.getByRole('button', { name: 'Annuler' }).click();
+  });
 });

--- a/ui/src/features/electricity/BoardPanel.tsx
+++ b/ui/src/features/electricity/BoardPanel.tsx
@@ -1,0 +1,301 @@
+/**
+ * BoardPanel — représentation graphique d'un tableau électrique.
+ *
+ * Affiche les appareils de protection placés dans leur rangée/position
+ * physique, comme si on regardait le tableau ouvert.
+ */
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import type { ElectricityBoard, ProtectiveDevice } from '@/lib/api/electricity';
+
+// ── Dimensions physiques (px) ─────────────────────────────────────────────────
+
+const SLOT_W = 34; // largeur d'un module 1P
+const SLOT_H = 88; // hauteur d'un module
+const GAP = 3;     // gouttière entre modules
+
+// ── Palette par type d'appareil ───────────────────────────────────────────────
+
+const COLORS: Record<string, { bg: string; border: string; text: string; handle: string }> = {
+  breaker:  { bg: 'bg-blue-50',   border: 'border-blue-300',   text: 'text-blue-900',   handle: 'bg-blue-400'   },
+  rcd:      { bg: 'bg-purple-50', border: 'border-purple-300', text: 'text-purple-900', handle: 'bg-purple-400' },
+  combined: { bg: 'bg-indigo-50', border: 'border-indigo-300', text: 'text-indigo-900', handle: 'bg-indigo-400' },
+  main:     { bg: 'bg-amber-50',  border: 'border-amber-300',  text: 'text-amber-900',  handle: 'bg-amber-400'  },
+};
+
+const PHASE_DOT: Record<string, string> = {
+  L1: 'bg-red-500',
+  L2: 'bg-yellow-400',
+  L3: 'bg-blue-500',
+};
+
+function clr(type: string) {
+  return COLORS[type] ?? COLORS.breaker;
+}
+
+// ── Types internes ────────────────────────────────────────────────────────────
+
+interface BoardPanelProps {
+  board: ElectricityBoard;
+  devices: ProtectiveDevice[];
+  /** Optionnel : clic sur un appareil (ex. ouvrir le dialog d'édition). */
+  onDeviceClick?: (device: ProtectiveDevice) => void;
+}
+
+type Cell =
+  | { kind: 'device'; device: ProtectiveDevice; span: number }
+  | { kind: 'empty' };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildCells(
+  devices: ProtectiveDevice[],
+  row: number,
+  totalSlots: number,
+): Cell[] {
+  const rowDevices = devices
+    .filter((d) => d.row === row && d.position != null)
+    .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+  const cells: Cell[] = [];
+  let cursor = 1;
+
+  for (const d of rowDevices) {
+    const start = d.position!;
+    const end = d.position_end ?? start;
+
+    for (let s = cursor; s < start && s <= totalSlots; s++) {
+      cells.push({ kind: 'empty' });
+    }
+
+    if (start <= totalSlots) {
+      cells.push({
+        kind: 'device',
+        device: d,
+        span: Math.min(end, totalSlots) - start + 1,
+      });
+    }
+    cursor = Math.max(cursor, end + 1);
+  }
+
+  for (let s = cursor; s <= totalSlots; s++) {
+    cells.push({ kind: 'empty' });
+  }
+
+  return cells;
+}
+
+// ── Sous-composants ───────────────────────────────────────────────────────────
+
+function EmptySlot() {
+  return (
+    <div
+      className="flex-none rounded border border-dashed border-slate-600"
+      style={{ width: SLOT_W, height: SLOT_H }}
+      aria-hidden
+    />
+  );
+}
+
+interface DeviceModuleProps {
+  device: ProtectiveDevice;
+  span: number;
+  onClick?: (d: ProtectiveDevice) => void;
+}
+
+function DeviceModule({ device, span, onClick }: DeviceModuleProps) {
+  const colors = clr(device.device_type);
+  const width = span * SLOT_W + (span - 1) * GAP;
+  const isRcd = device.device_type === 'rcd' || device.device_type === 'combined';
+
+  return (
+    <button
+      type="button"
+      onClick={() => onClick?.(device)}
+      className={cn(
+        'relative flex flex-shrink-0 flex-col items-center overflow-hidden rounded border-2 transition-opacity',
+        colors.bg,
+        colors.border,
+        onClick ? 'cursor-pointer hover:opacity-75 active:scale-95' : 'cursor-default',
+        device.is_spare && 'opacity-40',
+        !device.is_active && 'grayscale opacity-50',
+      )}
+      style={{ width, height: SLOT_H }}
+      title={[
+        device.label,
+        device.rating_amps != null ? `${device.rating_amps}A` : null,
+        device.notes || null,
+      ]
+        .filter(Boolean)
+        .join(' — ')}
+    >
+      {/* Phase indicator dot */}
+      {device.phase && (
+        <span
+          className={cn(
+            'absolute right-1 top-1 h-2 w-2 rounded-full',
+            PHASE_DOT[device.phase] ?? 'bg-slate-400',
+          )}
+        />
+      )}
+
+      {/* Toggle handle / TEST button */}
+      <div className="mt-2 flex justify-center">
+        {isRcd ? (
+          <div
+            className={cn(
+              'rounded-full border px-1.5 py-px text-[7px] font-bold uppercase',
+              colors.border,
+              colors.text,
+            )}
+          >
+            TEST
+          </div>
+        ) : (
+          <div className={cn('h-5 w-3 rounded-sm shadow-inner', colors.handle)} />
+        )}
+      </div>
+
+      {/* Ampérage */}
+      <div className={cn('mt-1 text-center text-xs font-bold leading-none', colors.text)}>
+        {device.rating_amps != null ? `${device.rating_amps}A` : '—'}
+      </div>
+
+      {/* Sensibilité RCD */}
+      {device.sensitivity_ma != null && (
+        <div className={cn('text-[9px] leading-none', colors.text)}>
+          {device.sensitivity_ma}mA
+        </div>
+      )}
+
+      {/* Type code RCD (AC, A, F…) */}
+      {device.type_code && (
+        <div className={cn('text-[8px] leading-none uppercase', colors.text)}>
+          {device.type_code}
+        </div>
+      )}
+
+      {/* Courbe (disjoncteurs) */}
+      {device.curve_type && !isRcd && (
+        <div className={cn('text-[8px] leading-none uppercase', colors.text)}>
+          {device.curve_type}
+        </div>
+      )}
+
+      {/* Étiquette */}
+      <div
+        className={cn(
+          'mt-auto truncate px-0.5 pb-1 text-center font-mono text-[8px]',
+          colors.text,
+        )}
+      >
+        {device.label ?? ''}
+      </div>
+
+      {/* Mention RÉSERVE */}
+      {device.is_spare && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="-rotate-12 text-[8px] font-semibold text-slate-500">
+            RÉSE.
+          </span>
+        </div>
+      )}
+    </button>
+  );
+}
+
+// ── Composant principal ───────────────────────────────────────────────────────
+
+export function BoardPanel({ board, devices, onDeviceClick }: BoardPanelProps) {
+  const { t } = useTranslation();
+
+  const placedDevices = devices.filter((d) => d.row != null && d.position != null);
+  const unplacedDevices = devices.filter((d) => d.row == null || d.position == null);
+
+  const totalRows =
+    board.rows ??
+    (placedDevices.length > 0
+      ? Math.max(...placedDevices.map((d) => d.row ?? 0))
+      : 0);
+
+  const totalSlots =
+    board.slots_per_row ??
+    (placedDevices.length > 0
+      ? Math.max(...placedDevices.map((d) => d.position_end ?? d.position ?? 0))
+      : 13);
+
+  // Ne rien rendre si aucune donnée de position et pas de config grille
+  if (totalRows === 0 && placedDevices.length === 0 && unplacedDevices.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="flex justify-center">
+    <div className="inline-block overflow-hidden rounded-2xl bg-slate-800 shadow-xl">
+      {/* En-tête du tableau */}
+      <div className="grid grid-cols-[1fr_auto_1fr] items-center border-b border-slate-700 px-4 py-2.5">
+        <div>
+          {board.label ? (
+            <span className="font-mono text-xs text-slate-400">{board.label}</span>
+          ) : null}
+        </div>
+        <span className="text-sm font-semibold text-slate-100">{board.name}</span>
+        <div className="flex justify-end">
+        <span className="rounded bg-slate-700 px-1.5 py-0.5 text-[10px] font-medium text-slate-300">
+          {board.supply_type === 'three_phase' ? '3~' : '1~'}
+        </span>
+        </div>
+      </div>
+
+      {/* Intérieur de l'armoire */}
+      <div className="space-y-2 p-3">
+        {totalRows > 0
+          ? Array.from({ length: totalRows }, (_, i) => i + 1).map((row) => {
+              const cells = buildCells(placedDevices, row, totalSlots);
+              return (
+                <div key={row} className="rounded-lg bg-slate-700 px-3 py-2">
+                  <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-slate-500">
+                    {t('electricity.board.rowLabel', { n: row })}
+                  </div>
+                  <div className="flex items-end overflow-x-auto pb-0.5" style={{ gap: GAP }}>
+                    {cells.map((cell, idx) =>
+                      cell.kind === 'device' ? (
+                        <DeviceModule
+                          key={cell.device.id}
+                          device={cell.device}
+                          span={cell.span}
+                          onClick={onDeviceClick}
+                        />
+                      ) : (
+                        <EmptySlot key={idx} />
+                      ),
+                    )}
+                  </div>
+                </div>
+              );
+            })
+          : null}
+
+        {/* Appareils sans position */}
+        {unplacedDevices.length > 0 && (
+          <div className="rounded-lg border border-dashed border-slate-600 px-3 py-2">
+            <div className="mb-1.5 text-[10px] font-medium uppercase tracking-wider text-slate-500">
+              {t('electricity.board.unplaced')}
+            </div>
+            <div className="flex flex-wrap" style={{ gap: GAP }}>
+              {unplacedDevices.map((d) => (
+                <DeviceModule
+                  key={d.id}
+                  device={d}
+                  span={d.pole_count ?? 1}
+                  onClick={onDeviceClick}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+    </div>
+  );
+}

--- a/ui/src/features/electricity/CircuitDialog.tsx
+++ b/ui/src/features/electricity/CircuitDialog.tsx
@@ -37,9 +37,9 @@ export default function CircuitDialog({
   const updateCircuit = useUpdateCircuit();
   const isPending = createCircuit.isPending || updateCircuit.isPending;
 
-  // Devices suitable as circuit breakers (breaker or combined)
+  // Devices suitable as circuit breakers: active, breaker or combined, not spare
   const eligibleDevices = devices.filter(
-    (d) => d.is_active !== false && (d.device_type === 'breaker' || d.device_type === 'combined'),
+    (d) => d.is_active !== false && !d.is_spare && (d.device_type === 'breaker' || d.device_type === 'combined'),
   );
 
   React.useEffect(() => {

--- a/ui/src/features/electricity/DeviceDialog.tsx
+++ b/ui/src/features/electricity/DeviceDialog.tsx
@@ -7,14 +7,15 @@ import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import { CheckboxField } from '@/design-system/checkbox-field';
-import { useCreateDevice, useUpdateDevice } from './hooks';
-import type { ProtectiveDevice, DeviceType, PhaseType, CurveType, RcdTypeCode, DeviceRole } from '@/lib/api/electricity';
+import { useCreateDevice, useUpdateDevice, useProtectiveDevices } from './hooks';
+import type { ProtectiveDevice, DeviceType, PhaseType, CurveType, RcdTypeCode, DeviceRole, DevicePayload } from '@/lib/api/electricity';
 
 interface DeviceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   boardId: string;
   supplyType: 'single_phase' | 'three_phase';
+  slotsPerRow?: number | null;
   existing?: ProtectiveDevice;
 }
 
@@ -23,6 +24,7 @@ export default function DeviceDialog({
   onOpenChange,
   boardId,
   supplyType,
+  slotsPerRow,
   existing,
 }: DeviceDialogProps) {
   const { t } = useTranslation();
@@ -36,6 +38,10 @@ export default function DeviceDialog({
   const [sensitivityMa, setSensitivityMa] = React.useState('30');
   const [typeCode, setTypeCode] = React.useState<RcdTypeCode | ''>('a');
   const [phase, setPhase] = React.useState<PhaseType | ''>('');
+  const [poleCount, setPoleCount] = React.useState<string>('');
+  const [row, setRow] = React.useState('');
+  const [position, setPosition] = React.useState('');
+  const [positionEnd, setPositionEnd] = React.useState('');
   const [brand, setBrand] = React.useState('');
   const [modelRef, setModelRef] = React.useState('');
   const [isSpare, setIsSpare] = React.useState(false);
@@ -45,6 +51,33 @@ export default function DeviceDialog({
   const createDevice = useCreateDevice();
   const updateDevice = useUpdateDevice();
   const isPending = createDevice.isPending || updateDevice.isPending;
+
+  const { data: allDevices = [] } = useProtectiveDevices(boardId);
+
+  const rowNum = row ? Number(row) : null;
+  const posNum = position ? Number(position) : null;
+  const posEndNum = positionEnd ? Number(positionEnd) : null;
+
+  // Devices on the selected row (excluding the device being edited)
+  const rowDevices = React.useMemo(() => {
+    if (rowNum === null) return [];
+    return allDevices.filter(
+      (d) => d.row === rowNum && d.position !== null && d.id !== existing?.id,
+    );
+  }, [allDevices, rowNum, existing?.id]);
+
+  // Detect client-side position conflict
+  const positionConflict = React.useMemo(() => {
+    if (posNum === null) return null;
+    const effEnd = posEndNum ?? posNum;
+    for (const d of rowDevices) {
+      const dEnd = d.position_end ?? d.position!;
+      if (posNum <= dEnd && d.position! <= effEnd) {
+        return d.label ?? `#${d.id.slice(0, 8)}`;
+      }
+    }
+    return null;
+  }, [posNum, posEndNum, rowDevices]);
 
   React.useEffect(() => {
     if (!open) return;
@@ -57,6 +90,10 @@ export default function DeviceDialog({
       setSensitivityMa(existing.sensitivity_ma != null ? String(existing.sensitivity_ma) : '30');
       setTypeCode((existing.type_code as RcdTypeCode | '') ?? 'a');
       setPhase((existing.phase as PhaseType | '') ?? '');
+      setPoleCount(existing.pole_count != null ? String(existing.pole_count) : '');
+      setRow(existing.row != null ? String(existing.row) : '');
+      setPosition(existing.position != null ? String(existing.position) : '');
+      setPositionEnd(existing.position_end != null ? String(existing.position_end) : '');
       setBrand(existing.brand ?? '');
       setModelRef(existing.model_ref ?? '');
       setIsSpare(existing.is_spare ?? false);
@@ -70,6 +107,10 @@ export default function DeviceDialog({
       setSensitivityMa('30');
       setTypeCode('a');
       setPhase('');
+      setPoleCount('');
+      setRow('');
+      setPosition('');
+      setPositionEnd('');
       setBrand('');
       setModelRef('');
       setIsSpare(false);
@@ -83,16 +124,66 @@ export default function DeviceDialog({
   const isCombined = deviceType === 'combined';
   const isThreePhase = supplyType === 'three_phase';
 
+  // Poles allowed per device type
+  const poleOptions = React.useMemo(() => {
+    const none = { value: '', label: '—' };
+    if (isRcd || isCombined) {
+      return [none, { value: '2', label: '2P' }, { value: '4', label: '4P' }];
+    }
+    return [none, { value: '1', label: '1P' }, { value: '2', label: '2P' }, { value: '3', label: '3P' }, { value: '4', label: '4P' }];
+  }, [isRcd, isCombined]);
+
+  function renderSlotGrid() {
+    if (!slotsPerRow || !rowNum) return null;
+    return (
+      <div className="flex flex-wrap gap-1 mt-1" data-testid="slot-grid">
+        {Array.from({ length: slotsPerRow }, (_, i) => i + 1).map((slot) => {
+          const occupant = rowDevices.find((d) => {
+            const dEnd = d.position_end ?? d.position!;
+            return d.position! <= slot && slot <= dEnd;
+          });
+          const isSelected =
+            posNum !== null && posNum <= slot && slot <= (posEndNum ?? posNum);
+          let cls =
+            'h-6 w-6 rounded text-[10px] flex items-center justify-center border font-medium ';
+          if (occupant && isSelected) {
+            cls += 'bg-red-200 border-red-500 text-red-700';
+          } else if (occupant) {
+            cls += 'bg-red-100 border-red-300 text-red-500';
+          } else if (isSelected) {
+            cls += 'bg-blue-100 border-blue-400 text-blue-700';
+          } else {
+            cls += 'bg-gray-50 border-gray-200 text-gray-400';
+          }
+          return (
+            <div key={slot} className={cls} title={occupant?.label ?? undefined}>
+              {slot}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
 
-    const payload = {
+    if (positionConflict) {
+      return;
+    }
+
+    const poleCountValue = poleCount ? (Number(poleCount) as DevicePayload['pole_count']) : null;
+    const payload: DevicePayload = {
       board: boardId,
       device_type: deviceType,
       label: label.trim() || undefined,
       role: (role as DeviceRole) || undefined,
       rating_amps: isBreaker || isCombined ? Number(ratingAmps) || null : null,
+      pole_count: poleCountValue,
+      row: row ? Number(row) : null,
+      position: position ? Number(position) : null,
+      position_end: positionEnd ? Number(positionEnd) : null,
       curve_type: isBreaker || isCombined ? (curveType as CurveType) : ('' as const),
       sensitivity_ma: isRcd || isCombined ? Number(sensitivityMa) || null : null,
       type_code: isRcd || isCombined ? (typeCode as RcdTypeCode) : ('' as const),
@@ -252,6 +343,54 @@ export default function DeviceDialog({
               />
             </FormField>
           )}
+
+          <FormField label={t('electricity.device.poleCount')} htmlFor="dev-poles">
+            <Select
+              id="dev-poles"
+              value={poleCount}
+              onChange={(e) => setPoleCount(e.target.value)}
+              options={poleOptions}
+            />
+          </FormField>
+
+          <div className="grid grid-cols-3 gap-3">
+            <FormField label={t('electricity.device.row')} htmlFor="dev-row">
+              <Input
+                id="dev-row"
+                type="number"
+                min={1}
+                value={row}
+                onChange={(e) => setRow(e.target.value)}
+                placeholder="1"
+              />
+            </FormField>
+            <FormField label={t('electricity.device.position')} htmlFor="dev-position">
+              <Input
+                id="dev-position"
+                type="number"
+                min={1}
+                value={position}
+                onChange={(e) => setPosition(e.target.value)}
+                placeholder="1"
+              />
+            </FormField>
+            <FormField label={t('electricity.device.positionEnd')} htmlFor="dev-position-end">
+              <Input
+                id="dev-position-end"
+                type="number"
+                min={1}
+                value={positionEnd}
+                onChange={(e) => setPositionEnd(e.target.value)}
+                placeholder="—"
+              />
+            </FormField>
+          </div>
+          {renderSlotGrid()}
+          {positionConflict ? (
+            <p className="text-sm text-destructive">
+              {t('electricity.device.positionConflict', { label: positionConflict })}
+            </p>
+          ) : null}
 
           <div className="grid grid-cols-2 gap-3">
             <FormField label={t('electricity.device.brand')} htmlFor="dev-brand">

--- a/ui/src/features/electricity/ElectricityPage.tsx
+++ b/ui/src/features/electricity/ElectricityPage.tsx
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import {
   Zap, Plus, Pencil, Trash2, Link2, Link2Off, Plug, Lightbulb, ShieldCheck,
-  TriangleAlert, Info, Search,
+  TriangleAlert, Info,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/design-system/button';
 import { Badge } from '@/design-system/badge';
 import { Card } from '@/design-system/card';
-import { Input } from '@/design-system/input';
 import { FilterPill } from '@/design-system/filter-pill';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import PageHeader from '@/components/PageHeader';
@@ -15,7 +14,6 @@ import EmptyState from '@/components/EmptyState';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useSessionState } from '@/lib/useSessionState';
-import { lookupByLabel, type LookupResult } from '@/lib/api/electricity';
 import type { ElectricityBoard, ProtectiveDevice, ElectricCircuit, UsagePoint, CircuitUsagePointLink } from '@/lib/api/electricity';
 import {
   electricityKeys,
@@ -31,6 +29,7 @@ import {
   useDeactivateLink,
 } from './hooks';
 import BoardDialog from './BoardDialog';
+import { BoardPanel } from './BoardPanel';
 import DeviceDialog from './DeviceDialog';
 import CircuitDialog from './CircuitDialog';
 import UsagePointDialog from './UsagePointDialog';
@@ -39,7 +38,7 @@ import { useQueryClient } from '@tanstack/react-query';
 
 // ── Tab types ─────────────────────────────────────────────────────────────────
 
-type Tab = 'board' | 'circuits' | 'usagePoints' | 'links' | 'lookup';
+type Tab = 'board' | 'circuits' | 'usagePoints' | 'links';
 
 // ── Device type helpers ───────────────────────────────────────────────────────
 
@@ -134,7 +133,14 @@ function DeviceCard({ device, onEdit, onDelete, t }: DeviceCardProps) {
   ];
 
   const specs: string[] = [];
+  if (device.row != null && device.position != null) {
+    const posStr = device.position_end != null && device.position_end !== device.position
+      ? `R${device.row} P${device.position}–${device.position_end}`
+      : `R${device.row} P${device.position}`;
+    specs.push(posStr);
+  }
   if (device.rating_amps) specs.push(`${device.rating_amps}A`);
+  if (device.pole_count) specs.push(`${device.pole_count}P`);
   if (device.curve_type) specs.push(`Courbe ${device.curve_type.toUpperCase()}`);
   if (device.sensitivity_ma) specs.push(`${device.sensitivity_ma} mA`);
   if (device.type_code) specs.push(device.type_code.toUpperCase());
@@ -324,56 +330,6 @@ function LinkCard({ link: _link, circuit, usagePoint, onDeactivate, t }: LinkCar
   );
 }
 
-// ── Lookup panel ──────────────────────────────────────────────────────────────
-
-function LookupPanel({ t }: { t: (key: string) => string }) {
-  const [ref, setRef] = React.useState('');
-  const [result, setResult] = React.useState<LookupResult | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
-  const [loading, setLoading] = React.useState(false);
-
-  async function handleLookup(e: React.FormEvent) {
-    e.preventDefault();
-    const trimmed = ref.trim();
-    if (!trimmed) { setError(t('electricity.lookup.required')); return; }
-    setLoading(true);
-    setError(null);
-    setResult(null);
-    try {
-      const data = await lookupByLabel(trimmed);
-      setResult(data);
-    } catch (err: unknown) {
-      const status = (err as { response?: { status?: number } })?.response?.status;
-      setError(status === 404 ? t('electricity.lookup.notFound') : t('electricity.lookup.failed'));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  return (
-    <div className="space-y-4">
-      <form onSubmit={(e) => void handleLookup(e)} className="flex gap-2">
-        <Input
-          value={ref}
-          onChange={(e) => setRef(e.target.value)}
-          placeholder={t('electricity.lookup.placeholder')}
-          className="flex-1"
-        />
-        <Button type="submit" disabled={loading} className="gap-1.5">
-          <Search className="h-4 w-4" />
-          {t('electricity.lookup.button')}
-        </Button>
-      </form>
-      {error ? <p className="text-sm text-destructive">{error}</p> : null}
-      {result ? (
-        <pre className="overflow-x-auto rounded-lg border border-border bg-muted p-4 text-xs">
-          {JSON.stringify(result, null, 2)}
-        </pre>
-      ) : null}
-    </div>
-  );
-}
-
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function ElectricityPage() {
@@ -447,13 +403,21 @@ export default function ElectricityPage() {
     onDelete: (id) => deleteUsagePointMutation.mutateAsync(id),
   });
 
+  // On initial load: if board exists but no devices, redirect to 'board' tab so the user creates one first.
+  // We only redirect once (on first non-loading render) to avoid kicking the user back if they delete devices later.
+  const hasRedirectedRef = React.useRef(false);
+  React.useEffect(() => {
+    if (!isLoading && boards.length > 0 && devices.length === 0 && activeTab !== 'board' && !hasRedirectedRef.current) {
+      hasRedirectedRef.current = true;
+      setActiveTab('board');
+    }
+    if (!isLoading && devices.length > 0) {
+      hasRedirectedRef.current = true;
+    }
+  }, [isLoading, boards.length, devices.length, activeTab, setActiveTab]);
+
   // Computed data
   const activeLinks = React.useMemo(() => links.filter((l) => l.is_active !== false), [links]);
-
-  const eligibleDevices = React.useMemo(
-    () => devices.filter((d) => d.is_active !== false && (d.device_type === 'breaker' || d.device_type === 'combined')),
-    [devices],
-  );
 
   const deviceMap = React.useMemo(
     () => new Map(devices.map((d) => [d.id, d])),
@@ -508,7 +472,6 @@ export default function ElectricityPage() {
     { key: 'circuits', label: t('electricity.tabs.circuits') },
     { key: 'usagePoints', label: t('electricity.tabs.usagePoints') },
     { key: 'links', label: t('electricity.tabs.links') },
-    { key: 'lookup', label: t('electricity.tabs.lookup') },
   ];
 
   // Skeleton
@@ -525,16 +488,11 @@ export default function ElectricityPage() {
     );
   }
 
-  // No board: show empty state
+  // No board: show empty state — no button in PageHeader (only in EmptyState)
   if (!isLoading && boards.length === 0) {
     return (
       <>
-        <PageHeader title={t('electricity.title')} description={t('electricity.description')}>
-          <Button onClick={openCreateBoard} className="gap-1.5">
-            <Plus className="h-4 w-4" />
-            {t('electricity.board.new')}
-          </Button>
-        </PageHeader>
+        <PageHeader title={t('electricity.title')} description={t('electricity.description')} />
         <EmptyState
           icon={Zap}
           title={t('electricity.board.empty')}
@@ -601,16 +559,25 @@ export default function ElectricityPage() {
             t={t}
           />
 
+          {/* Représentation graphique du tableau */}
+          <BoardPanel
+            board={selectedBoard}
+            devices={devices}
+            onDeviceClick={(d) => openEditDevice(d)}
+          />
+
           {/* Devices section */}
           <div className="space-y-2">
             <div className="flex items-center justify-between">
               <h3 className="text-sm font-semibold text-muted-foreground">
                 {t('electricity.device.title')} ({devices.length})
               </h3>
-              <Button size="sm" onClick={openCreateDevice} className="gap-1">
-                <Plus className="h-3.5 w-3.5" />
-                {t('electricity.device.new')}
-              </Button>
+              {devices.length > 0 && (
+                <Button size="sm" onClick={openCreateDevice} className="gap-1">
+                  <Plus className="h-3.5 w-3.5" />
+                  {t('electricity.device.new')}
+                </Button>
+              )}
             </div>
             {devices.length === 0 ? (
               <EmptyState
@@ -650,51 +617,60 @@ export default function ElectricityPage() {
       {/* ── Circuits tab ──────────────────────────────────────────────────── */}
       {activeTab === 'circuits' && (
         <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <p className="text-sm text-muted-foreground">
-              {circuits.length} {t('electricity.circuit.title').toLowerCase()}
-            </p>
-            <Button size="sm" onClick={openCreateCircuit} className="gap-1" disabled={eligibleDevices.length === 0}>
-              <Plus className="h-3.5 w-3.5" />
-              {t('electricity.circuit.new')}
-            </Button>
-          </div>
-          {circuits.length === 0 ? (
+          {devices.length === 0 ? (
             <EmptyState
-              icon={Link2}
-              title={t('electricity.circuit.empty')}
-              description={
-                eligibleDevices.length === 0
-                  ? t('electricity.circuit.emptyNoDevices')
-                  : t('electricity.circuit.emptyDescription')
-              }
-              action={eligibleDevices.length > 0 ? { label: t('electricity.circuit.new'), onClick: openCreateCircuit } : undefined}
+              icon={Zap}
+              title={t('electricity.device.empty')}
+              description={t('electricity.device.emptyDescription')}
+              action={{ label: t('electricity.device.new'), onClick: openCreateDevice }}
             />
           ) : (
-            <div className="space-y-2">
-              {circuits.map((circuit) => (
-                <CircuitCard
-                  key={circuit.id}
-                  circuit={circuit}
-                  device={deviceMap.get(circuit.protective_device)}
-                  linkedCount={linkCountByCircuit.get(circuit.id) ?? 0}
-                  onEdit={() => openEditCircuit(circuit)}
-                  onDelete={() => {
-                    deleteCircuitWithUndo(circuit.id, {
-                      onRemove: () => qc.setQueryData<ElectricCircuit[]>(
-                        electricityKeys.circuits(boardId),
-                        (old) => old?.filter((c) => c.id !== circuit.id),
-                      ),
-                      onRestore: () => qc.setQueryData<ElectricCircuit[]>(
-                        electricityKeys.circuits(boardId),
-                        (old) => old ? [...old, circuit] : [circuit],
-                      ),
-                    });
-                  }}
-                  t={t}
+            <>
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-muted-foreground">
+                  {circuits.length} {t('electricity.circuit.title').toLowerCase()}
+                </p>
+                {circuits.length > 0 && (
+                  <Button size="sm" onClick={openCreateCircuit} className="gap-1">
+                    <Plus className="h-3.5 w-3.5" />
+                    {t('electricity.circuit.new')}
+                  </Button>
+                )}
+              </div>
+              {circuits.length === 0 ? (
+                <EmptyState
+                  icon={Link2}
+                  title={t('electricity.circuit.empty')}
+                  description={t('electricity.circuit.emptyDescription')}
+                  action={{ label: t('electricity.circuit.new'), onClick: openCreateCircuit }}
                 />
-              ))}
-            </div>
+              ) : (
+                <div className="space-y-2">
+                  {circuits.map((circuit) => (
+                    <CircuitCard
+                      key={circuit.id}
+                      circuit={circuit}
+                      device={deviceMap.get(circuit.protective_device)}
+                      linkedCount={linkCountByCircuit.get(circuit.id) ?? 0}
+                      onEdit={() => openEditCircuit(circuit)}
+                      onDelete={() => {
+                        deleteCircuitWithUndo(circuit.id, {
+                          onRemove: () => qc.setQueryData<ElectricCircuit[]>(
+                            electricityKeys.circuits(boardId),
+                            (old) => old?.filter((c) => c.id !== circuit.id),
+                          ),
+                          onRestore: () => qc.setQueryData<ElectricCircuit[]>(
+                            electricityKeys.circuits(boardId),
+                            (old) => old ? [...old, circuit] : [circuit],
+                          ),
+                        });
+                      }}
+                      t={t}
+                    />
+                  ))}
+                </div>
+              )}
+            </>
           )}
         </div>
       )}
@@ -716,10 +692,12 @@ export default function ElectricityPage() {
                 </FilterPill>
               ))}
             </div>
-            <Button size="sm" onClick={openCreateUp} className="gap-1">
-              <Plus className="h-3.5 w-3.5" />
-              {t('electricity.usagePoint.new')}
-            </Button>
+            {usagePoints.length > 0 && (
+              <Button size="sm" onClick={openCreateUp} className="gap-1">
+                <Plus className="h-3.5 w-3.5" />
+                {t('electricity.usagePoint.new')}
+              </Button>
+            )}
           </div>
           {usagePoints.length === 0 ? (
             <EmptyState
@@ -771,10 +749,12 @@ export default function ElectricityPage() {
             <p className="text-sm text-muted-foreground">
               {activeLinks.length} {t('electricity.link.active').toLowerCase()}
             </p>
-            <Button size="sm" onClick={() => setLinkDialogOpen(true)} className="gap-1" disabled={circuits.length === 0 || usagePoints.length === 0}>
-              <Plus className="h-3.5 w-3.5" />
-              {t('electricity.link.new')}
-            </Button>
+            {activeLinks.length > 0 && (
+              <Button size="sm" onClick={() => setLinkDialogOpen(true)} className="gap-1" disabled={circuits.length === 0 || usagePoints.length === 0}>
+                <Plus className="h-3.5 w-3.5" />
+                {t('electricity.link.new')}
+              </Button>
+            )}
           </div>
           {activeLinks.length === 0 ? (
             <EmptyState
@@ -806,9 +786,6 @@ export default function ElectricityPage() {
         </div>
       )}
 
-      {/* ── Lookup tab ────────────────────────────────────────────────────── */}
-      {activeTab === 'lookup' && <LookupPanel t={t} />}
-
       {/* ── Dialogs ───────────────────────────────────────────────────────── */}
       <BoardDialog
         open={boardDialogOpen}
@@ -823,6 +800,7 @@ export default function ElectricityPage() {
             onOpenChange={setDeviceDialogOpen}
             boardId={selectedBoard.id}
             supplyType={selectedBoard.supply_type as 'single_phase' | 'three_phase'}
+            slotsPerRow={selectedBoard.slots_per_row}
             existing={editingDevice}
           />
           <CircuitDialog

--- a/ui/src/features/electricity/UsagePointDialog.tsx
+++ b/ui/src/features/electricity/UsagePointDialog.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import { fetchZones } from '@/lib/api/zones';
 import type { Zone } from '@/lib/api/zones';
-import { useCreateUsagePoint, useUpdateUsagePoint } from './hooks';
+import { useCreateUsagePoint, useBulkCreateUsagePoints, useUpdateUsagePoint } from './hooks';
 import type { UsagePoint, UsagePointKind } from '@/lib/api/electricity';
 
 interface UsagePointDialogProps {
@@ -26,12 +26,14 @@ export default function UsagePointDialog({ open, onOpenChange, existing }: Usage
   const [kind, setKind] = React.useState<UsagePointKind>('socket');
   const [zoneId, setZoneId] = React.useState('');
   const [notes, setNotes] = React.useState('');
+  const [quantity, setQuantity] = React.useState(1);
   const [zones, setZones] = React.useState<Zone[]>([]);
   const [error, setError] = React.useState<string | null>(null);
 
   const createUsagePoint = useCreateUsagePoint();
+  const bulkCreateUsagePoints = useBulkCreateUsagePoints();
   const updateUsagePoint = useUpdateUsagePoint();
-  const isPending = createUsagePoint.isPending || updateUsagePoint.isPending;
+  const isPending = createUsagePoint.isPending || bulkCreateUsagePoints.isPending || updateUsagePoint.isPending;
 
   React.useEffect(() => {
     if (!open) return;
@@ -52,6 +54,7 @@ export default function UsagePointDialog({ open, onOpenChange, existing }: Usage
       setKind('socket');
       setZoneId('');
       setNotes('');
+      setQuantity(1);
     }
     setError(null);
   }, [open, existing]);
@@ -73,6 +76,8 @@ export default function UsagePointDialog({ open, onOpenChange, existing }: Usage
     try {
       if (isEditing && existing) {
         await updateUsagePoint.mutateAsync({ id: existing.id, payload });
+      } else if (quantity > 1) {
+        await bulkCreateUsagePoints.mutateAsync({ ...payload, quantity });
       } else {
         await createUsagePoint.mutateAsync(payload);
       }
@@ -111,7 +116,7 @@ export default function UsagePointDialog({ open, onOpenChange, existing }: Usage
                 id="up-label"
                 value={label}
                 onChange={(e) => setLabel(e.target.value)}
-                placeholder="UP-01"
+                placeholder={quantity > 1 ? 'UP-SAL' : 'UP-01'}
                 required
               />
             </FormField>
@@ -143,6 +148,24 @@ export default function UsagePointDialog({ open, onOpenChange, existing }: Usage
               options={zoneOptions}
             />
           </FormField>
+
+          {!isEditing && (
+            <FormField label={t('electricity.usagePoint.quantity')} htmlFor="up-quantity">
+              <Input
+                id="up-quantity"
+                type="number"
+                min={1}
+                max={50}
+                value={quantity}
+                onChange={(e) => setQuantity(Math.max(1, Math.min(50, Number(e.target.value))))}
+              />
+              {quantity > 1 && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('electricity.usagePoint.quantityHint', { label: label.trim() || '…', count: quantity })}
+                </p>
+              )}
+            </FormField>
+          )}
 
           <FormField label={t('electricity.usagePoint.notes')} htmlFor="up-notes">
             <Textarea

--- a/ui/src/features/electricity/hooks.ts
+++ b/ui/src/features/electricity/hooks.ts
@@ -17,6 +17,7 @@ import {
   updateCircuit,
   deleteCircuit,
   createUsagePoint,
+  bulkCreateUsagePoints,
   updateUsagePoint,
   deleteUsagePoint,
   createLink,
@@ -214,6 +215,23 @@ export function useCreateUsagePoint() {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: electricityKeys.usagePoints() });
       toast({ description: t('electricity.usagePoint.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useBulkCreateUsagePoints() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: UsagePointPayload & { quantity: number }) =>
+      bulkCreateUsagePoints(payload),
+    onSuccess: (data) => {
+      void qc.invalidateQueries({ queryKey: electricityKeys.usagePoints() });
+      toast({
+        description: t('electricity.usagePoint.createdBulk', { count: data.length }),
+        variant: 'success',
+      });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });

--- a/ui/src/lib/api/electricity.ts
+++ b/ui/src/lib/api/electricity.ts
@@ -54,8 +54,10 @@ export interface ProtectiveDevice {
   role?: DeviceRole | null;
   row?: number | null;
   position?: number | null;
+  position_end?: number | null;
   phase?: PhaseType | null;
   rating_amps?: number | null;
+  pole_count?: 1 | 2 | 3 | 4 | null;
   curve_type?: CurveType | '';
   sensitivity_ma?: number | null;
   type_code?: RcdTypeCode | '';
@@ -80,6 +82,10 @@ export interface DevicePayload {
   sensitivity_ma?: number | null;
   type_code?: RcdTypeCode | '';
   phase?: PhaseType | null;
+  row?: number | null;
+  position?: number | null;
+  position_end?: number | null;
+  pole_count?: 1 | 2 | 3 | 4 | null;
   parent_rcd?: string | null;
   brand?: string;
   model_ref?: string;
@@ -229,6 +235,13 @@ export async function createUsagePoint(payload: UsagePointPayload): Promise<Usag
   return data as UsagePoint;
 }
 
+export async function bulkCreateUsagePoints(
+  payload: UsagePointPayload & { quantity: number },
+): Promise<UsagePoint[]> {
+  const { data } = await api.post('/electricity/usage-points/bulk-create/', payload);
+  return data as UsagePoint[];
+}
+
 export async function updateUsagePoint(id: string, payload: Partial<UsagePointPayload>): Promise<UsagePoint> {
   const { data } = await api.patch(`/electricity/usage-points/${id}/`, payload);
   return data as UsagePoint;
@@ -259,15 +272,3 @@ export async function deactivateLink(id: string): Promise<void> {
   await api.post(`/electricity/links/${id}/deactivate/`, {});
 }
 
-// ── Lookup ────────────────────────────────────────────────────────────────────
-
-export interface LookupResult {
-  label: string;
-  type: string;
-  [key: string]: unknown;
-}
-
-export async function lookupByLabel(ref: string): Promise<LookupResult> {
-  const { data } = await api.get('/electricity/mapping/lookup/', { params: { ref } });
-  return data as LookupResult;
-}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -66,7 +66,9 @@
       "zoneRequired": "Zone ist erforderlich.",
       "created": "Verteiler erstellt.",
       "updated": "Verteiler aktualisiert.",
-      "deleted": "Verteiler gelöscht."
+      "deleted": "Verteiler gelöscht.",
+      "rowLabel": "Reihe {{n}}",
+      "unplaced": "Ohne Position"
     },
     "device": {
       "title": "Schutzgeräte",
@@ -89,6 +91,11 @@
       "typeCode": "Typcode",
       "typeCodeOther": "Sonstige",
       "phase": "Phase",
+      "poleCount": "Polzahl",
+      "row": "Reihe",
+      "position": "Position",
+      "positionEnd": "Endposition",
+      "positionConflict": "Position bereits belegt durch {{label}}",
       "brand": "Marke",
       "modelRef": "Modellreferenz",
       "isSpare": "Reserveplatz",
@@ -142,7 +149,10 @@
       "nameRequired": "Name ist erforderlich.",
       "created": "Nutzungspunkt hinzugefügt.",
       "updated": "Nutzungspunkt aktualisiert.",
-      "deleted": "Nutzungspunkt gelöscht."
+      "deleted": "Nutzungspunkt gelöscht.",
+      "quantity": "Anzahl",
+      "quantityHint": "Erstellt {{label}}-01 … {{label}}-{{count}}",
+      "createdBulk": "{{count}} Nutzungspunkte erstellt"
     },
     "link": {
       "new": "Neue Verbindung",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -66,7 +66,9 @@
       "zoneRequired": "Zone is required.",
       "created": "Board created.",
       "updated": "Board updated.",
-      "deleted": "Board deleted."
+      "deleted": "Board deleted.",
+      "rowLabel": "Row {{n}}",
+      "unplaced": "Unplaced"
     },
     "device": {
       "title": "Protective devices",
@@ -89,6 +91,11 @@
       "typeCode": "Type code",
       "typeCodeOther": "Other",
       "phase": "Phase",
+      "poleCount": "Pole count",
+      "row": "Row",
+      "position": "Position",
+      "positionEnd": "End position",
+      "positionConflict": "Position already taken by {{label}}",
       "brand": "Brand",
       "modelRef": "Model ref.",
       "isSpare": "Spare position",
@@ -142,7 +149,10 @@
       "nameRequired": "Name is required.",
       "created": "Usage point added.",
       "updated": "Usage point updated.",
-      "deleted": "Usage point deleted."
+      "deleted": "Usage point deleted.",
+      "quantity": "Quantity",
+      "quantityHint": "Will create {{label}}-01 … {{label}}-{{count}}",
+      "createdBulk": "{{count}} usage points created"
     },
     "link": {
       "new": "New link",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -66,7 +66,9 @@
       "zoneRequired": "La zona es obligatoria.",
       "created": "Cuadro creado.",
       "updated": "Cuadro actualizado.",
-      "deleted": "Cuadro eliminado."
+      "deleted": "Cuadro eliminado.",
+      "rowLabel": "Fila {{n}}",
+      "unplaced": "Sin posición"
     },
     "device": {
       "title": "Dispositivos de protección",
@@ -89,6 +91,11 @@
       "typeCode": "Código de tipo",
       "typeCodeOther": "Otro",
       "phase": "Fase",
+      "poleCount": "Número de polos",
+      "row": "Fila",
+      "position": "Posición",
+      "positionEnd": "Posición final",
+      "positionConflict": "Posición ocupada por {{label}}",
       "brand": "Marca",
       "modelRef": "Referencia de modelo",
       "isSpare": "Posición de reserva",
@@ -142,7 +149,10 @@
       "nameRequired": "El nombre es obligatorio.",
       "created": "Punto de uso agregado.",
       "updated": "Punto de uso actualizado.",
-      "deleted": "Punto de uso eliminado."
+      "deleted": "Punto de uso eliminado.",
+      "quantity": "Cantidad",
+      "quantityHint": "Creará {{label}}-01 … {{label}}-{{count}}",
+      "createdBulk": "{{count}} puntos de uso creados"
     },
     "link": {
       "new": "Nuevo vínculo",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -66,7 +66,9 @@
       "zoneRequired": "La zone est requise.",
       "created": "Tableau créé.",
       "updated": "Tableau mis à jour.",
-      "deleted": "Tableau supprimé."
+      "deleted": "Tableau supprimé.",
+      "rowLabel": "Rangée {{n}}",
+      "unplaced": "Non positionné"
     },
     "device": {
       "title": "Appareils de protection",
@@ -89,6 +91,11 @@
       "typeCode": "Code type",
       "typeCodeOther": "Autre",
       "phase": "Phase",
+      "poleCount": "Nombre de pôles",
+      "row": "Rangée",
+      "position": "Position",
+      "positionEnd": "Position fin",
+      "positionConflict": "Position occupée par {{label}}",
       "brand": "Marque",
       "modelRef": "Référence modèle",
       "isSpare": "Emplacement de réserve",
@@ -142,7 +149,10 @@
       "nameRequired": "Le nom est requis.",
       "created": "Point d'usage ajouté.",
       "updated": "Point d'usage mis à jour.",
-      "deleted": "Point d'usage supprimé."
+      "deleted": "Point d'usage supprimé.",
+      "quantity": "Quantité",
+      "quantityHint": "Créera {{label}}-01 … {{label}}-{{count}}",
+      "createdBulk": "{{count}} points d'usage créés"
     },
     "link": {
       "new": "Nouveau lien",


### PR DESCRIPTION
## Summary

- Add `pole_count` (1–4 poles) and `position_end` (physical span) to `ProtectiveDevice`
- Add visual board panel (rows, slots, placed/unplaced devices)
- Add bulk creation for usage points (up to 50 at once)
- Position overlap validation with `select_for_update()` to prevent race conditions
- Remove lookup tab and `MappingLookupView`
- Spare devices are now excluded from circuit breaker selection
- Initial redirect to board tab when no devices exist (one-time, via `useRef`)

## Test plan

- [ ] Create a breaker with row/position/position_end and verify it renders in BoardPanel
- [ ] Verify overlapping positions are rejected (both client-side grid and API)
- [ ] Create 5 usage points at once and verify labels are suffixed `-01` → `-05`
- [ ] Confirm spare devices don't appear in CircuitDialog device selector
- [ ] Run `pytest apps/electricity/` — all tests pass
- [ ] Run `npm run test:e2e` — all E2E tests pass