### PR TITLE
feat(documents): Vision OCR fallback on scanned PDFs (#107)

### DIFF
--- a/apps/documents/extraction.py
+++ b/apps/documents/extraction.py
@@ -1,16 +1,18 @@
 """
 Text extraction for uploaded documents.
 
-Two pipelines:
+Three pipelines:
 - images → Claude Haiku 4.5 Vision (OCR)
-- PDFs   → pypdf (text-based PDFs only — scanned PDFs are V2)
+- text-based PDFs → pypdf (fast, free)
+- scanned PDFs → fallback Vision page-by-page (each page rendered as image)
 
-Everything is fail-soft. Returning ``("", "skipped")`` is a perfectly acceptable
+Everything is fail-soft. Returning ``("", <method>)`` is a perfectly acceptable
 outcome — the upload must never fail because text extraction did.
 """
 from __future__ import annotations
 
 import base64
+import io
 import logging
 from typing import TYPE_CHECKING, Tuple
 
@@ -35,6 +37,11 @@ VISION_MEDIA_TYPES = {
     "image/webp": "image/webp",
     "image/gif": "image/gif",
 }
+
+# DPI used when rasterizing scanned PDF pages for Vision OCR.
+# Higher = better OCR quality but bigger payloads. 200 DPI is a typical
+# balance — sharp enough for receipts/contracts, image stays under 2 MB.
+PDF_VISION_RENDER_DPI = 200
 
 ExtractionResult = Tuple[str, str]
 
@@ -100,9 +107,7 @@ def _extract_with_pypdf(file_bytes: bytes) -> str:
         logger.warning("extraction: pypdf not installed")
         return ""
 
-    from io import BytesIO
-
-    reader = PdfReader(BytesIO(file_bytes))
+    reader = PdfReader(io.BytesIO(file_bytes))
     pages: list[str] = []
     for page in reader.pages:
         try:
@@ -112,15 +117,51 @@ def _extract_with_pypdf(file_bytes: bytes) -> str:
     return "\n\n".join(p.strip() for p in pages if p and p.strip()).strip()
 
 
+def _extract_pdf_with_vision(file_bytes: bytes) -> str:
+    """Render every PDF page and run Vision OCR on each. Concatenate the results.
+
+    Used as a fallback when ``_extract_with_pypdf`` returns nothing — typically
+    a scanned PDF where the pages are images embedded in a PDF wrapper. Each
+    page is rasterized via pypdfium2, encoded as JPEG, then sent to Vision.
+    """
+    try:
+        import pypdfium2  # type: ignore[import-not-found]
+    except ImportError:
+        logger.warning("extraction: pypdfium2 not installed, can't OCR scanned PDFs")
+        return ""
+
+    if _get_anthropic_client() is None:
+        return ""
+
+    pdf = pypdfium2.PdfDocument(file_bytes)
+    page_texts: list[str] = []
+    scale = PDF_VISION_RENDER_DPI / 72.0
+    for page_index in range(len(pdf)):
+        page = pdf[page_index]
+        try:
+            bitmap = page.render(scale=scale)
+            pil_image = bitmap.to_pil()
+            buffer = io.BytesIO()
+            pil_image.save(buffer, format="JPEG", quality=85)
+            text = _extract_with_vision(buffer.getvalue(), "image/jpeg")
+        except Exception as exc:
+            logger.warning("extraction: pdf-vision page %d failed: %s", page_index, exc)
+            continue
+        if text:
+            page_texts.append(text)
+    return "\n\n".join(page_texts).strip()
+
+
 def extract_text(document: "Document") -> ExtractionResult:
     """Extract text content from a stored document.
 
     Returns ``(text, method)`` where ``method`` is one of:
-    - ``"vision_haiku"`` : Vision called, returned text
-    - ``"vision_empty"`` : Vision called, returned no text (image with no readable text)
-    - ``"pypdf"``        : pypdf returned text
-    - ``"pypdf_empty"``  : pypdf called, returned no text (image-only/scanned PDF)
-    - ``"skipped"``      : not attempted (no file, unsupported mime, IO error)
+    - ``"vision_haiku"``     : Vision called on an image, returned text
+    - ``"vision_empty"``     : Vision called on an image, returned no text
+    - ``"pypdf"``            : pypdf returned text from a text-based PDF
+    - ``"pdf_vision_haiku"`` : pypdf was empty, Vision OCR'd each page successfully
+    - ``"pdf_vision_empty"`` : pypdf was empty, Vision called on each page but no text
+    - ``"skipped"``          : not attempted (no file, unsupported mime, IO error)
 
     The ``_empty`` variants indicate the API/library was actually invoked, which
     matters for cost accounting (a Vision call has a real $ cost even when the
@@ -158,10 +199,19 @@ def extract_text(document: "Document") -> ExtractionResult:
             text = _extract_with_pypdf(file_bytes)
         except Exception as exc:
             logger.warning("extraction: pypdf failed for %s: %s", document.file_path, exc)
-            return "", "pypdf_empty"
-        if not text:
-            return "", "pypdf_empty"
-        return text, "pypdf"
+            text = ""
+        if text:
+            return text, "pypdf"
+
+        # Scanned/image-only PDF — fall back to Vision page by page.
+        try:
+            vision_text = _extract_pdf_with_vision(file_bytes)
+        except Exception as exc:
+            logger.warning("extraction: pdf-vision failed for %s: %s", document.file_path, exc)
+            return "", "pdf_vision_empty"
+        if not vision_text:
+            return "", "pdf_vision_empty"
+        return vision_text, "pdf_vision_haiku"
 
     return "", "skipped"
 

--- a/apps/documents/management/commands/extract_documents_text.py
+++ b/apps/documents/management/commands/extract_documents_text.py
@@ -121,7 +121,10 @@ class Command(BaseCommand):
             document.metadata = metadata
             document.save(update_fields=["ocr_text", "metadata", "updated_at"])
 
-            if method in ("vision_haiku", "vision_empty"):
+            if method in ("vision_haiku", "vision_empty", "pdf_vision_haiku", "pdf_vision_empty"):
+                # Note: this counts documents that triggered Vision, not API
+                # calls. A multi-page PDF can mean N calls per document — for
+                # accurate per-call accounting see lot 6 (#109).
                 vision_attempts += 1
 
             if text:

--- a/apps/documents/tests/test_extraction.py
+++ b/apps/documents/tests/test_extraction.py
@@ -118,16 +118,97 @@ class TestExtractText:
         # Vision was actually called — that's the whole point of this state.
         fake_client.messages.create.assert_called_once()
 
-    def test_pdf_returns_pypdf_empty_for_blank_pages(self, monkeypatch, household, owner):
+    def test_pdf_with_empty_pypdf_returns_pdf_vision_empty_when_no_client(self, monkeypatch, household, owner):
+        """Blank PDF: pypdf returns empty, Vision fallback can't run (no client) → pdf_vision_empty."""
         path = _save("docs/blank.pdf", _make_pdf_bytes())
         document = self._make_document(household, owner, file_path=path, mime="application/pdf")
-        # No anthropic call for PDFs — guard anyway.
         monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: None)
 
         text, method = extraction.extract_text(document)
 
         assert text == ""
-        assert method == "pypdf_empty"
+        assert method == "pdf_vision_empty"
+
+    def test_scanned_pdf_falls_back_to_vision_per_page(self, monkeypatch, household, owner):
+        """pypdf returns empty (image-only PDF). Vision OCR-s each page."""
+        path = _save("docs/scanned.pdf", _make_pdf_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+
+        monkeypatch.setattr(extraction, "_extract_with_pypdf", lambda _b: "")
+        monkeypatch.setattr(extraction, "_extract_pdf_with_vision", lambda _b: "Page 1 text\n\nPage 2 text")
+
+        text, method = extraction.extract_text(document)
+
+        assert text == "Page 1 text\n\nPage 2 text"
+        assert method == "pdf_vision_haiku"
+
+    def test_scanned_pdf_renders_pages_via_pypdfium(self, monkeypatch, household, owner):
+        """End-to-end: real pypdfium rendering + mocked Vision client returning text per call."""
+        path = _save("docs/scanned-real.pdf", _make_pdf_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+
+        monkeypatch.setattr(extraction, "_extract_with_pypdf", lambda _b: "")
+
+        call_count = {"n": 0}
+
+        def fake_vision(_bytes, _media):
+            call_count["n"] += 1
+            return f"Page {call_count['n']}"
+
+        monkeypatch.setattr(extraction, "_extract_with_vision", fake_vision)
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: object())
+
+        text, method = extraction.extract_text(document)
+
+        assert method == "pdf_vision_haiku"
+        assert "Page 1" in text
+
+    def test_scanned_pdf_keeps_partial_text_when_some_pages_fail(self, monkeypatch, household, owner):
+        """If Vision raises on one page, other pages' text is still kept."""
+        from pypdf import PdfWriter
+
+        writer = PdfWriter()
+        writer.add_blank_page(width=72, height=72)
+        writer.add_blank_page(width=72, height=72)
+        buffer = io.BytesIO()
+        writer.write(buffer)
+        path = _save("docs/partial.pdf", buffer.getvalue())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+
+        monkeypatch.setattr(extraction, "_extract_with_pypdf", lambda _b: "")
+        monkeypatch.setattr(extraction, "_get_anthropic_client", lambda: object())
+
+        call = {"n": 0}
+
+        def flaky_vision(_b, _m):
+            call["n"] += 1
+            if call["n"] == 1:
+                raise RuntimeError("page 1 boom")
+            return "page 2 ok"
+
+        monkeypatch.setattr(extraction, "_extract_with_vision", flaky_vision)
+
+        text, method = extraction.extract_text(document)
+
+        assert "page 2 ok" in text
+        assert method == "pdf_vision_haiku"
+
+    def test_pypdf_text_pdfs_skip_vision_fallback(self, monkeypatch, household, owner):
+        """Text-based PDFs: pypdf works, Vision is never called."""
+        path = _save("docs/text.pdf", _make_pdf_bytes())
+        document = self._make_document(household, owner, file_path=path, mime="application/pdf")
+
+        monkeypatch.setattr(extraction, "_extract_with_pypdf", lambda _b: "I am text from pypdf")
+
+        def must_not_run(_b, _m):
+            raise AssertionError("Vision should not run when pypdf returns text")
+
+        monkeypatch.setattr(extraction, "_extract_with_vision", must_not_run)
+
+        text, method = extraction.extract_text(document)
+
+        assert text == "I am text from pypdf"
+        assert method == "pypdf"
 
     def test_pdf_extraction_uses_pypdf(self, monkeypatch, household, owner):
         path = _save("docs/text.pdf", _make_pdf_bytes())

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,6 +19,7 @@ psycopg==3.3.2
 psycopg-binary==3.3.2
 PyJWT==2.11.0
 pypdf==5.1.0
+pypdfium2==4.30.1
 PyYAML==6.0.3
 referencing==0.37.0
 rpds-py==0.30.0


### PR DESCRIPTION
## Summary

Quand un PDF est scanné (images embarquées, pas de texte natif), \`pypdf\` renvoie vide. On bascule alors sur un fallback Vision page-par-page :

1. \`pypdfium2\` rend chaque page en image PIL
2. encode JPEG (qualité 85 @ 200 DPI)
3. envoie à Vision Haiku 4.5
4. concatène les textes par page

Robuste aux échecs : si Vision casse sur la page 3, les pages 1, 2 et 4+ restent gardées.

Nouvelles valeurs \`Document.metadata.ocr_method\` :
- \`pdf_vision_haiku\` — fallback Vision a produit du texte
- \`pdf_vision_empty\` — fallback Vision tenté, aucun texte (PDF totalement illisible)

Closes #107.

## Notes

- pas de cap arbitraire de pages (cf décision : ne pas mutiler la qualité par souci de coût)
- le compteur \`vision_attempts\` compte le doc, pas les appels API exacts. Le détail par page sera capturé via \`AIUsageLog\` au lot 6 (#109).
- ajout dépendance : \`pypdfium2==4.30.1\` (paquet mature, ~5 Mo, basé sur Chromium PDF engine)

## Test plan

- [x] 53 tests pytest passent localement
- [x] nouveau test : end-to-end avec real pypdfium2 + Vision mocké
- [x] nouveau test : panne sur une page n'arrête pas le batch
- [x] nouveau test : PDF text-based skippe le fallback Vision (pas de double traitement)
- [ ] post-merge : relancer \`extract_documents_text --force --type document --type invoice\` sur prod pour les 4 PDFs scannés (id 13, 170, 179, 180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)