### PR TITLE
feat(projects): wire documents tab to ProjectDocument links

### DIFF
--- a/apps/documents/tests/test_api_documents.py
+++ b/apps/documents/tests/test_api_documents.py
@@ -238,6 +238,50 @@ class TestDocumentsApi:
             'Heating inspection',
         }
 
+    def test_list_filters_by_project(self, owner_client, owner, household):
+        linked = Document.objects.create(
+            household=household, created_by=owner,
+            file_path='docs/p-linked.pdf', name='Linked',
+            mime_type='application/pdf', type='document',
+        )
+        Document.objects.create(
+            household=household, created_by=owner,
+            file_path='docs/p-other.pdf', name='Other',
+            mime_type='application/pdf', type='document',
+        )
+        project = Project.objects.create(
+            household=household, created_by=owner, title='Renovation',
+        )
+        ProjectDocument.objects.create(project=project, document=linked, created_by=owner)
+
+        url = reverse('document-list')
+        response = owner_client.get(url, {'project': str(project.id)})
+
+        assert response.status_code == status.HTTP_200_OK
+        names = {item['name'] for item in response.data}
+        assert names == {'Linked'}
+
+    def test_list_filters_by_zone(self, owner_client, owner, household):
+        zone = Zone.objects.create(household=household, name='Garage', created_by=owner)
+        linked = Document.objects.create(
+            household=household, created_by=owner,
+            file_path='docs/z-linked.pdf', name='ZoneLinked',
+            mime_type='application/pdf', type='document',
+        )
+        Document.objects.create(
+            household=household, created_by=owner,
+            file_path='docs/z-other.pdf', name='ZoneOther',
+            mime_type='application/pdf', type='document',
+        )
+        ZoneDocument.objects.create(zone=zone, document=linked, created_by=owner)
+
+        url = reverse('document-list')
+        response = owner_client.get(url, {'zone': str(zone.id)})
+
+        assert response.status_code == status.HTTP_200_OK
+        names = {item['name'] for item in response.data}
+        assert names == {'ZoneLinked'}
+
 
 # ---------------------------------------------------------------------------
 # TestDocumentPrivacy

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -62,6 +62,14 @@ def get_documents_queryset_for_request(request):
     if qualification_state == 'without_activity' or without_activity in {'1', 'true', 'yes'}:
         queryset = queryset.filter(interaction_documents__isnull=True)
 
+    zone_id = (query_params.get('zone') or '').strip()
+    if zone_id:
+        queryset = queryset.filter(zonedocument__zone_id=zone_id)
+
+    project_id = (query_params.get('project') or '').strip()
+    if project_id:
+        queryset = queryset.filter(project_documents__project_id=project_id)
+
     return queryset.distinct()
 
 

--- a/apps/projects/tests/test_api_projects.py
+++ b/apps/projects/tests/test_api_projects.py
@@ -7,7 +7,16 @@ from rest_framework.test import APIClient
 
 from accounts.tests.factories import UserFactory
 from households.models import Household, HouseholdMember
-from projects.models import Project, ProjectAIMessage, ProjectAIThread, ProjectGroup, ProjectZone, UserPinnedProject
+from documents.models import Document
+from projects.models import (
+    Project,
+    ProjectAIMessage,
+    ProjectAIThread,
+    ProjectDocument,
+    ProjectGroup,
+    ProjectZone,
+    UserPinnedProject,
+)
 from zones.models import Zone
 
 
@@ -422,3 +431,81 @@ class TestProjectZoneFilter:
         data = response.data
         results = data['results'] if isinstance(data, dict) else data
         assert all(r['status'] == 'active' for r in results)
+
+
+@pytest.mark.django_db
+class TestProjectDocumentLinks:
+    def _project(self, household, owner):
+        return Project.objects.create(
+            household=household,
+            created_by=owner,
+            title="Doc-attached project",
+            status=Project.Status.ACTIVE,
+            priority=3,
+            type=Project.Type.OTHER,
+        )
+
+    def _document(self, household, owner, name="Plan", file_path="docs/plan.pdf"):
+        return Document.objects.create(
+            household=household,
+            created_by=owner,
+            file_path=file_path,
+            name=name,
+            mime_type="application/pdf",
+            type="document",
+        )
+
+    def test_attach_document_creates_link(self, owner_client, owner, household):
+        project = self._project(household, owner)
+        document = self._document(household, owner)
+
+        url = reverse("project-attach-document", kwargs={"pk": project.id})
+        response = owner_client.post(url, {"document_id": str(document.id)}, format="json")
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert ProjectDocument.objects.filter(project=project, document=document).exists()
+
+    def test_attach_document_is_idempotent(self, owner_client, owner, household):
+        project = self._project(household, owner)
+        document = self._document(household, owner)
+        ProjectDocument.objects.create(project=project, document=document, created_by=owner)
+
+        url = reverse("project-attach-document", kwargs={"pk": project.id})
+        response = owner_client.post(url, {"document_id": str(document.id)}, format="json")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert ProjectDocument.objects.filter(project=project, document=document).count() == 1
+
+    def test_attach_document_rejects_other_household(self, owner_client, owner, household):
+        project = self._project(household, owner)
+        other = _household("Other House")
+        _membership(owner, other)
+        foreign_doc = self._document(other, owner, name="Foreign", file_path="docs/foreign.pdf")
+
+        url = reverse("project-attach-document", kwargs={"pk": project.id})
+        response = owner_client.post(url, {"document_id": str(foreign_doc.id)}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert not ProjectDocument.objects.filter(project=project, document=foreign_doc).exists()
+
+    def test_detach_document_removes_link(self, owner_client, owner, household):
+        project = self._project(household, owner)
+        document = self._document(household, owner)
+        ProjectDocument.objects.create(project=project, document=document, created_by=owner)
+
+        url = reverse("project-detach-document", kwargs={"pk": project.id})
+        response = owner_client.post(url, {"document_id": str(document.id)}, format="json")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert not ProjectDocument.objects.filter(project=project, document=document).exists()
+        # Document itself is preserved
+        assert Document.objects.filter(id=document.id).exists()
+
+    def test_detach_document_returns_404_when_not_linked(self, owner_client, owner, household):
+        project = self._project(household, owner)
+        document = self._document(household, owner)
+
+        url = reverse("project-detach-document", kwargs={"pk": project.id})
+        response = owner_client.post(url, {"document_id": str(document.id)}, format="json")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -1,11 +1,20 @@
-from rest_framework import viewsets
+from rest_framework import status as drf_status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
-from .models import Project, ProjectGroup, ProjectZone, ProjectAIThread, ProjectAIMessage, UserPinnedProject
+from documents.models import Document
+from .models import (
+    Project,
+    ProjectDocument,
+    ProjectGroup,
+    ProjectZone,
+    ProjectAIThread,
+    ProjectAIMessage,
+    UserPinnedProject,
+)
 from .serializers import (
     ProjectSerializer,
     ProjectGroupSerializer,
@@ -103,6 +112,57 @@ class ProjectViewSet(_HouseholdScopedViewSet):
             UserPinnedProject.objects.filter(household_member=member, project=project).delete()
         serializer = self.get_serializer(project)
         return Response(serializer.data)
+
+    @action(detail=True, methods=["post"], url_path="attach_document")
+    def attach_document(self, request, pk=None):
+        project = self.get_object()
+        document_id = request.data.get("document_id")
+        if not document_id:
+            raise ValidationError({"document_id": "document_id is required."})
+
+        document = Document.objects.filter(id=document_id, household_id=project.household_id).first()
+        if not document:
+            return Response(
+                {"detail": "Document not found in this household."},
+                status=drf_status.HTTP_404_NOT_FOUND,
+            )
+
+        link, created = ProjectDocument.objects.get_or_create(
+            project=project,
+            document=document,
+            defaults={
+                "role": request.data.get("role") or "supporting",
+                "note": request.data.get("note") or "",
+                "created_by": request.user,
+            },
+        )
+        return Response(
+            {
+                "id": link.id,
+                "project": str(project.id),
+                "document": str(document.id),
+                "role": link.role,
+                "note": link.note,
+            },
+            status=drf_status.HTTP_201_CREATED if created else drf_status.HTTP_200_OK,
+        )
+
+    @action(detail=True, methods=["post"], url_path="detach_document")
+    def detach_document(self, request, pk=None):
+        project = self.get_object()
+        document_id = request.data.get("document_id")
+        if not document_id:
+            raise ValidationError({"document_id": "document_id is required."})
+
+        deleted, _ = ProjectDocument.objects.filter(
+            project=project, document_id=document_id
+        ).delete()
+        if deleted == 0:
+            return Response(
+                {"detail": "Document is not linked to this project."},
+                status=drf_status.HTTP_404_NOT_FOUND,
+            )
+        return Response(status=drf_status.HTTP_204_NO_CONTENT)
 
 
 class ProjectZoneViewSet(viewsets.ModelViewSet):

--- a/ui/src/features/documents/DocumentCard.tsx
+++ b/ui/src/features/documents/DocumentCard.tsx
@@ -10,9 +10,10 @@ interface DocumentCardProps {
   doc: DocumentItem;
   onEdit: (doc: DocumentItem) => void;
   onDelete: (id: string) => void;
+  deleteLabel?: string;
 }
 
-export default function DocumentCard({ doc, onEdit, onDelete }: DocumentCardProps) {
+export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: DocumentCardProps) {
   const { t } = useTranslation();
 
   const fileName = doc.name || doc.file_path.split('/').pop() || '';
@@ -22,7 +23,7 @@ export default function DocumentCard({ doc, onEdit, onDelete }: DocumentCardProp
 
   const actions: CardAction[] = [
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(doc) },
-    { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(doc.id), variant: 'danger' },
+    { label: deleteLabel ?? t('common.delete'), icon: Trash2, onClick: () => onDelete(doc.id), variant: 'danger' },
   ];
 
   return (

--- a/ui/src/features/projects/ProjectAttachDocumentDialog.tsx
+++ b/ui/src/features/projects/ProjectAttachDocumentDialog.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
+import { Input } from '@/design-system/input';
+import { Button } from '@/design-system/button';
+import { useDocuments, documentKeys } from '@/features/documents/hooks';
+import { useAttachProjectDocument } from './hooks';
+import type { DocumentItem } from '@/lib/api/documents';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId: string;
+  attachedIds: Set<string>;
+}
+
+export default function ProjectAttachDocumentDialog({
+  open,
+  onOpenChange,
+  projectId,
+  attachedIds,
+}: Props) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const [search, setSearch] = React.useState('');
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [error, setError] = React.useState<string | null>(null);
+
+  const filters = React.useMemo(
+    () => (search ? { search } : {}),
+    [search],
+  );
+  const { data: documents = [], isLoading } = useDocuments(filters);
+  const attachMutation = useAttachProjectDocument(projectId);
+
+  React.useEffect(() => {
+    if (!open) {
+      setSelected(new Set());
+      setSearch('');
+      setError(null);
+    }
+  }, [open]);
+
+  const candidates = React.useMemo<DocumentItem[]>(
+    () => documents.filter((d) => !attachedIds.has(d.id)),
+    [documents, attachedIds],
+  );
+
+  function toggle(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function handleAttach() {
+    if (selected.size === 0) return;
+    setError(null);
+    try {
+      await Promise.all(
+        Array.from(selected).map((id) => attachMutation.mutateAsync(id)),
+      );
+      void qc.invalidateQueries({ queryKey: documentKeys.all });
+      onOpenChange(false);
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{t('projects.attach_document.title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-2 space-y-3">
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-2 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <Input
+            placeholder={t('projects.attach_document.search_placeholder')}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+
+          <div className="max-h-72 overflow-y-auto rounded-md border border-border">
+            {isLoading ? (
+              <p className="p-3 text-sm text-muted-foreground">{t('common.search')}…</p>
+            ) : candidates.length === 0 ? (
+              <p className="p-3 text-sm italic text-muted-foreground">
+                {t('projects.attach_document.empty')}
+              </p>
+            ) : (
+              <ul className="divide-y divide-border">
+                {candidates.map((doc) => {
+                  const checked = selected.has(doc.id);
+                  return (
+                    <li key={doc.id}>
+                      <label className="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-muted/40">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => toggle(doc.id)}
+                          className="h-4 w-4"
+                        />
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate text-sm text-foreground">{doc.name}</p>
+                          {doc.type ? (
+                            <p className="text-xs text-muted-foreground">
+                              {t(`documents.type.${doc.type}`, { defaultValue: doc.type })}
+                            </p>
+                          ) : null}
+                        </div>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={attachMutation.isPending}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleAttach}
+              disabled={selected.size === 0 || attachMutation.isPending}
+            >
+              {attachMutation.isPending
+                ? t('common.saving')
+                : t('projects.attach_document.attach', { count: selected.size })}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -18,6 +18,7 @@ import {
   projectKeys,
 } from './hooks';
 import ProjectDialog from './ProjectDialog';
+import ProjectDocumentsTab from './ProjectDocumentsTab';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Helpers ────────────────────────────────────────────────
@@ -409,11 +410,7 @@ export default function ProjectDetailPage() {
                 ) : null}
 
                 {tab === 'documents' ? (
-                  <TabInteractions
-                    projectId={project.id}
-                    type="document"
-                    emptyKey="projects.empty_documents"
-                  />
+                  <ProjectDocumentsTab projectId={project.id} />
                 ) : null}
 
                 {tab === 'timeline' ? (

--- a/ui/src/features/projects/ProjectDocumentsTab.tsx
+++ b/ui/src/features/projects/ProjectDocumentsTab.tsx
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { Button } from '@/design-system/button';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import { useDocuments, documentKeys } from '@/features/documents/hooks';
+import DocumentCard from '@/features/documents/DocumentCard';
+import DocumentEditDialog from '@/features/documents/DocumentEditDialog';
+import { useDetachProjectDocument } from './hooks';
+import ProjectAttachDocumentDialog from './ProjectAttachDocumentDialog';
+import type { DocumentItem } from '@/lib/api/documents';
+
+interface Props {
+  projectId: string;
+}
+
+export default function ProjectDocumentsTab({ projectId }: Props) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+
+  const filters = React.useMemo(() => ({ project: projectId }), [projectId]);
+  const { data: documents = [], isLoading, error } = useDocuments(filters);
+  const detachMutation = useDetachProjectDocument(projectId);
+
+  const [editingDoc, setEditingDoc] = React.useState<DocumentItem | null>(null);
+  const [attachOpen, setAttachOpen] = React.useState(false);
+
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('projects.attach_document.detached'),
+    onDelete: (id) => detachMutation.mutateAsync(id),
+  });
+
+  const handleDetach = React.useCallback(
+    (docId: string) => {
+      const doc = documents.find((d) => d.id === docId);
+      if (!doc) return;
+      deleteWithUndo(docId, {
+        onRemove: () =>
+          qc.setQueryData<DocumentItem[]>(
+            documentKeys.list(filters),
+            (old) => old?.filter((d) => d.id !== docId),
+          ),
+        onRestore: () =>
+          qc.setQueryData<DocumentItem[]>(
+            documentKeys.list(filters),
+            (old) => (old ? [...old, doc] : [doc]),
+          ),
+      });
+    },
+    [documents, deleteWithUndo, qc, filters],
+  );
+
+  const showSkeleton = useDelayedLoading(isLoading);
+  const attachedIds = React.useMemo(
+    () => new Set(documents.map((d) => d.id)),
+    [documents],
+  );
+
+  return (
+    <>
+      <div className="space-y-3">
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => setAttachOpen(true)}
+            className="gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t('projects.attach_document.title')}
+          </Button>
+        </div>
+
+        {showSkeleton ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+            ))}
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive">{t('common.error_loading')}</p>
+        ) : documents.length === 0 ? (
+          <p className="text-sm italic text-muted-foreground">
+            {t('projects.empty_documents')}
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {documents.map((doc) => (
+              <DocumentCard
+                key={doc.id}
+                doc={doc}
+                onEdit={setEditingDoc}
+                onDelete={handleDetach}
+                deleteLabel={t('projects.attach_document.detach')}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <DocumentEditDialog
+        open={editingDoc !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingDoc(null);
+        }}
+        doc={editingDoc}
+        onSaved={() => qc.invalidateQueries({ queryKey: documentKeys.all })}
+      />
+
+      <ProjectAttachDocumentDialog
+        open={attachOpen}
+        onOpenChange={setAttachOpen}
+        projectId={projectId}
+        attachedIds={attachedIds}
+      />
+    </>
+  );
+}

--- a/ui/src/features/projects/hooks.ts
+++ b/ui/src/features/projects/hooks.ts
@@ -12,11 +12,14 @@ import {
   deleteProjectGroup,
   pinProject,
   unpinProject,
+  attachProjectDocument,
+  detachProjectDocument,
   type ProjectListItem,
   type ProjectInteractionItem,
   type ProjectPayload,
   type ProjectGroupPayload,
 } from '@/lib/api/projects';
+import { documentKeys } from '@/features/documents/hooks';
 import { fetchZones } from '@/lib/api/zones';
 
 interface ProjectFilters {
@@ -123,6 +126,22 @@ export function useDeleteGroup() {
   return useMutation({
     mutationFn: (id: string) => deleteProjectGroup(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.groups() }),
+  });
+}
+
+export function useAttachProjectDocument(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (documentId: string) => attachProjectDocument(projectId, documentId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
+  });
+}
+
+export function useDetachProjectDocument(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (documentId: string) => detachProjectDocument(projectId, documentId),
+    onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
   });
 }
 

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -67,6 +67,7 @@ export interface DocumentFilters {
   search?: string;
   type?: string;
   zone?: string;
+  project?: string;
   [key: string]: string | undefined;
 }
 
@@ -79,6 +80,7 @@ export async function fetchDocuments(filters: DocumentFilters = {}): Promise<Doc
   if (filters.search) params.search = filters.search;
   if (filters.type) params.type = filters.type;
   if (filters.zone) params.zone = filters.zone;
+  if (filters.project) params.project = filters.project;
 
   const { data } = await api.get('/documents/documents/', { params });
   const list: Array<DocumentItem & { id: string | number }> = Array.isArray(data)

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -157,6 +157,14 @@ export async function unpinProject(id: string): Promise<ProjectListItem> {
   return data as ProjectListItem;
 }
 
+export async function attachProjectDocument(projectId: string, documentId: string): Promise<void> {
+  await api.post(`/projects/projects/${projectId}/attach_document/`, { document_id: documentId });
+}
+
+export async function detachProjectDocument(projectId: string, documentId: string): Promise<void> {
+  await api.post(`/projects/projects/${projectId}/detach_document/`, { document_id: documentId });
+}
+
 export interface ProjectInteractionItem {
   id: string;
   subject: string;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -16,7 +16,8 @@
     "search": "Suchen",
     "noResults": "Keine Ergebnisse",
     "linked": "Bereits verknüpft",
-    "actions": "Aktionen"
+    "actions": "Aktionen",
+    "error_loading": "Laden fehlgeschlagen."
   },
   "sidebar": {
     "open": "Menü öffnen",
@@ -1271,6 +1272,14 @@
     "empty_notes": "Noch keine Notizen.",
     "empty_expenses": "Noch keine Ausgaben.",
     "empty_documents": "Noch keine Dokumente.",
+    "attach_document": {
+      "title": "Dokument anhängen",
+      "search_placeholder": "Dokumente suchen…",
+      "empty": "Keine Dokumente verfügbar.",
+      "attach": "Anhängen ({{count}})",
+      "detach": "Trennen",
+      "detached": "Dokument getrennt"
+    },
     "empty_timeline": "Noch keine Aktivität.",
     "add_task": "Aufgabe hinzufügen",
     "add_note": "Notiz hinzufügen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -16,7 +16,8 @@
     "search": "Search",
     "noResults": "No results",
     "linked": "Already linked",
-    "actions": "Actions"
+    "actions": "Actions",
+    "error_loading": "Failed to load."
   },
   "sidebar": {
     "open": "Open menu",
@@ -1271,6 +1272,14 @@
     "empty_notes": "No notes yet.",
     "empty_expenses": "No expenses yet.",
     "empty_documents": "No documents yet.",
+    "attach_document": {
+      "title": "Attach a document",
+      "search_placeholder": "Search documents…",
+      "empty": "No documents available.",
+      "attach": "Attach ({{count}})",
+      "detach": "Detach",
+      "detached": "Document detached"
+    },
     "empty_timeline": "No activity yet.",
     "add_task": "Add a task",
     "add_note": "Add a note",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -16,7 +16,8 @@
     "search": "Buscar",
     "noResults": "Sin resultados",
     "linked": "Ya vinculado",
-    "actions": "Acciones"
+    "actions": "Acciones",
+    "error_loading": "Error al cargar."
   },
   "sidebar": {
     "open": "Abrir menú",
@@ -1271,6 +1272,14 @@
     "empty_notes": "Aún no hay notas.",
     "empty_expenses": "Aún no hay gastos.",
     "empty_documents": "Aún no hay documentos.",
+    "attach_document": {
+      "title": "Adjuntar un documento",
+      "search_placeholder": "Buscar documentos…",
+      "empty": "No hay documentos disponibles.",
+      "attach": "Adjuntar ({{count}})",
+      "detach": "Desvincular",
+      "detached": "Documento desvinculado"
+    },
     "empty_timeline": "Aún no hay actividad.",
     "add_task": "Añadir una tarea",
     "add_note": "Añadir una nota",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -16,7 +16,8 @@
     "search": "Rechercher",
     "noResults": "Aucun résultat",
     "linked": "Déjà lié",
-    "actions": "Actions"
+    "actions": "Actions",
+    "error_loading": "Erreur lors du chargement."
   },
   "sidebar": {
     "open": "Ouvrir le menu",
@@ -1276,6 +1277,14 @@
     "add_note": "Ajouter une note",
     "add_expense": "Ajouter une dépense",
     "add_activity": "Ajouter une activité",
+    "attach_document": {
+      "title": "Joindre un document",
+      "search_placeholder": "Rechercher un document…",
+      "empty": "Aucun document disponible.",
+      "attach": "Joindre ({{count}})",
+      "detach": "Détacher",
+      "detached": "Document détaché"
+    },
     "status": {
       "draft": "Brouillon",
       "active": "Actif",


### PR DESCRIPTION
## Summary

- Documents tab on project detail was hitting `/interactions/?type=document` (invalid choice) → 400 → unloadable. Now it queries documents via the `ProjectDocument` join.
- Adds `attach_document` / `detach_document` endpoints on `ProjectViewSet` and an attach dialog with search + multi-select.
- Fixes silently-ignored `?project=` and `?zone=` filters on `DocumentViewSet`.

## Changes

**Backend**
- `DocumentViewSet`: support `?project=<id>` and `?zone=<id>`.
- `ProjectViewSet`: new `attach_document` (idempotent, 404 on cross-household), `detach_document` (204, 404 if not linked) — only the link is removed, the document is preserved.

**Frontend**
- `ProjectDocumentsTab.tsx` replaces the broken `TabInteractions` for the documents tab (skeleton + empty + error states; "Détacher" with undo).
- `ProjectAttachDocumentDialog.tsx` lets the user pick household documents not yet linked.
- `DocumentCard` exposes an optional `deleteLabel` so the project tab can label the destructive action "Détacher".

**i18n**
- `common.error_loading` + `projects.attach_document.*` in fr/en/de/es.

## Test plan

- [x] `pytest apps/projects/ apps/documents/` — 46 pass
- [x] `tsc --noEmit` clean
- [x] `npm run lint` — 0 new errors
- [ ] Manuel : ouvrir un projet → onglet Documents → "Joindre un document" → sélectionner → vérifier l'apparition. "Détacher" → toast undo → restaurer.
- [ ] Manuel : confirmer que le document détaché est toujours visible dans `/app/documents/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)