### PR TITLE
fix(prod): defaults for DEFAULT_FROM_EMAIL & FRONTEND_URL (unbreak deploy)

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -65,8 +65,12 @@ EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD", default="")
 EMAIL_USE_TLS = env.bool("EMAIL_USE_TLS", default=True)
 EMAIL_USE_SSL = env.bool("EMAIL_USE_SSL", default=False)
 EMAIL_TIMEOUT = env.int("EMAIL_TIMEOUT", default=10)
-DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL")
-FRONTEND_URL = env("FRONTEND_URL")
+# DEFAULT_FROM_EMAIL and FRONTEND_URL fall back to the first ALLOWED_HOSTS entry
+# so deploys don't crash if these vars are missing from .env. Override in .env
+# when you need a different sender address or SPA host.
+_primary_host = ALLOWED_HOSTS[0] if ALLOWED_HOSTS else "localhost"
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default=f"noreply@{_primary_host}")
+FRONTEND_URL = env("FRONTEND_URL", default=f"https://{_primary_host}")
 
 # Django Vite Configuration (compiled assets in production)
 DJANGO_VITE = {


### PR DESCRIPTION
## Why

PR #86 added two **required** env vars in \`config/settings/production.py\` :
\`\`\`python
DEFAULT_FROM_EMAIL = env(\"DEFAULT_FROM_EMAIL\")
FRONTEND_URL = env(\"FRONTEND_URL\")
\`\`\`

Le \`.env\` sur le Mac Mini n'a pas été mis à jour → \`ImproperlyConfigured\` à l'import → container \`house-web-1\` en boucle de restart → CI échoue sur \`docker exec migrate\` (\"Container is restarting\"). Le déploiement de PR #86 lui-même a échoué pour la même raison, et celui de PR #87 aussi.

## What

Defaults dérivés de \`ALLOWED_HOSTS[0]\` :
- \`DEFAULT_FROM_EMAIL\` → \`noreply@<host>\`
- \`FRONTEND_URL\` → \`https://<host>\`

Toujours overridable via \`.env\` quand on veut une adresse d'envoi ou un host SPA différent.

## Test plan
- [x] Vérification locale : \`DJANGO_SETTINGS_MODULE=config.settings.production ALLOWED_HOSTS=house-django.jammin-dev.com python -c \"from django.conf import settings; print(settings.FRONTEND_URL, settings.DEFAULT_FROM_EMAIL)\"\` → valeurs correctes
- [ ] Après merge : vérifier que le déploiement passe et que le container reste up

🤖 Generated with [Claude Code](https://claude.com/claude-code)