### PR TITLE
fix(documents): render linked interactions on detail page

### DIFF
--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { formatFileSize } from '@/lib/api/documents';
-import { useDocument, useDocumentInteractions, useDeleteDocument, documentKeys } from './hooks';
+import { useDocument, useDeleteDocument, documentKeys } from './hooks';
 import DocumentEditDialog from './DocumentEditDialog';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
@@ -29,7 +29,6 @@ export default function DocumentDetailPage() {
   const [deleteOpen, setDeleteOpen] = React.useState(false);
 
   const { data: doc, isLoading, error } = useDocument(id ?? '');
-  const { data: interactions = [], isLoading: interactionsLoading } = useDocumentInteractions(id ?? '');
   const deleteMutation = useDeleteDocument();
 
   const handleSaved = React.useCallback(() => {
@@ -49,7 +48,7 @@ export default function DocumentDetailPage() {
     return (
       <div className="space-y-2 p-4">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-14 animate-pulse rounded-lg bg-slate-100" />
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
         ))}
       </div>
     );
@@ -87,7 +86,7 @@ export default function DocumentDetailPage() {
               <h1 className="text-2xl font-bold text-foreground">{fileName}</h1>
               {doc.type && doc.type !== 'photo' && (
                 <Badge variant="secondary" className="text-xs">
-                  {t(`documents.type.${doc.type}`, { defaultValue: doc.type })}
+                  {t(`documents.type.${doc.type}`)}
                 </Badge>
               )}
             </div>
@@ -159,19 +158,13 @@ export default function DocumentDetailPage() {
             </Link>
           </div>
 
-          {interactionsLoading ? (
-            <div className="space-y-2">
-              {[1, 2].map((i) => (
-                <div key={i} className="h-12 animate-pulse rounded-lg bg-slate-100" />
-              ))}
-            </div>
-          ) : interactions.length === 0 ? (
+          {doc.linked_interactions.length === 0 ? (
             <p className="text-sm italic text-muted-foreground">
               {t('documents.detail.no_linked_interactions')}
             </p>
           ) : (
             <ul className="space-y-2">
-              {interactions.map((item) => (
+              {doc.linked_interactions.map((item) => (
                 <li key={item.id} className="rounded-md border p-3 text-sm">
                   <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0 flex-1">
@@ -185,7 +178,7 @@ export default function DocumentDetailPage() {
                     <div className="flex shrink-0 items-center gap-1">
                       {item.type && (
                         <Badge variant="outline" className="h-5 text-[10px]">
-                          {t(`interactions.type.${item.type}`, { defaultValue: item.type })}
+                          {t(`interactions.type.${item.type}`)}
                         </Badge>
                       )}
                       <Link

--- a/ui/src/features/documents/hooks.ts
+++ b/ui/src/features/documents/hooks.ts
@@ -2,7 +2,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   fetchDocuments,
   fetchDocumentDetail,
-  fetchDocumentInteractions,
   uploadDocument,
   updateDocument,
   deleteDocument,
@@ -28,14 +27,6 @@ export function useDocument(id: string) {
   return useQuery({
     queryKey: documentKeys.detail(id),
     queryFn: () => fetchDocumentDetail(id),
-    enabled: !!id,
-  });
-}
-
-export function useDocumentInteractions(id: string) {
-  return useQuery({
-    queryKey: [...documentKeys.detail(id), 'interactions'],
-    queryFn: () => fetchDocumentInteractions(id),
     enabled: !!id,
   });
 }

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -141,14 +141,6 @@ export async function deleteDocument(id: string): Promise<void> {
   await api.delete(`/documents/documents/${id}/`);
 }
 
-export async function fetchDocumentInteractions(documentId: string): Promise<LinkedInteractionSummary[]> {
-  const { data } = await api.get('/interactions/interaction-documents/', {
-    params: { document: documentId },
-  });
-  if (Array.isArray(data)) return data as LinkedInteractionSummary[];
-  return ((data as { results?: LinkedInteractionSummary[] }).results ?? []);
-}
-
 export function formatFileSize(bytes?: number | null): string {
   if (!bytes) return '';
   if (bytes < 1024) return `${bytes} B`;


### PR DESCRIPTION
Closes #91.

## Summary
- Use `doc.linked_interactions` (already populated by `DocumentDetailSerializer`) instead of a separate call to `/interactions/interaction-documents/`, whose join-table serializer only exposed UUIDs — every row was rendering as "—".
- Drop the now-dead `useDocumentInteractions` hook and `fetchDocumentInteractions` helper.
- While in the file, fix two CLAUDE.md violations: `bg-slate-100` → `bg-muted` (skeleton), and remove `defaultValue` from `t()` calls for `documents.type.*` and `interactions.type.*` (all keys verified present in en/fr/de/es).

## Test plan
- [ ] Open a document detail with at least one linked interaction → subject, date and type badge render correctly.
- [ ] Open a document with zero linked interactions → empty-state message shows.
- [ ] Skeleton flash on slow network looks correct (same `bg-muted` as elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)