### PR TITLE
feat(documents): OCR pipeline at upload (HEIC + resize + Vision)

### DIFF
--- a/apps/core/file_validation.py
+++ b/apps/core/file_validation.py
@@ -31,23 +31,41 @@ _SIGNATURES = [
         lambda h: h[:4] == b'RIFF' and h[8:12] == b'WEBP',
     ),
     (
+        'image/heic',
+        _('HEIC image'),
+        lambda h: len(h) >= 12 and h[4:8] == b'ftyp' and h[8:12] in (b'heic', b'heix', b'hevc', b'hevx'),
+    ),
+    (
+        'image/heif',
+        _('HEIF image'),
+        lambda h: len(h) >= 12 and h[4:8] == b'ftyp' and h[8:12] in (b'mif1', b'msf1', b'heim', b'heis', b'hevm', b'hevs'),
+    ),
+    (
         'application/pdf',
         _('PDF document'),
         lambda h: h[:4] == b'%PDF',
     ),
 ]
 
-ALLOWED_DOCUMENT_TYPES = {'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'application/pdf'}
-ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/png', 'image/gif', 'image/webp'}
+ALLOWED_DOCUMENT_TYPES = {
+    'image/jpeg',
+    'image/png',
+    'image/gif',
+    'image/webp',
+    'image/heic',
+    'image/heif',
+    'application/pdf',
+}
+ALLOWED_IMAGE_TYPES = {'image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/heic', 'image/heif'}
 
 DOCUMENT_MAX_SIZE = 20 * 1024 * 1024   # 20 MB
 AVATAR_MAX_SIZE = 2 * 1024 * 1024      # 2 MB
 
 
 def detect_mime_type(file) -> str | None:
-    """Read the first 12 bytes and return the detected MIME type, or None."""
+    """Read the first bytes and return the detected MIME type, or None."""
     file.seek(0)
-    header = file.read(12)
+    header = file.read(16)
     file.seek(0)
     for mime, _label, detector in _SIGNATURES:
         if detector(header):

--- a/apps/core/tests/test_file_validation.py
+++ b/apps/core/tests/test_file_validation.py
@@ -19,6 +19,8 @@ PNG_HEADER = b'\x89PNG\r\n\x1a\n' + b'\x00' * 20
 GIF_HEADER = b'GIF89a' + b'\x00' * 20
 WEBP_HEADER = b'RIFF\x00\x00\x00\x00WEBP' + b'\x00' * 20
 PDF_HEADER = b'%PDF-1.4\n' + b'\x00' * 20
+HEIC_HEADER = b'\x00\x00\x00\x18ftypheic' + b'\x00' * 20
+HEIF_HEADER = b'\x00\x00\x00\x18ftypmif1' + b'\x00' * 20
 UNKNOWN_HEADER = b'\x00\x01\x02\x03' + b'\x00' * 20
 
 
@@ -45,6 +47,12 @@ class TestDetectMimeType:
     def test_detects_pdf(self):
         assert detect_mime_type(make_file(PDF_HEADER)) == 'application/pdf'
 
+    def test_detects_heic(self):
+        assert detect_mime_type(make_file(HEIC_HEADER)) == 'image/heic'
+
+    def test_detects_heif(self):
+        assert detect_mime_type(make_file(HEIF_HEADER)) == 'image/heif'
+
     def test_returns_none_for_unknown(self):
         assert detect_mime_type(make_file(UNKNOWN_HEADER)) is None
 
@@ -67,6 +75,11 @@ class TestValidateUpload:
         f = make_file(JPEG_HEADER, 'photo.jpg', 'image/jpeg')
         mime = validate_upload(f, ALLOWED_IMAGE_TYPES, AVATAR_MAX_SIZE)
         assert mime == 'image/jpeg'
+
+    def test_accepts_valid_heic_document(self):
+        f = make_file(HEIC_HEADER, 'photo.heic', 'image/heic')
+        mime = validate_upload(f, ALLOWED_DOCUMENT_TYPES, DOCUMENT_MAX_SIZE)
+        assert mime == 'image/heic'
 
     def test_rejects_unknown_file_type(self):
         f = make_file(UNKNOWN_HEADER, 'evil.exe', 'application/octet-stream')

--- a/apps/documents/extraction.py
+++ b/apps/documents/extraction.py
@@ -1,0 +1,163 @@
+"""
+Text extraction for uploaded documents.
+
+Two pipelines:
+- images → Claude Haiku 4.5 Vision (OCR)
+- PDFs   → pypdf (text-based PDFs only — scanned PDFs are V2)
+
+Everything is fail-soft. Returning ``("", "skipped")`` is a perfectly acceptable
+outcome — the upload must never fail because text extraction did.
+"""
+from __future__ import annotations
+
+import base64
+import logging
+from typing import TYPE_CHECKING, Tuple
+
+from django.conf import settings
+from django.core.files.storage import default_storage
+
+if TYPE_CHECKING:
+    from documents.models import Document
+
+logger = logging.getLogger(__name__)
+
+VISION_MODEL = "claude-haiku-4-5"
+VISION_MAX_TOKENS = 4096
+VISION_PROMPT = (
+    "Extract all visible text from this image, preserving the original line "
+    "breaks and reading order. Return only the raw text — no commentary, no "
+    "labels, no markdown."
+)
+VISION_MEDIA_TYPES = {
+    "image/jpeg": "image/jpeg",
+    "image/png": "image/png",
+    "image/webp": "image/webp",
+    "image/gif": "image/gif",
+}
+
+ExtractionResult = Tuple[str, str]
+
+
+def _get_anthropic_client():
+    """Return an Anthropic client or ``None`` when no key is configured.
+
+    Indirected so tests can patch ``apps.documents.extraction._get_anthropic_client``
+    without touching the SDK or the network.
+    """
+    api_key = getattr(settings, "ANTHROPIC_API_KEY", "") or ""
+    if not api_key:
+        return None
+    try:
+        import anthropic
+    except ImportError:
+        logger.warning("extraction: anthropic SDK not installed")
+        return None
+    return anthropic.Anthropic(api_key=api_key)
+
+
+def _extract_with_vision(file_bytes: bytes, media_type: str) -> str:
+    client = _get_anthropic_client()
+    if client is None:
+        return ""
+
+    encoded = base64.standard_b64encode(file_bytes).decode("ascii")
+    message = client.messages.create(
+        model=VISION_MODEL,
+        max_tokens=VISION_MAX_TOKENS,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": encoded,
+                        },
+                    },
+                    {"type": "text", "text": VISION_PROMPT},
+                ],
+            }
+        ],
+    )
+
+    parts: list[str] = []
+    for block in getattr(message, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text:
+            parts.append(text)
+        elif isinstance(block, dict) and block.get("type") == "text":
+            parts.append(block.get("text", ""))
+    return "\n".join(p for p in parts if p).strip()
+
+
+def _extract_with_pypdf(file_bytes: bytes) -> str:
+    try:
+        from pypdf import PdfReader
+    except ImportError:
+        logger.warning("extraction: pypdf not installed")
+        return ""
+
+    from io import BytesIO
+
+    reader = PdfReader(BytesIO(file_bytes))
+    pages: list[str] = []
+    for page in reader.pages:
+        try:
+            pages.append(page.extract_text() or "")
+        except Exception as exc:
+            logger.info("extraction: pypdf page failed: %s", exc)
+    return "\n\n".join(p.strip() for p in pages if p and p.strip()).strip()
+
+
+def extract_text(document: "Document") -> ExtractionResult:
+    """Extract text content from a stored document.
+
+    Returns ``(text, method)`` where ``method`` is one of:
+    - ``"vision_haiku"`` : image processed by Claude Haiku Vision
+    - ``"pypdf"``        : PDF text extracted by pypdf
+    - ``"skipped"``      : nothing extracted (unsupported, error, or empty)
+    """
+    if not document.file_path:
+        return "", "skipped"
+    try:
+        if not default_storage.exists(document.file_path):
+            return "", "skipped"
+    except OSError as exc:
+        logger.info("extraction: storage check failed for %s: %s", document.file_path, exc)
+        return "", "skipped"
+
+    mime = (document.mime_type or "").lower()
+    try:
+        with default_storage.open(document.file_path, "rb") as fh:
+            file_bytes = fh.read()
+    except OSError as exc:
+        logger.info("extraction: cannot read %s: %s", document.file_path, exc)
+        return "", "skipped"
+
+    if mime in VISION_MEDIA_TYPES:
+        try:
+            text = _extract_with_vision(file_bytes, VISION_MEDIA_TYPES[mime])
+        except Exception as exc:
+            logger.warning("extraction: vision failed for %s: %s", document.file_path, exc)
+            return "", "skipped"
+        if not text:
+            return "", "skipped"
+        return text, "vision_haiku"
+
+    if mime == "application/pdf":
+        try:
+            text = _extract_with_pypdf(file_bytes)
+        except Exception as exc:
+            logger.warning("extraction: pypdf failed for %s: %s", document.file_path, exc)
+            return "", "skipped"
+        if not text:
+            return "", "skipped"
+        return text, "pypdf"
+
+    return "", "skipped"
+
+
+__all__ = ["extract_text", "VISION_MODEL"]

--- a/apps/documents/image_processing.py
+++ b/apps/documents/image_processing.py
@@ -1,0 +1,107 @@
+"""
+Upload-time image normalization for documents.
+
+Two responsibilities:
+- HEIC / HEIF → JPEG (transcoded so downstream tooling, browsers and Vision
+  models can read it without depending on pillow-heif everywhere)
+- resize images whose longest edge exceeds ``MAX_DIMENSION`` to keep storage
+  and Vision token cost bounded
+
+Standard formats below the size threshold are returned unchanged: re-encoding
+a JPEG just to "normalize" would grow it and lose quality.
+
+The function is fail-soft: any unexpected error returns the original file. An
+upload must never be lost because of normalization.
+"""
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import PurePosixPath
+
+from django.core.files.base import ContentFile
+from django.core.files.uploadedfile import UploadedFile
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+logger = logging.getLogger(__name__)
+
+MAX_DIMENSION = 2000
+JPEG_QUALITY = 85
+HEIF_MIME_TYPES = {"image/heic", "image/heif"}
+TRANSCODABLE_MIME_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+} | HEIF_MIME_TYPES
+
+
+def _replace_extension(filename: str, new_ext: str) -> str:
+    """Swap the extension of ``filename`` for ``new_ext`` (without leading dot)."""
+    name = PurePosixPath(filename or "image").name
+    stem = PurePosixPath(name).stem or "image"
+    return f"{stem}.{new_ext}"
+
+
+def normalize_image(uploaded_file, mime_type: str) -> tuple[object, str, dict]:
+    """Return a possibly-rewritten file together with its final mime type.
+
+    The returned file is either ``uploaded_file`` itself (passthrough) or a
+    fresh ``ContentFile`` with a sensible ``name``. The third element is a
+    diagnostic dict describing what happened — useful for tests and metadata.
+    """
+    info: dict = {
+        "original_mime_type": mime_type,
+        "transcoded": False,
+        "resized": False,
+    }
+
+    if mime_type not in TRANSCODABLE_MIME_TYPES:
+        return uploaded_file, mime_type, info
+
+    try:
+        uploaded_file.seek(0)
+        with Image.open(uploaded_file) as raw:
+            raw.load()
+            image = ImageOps.exif_transpose(raw) or raw
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        logger.info("normalize_image: cannot decode (%s): %s", mime_type, exc)
+        try:
+            uploaded_file.seek(0)
+        except (OSError, ValueError):
+            pass
+        return uploaded_file, mime_type, info
+
+    is_heif = mime_type in HEIF_MIME_TYPES
+    longest = max(image.size)
+    needs_resize = longest > MAX_DIMENSION
+
+    if not is_heif and not needs_resize:
+        try:
+            uploaded_file.seek(0)
+        except (OSError, ValueError):
+            pass
+        return uploaded_file, mime_type, info
+
+    if needs_resize:
+        image.thumbnail((MAX_DIMENSION, MAX_DIMENSION), Image.Resampling.LANCZOS)
+        info["resized"] = True
+
+    if image.mode not in ("RGB", "L"):
+        image = image.convert("RGB")
+
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG", quality=JPEG_QUALITY, optimize=True, progressive=True)
+    buffer.seek(0)
+
+    original_name = getattr(uploaded_file, "name", "image")
+    new_name = _replace_extension(original_name, "jpg")
+    new_file = ContentFile(buffer.getvalue(), name=new_name)
+
+    info["transcoded"] = True
+    info["final_mime_type"] = "image/jpeg"
+    info["final_dimensions"] = list(image.size)
+    return new_file, "image/jpeg", info
+
+
+__all__ = ["normalize_image", "MAX_DIMENSION", "JPEG_QUALITY"]

--- a/apps/documents/tests/test_api_documents.py
+++ b/apps/documents/tests/test_api_documents.py
@@ -1,7 +1,10 @@
+import io
+
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import Client, override_settings
 from django.urls import reverse
+from PIL import Image
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -12,6 +15,13 @@ from interactions.models import Interaction
 from projects.models import Project, ProjectDocument
 from zones.models import Zone
 from zones.models import ZoneDocument
+
+
+def _jpeg_bytes(width: int = 100, height: int = 100, color: str = "red") -> bytes:
+    image = Image.new("RGB", (width, height), color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG", quality=85)
+    return buffer.getvalue()
 
 
 def _client_for(user) -> APIClient:
@@ -132,7 +142,7 @@ class TestDocumentsApi:
         assert response.data["document"]["count"] == 1
         assert response.data["photo"]["count"] == 1
 
-    def test_reprocess_ocr_returns_accepted(self, owner_client, owner, household):
+    def test_reprocess_ocr_runs_extraction_and_returns_document(self, monkeypatch, owner_client, owner, household):
         document = Document.objects.create(
             household=household,
             created_by=owner,
@@ -142,10 +152,87 @@ class TestDocumentsApi:
             type="document",
         )
 
+        monkeypatch.setattr(
+            "documents.views.extract_text",
+            lambda doc: ("Extracted via reprocess", "pypdf"),
+        )
+
         url = reverse("document-reprocess-ocr", kwargs={"pk": document.id})
         response = owner_client.post(url, {}, format="json")
 
-        assert response.status_code == status.HTTP_202_ACCEPTED
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["ocr_text"] == "Extracted via reprocess"
+        document.refresh_from_db()
+        assert document.ocr_text == "Extracted via reprocess"
+        assert document.metadata["ocr_method"] == "pypdf"
+        assert "ocr_extracted_at" in document.metadata
+
+    @override_settings(MEDIA_ROOT='/tmp/house-test-media-heic')
+    def test_upload_heic_image_is_normalized_to_jpeg(self, monkeypatch, owner_client, household):
+        """HEIC magic bytes are accepted; the file is transcoded to JPEG before save."""
+        monkeypatch.setattr(
+            "documents.views.normalize_image",
+            lambda f, mime: (
+                SimpleUploadedFile("photo.jpg", _jpeg_bytes(), content_type="image/jpeg"),
+                "image/jpeg",
+                {"transcoded": True, "resized": False, "original_mime_type": "image/heic", "final_dimensions": [100, 100]},
+            ),
+        )
+        monkeypatch.setattr("documents.views.extract_text", lambda doc: ("Text from HEIC", "vision_haiku"))
+
+        heic_payload = b"\x00\x00\x00\x18ftypheic" + b"\x00" * 60
+        upload = SimpleUploadedFile("photo.heic", heic_payload, content_type="image/heic")
+
+        response = owner_client.post(
+            reverse("document-upload"),
+            {"file": upload, "name": "HEIC photo", "type": "document"},
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        document = Document.objects.get(pk=response.data["document"]["id"])
+        assert document.mime_type == "image/jpeg"
+        assert document.file_path.endswith(".jpg")
+        assert document.ocr_text == "Text from HEIC"
+        assert document.metadata["ocr_method"] == "vision_haiku"
+        assert document.metadata["original_mime_type"] == "image/heic"
+        assert document.metadata["normalized"] is True
+
+    @override_settings(MEDIA_ROOT='/tmp/house-test-media-ocr')
+    def test_upload_image_runs_text_extraction(self, monkeypatch, owner_client, household):
+        monkeypatch.setattr("documents.views.extract_text", lambda doc: ("Receipt total 12.50", "vision_haiku"))
+
+        upload = SimpleUploadedFile("receipt.jpg", _jpeg_bytes(), content_type="image/jpeg")
+        response = owner_client.post(
+            reverse("document-upload"),
+            {"file": upload, "name": "Receipt", "type": "receipt"},
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        document = Document.objects.get(pk=response.data["document"]["id"])
+        assert document.ocr_text == "Receipt total 12.50"
+        assert document.metadata["ocr_method"] == "vision_haiku"
+        assert "ocr_extracted_at" in document.metadata
+
+    @override_settings(MEDIA_ROOT='/tmp/house-test-media-failsoft')
+    def test_upload_succeeds_when_extraction_throws(self, monkeypatch, owner_client, household):
+        def boom(_doc):
+            raise RuntimeError("vision exploded")
+
+        monkeypatch.setattr("documents.views.extract_text", boom)
+
+        upload = SimpleUploadedFile("receipt.jpg", _jpeg_bytes(), content_type="image/jpeg")
+        response = owner_client.post(
+            reverse("document-upload"),
+            {"file": upload, "name": "Receipt", "type": "receipt"},
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        document = Document.objects.get(pk=response.data["document"]["id"])
+        assert document.ocr_text == ""
+        assert document.metadata["ocr_method"] == "skipped"
 
     def test_upload_requires_household_context(self, owner_client):
         url = reverse('document-upload')

--- a/apps/documents/tests/test_api_documents.py
+++ b/apps/documents/tests/test_api_documents.py
@@ -234,6 +234,48 @@ class TestDocumentsApi:
         assert document.ocr_text == ""
         assert document.metadata["ocr_method"] == "skipped"
 
+    @override_settings(MEDIA_ROOT='/tmp/house-test-media-photo-skip')
+    def test_upload_photo_type_skips_extraction(self, monkeypatch, owner_client, household):
+        """type='photo' goes to the photo grid; running Vision OCR on it is wasted."""
+        from rest_framework import serializers as drf_serializers
+
+        class _PermissiveUploadSerializer(drf_serializers.Serializer):
+            file = drf_serializers.FileField()
+            name = drf_serializers.CharField(required=False, allow_blank=True, max_length=255)
+            type = drf_serializers.ChoiceField(
+                choices=[(v, l) for v, l in Document.DOCUMENT_TYPES],
+                required=False,
+                allow_null=True,
+            )
+            notes = drf_serializers.CharField(required=False, allow_blank=True)
+            is_private = drf_serializers.BooleanField(required=False, default=False)
+
+        monkeypatch.setattr("documents.views.DocumentUploadSerializer", _PermissiveUploadSerializer)
+        monkeypatch.setattr("documents.views.generate_thumbnails", lambda doc: None)
+
+        extract_calls = []
+
+        def fake_extract(doc):
+            extract_calls.append(doc.pk)
+            return ("should not run", "vision_haiku")
+
+        monkeypatch.setattr("documents.views.extract_text", fake_extract)
+
+        upload = SimpleUploadedFile("vacation.jpg", _jpeg_bytes(), content_type="image/jpeg")
+        response = owner_client.post(
+            reverse("document-upload"),
+            {"file": upload, "name": "Vacation", "type": "photo"},
+            format="multipart",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        document = Document.objects.get(pk=response.data["document"]["id"])
+        assert document.type == "photo"
+        assert document.ocr_text == ""
+        assert "ocr_method" not in (document.metadata or {})
+        assert "ocr_extracted_at" not in (document.metadata or {})
+        assert extract_calls == [], f"extract_text should not run for photos (got {extract_calls})"
+
     def test_upload_requires_household_context(self, owner_client):
         url = reverse('document-upload')
         upload = SimpleUploadedFile('invoice.pdf', b'%PDF-1.4 test', content_type='application/pdf')

--- a/apps/documents/tests/test_extraction.py
+++ b/apps/documents/tests/test_extraction.py
@@ -1,0 +1,160 @@
+"""Tests for document text extraction (Vision + pypdf), with the SDK mocked."""
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from django.core.files.storage import default_storage
+from PIL import Image
+from pypdf import PdfWriter
+
+from documents import extraction
+from documents.models import Document
+
+
+def _save(path: str, content: bytes) -> str:
+    if default_storage.exists(path):
+        default_storage.delete(path)
+    return default_storage.save(path, io.BytesIO(content))
+
+
+def _make_jpeg_bytes() -> bytes:
+    image = Image.new("RGB", (10, 10), "red")
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def _make_pdf_bytes() -> bytes:
+    writer = PdfWriter()
+    writer.add_blank_page(width=72, height=72)
+    buffer = io.BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_media(tmp_path, settings):
+    settings.MEDIA_ROOT = str(tmp_path)
+    yield
+
+
+@pytest.mark.django_db
+class TestExtractText:
+    def _make_document(self, household, owner, *, file_path: str, mime: str) -> Document:
+        return Document.objects.create(
+            household=household,
+            created_by=owner,
+            file_path=file_path,
+            name="doc",
+            mime_type=mime,
+            type="document",
+        )
+
+    def test_returns_skipped_when_file_missing(self, household, owner):
+        document = self._make_document(household, owner, file_path="missing.pdf", mime="application/pdf")
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "skipped"
+
+    def test_image_uses_vision_haiku(self, monkeypatch, household, owner):
+        path = _save("docs/test.jpg", _make_jpeg_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
+
+        fake_block = SimpleNamespace(text="Hello from receipt")
+        fake_message = SimpleNamespace(content=[fake_block])
+        fake_client = MagicMock()
+        fake_client.messages.create.return_value = fake_message
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: fake_client)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == "Hello from receipt"
+        assert method == "vision_haiku"
+        fake_client.messages.create.assert_called_once()
+
+    def test_image_returns_skipped_when_client_unavailable(self, monkeypatch, household, owner):
+        path = _save("docs/test.jpg", _make_jpeg_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
+
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: None)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "skipped"
+
+    def test_image_failure_in_sdk_returns_skipped(self, monkeypatch, household, owner):
+        path = _save("docs/test.jpg", _make_jpeg_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
+
+        fake_client = MagicMock()
+        fake_client.messages.create.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: fake_client)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "skipped"
+
+    def test_pdf_returns_skipped_for_blank_pages(self, monkeypatch, household, owner):
+        path = _save("docs/blank.pdf", _make_pdf_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+        # No anthropic call for PDFs — guard anyway.
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: None)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "skipped"
+
+    def test_pdf_extraction_uses_pypdf(self, monkeypatch, household, owner):
+        path = _save("docs/text.pdf", _make_pdf_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+
+        fake_page = MagicMock()
+        fake_page.extract_text.return_value = "Some PDF body"
+        fake_reader = MagicMock()
+        fake_reader.pages = [fake_page]
+
+        class _Reader:
+            def __init__(self, _):
+                self.pages = fake_reader.pages
+
+        monkeypatch.setattr("pypdf.PdfReader", _Reader)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == "Some PDF body"
+        assert method == "pypdf"
+
+    def test_unsupported_mime_returns_skipped(self, household, owner):
+        path = _save("docs/file.txt", b"plain text")
+        document = self._make_document(household, owner, file_path=path, mime="text/plain")
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "skipped"
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="extraction-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    instance = Household.objects.create(name="Extraction House")
+    HouseholdMember.objects.create(user=owner, household=instance, role=HouseholdMember.Role.OWNER)
+    owner.active_household = instance
+    owner.save(update_fields=["active_household"])
+    return instance

--- a/apps/documents/tests/test_image_processing.py
+++ b/apps/documents/tests/test_image_processing.py
@@ -1,0 +1,115 @@
+"""Tests for upload-time image normalization."""
+import io
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+
+from documents.image_processing import (
+    JPEG_QUALITY,
+    MAX_DIMENSION,
+    normalize_image,
+)
+
+
+def _jpeg_bytes(width: int, height: int, color: str = "red") -> bytes:
+    image = Image.new("RGB", (width, height), color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="JPEG", quality=JPEG_QUALITY)
+    return buffer.getvalue()
+
+
+def _png_bytes(width: int, height: int, color: str = "blue") -> bytes:
+    image = Image.new("RGB", (width, height), color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _file(name: str, content: bytes, content_type: str) -> SimpleUploadedFile:
+    return SimpleUploadedFile(name, content, content_type=content_type)
+
+
+class TestNormalizeImage:
+    def test_small_jpeg_is_passed_through(self):
+        original = _jpeg_bytes(400, 300)
+        upload = _file("photo.jpg", original, "image/jpeg")
+
+        out, mime, info = normalize_image(upload, "image/jpeg")
+
+        assert out is upload
+        assert mime == "image/jpeg"
+        assert info["transcoded"] is False
+        assert info["resized"] is False
+
+    def test_large_jpeg_is_resized_and_re_encoded(self):
+        original = _jpeg_bytes(MAX_DIMENSION + 800, MAX_DIMENSION + 800)
+        upload = _file("big.jpg", original, "image/jpeg")
+
+        out, mime, info = normalize_image(upload, "image/jpeg")
+
+        assert out is not upload
+        assert mime == "image/jpeg"
+        assert info["resized"] is True
+        assert info["transcoded"] is True
+        out.seek(0)
+        with Image.open(io.BytesIO(out.read())) as result:
+            assert max(result.size) == MAX_DIMENSION
+        assert out.name.endswith(".jpg")
+
+    def test_pdf_is_passed_through(self):
+        original = b"%PDF-1.4 fake"
+        upload = _file("file.pdf", original, "application/pdf")
+
+        out, mime, info = normalize_image(upload, "application/pdf")
+
+        assert out is upload
+        assert mime == "application/pdf"
+        assert info["transcoded"] is False
+
+    def test_heic_branch_transcodes_to_jpeg(self, monkeypatch):
+        """HEIC content is transcoded — exercised via a stubbed ``Image.open``."""
+        sentinel_image = Image.new("RGB", (300, 200), "green")
+
+        class _StubOpenContext:
+            def __enter__(self_inner):
+                return sentinel_image
+
+            def __exit__(self_inner, *a):
+                return False
+
+        def fake_open(_file):
+            return _StubOpenContext()
+
+        monkeypatch.setattr("documents.image_processing.Image.open", fake_open)
+        monkeypatch.setattr(
+            "documents.image_processing.ImageOps.exif_transpose",
+            lambda image: image,
+        )
+
+        upload = _file("photo.heic", b"\x00" * 32, "image/heic")
+        out, mime, info = normalize_image(upload, "image/heic")
+
+        assert mime == "image/jpeg"
+        assert info["transcoded"] is True
+        assert out.name.endswith(".jpg")
+        out.seek(0)
+        payload = out.read()
+        assert payload.startswith(b"\xff\xd8\xff")  # JPEG SOI
+
+    def test_corrupt_image_falls_back_to_passthrough(self):
+        upload = _file("broken.jpg", b"not really a jpeg", "image/jpeg")
+
+        out, mime, info = normalize_image(upload, "image/jpeg")
+
+        assert out is upload
+        assert mime == "image/jpeg"
+        assert info["transcoded"] is False
+
+    def test_png_under_threshold_is_passed_through(self):
+        upload = _file("logo.png", _png_bytes(800, 600), "image/png")
+
+        out, mime, info = normalize_image(upload, "image/png")
+
+        assert out is upload
+        assert mime == "image/png"

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -258,8 +258,8 @@ class DocumentViewSet(viewsets.ModelViewSet):
 
         if document.type == 'photo':
             generate_thumbnails(document)
-
-        _run_extraction(document)
+        else:
+            _run_extraction(document)
 
         recent_candidates = get_recent_interaction_candidates(request, household)
         response_payload = {

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -1,9 +1,11 @@
 """Document views for REST API."""
+import logging
 from pathlib import Path
 
 from django.core.files.storage import default_storage
 from django.db import models as db_models, transaction
 from django.db.models import Prefetch
+from django.utils import timezone
 from rest_framework import status
 from rest_framework import viewsets, filters
 from rest_framework.decorators import action
@@ -14,6 +16,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsHouseholdMember
 from core.file_validation import validate_upload, ALLOWED_DOCUMENT_TYPES, DOCUMENT_MAX_SIZE
+from .extraction import extract_text
+from .image_processing import normalize_image
 from .models import Document
 from .serializers import (
     DocumentSerializer,
@@ -25,6 +29,24 @@ from interactions.models import Interaction
 from interactions.models import InteractionDocument
 from projects.models import ProjectDocument
 from zones.models import ZoneDocument
+
+logger = logging.getLogger(__name__)
+
+
+def _run_extraction(document: Document) -> None:
+    """Extract text and persist it on the document, fail-soft."""
+    try:
+        text, method = extract_text(document)
+    except Exception as exc:
+        logger.warning("extract_text raised for document %s: %s", document.pk, exc)
+        text, method = "", "skipped"
+
+    document.ocr_text = text or ""
+    metadata = dict(document.metadata or {})
+    metadata["ocr_extracted_at"] = timezone.now().isoformat()
+    metadata["ocr_method"] = method
+    document.metadata = metadata
+    document.save(update_fields=["ocr_text", "metadata", "updated_at"])
 
 
 def get_documents_queryset_for_request(request):
@@ -188,26 +210,46 @@ class DocumentViewSet(viewsets.ModelViewSet):
             max_size=DOCUMENT_MAX_SIZE,
             field_name='file',
         )
+
+        original_name = Path(uploaded_file.name).name or 'Document'
+        try:
+            normalized_file, final_mime, normalize_info = normalize_image(uploaded_file, detected_mime)
+        except Exception as exc:
+            logger.warning("normalize_image failed for %s: %s", original_name, exc)
+            normalized_file, final_mime, normalize_info = uploaded_file, detected_mime, {}
+
+        storage_filename = getattr(normalized_file, 'name', uploaded_file.name) or uploaded_file.name
         storage_path = Document.build_upload_path(
             household_id=household.id,
-            filename=uploaded_file.name,
+            filename=storage_filename,
         )
-        saved_path = default_storage.save(storage_path, uploaded_file)
+        saved_path = default_storage.save(storage_path, normalized_file)
+        stored_size = default_storage.size(saved_path) if default_storage.exists(saved_path) else uploaded_file.size
 
         try:
             with transaction.atomic():
+                metadata = {
+                    'size': stored_size,
+                    'original_filename': original_name,
+                }
+                if normalize_info.get('transcoded'):
+                    metadata['original_mime_type'] = normalize_info.get('original_mime_type')
+                    metadata['normalized'] = True
+                if normalize_info.get('resized'):
+                    metadata['resized'] = True
+                if normalize_info.get('final_dimensions'):
+                    metadata['dimensions'] = normalize_info['final_dimensions']
+
                 document = Document.objects.create(
                     household=household,
                     created_by=request.user,
                     file_path=saved_path,
-                    name=(serializer.validated_data.get('name') or Path(uploaded_file.name).name or 'Document')[:255],
-                    mime_type=detected_mime,
+                    name=(serializer.validated_data.get('name') or original_name)[:255],
+                    mime_type=final_mime,
                     type=serializer.validated_data.get('type') or 'document',
                     is_private=serializer.validated_data.get('is_private', False),
                     notes=serializer.validated_data.get('notes', ''),
-                    metadata={
-                        'size': uploaded_file.size,
-                    },
+                    metadata=metadata,
                 )
         except Exception:
             if default_storage.exists(saved_path):
@@ -216,6 +258,8 @@ class DocumentViewSet(viewsets.ModelViewSet):
 
         if document.type == 'photo':
             generate_thumbnails(document)
+
+        _run_extraction(document)
 
         recent_candidates = get_recent_interaction_candidates(request, household)
         response_payload = {
@@ -249,10 +293,19 @@ class DocumentViewSet(viewsets.ModelViewSet):
     
     @action(detail=True, methods=['post'])
     def reprocess_ocr(self, request, pk=None):
-        """Trigger OCR reprocessing (placeholder)."""
+        """Re-run text extraction on this document and persist the result."""
         document = self.get_object()
-        # TODO: Queue OCR task
-        return Response({
-            'message': 'OCR reprocessing queued',
-            'document_id': document.id
-        }, status=status.HTTP_202_ACCEPTED)
+        _run_extraction(document)
+        document.refresh_from_db()
+        serializer = DocumentDetailSerializer(
+            document,
+            context={
+                'request': request,
+                'recent_interaction_candidates': get_recent_interaction_candidates(
+                    request,
+                    document.household,
+                    document_id=document.id,
+                ),
+            },
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import sys
 
 import environ
+from pillow_heif import register_heif_opener
+
+register_heif_opener()
 
 # Build paths
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -183,3 +186,8 @@ CORS_ALLOW_CREDENTIALS = True
 # Overridden per environment in local.py / production.py.
 FRONTEND_URL = "http://localhost:5174"
 DEFAULT_FROM_EMAIL = "noreply@house.local"
+
+# Anthropic API key for the AI layer (Claude Vision OCR, agent, ...).
+# Empty string by default — extraction degrades to a no-op when unset.
+# Overridden per environment in local.py / production.py.
+ANTHROPIC_API_KEY = ""

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -57,6 +57,9 @@ EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@house.local")
 FRONTEND_URL = env("FRONTEND_URL", default="http://localhost:5174")
 
+# Anthropic API key — leave blank locally to disable LLM calls.
+ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
+
 # Django Vite Configuration (HMR for local development)
 DJANGO_VITE = {
     "default": {

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -72,6 +72,9 @@ _primary_host = ALLOWED_HOSTS[0] if ALLOWED_HOSTS else "localhost"
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default=f"noreply@{_primary_host}")
 FRONTEND_URL = env("FRONTEND_URL", default=f"https://{_primary_host}")
 
+# Anthropic API key — must be set in .env for LLM features (OCR, agent).
+ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY", default="")
+
 # Django Vite Configuration (compiled assets in production)
 DJANGO_VITE = {
     "default": {

--- a/docs/parcours/PARCOURS_07_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_07_BACKLOG_TECHNIQUE.md
@@ -59,8 +59,8 @@ Voir l'issue #88 pour le détail. Synthèse :
 4. exposer `ANTHROPIC_API_KEY` dans les settings
 5. `normalize_image()` — HEIC → JPEG, resize si > 2000px, q85
 6. `extract_text(document)` — Vision Haiku pour images, `pypdf` pour PDFs texte, `""` sur erreur
-7. wire des deux dans l'action `upload` du `DocumentViewSet`
-8. remplacer le placeholder `reprocess_ocr` par une vraie implémentation
+7. wire des deux dans l'action `upload` du `DocumentViewSet` — **skipper l'OCR si `type='photo'`** (la photo grid est dédiée aux souvenirs visuels, l'OCR n'apporte rien et pollue `search_fields=['ocr_text']`)
+8. remplacer le placeholder `reprocess_ocr` par une vraie implémentation (l'utilisateur peut forcer l'OCR sur une photo via cette action)
 9. afficher `ocr_text` dans `DocumentDetailPage.tsx` (section pliable)
 10. loading state pendant l'upload + clés i18n dans les 4 locales
 11. tests : upload HEIC, resize, mock anthropic, extraction qui throw, PDF texte
@@ -71,6 +71,7 @@ Voir l'issue #88 pour le détail. Synthèse :
 - détail document affiche le texte extrait
 - upload qui échoue à l'extraction reste réussi (`ocr_text=""`)
 - aucune régression sur JPEG/PNG/PDF existants
+- upload avec `type='photo'` → thumbnails générés mais `ocr_text=""` et pas de `ocr_method` dans `metadata`
 
 ### Hors scope (déjà documenté dans #88)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,3 +1,4 @@
+anthropic==0.43.0
 asgiref==3.11.1
 Django==5.2.11
 django-cors-headers==4.9.0
@@ -13,9 +14,11 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 packaging==26.0
 pillow==12.1.1
+pillow-heif==0.18.0
 psycopg==3.3.2
 psycopg-binary==3.3.2
 PyJWT==2.11.0
+pypdf==5.1.0
 PyYAML==6.0.3
 referencing==0.37.0
 rpds-py==0.30.0

--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -57,7 +57,7 @@ export default function DocumentDetailPage() {
 
   if (error || !doc) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+      <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
         {t('documents.detail.not_found')}
       </div>
     );
@@ -66,6 +66,12 @@ export default function DocumentDetailPage() {
   const fileName = doc.name || doc.file_path.split('/').pop() || '';
   const fileSize =
     typeof doc.metadata?.size === 'number' ? formatFileSize(doc.metadata.size) : null;
+  const ocrText = (doc.ocr_text || '').trim();
+  const ocrMethod =
+    typeof doc.metadata?.ocr_method === 'string' ? (doc.metadata.ocr_method as string) : null;
+  const isImage = (doc.mime_type || '').startsWith('image/');
+  const isPdf = doc.mime_type === 'application/pdf';
+  const showOcrSection = isImage || isPdf || Boolean(ocrText);
 
   return (
     <>
@@ -142,6 +148,33 @@ export default function DocumentDetailPage() {
             ) : null}
           </CardContent>
         </Card>
+
+        {/* OCR text */}
+        {showOcrSection && (
+          <Card>
+            <CardContent className="pt-4">
+              <details className="group" {...(ocrText ? { open: true } : {})}>
+                <summary className="flex cursor-pointer items-center justify-between gap-2 text-sm font-medium text-foreground">
+                  <span>{t('documents.ocr.title')}</span>
+                  {ocrMethod && ocrMethod !== 'skipped' && (
+                    <Badge variant="outline" className="h-5 text-[10px]">
+                      {ocrMethod}
+                    </Badge>
+                  )}
+                </summary>
+                <div className="mt-3 text-sm">
+                  {ocrText ? (
+                    <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-sans text-xs text-foreground">
+                      {ocrText}
+                    </pre>
+                  ) : (
+                    <p className="italic text-muted-foreground">{t('documents.ocr.empty')}</p>
+                  )}
+                </div>
+              </details>
+            </CardContent>
+          </Card>
+        )}
 
         {/* Linked interactions */}
         <div className="space-y-2">

--- a/ui/src/features/documents/DocumentUploadDialog.tsx
+++ b/ui/src/features/documents/DocumentUploadDialog.tsx
@@ -83,7 +83,7 @@ export default function DocumentUploadDialog({
     { value: '', label: t('documents.filter.allTypes') },
     ...DOCUMENT_TYPES.map((v) => ({
       value: v,
-      label: t(`documents.type.${v}`, { defaultValue: v }),
+      label: t(`documents.type.${v}`),
     })),
   ];
 
@@ -101,24 +101,30 @@ export default function DocumentUploadDialog({
 
         <form onSubmit={handleSubmit} className="mt-2 space-y-4">
           {error && (
-            <div className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</div>
+            <div className="rounded-lg bg-destructive/10 p-3 text-sm text-destructive">{error}</div>
           )}
 
           {/* File input */}
           <div className="space-y-1.5">
             <Label htmlFor="upload-file">
               {t('documents.new.selectFile')}
-              <span className="ml-1 text-red-500">*</span>
+              <span className="ml-1 text-destructive">*</span>
             </Label>
             <Input
               id="upload-file"
               type="file"
+              accept="image/jpeg,image/png,image/gif,image/webp,image/heic,image/heif,application/pdf"
               onChange={handleFileChange}
               required
             />
             {selectedFile && (
               <p className="text-xs text-muted-foreground">
                 {t('documents.new.selectedFile')}: {selectedFile.name}
+              </p>
+            )}
+            {createDocument.isPending && (
+              <p className="text-xs text-muted-foreground" role="status">
+                {t('documents.ocr.processing')}
               </p>
             )}
           </div>

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -746,6 +746,11 @@
       "withoutActivity": "Ohne Kontext",
       "activityLinked": "Aktivität verknüpft"
     },
+    "ocr": {
+      "title": "Extrahierter Text",
+      "empty": "Noch kein Text extrahiert.",
+      "processing": "Analyse läuft…"
+    },
     "new": {
       "title": "Dokument hinzufügen",
       "subtitle": "Lade zuerst eine Datei hoch und qualifiziere sie dann auf der Detailseite.",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -746,6 +746,11 @@
       "withoutActivity": "Without context",
       "activityLinked": "Activity linked"
     },
+    "ocr": {
+      "title": "Extracted text",
+      "empty": "No text extracted yet.",
+      "processing": "Analysis in progress…"
+    },
     "new": {
       "title": "Add document",
       "subtitle": "Upload a file first, then qualify it from its detail page.",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -746,6 +746,11 @@
       "withoutActivity": "Sin contexto",
       "activityLinked": "Actividad vinculada"
     },
+    "ocr": {
+      "title": "Texto extraído",
+      "empty": "Aún no se ha extraído ningún texto.",
+      "processing": "Análisis en curso…"
+    },
     "new": {
       "title": "Añadir documento",
       "subtitle": "Sube primero un archivo y luego califícalo desde su página de detalle.",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -746,6 +746,11 @@
       "withoutActivity": "Sans contexte",
       "activityLinked": "Activité liée"
     },
+    "ocr": {
+      "title": "Texte extrait",
+      "empty": "Aucun texte extrait pour le moment.",
+      "processing": "Analyse en cours…"
+    },
     "new": {
       "title": "Ajouter un document",
       "subtitle": "Téléversez d'abord un fichier, puis qualifiez-le depuis sa page détail.",


### PR DESCRIPTION
## Summary

- Wire text extraction into the document upload flow so `Document.ocr_text` is populated automatically — pre-requisite for parcours 07 (agent conversationnel).
- Accept HEIC/HEIF uploads (iPhone photos) and transcode them to JPEG; resize images whose longest edge > 2000 px to bound storage and Vision token cost.
- Use Claude Haiku 4.5 Vision for images, `pypdf` for text-based PDFs, with a fail-soft contract (an upload never fails because OCR did).

## Implementation

**Backend**
- `apps/core/file_validation.py` — HEIC/HEIF magic bytes; `ALLOWED_DOCUMENT_TYPES` extended.
- `apps/documents/image_processing.py` (new) — `normalize_image()`: HEIC→JPEG, resize >2000 px, q85, passthrough for small standard images, fail-soft on decode errors.
- `apps/documents/extraction.py` (new) — `extract_text()` returns `(text, method)` where `method ∈ {"vision_haiku", "pypdf", "skipped"}`. Anthropic client indirected for testability.
- `apps/documents/views.py` — `upload` wires `normalize_image` then `extract_text`; persists `ocr_text` and `metadata.{ocr_extracted_at, ocr_method, original_mime_type, normalized, resized, dimensions}`. `reprocess_ocr` now actually re-runs extraction and returns the refreshed document.
- `config/settings/{base,local,production}.py` — `ANTHROPIC_API_KEY` plumbed through; `register_heif_opener()` registered globally.
- `requirements/base.txt` — `anthropic`, `pillow-heif`, `pypdf`.

**Frontend**
- `DocumentUploadDialog.tsx` — `accept` covers HEIC/HEIF + standard image/PDF; "Analysis in progress" status text during upload; fixed two pre-existing CLAUDE.md violations (hardcoded red colors, `defaultValue` on `t()`).
- `DocumentDetailPage.tsx` — collapsible "Extracted text" section with method badge and empty state; fixed pre-existing hardcoded red color violation.
- `documents.ocr.{title, empty, processing}` added to `en`, `fr`, `de`, `es`.

**Tests** — 623 backend tests pass.
- `test_file_validation`: HEIC and HEIF magic bytes detected and accepted.
- `test_image_processing` (new): passthrough/resize/transcode/corrupt fallback.
- `test_extraction` (new): Vision happy path, missing file, no client, SDK error, blank PDF, pypdf success, unsupported mime — all with the Anthropic SDK fully mocked.
- `test_api_documents`: HEIC upload → JPEG persisted, image upload runs OCR, extraction failure → upload still 201, `reprocess_ocr` updates document and returns 200.

## Out of scope (next lots)

- Backfill of existing documents — issue #89 (lot 0b).
- Async OCR (Celery), full-text search, scanned-PDF rendering.

## Test plan

- [x] `pytest -q --no-cov` (623 passed)
- [x] `npm run lint` (no new errors; 5 pre-existing warnings untouched)
- [x] `npm run build` (clean)
- [ ] Manual: upload HEIC iPhone photo of a paper invoice on the Mac Mini env once `ANTHROPIC_API_KEY` is set; verify `ocr_text` populated and detail page shows the section.
- [ ] Manual: upload large JPEG (>2000 px) and confirm it is downscaled.
- [ ] Manual: simulate Anthropic outage (invalid key) → upload still succeeds with empty OCR.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)