### PR TITLE
feat(documents): backfill OCR command + Re-extract button

### DIFF
--- a/apps/documents/management/commands/extract_documents_text.py
+++ b/apps/documents/management/commands/extract_documents_text.py
@@ -1,0 +1,135 @@
+"""Backfill text extraction (OCR / pypdf) on existing documents.
+
+Usage:
+
+    python manage.py extract_documents_text                       # all empty docs, all households
+    python manage.py extract_documents_text --household <uuid>    # scope to one household
+    python manage.py extract_documents_text --type invoice        # filter by Document.type
+    python manage.py extract_documents_text --limit 10            # cap batch size
+    python manage.py extract_documents_text --force               # re-extract docs that already have text
+    python manage.py extract_documents_text --dry-run             # list what would be processed, change nothing
+"""
+from __future__ import annotations
+
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+
+from documents.extraction import extract_text
+from documents.models import Document
+
+
+logger = logging.getLogger(__name__)
+
+
+VISION_COST_PER_IMAGE_USD = 0.003
+
+
+class Command(BaseCommand):
+    help = "Backfill ocr_text for documents that haven't been processed yet."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--household",
+            help="Only process documents of the given household id (UUID).",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-extract even when ocr_text is already populated.",
+        )
+        parser.add_argument(
+            "--type",
+            dest="doc_type",
+            help="Filter by Document.type (invoice, manual, photo, ...).",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            help="Maximum number of documents to process.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List candidates without writing to the database.",
+        )
+
+    def handle(self, *args, **options):
+        household_id = options.get("household")
+        force: bool = options["force"]
+        doc_type: str | None = options.get("doc_type")
+        limit: int | None = options.get("limit")
+        dry_run: bool = options["dry_run"]
+
+        if limit is not None and limit <= 0:
+            raise CommandError("--limit must be a positive integer.")
+
+        candidates = Document.objects.exclude(file_path="").order_by("created_at")
+        if household_id:
+            candidates = candidates.filter(household_id=household_id)
+        if doc_type:
+            candidates = candidates.filter(type=doc_type)
+
+        already_processed = candidates.exclude(ocr_text="").count() if not force else 0
+        if not force:
+            candidates = candidates.filter(ocr_text="")
+        if limit is not None:
+            candidates = candidates[:limit]
+
+        total = candidates.count()
+        self.stdout.write(f"Documents to process: {total} (skipped already-extracted: {already_processed})")
+        if total == 0:
+            return
+
+        extracted = 0
+        failed = 0
+        vision_calls = 0
+
+        for index, document in enumerate(candidates.iterator(), start=1):
+            prefix = f"[{index}/{total}]"
+
+            if dry_run:
+                self.stdout.write(
+                    f"  {prefix} would process {document.id} ({document.mime_type or 'unknown'})"
+                )
+                continue
+
+            try:
+                text, method = extract_text(document)
+            except Exception as exc:
+                logger.warning("extract_documents_text: %s raised: %s", document.pk, exc)
+                text, method = "", "skipped"
+
+            metadata = dict(document.metadata or {})
+            metadata["ocr_extracted_at"] = timezone.now().isoformat()
+            metadata["ocr_method"] = method
+            document.ocr_text = text or ""
+            document.metadata = metadata
+            document.save(update_fields=["ocr_text", "metadata", "updated_at"])
+
+            if method == "vision_haiku":
+                vision_calls += 1
+
+            if text:
+                extracted += 1
+                self.stdout.write(
+                    f"  {prefix} ✓ {document.id} via {method} ({len(text)} chars)"
+                )
+            else:
+                failed += 1
+                self.stderr.write(
+                    f"  {prefix} ✗ {document.id} no text ({document.mime_type or 'unknown'})"
+                )
+
+        cost_estimate = vision_calls * VISION_COST_PER_IMAGE_USD
+        if dry_run:
+            summary = f"Dry-run complete. would_process={total}"
+        else:
+            summary = (
+                f"Done. extracted={extracted} failed={failed} "
+                f"skipped={already_processed} vision_calls={vision_calls} "
+                f"estimated_cost_usd={cost_estimate:.3f}"
+            )
+
+        self.stdout.write(self.style.SUCCESS(summary))

--- a/apps/documents/tests/test_extract_documents_text_command.py
+++ b/apps/documents/tests/test_extract_documents_text_command.py
@@ -1,0 +1,224 @@
+"""Tests for the `extract_documents_text` management command."""
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+import pytest
+from django.core.management import CommandError, call_command
+
+from documents.models import Document
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="extract-cmd-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    instance = Household.objects.create(name="Backfill House")
+    HouseholdMember.objects.create(user=owner, household=instance, role=HouseholdMember.Role.OWNER)
+    owner.active_household = instance
+    owner.save(update_fields=["active_household"])
+    return instance
+
+
+@pytest.fixture
+def other_household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    instance = Household.objects.create(name="Other House")
+    HouseholdMember.objects.create(user=owner, household=instance, role=HouseholdMember.Role.OWNER)
+    return instance
+
+
+def _make_document(household, owner, **overrides) -> Document:
+    payload = {
+        "household": household,
+        "created_by": owner,
+        "file_path": f"docs/{overrides.get('name', 'doc')}.pdf",
+        "name": overrides.get("name", "doc"),
+        "mime_type": overrides.get("mime_type", "application/pdf"),
+        "type": overrides.get("type", "document"),
+        "ocr_text": overrides.get("ocr_text", ""),
+    }
+    return Document.objects.create(**payload)
+
+
+def _call(*args) -> tuple[str, str]:
+    out, err = io.StringIO(), io.StringIO()
+    call_command("extract_documents_text", *args, stdout=out, stderr=err)
+    return out.getvalue(), err.getvalue()
+
+
+def _scoped(household, *extra):
+    return ("--household", str(household.id), *extra)
+
+
+class TestExtractDocumentsTextCommand:
+    def test_skips_documents_with_existing_ocr_text_by_default(self, household, owner):
+        already = _make_document(household, owner, name="already", ocr_text="cached")
+        empty = _make_document(household, owner, name="empty")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("Hello world", "pypdf"),
+        ) as mock_extract:
+            out, _ = _call(*_scoped(household))
+
+        already.refresh_from_db()
+        empty.refresh_from_db()
+
+        assert already.ocr_text == "cached"
+        assert empty.ocr_text == "Hello world"
+        assert mock_extract.call_count == 1
+        assert "Documents to process: 1" in out
+        assert "skipped already-extracted: 1" in out
+        assert "extracted=1" in out
+
+    def test_force_reprocesses_documents_already_having_text(self, household, owner):
+        document = _make_document(household, owner, name="cached", ocr_text="old text")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("fresh text", "pypdf"),
+        ):
+            _call(*_scoped(household, "--force"))
+
+        document.refresh_from_db()
+        assert document.ocr_text == "fresh text"
+        assert document.metadata["ocr_method"] == "pypdf"
+        assert "ocr_extracted_at" in document.metadata
+
+    def test_household_filter_scopes_processing(self, household, other_household, owner):
+        in_scope = _make_document(household, owner, name="in")
+        out_of_scope = _make_document(other_household, owner, name="out")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "pypdf"),
+        ) as mock_extract:
+            _call("--household", str(household.id))
+
+        in_scope.refresh_from_db()
+        out_of_scope.refresh_from_db()
+
+        assert in_scope.ocr_text == "text"
+        assert out_of_scope.ocr_text == ""
+        assert mock_extract.call_count == 1
+
+    def test_type_filter_restricts_to_given_document_type(self, household, owner):
+        invoice = _make_document(household, owner, name="invoice", type="invoice")
+        manual = _make_document(household, owner, name="manual", type="manual")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "pypdf"),
+        ) as mock_extract:
+            _call(*_scoped(household, "--type", "invoice"))
+
+        invoice.refresh_from_db()
+        manual.refresh_from_db()
+
+        assert invoice.ocr_text == "text"
+        assert manual.ocr_text == ""
+        assert mock_extract.call_count == 1
+
+    def test_limit_caps_batch_size(self, household, owner):
+        for i in range(5):
+            _make_document(household, owner, name=f"doc{i}")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "pypdf"),
+        ) as mock_extract:
+            _call(*_scoped(household, "--limit", "2"))
+
+        assert mock_extract.call_count == 2
+        assert Document.objects.filter(household=household).exclude(ocr_text="").count() == 2
+
+    def test_dry_run_does_not_write_anything(self, household, owner):
+        document = _make_document(household, owner, name="doc")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+        ) as mock_extract:
+            out, _ = _call(*_scoped(household, "--dry-run"))
+
+        document.refresh_from_db()
+        assert document.ocr_text == ""
+        assert "ocr_method" not in (document.metadata or {})
+        mock_extract.assert_not_called()
+        assert "would process" in out
+        assert "Dry-run complete" in out
+
+    def test_extraction_exception_is_recorded_as_failure(self, household, owner):
+        good = _make_document(household, owner, name="good")
+        boom = _make_document(household, owner, name="boom")
+
+        def fake_extract(document):
+            if document.name == "boom":
+                raise RuntimeError("explode")
+            return ("text ok", "pypdf")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            side_effect=fake_extract,
+        ):
+            out, err = _call(*_scoped(household))
+
+        good.refresh_from_db()
+        boom.refresh_from_db()
+
+        assert good.ocr_text == "text ok"
+        assert boom.ocr_text == ""
+        assert boom.metadata["ocr_method"] == "skipped"
+        assert "extracted=1" in out
+        assert "failed=1" in out
+        assert str(boom.id) in err
+
+    def test_vision_calls_appear_in_summary_with_cost(self, household, owner):
+        _make_document(household, owner, name="img1", mime_type="image/jpeg")
+        _make_document(household, owner, name="img2", mime_type="image/jpeg")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "vision_haiku"),
+        ):
+            out, _ = _call(*_scoped(household))
+
+        assert "vision_calls=2" in out
+        assert "estimated_cost_usd=0.006" in out
+
+    def test_negative_limit_raises(self, household, owner):
+        with pytest.raises(CommandError):
+            _call("--limit", "0")
+
+    def test_excludes_documents_without_file_path(self, household, owner):
+        empty = Document.objects.create(
+            household=household,
+            created_by=owner,
+            file_path="",
+            name="no-file",
+            mime_type="application/pdf",
+            type="document",
+        )
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "pypdf"),
+        ) as mock_extract:
+            out, _ = _call(*_scoped(household))
+
+        empty.refresh_from_db()
+        assert empty.ocr_text == ""
+        mock_extract.assert_not_called()
+        assert "Documents to process: 0" in out

--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -2,15 +2,21 @@ import * as React from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Download, ExternalLink, Plus } from 'lucide-react';
+import { ArrowLeft, Download, ExternalLink, Plus, RefreshCcw } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { formatFileSize } from '@/lib/api/documents';
-import { useDocument, useDeleteDocument, documentKeys } from './hooks';
+import {
+  useDocument,
+  useDeleteDocument,
+  useReprocessDocumentOcr,
+  documentKeys,
+} from './hooks';
 import DocumentEditDialog from './DocumentEditDialog';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useToast } from '@/lib/toast';
 
 function formatDate(value?: string | null): string {
   if (!value) return '—';
@@ -30,6 +36,8 @@ export default function DocumentDetailPage() {
 
   const { data: doc, isLoading, error } = useDocument(id ?? '');
   const deleteMutation = useDeleteDocument();
+  const reprocessMutation = useReprocessDocumentOcr();
+  const { toast } = useToast();
 
   const handleSaved = React.useCallback(() => {
     qc.invalidateQueries({ queryKey: documentKeys.all });
@@ -41,6 +49,16 @@ export default function DocumentDetailPage() {
     if (!id) return;
     deleteMutation.mutate(id, {
       onSuccess: () => navigate('/app/documents'),
+    });
+  }
+
+  function handleReprocess() {
+    if (!id) return;
+    reprocessMutation.mutate(id, {
+      onSuccess: () =>
+        toast({ description: t('documents.ocr.reprocessSuccess'), variant: 'success' }),
+      onError: () =>
+        toast({ description: t('documents.ocr.reprocessError'), variant: 'destructive' }),
     });
   }
 
@@ -170,6 +188,20 @@ export default function DocumentDetailPage() {
                   ) : (
                     <p className="italic text-muted-foreground">{t('documents.ocr.empty')}</p>
                   )}
+                  <div className="mt-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      className="h-8 px-3 text-xs"
+                      onClick={handleReprocess}
+                      disabled={reprocessMutation.isPending}
+                    >
+                      <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+                      {reprocessMutation.isPending
+                        ? t('documents.ocr.reprocessing')
+                        : t('documents.ocr.reprocess')}
+                    </Button>
+                  </div>
                 </div>
               </details>
             </CardContent>

--- a/ui/src/features/documents/hooks.ts
+++ b/ui/src/features/documents/hooks.ts
@@ -5,6 +5,7 @@ import {
   uploadDocument,
   updateDocument,
   deleteDocument,
+  reprocessDocumentOcr,
   type DocumentFilters,
   type UploadDocumentInput,
 } from '@/lib/api/documents';
@@ -61,5 +62,16 @@ export function useDeleteDocument() {
   return useMutation({
     mutationFn: (id: string) => deleteDocument(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
+  });
+}
+
+export function useReprocessDocumentOcr() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => reprocessDocumentOcr(id),
+    onSuccess: (data) => {
+      qc.invalidateQueries({ queryKey: documentKeys.detail(String(data.id)) });
+      qc.invalidateQueries({ queryKey: documentKeys.all });
+    },
   });
 }

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -143,6 +143,11 @@ export async function deleteDocument(id: string): Promise<void> {
   await api.delete(`/documents/documents/${id}/`);
 }
 
+export async function reprocessDocumentOcr(id: string): Promise<DocumentDetail> {
+  const { data } = await api.post(`/documents/documents/${id}/reprocess_ocr/`);
+  return { ...(data as DocumentDetail & { id: string | number }), id: String((data as { id: string | number }).id) };
+}
+
 export function formatFileSize(bytes?: number | null): string {
   if (!bytes) return '';
   if (bytes < 1024) return `${bytes} B`;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -749,7 +749,11 @@
     "ocr": {
       "title": "Extrahierter Text",
       "empty": "Noch kein Text extrahiert.",
-      "processing": "Analyse läuft…"
+      "processing": "Analyse läuft…",
+      "reprocess": "Text neu extrahieren",
+      "reprocessing": "Extraktion läuft…",
+      "reprocessSuccess": "Text neu extrahiert.",
+      "reprocessError": "Neu-Extraktion fehlgeschlagen."
     },
     "new": {
       "title": "Dokument hinzufügen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -749,7 +749,11 @@
     "ocr": {
       "title": "Extracted text",
       "empty": "No text extracted yet.",
-      "processing": "Analysis in progress…"
+      "processing": "Analysis in progress…",
+      "reprocess": "Re-extract text",
+      "reprocessing": "Re-extracting…",
+      "reprocessSuccess": "Text re-extracted.",
+      "reprocessError": "Re-extraction failed."
     },
     "new": {
       "title": "Add document",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -749,7 +749,11 @@
     "ocr": {
       "title": "Texto extraído",
       "empty": "Aún no se ha extraído ningún texto.",
-      "processing": "Análisis en curso…"
+      "processing": "Análisis en curso…",
+      "reprocess": "Volver a extraer el texto",
+      "reprocessing": "Extrayendo…",
+      "reprocessSuccess": "Texto re-extraído.",
+      "reprocessError": "Error al volver a extraer."
     },
     "new": {
       "title": "Añadir documento",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -749,7 +749,11 @@
     "ocr": {
       "title": "Texte extrait",
       "empty": "Aucun texte extrait pour le moment.",
-      "processing": "Analyse en cours…"
+      "processing": "Analyse en cours…",
+      "reprocess": "Re-extraire le texte",
+      "reprocessing": "Extraction en cours…",
+      "reprocessSuccess": "Texte ré-extrait.",
+      "reprocessError": "Échec de la ré-extraction."
     },
     "new": {
       "title": "Ajouter un document",


### PR DESCRIPTION
## Summary
- Management command `extract_documents_text` pour rétro-traiter les documents existants (imports Supabase + uploads pré-pipeline) avec filtres `--household`, `--type`, `--limit`, `--force` et `--dry-run`. Le résumé inclut le nombre d'appels Vision et le coût estimé.
- Bouton "Re-extraire" sur la page détail document qui appelle l'endpoint `reprocess_ocr` existant, avec toast et i18n (en/fr/de/es).
- 10 tests pytest qui couvrent skip par défaut, `--force`, `--household`, `--type`, `--limit`, `--dry-run`, exception → failed, coût Vision, limite invalide, file_path vide.

Lot 0b du parcours 07 — closes #89.

## Test plan
- [x] `pytest apps/documents/` (65 passed)
- [x] `tsc --noEmit`
- [x] `eslint` sur les fichiers modifiés
- [ ] Manuel : `python manage.py extract_documents_text --dry-run` sur un foyer test, vérifier la liste
- [ ] Manuel : `python manage.py extract_documents_text --limit 3 --household <uuid>` puis vérifier `ocr_text` peuplé + `metadata.ocr_method`
- [ ] Manuel : sur la page détail document, cliquer "Re-extraire", vérifier toast + texte mis à jour

🤖 Generated with [Claude Code](https://claude.com/claude-code)