### PR TITLE
fix(documents): skip photos in OCR backfill (#103)

### DIFF
--- a/apps/documents/management/commands/extract_documents_text.py
+++ b/apps/documents/management/commands/extract_documents_text.py
@@ -1,12 +1,17 @@
 """Backfill text extraction (OCR / pypdf) on existing documents.
 
+By default photos (Document.type == 'photo') are excluded — consistent with
+the upload pipeline (#88) which also skips OCR on photos. Use --include-photos
+to opt in, or --type photo to backfill only photos explicitly.
+
 Usage:
 
-    python manage.py extract_documents_text                       # all empty docs, all households
+    python manage.py extract_documents_text                       # all non-photo docs
     python manage.py extract_documents_text --household <uuid>    # scope to one household
     python manage.py extract_documents_text --type invoice        # filter by Document.type
     python manage.py extract_documents_text --limit 10            # cap batch size
     python manage.py extract_documents_text --force               # re-extract docs that already have text
+    python manage.py extract_documents_text --include-photos      # also process type='photo'
     python manage.py extract_documents_text --dry-run             # list what would be processed, change nothing
 """
 from __future__ import annotations
@@ -50,6 +55,11 @@ class Command(BaseCommand):
             help="Maximum number of documents to process.",
         )
         parser.add_argument(
+            "--include-photos",
+            action="store_true",
+            help="Also process documents with type='photo' (excluded by default).",
+        )
+        parser.add_argument(
             "--dry-run",
             action="store_true",
             help="List candidates without writing to the database.",
@@ -60,6 +70,7 @@ class Command(BaseCommand):
         force: bool = options["force"]
         doc_type: str | None = options.get("doc_type")
         limit: int | None = options.get("limit")
+        include_photos: bool = options["include_photos"]
         dry_run: bool = options["dry_run"]
 
         if limit is not None and limit <= 0:
@@ -70,6 +81,8 @@ class Command(BaseCommand):
             candidates = candidates.filter(household_id=household_id)
         if doc_type:
             candidates = candidates.filter(type=doc_type)
+        elif not include_photos:
+            candidates = candidates.exclude(type="photo")
 
         already_processed = candidates.exclude(ocr_text="").count() if not force else 0
         if not force:

--- a/apps/documents/tests/test_extract_documents_text_command.py
+++ b/apps/documents/tests/test_extract_documents_text_command.py
@@ -202,6 +202,58 @@ class TestExtractDocumentsTextCommand:
         with pytest.raises(CommandError):
             _call("--limit", "0")
 
+    def test_skips_photos_by_default(self, household, owner):
+        document = _make_document(household, owner, name="invoice", type="document")
+        photo = _make_document(household, owner, name="souvenir", type="photo")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "pypdf"),
+        ) as mock_extract:
+            out, _ = _call(*_scoped(household))
+
+        document.refresh_from_db()
+        photo.refresh_from_db()
+
+        assert document.ocr_text == "text"
+        assert photo.ocr_text == ""
+        assert mock_extract.call_count == 1
+        assert "Documents to process: 1" in out
+
+    def test_include_photos_flag_processes_photos(self, household, owner):
+        document = _make_document(household, owner, name="invoice", type="document")
+        photo = _make_document(household, owner, name="souvenir", type="photo")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "vision_haiku"),
+        ) as mock_extract:
+            _call(*_scoped(household, "--include-photos"))
+
+        document.refresh_from_db()
+        photo.refresh_from_db()
+
+        assert document.ocr_text == "text"
+        assert photo.ocr_text == "text"
+        assert mock_extract.call_count == 2
+
+    def test_explicit_type_photo_overrides_default_exclusion(self, household, owner):
+        document = _make_document(household, owner, name="invoice", type="document")
+        photo = _make_document(household, owner, name="souvenir", type="photo")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("text", "vision_haiku"),
+        ) as mock_extract:
+            _call(*_scoped(household, "--type", "photo"))
+
+        document.refresh_from_db()
+        photo.refresh_from_db()
+
+        assert document.ocr_text == ""
+        assert photo.ocr_text == "text"
+        assert mock_extract.call_count == 1
+
     def test_excludes_documents_without_file_path(self, household, owner):
         empty = Document.objects.create(
             household=household,


### PR DESCRIPTION
## Summary

- exclure `type='photo'` par défaut dans `extract_documents_text` (cohérence avec #88 qui skippe l'OCR sur photos à l'upload)
- ajouter `--include-photos` pour opt-in explicite
- `--type photo` continue de marcher (overrides la default exclusion)

Découvert en lançant le dry-run prod : 150 photos sur 189 candidats auraient été inutilement OCR-isées (~\$0.45 + pollution de `ocr_text`).

Closes #103.

## Test plan

- [x] 3 nouveaux tests pytest : skip photos par défaut, `--include-photos` opt-in, `--type photo` explicite
- [x] 13 tests pass localement
- [ ] dry-run prod après merge → confirmer 39 docs (au lieu de 189)
- [ ] run réel prod → vérifier les `ocr_text` peuplés sur les 39

🤖 Generated with [Claude Code](https://claude.com/claude-code)