### PR TITLE
fix(documents): count Vision attempts not just successes (#105)

### DIFF
--- a/apps/documents/extraction.py
+++ b/apps/documents/extraction.py
@@ -116,9 +116,15 @@ def extract_text(document: "Document") -> ExtractionResult:
     """Extract text content from a stored document.
 
     Returns ``(text, method)`` where ``method`` is one of:
-    - ``"vision_haiku"`` : image processed by Claude Haiku Vision
-    - ``"pypdf"``        : PDF text extracted by pypdf
-    - ``"skipped"``      : nothing extracted (unsupported, error, or empty)
+    - ``"vision_haiku"`` : Vision called, returned text
+    - ``"vision_empty"`` : Vision called, returned no text (image with no readable text)
+    - ``"pypdf"``        : pypdf returned text
+    - ``"pypdf_empty"``  : pypdf called, returned no text (image-only/scanned PDF)
+    - ``"skipped"``      : not attempted (no file, unsupported mime, IO error)
+
+    The ``_empty`` variants indicate the API/library was actually invoked, which
+    matters for cost accounting (a Vision call has a real $ cost even when the
+    response is empty).
     """
     if not document.file_path:
         return "", "skipped"
@@ -142,9 +148,9 @@ def extract_text(document: "Document") -> ExtractionResult:
             text = _extract_with_vision(file_bytes, VISION_MEDIA_TYPES[mime])
         except Exception as exc:
             logger.warning("extraction: vision failed for %s: %s", document.file_path, exc)
-            return "", "skipped"
+            return "", "vision_empty"
         if not text:
-            return "", "skipped"
+            return "", "vision_empty"
         return text, "vision_haiku"
 
     if mime == "application/pdf":
@@ -152,9 +158,9 @@ def extract_text(document: "Document") -> ExtractionResult:
             text = _extract_with_pypdf(file_bytes)
         except Exception as exc:
             logger.warning("extraction: pypdf failed for %s: %s", document.file_path, exc)
-            return "", "skipped"
+            return "", "pypdf_empty"
         if not text:
-            return "", "skipped"
+            return "", "pypdf_empty"
         return text, "pypdf"
 
     return "", "skipped"

--- a/apps/documents/management/commands/extract_documents_text.py
+++ b/apps/documents/management/commands/extract_documents_text.py
@@ -97,7 +97,7 @@ class Command(BaseCommand):
 
         extracted = 0
         failed = 0
-        vision_calls = 0
+        vision_attempts = 0
 
         for index, document in enumerate(candidates.iterator(), start=1):
             prefix = f"[{index}/{total}]"
@@ -121,8 +121,8 @@ class Command(BaseCommand):
             document.metadata = metadata
             document.save(update_fields=["ocr_text", "metadata", "updated_at"])
 
-            if method == "vision_haiku":
-                vision_calls += 1
+            if method in ("vision_haiku", "vision_empty"):
+                vision_attempts += 1
 
             if text:
                 extracted += 1
@@ -132,16 +132,16 @@ class Command(BaseCommand):
             else:
                 failed += 1
                 self.stderr.write(
-                    f"  {prefix} ✗ {document.id} no text ({document.mime_type or 'unknown'})"
+                    f"  {prefix} ✗ {document.id} no text via {method} ({document.mime_type or 'unknown'})"
                 )
 
-        cost_estimate = vision_calls * VISION_COST_PER_IMAGE_USD
+        cost_estimate = vision_attempts * VISION_COST_PER_IMAGE_USD
         if dry_run:
             summary = f"Dry-run complete. would_process={total}"
         else:
             summary = (
                 f"Done. extracted={extracted} failed={failed} "
-                f"skipped={already_processed} vision_calls={vision_calls} "
+                f"skipped={already_processed} vision_attempts={vision_attempts} "
                 f"estimated_cost_usd={cost_estimate:.3f}"
             )
 

--- a/apps/documents/tests/test_extract_documents_text_command.py
+++ b/apps/documents/tests/test_extract_documents_text_command.py
@@ -185,7 +185,7 @@ class TestExtractDocumentsTextCommand:
         assert "failed=1" in out
         assert str(boom.id) in err
 
-    def test_vision_calls_appear_in_summary_with_cost(self, household, owner):
+    def test_vision_attempts_appear_in_summary_with_cost(self, household, owner):
         _make_document(household, owner, name="img1", mime_type="image/jpeg")
         _make_document(household, owner, name="img2", mime_type="image/jpeg")
 
@@ -195,8 +195,24 @@ class TestExtractDocumentsTextCommand:
         ):
             out, _ = _call(*_scoped(household))
 
-        assert "vision_calls=2" in out
+        assert "vision_attempts=2" in out
         assert "estimated_cost_usd=0.006" in out
+
+    def test_vision_attempts_count_empty_results_too(self, household, owner):
+        """Vision API was billed even when it returned no text (the whole reason for this fix)."""
+        _make_document(household, owner, name="img1", mime_type="image/jpeg")
+        _make_document(household, owner, name="img2", mime_type="image/jpeg")
+
+        with patch(
+            "documents.management.commands.extract_documents_text.extract_text",
+            return_value=("", "vision_empty"),
+        ):
+            out, _ = _call(*_scoped(household))
+
+        assert "vision_attempts=2" in out
+        assert "estimated_cost_usd=0.006" in out
+        assert "extracted=0" in out
+        assert "failed=2" in out
 
     def test_negative_limit_raises(self, household, owner):
         with pytest.raises(CommandError):

--- a/apps/documents/tests/test_extraction.py
+++ b/apps/documents/tests/test_extraction.py
@@ -77,7 +77,7 @@ class TestExtractText:
         assert method == "vision_haiku"
         fake_client.messages.create.assert_called_once()
 
-    def test_image_returns_skipped_when_client_unavailable(self, monkeypatch, household, owner):
+    def test_image_returns_vision_empty_when_client_unavailable(self, monkeypatch, household, owner):
         path = _save("docs/test.jpg", _make_jpeg_bytes())
         document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
 
@@ -86,9 +86,9 @@ class TestExtractText:
         text, method = extraction.extract_text(document)
 
         assert text == ""
-        assert method == "skipped"
+        assert method == "vision_empty"
 
-    def test_image_failure_in_sdk_returns_skipped(self, monkeypatch, household, owner):
+    def test_image_failure_in_sdk_returns_vision_empty(self, monkeypatch, household, owner):
         path = _save("docs/test.jpg", _make_jpeg_bytes())
         document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
 
@@ -99,9 +99,26 @@ class TestExtractText:
         text, method = extraction.extract_text(document)
 
         assert text == ""
-        assert method == "skipped"
+        assert method == "vision_empty"
 
-    def test_pdf_returns_skipped_for_blank_pages(self, monkeypatch, household, owner):
+    def test_image_with_no_text_returns_vision_empty(self, monkeypatch, household, owner):
+        path = _save("docs/test.jpg", _make_jpeg_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="image/jpeg")
+
+        fake_block = SimpleNamespace(text="")
+        fake_message = SimpleNamespace(content=[fake_block])
+        fake_client = MagicMock()
+        fake_client.messages.create.return_value = fake_message
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: fake_client)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == ""
+        assert method == "vision_empty"
+        # Vision was actually called — that's the whole point of this state.
+        fake_client.messages.create.assert_called_once()
+
+    def test_pdf_returns_pypdf_empty_for_blank_pages(self, monkeypatch, household, owner):
         path = _save("docs/blank.pdf", _make_pdf_bytes())
         document = self._make_document(household, owner, file_path=path, mime="application/pdf")
         # No anthropic call for PDFs — guard anyway.
@@ -110,7 +127,7 @@ class TestExtractText:
         text, method = extraction.extract_text(document)
 
         assert text == ""
-        assert method == "skipped"
+        assert method == "pypdf_empty"
 
     def test_pdf_extraction_uses_pypdf(self, monkeypatch, household, owner):
         path = _save("docs/text.pdf", _make_pdf_bytes())


### PR DESCRIPTION
## Summary

- distinction des états \`vision_empty\` / \`pypdf_empty\` (API tentée, pas de texte) vs \`skipped\` (non tentée)
- compteur renommé \`vision_calls\` → \`vision_attempts\` pour refléter qu'on compte les appels API, pas les succès
- coût estimé prend en compte les appels Vision qui retournent vide

Closes #105.

## Test plan

- [x] 49 tests pytest passent localement (extraction + command + API)
- [x] nouveau test : \`test_image_with_no_text_returns_vision_empty\` confirme que Vision est bien appelé même si le retour est vide
- [x] nouveau test : \`test_vision_attempts_count_empty_results_too\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)