### PR TITLE
feat(agent): UI chat avec citations cliquables (#102)

### DIFF
--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -137,6 +137,20 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 
 ---
 
+## Agent (`agent.spec.ts`)
+
+API mockée (`/api/agent/ask/`) — la couverture du retrieval/LLM côté backend reste pytest.
+
+| Parcours | Statut |
+|---|---|
+| Affichage de la page + mention de confidentialité au premier usage (input désactivé tant qu'elle n'est pas acceptée) | ✅ |
+| Mention de confidentialité non rejouée si déjà acceptée (localStorage) | ✅ |
+| Pose d'une question → bulle question + bulle réponse + citation cliquable (label + chip dans la bulle) | ✅ |
+| URL de la citation cohérente avec `entity_type` (mapping `equipment:id` → `/app/equipment/id`) | ✅ |
+| Réponse "je ne sais pas" → message clair, aucune citation | ✅ |
+
+---
+
 ## Notifications (`notifications.spec.ts`)
 
 | Parcours | Statut |

--- a/e2e/agent.spec.ts
+++ b/e2e/agent.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from './fixtures';
+import type { Page, Route } from '@playwright/test';
+
+const PRIVACY_KEY = 'agent.privacyAccepted.v1';
+
+interface MockAnswer {
+  answer: string;
+  citations: Array<{
+    entity_type: string;
+    id: string;
+    label: string;
+    snippet: string;
+    url_path: string;
+  }>;
+  metadata?: Record<string, unknown>;
+}
+
+async function mockAskAgent(page: Page, payload: MockAnswer | (() => MockAnswer)): Promise<void> {
+  await page.route('**/api/agent/ask/', async (route: Route) => {
+    const data = typeof payload === 'function' ? payload() : payload;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        answer: data.answer,
+        citations: data.citations,
+        metadata: data.metadata ?? { duration_ms: 1234, tokens_in: 100, tokens_out: 30, model: 'claude-haiku-4-5-20251001', hits_count: 1 },
+      }),
+    });
+  });
+}
+
+async function setPrivacyAccepted(page: Page, accepted: boolean): Promise<void> {
+  await page.addInitScript(([key, value]) => {
+    if (value) {
+      localStorage.setItem(key, 'true');
+    } else {
+      localStorage.removeItem(key);
+    }
+  }, [PRIVACY_KEY, accepted]);
+}
+
+// ---------------------------------------------------------------------------
+// Page d'accueil + mention de confidentialité
+// ---------------------------------------------------------------------------
+
+test('affiche la page agent et la mention de confidentialité au premier usage', async ({ page }) => {
+  await setPrivacyAccepted(page, false);
+  await page.goto('/app/agent');
+
+  await expect(page).toHaveURL(/\/app\/agent/);
+  // La mention de confidentialité s'affiche d'abord (modale Radix qui aria-hide le reste).
+  await expect(page.getByTestId('agent-privacy-notice')).toBeVisible();
+  await expect(page.getByTestId('agent-input')).toBeDisabled();
+
+  // Une fois acceptée, la modale se ferme et la page agent est utilisable.
+  await page.getByTestId('agent-privacy-accept').click();
+  await expect(page.getByTestId('agent-privacy-notice')).not.toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Agent' })).toBeVisible();
+  await expect(page.getByTestId('agent-input')).toBeEnabled();
+});
+
+test('ne montre pas la mention si déjà acceptée', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await page.goto('/app/agent');
+
+  await expect(page.getByTestId('agent-privacy-notice')).not.toBeVisible();
+  await expect(page.getByTestId('agent-input')).toBeEnabled();
+});
+
+// ---------------------------------------------------------------------------
+// Pose d'une question + bulles + citations
+// ---------------------------------------------------------------------------
+
+test('pose une question et reçoit une réponse avec citation cliquable', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await mockAskAgent(page, {
+    answer:
+      "D'après ta facture Engie de mars 2026, tu as payé 142,67€ <cite id=\"document:abc-123\"/>.",
+    citations: [
+      {
+        entity_type: 'document',
+        id: 'abc-123',
+        label: 'Facture Engie mars 2026',
+        snippet: 'Total à payer 142,67€ TTC',
+        url_path: '/app/documents/abc-123',
+      },
+    ],
+  });
+
+  await page.goto('/app/agent');
+
+  await page.getByTestId('agent-input').fill("Combien j'ai payé Engie en mars ?");
+  await page.getByTestId('agent-send').click();
+
+  // Bulle question
+  await expect(page.getByTestId('agent-bubble-user')).toContainText("Combien j'ai payé Engie en mars ?");
+
+  // Bulle réponse
+  const agentBubble = page.getByTestId('agent-bubble-agent');
+  await expect(agentBubble).toBeVisible();
+  await expect(agentBubble).toContainText("D'après ta facture Engie");
+
+  // Citation cliquable (au moins une, dans la bulle agent)
+  const citation = agentBubble.getByTestId('agent-citation').first();
+  await expect(citation).toBeVisible();
+  await expect(citation).toContainText('Facture Engie mars 2026');
+});
+
+test('clique sur une citation et navigue vers la fiche entité', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await mockAskAgent(page, {
+    answer: 'Voici l\'équipement <cite id="equipment:xyz-789"/>.',
+    citations: [
+      {
+        entity_type: 'equipment',
+        id: 'xyz-789',
+        label: 'Chaudière Atlantic',
+        snippet: 'Atlantic gaz condensation',
+        url_path: '/app/equipment/xyz-789',
+      },
+    ],
+  });
+
+  await page.goto('/app/agent');
+  await page.getByTestId('agent-input').fill('Quel est mon équipement de chauffage ?');
+  await page.getByTestId('agent-send').click();
+
+  const citation = page.getByTestId('agent-bubble-agent').getByTestId('agent-citation').first();
+  await expect(citation).toBeVisible();
+
+  // Le lien pointe vers la bonne URL — pas besoin de cliquer puisqu'aucune route equipment/xyz-789 n'existe en DB E2E.
+  await expect(citation).toHaveAttribute('href', '/app/equipment/xyz-789');
+});
+
+// ---------------------------------------------------------------------------
+// "Je ne sais pas" → pas de citation
+// ---------------------------------------------------------------------------
+
+test('réponse "je ne sais pas" → message sans citation', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await mockAskAgent(page, {
+    answer:
+      "Je n'ai pas trouvé d'information pertinente dans les données de ton foyer pour répondre à cette question.",
+    citations: [],
+    metadata: { reason: 'no_household_match' },
+  });
+
+  await page.goto('/app/agent');
+  await page.getByTestId('agent-input').fill('Question hors-domaine zzz');
+  await page.getByTestId('agent-send').click();
+
+  const bubble = page.getByTestId('agent-bubble-agent');
+  await expect(bubble).toContainText("Je n'ai pas trouvé");
+  await expect(bubble.getByTestId('agent-citation')).toHaveCount(0);
+});

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 import {
   LayoutDashboard, ListTodo, FolderKanban, Wrench, Box,
   Zap, MapPin, Users, FileText, Image, Notebook, User,
-  ShieldCheck, X, AlertCircle,
+  ShieldCheck, X, AlertCircle, Sparkles,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/lib/auth/useAuth';
@@ -14,6 +14,7 @@ const NAV_GROUPS = [
   {
     items: [
       { to: '/app/dashboard', labelKey: 'dashboard.title', Icon: LayoutDashboard },
+      { to: '/app/agent', labelKey: 'agent.title', Icon: Sparkles },
       { to: '/app/alerts', labelKey: 'alerts.title', Icon: AlertCircle, badge: 'alerts' as const },
     ],
   },

--- a/ui/src/features/agent/AgentCitation.tsx
+++ b/ui/src/features/agent/AgentCitation.tsx
@@ -1,0 +1,45 @@
+import { Link } from 'react-router-dom';
+import {
+  FileText, Notebook, Wrench, ListTodo, FolderKanban, MapPin,
+  Box, ShieldCheck, User, Building2, ExternalLink,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type { AgentCitation as Citation } from './api';
+
+const ENTITY_ICONS: Record<string, LucideIcon> = {
+  document: FileText,
+  interaction: Notebook,
+  equipment: Wrench,
+  task: ListTodo,
+  project: FolderKanban,
+  zone: MapPin,
+  stock_item: Box,
+  insurance_contract: ShieldCheck,
+  contact: User,
+  structure: Building2,
+};
+
+interface Props {
+  citation: Citation;
+  /** Numeric superscript shown alongside the chip (1-based) */
+  index?: number;
+}
+
+export default function AgentCitation({ citation, index }: Props) {
+  const Icon = ENTITY_ICONS[citation.entity_type] ?? ExternalLink;
+  return (
+    <Link
+      to={citation.url_path}
+      data-testid="agent-citation"
+      data-entity-type={citation.entity_type}
+      title={citation.snippet || citation.label}
+      className="inline-flex max-w-full items-center gap-1 rounded-full border border-border bg-card px-2 py-0.5 text-xs text-foreground hover:bg-primary/10 hover:text-primary hover:border-primary/30 transition-colors"
+    >
+      {typeof index === 'number' ? (
+        <span className="font-semibold tabular-nums text-muted-foreground">{index}</span>
+      ) : null}
+      <Icon className="h-3 w-3 shrink-0" />
+      <span className="truncate">{citation.label}</span>
+    </Link>
+  );
+}

--- a/ui/src/features/agent/AgentPage.tsx
+++ b/ui/src/features/agent/AgentPage.tsx
@@ -1,0 +1,196 @@
+import * as React from 'react';
+import { Send, Sparkles, AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import PageHeader from '@/components/PageHeader';
+import { Button } from '@/design-system/button';
+import { Textarea } from '@/design-system/textarea';
+import ChatBubble from './ChatBubble';
+import PrivacyNotice from './PrivacyNotice';
+import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
+import { useAskAgent } from './hooks';
+import type { AgentCitation } from './api';
+
+interface UserMessage {
+  id: string;
+  variant: 'user';
+  text: string;
+}
+
+interface AgentMessage {
+  id: string;
+  variant: 'agent';
+  text: string;
+  citations: AgentCitation[];
+}
+
+interface ErrorMessage {
+  id: string;
+  variant: 'error';
+  text: string;
+}
+
+type Message = UserMessage | AgentMessage | ErrorMessage;
+
+export default function AgentPage() {
+  const { t } = useTranslation();
+  const askMutation = useAskAgent();
+
+  const [messages, setMessages] = React.useState<Message[]>([]);
+  const [draft, setDraft] = React.useState('');
+  const [needsPrivacy, setNeedsPrivacy] = React.useState(false);
+
+  const scrollAnchorRef = React.useRef<HTMLDivElement | null>(null);
+  const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+  React.useEffect(() => {
+    setNeedsPrivacy(!hasAcceptedAgentPrivacy());
+  }, []);
+
+  React.useEffect(() => {
+    scrollAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
+  }, [messages.length, askMutation.isPending]);
+
+  const handleAcceptPrivacy = React.useCallback(() => {
+    acceptAgentPrivacy();
+    setNeedsPrivacy(false);
+    textareaRef.current?.focus();
+  }, []);
+
+  const submit = React.useCallback(() => {
+    const trimmed = draft.trim();
+    if (!trimmed || askMutation.isPending) return;
+    const userMsg: UserMessage = {
+      id: `u-${Date.now()}`,
+      variant: 'user',
+      text: trimmed,
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setDraft('');
+    askMutation.mutate(trimmed, {
+      onSuccess: (data) => {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `a-${Date.now()}`,
+            variant: 'agent',
+            text: data.answer,
+            citations: data.citations,
+          },
+        ]);
+      },
+      onError: () => {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: `e-${Date.now()}`,
+            variant: 'error',
+            text: t('agent.error'),
+          },
+        ]);
+      },
+    });
+  }, [draft, askMutation, t]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const isEmpty = messages.length === 0 && !askMutation.isPending;
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <PageHeader title={t('agent.title')} description={t('agent.description')} />
+
+      <PrivacyNotice open={needsPrivacy} onAccept={handleAcceptPrivacy} />
+
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
+        <div
+          className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
+          data-testid="agent-messages"
+        >
+          {isEmpty ? (
+            <EmptyHint />
+          ) : (
+            messages.map((msg) => {
+              if (msg.variant === 'user') {
+                return <ChatBubble key={msg.id} variant="user" text={msg.text} />;
+              }
+              if (msg.variant === 'agent') {
+                return (
+                  <ChatBubble
+                    key={msg.id}
+                    variant="agent"
+                    text={msg.text}
+                    citations={msg.citations}
+                  />
+                );
+              }
+              return <ErrorBubble key={msg.id} text={msg.text} />;
+            })
+          )}
+          {askMutation.isPending ? <ChatBubble variant="loading" /> : null}
+          <div ref={scrollAnchorRef} />
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit();
+          }}
+          className="flex items-end gap-2 rounded-xl border border-border bg-card p-2"
+        >
+          <Textarea
+            ref={textareaRef}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={t('agent.input_placeholder')}
+            rows={2}
+            disabled={needsPrivacy || askMutation.isPending}
+            className="min-h-0 flex-1 resize-none border-0 bg-transparent shadow-none focus-visible:ring-0"
+            data-testid="agent-input"
+          />
+          <Button
+            type="submit"
+            disabled={needsPrivacy || askMutation.isPending || draft.trim().length === 0}
+            data-testid="agent-send"
+            aria-label={t('agent.send')}
+          >
+            <Send className="h-4 w-4" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function EmptyHint() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-2 py-12 text-center text-muted-foreground">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Sparkles className="h-6 w-6" />
+      </div>
+      <p className="text-sm font-medium text-foreground">{t('agent.empty_title')}</p>
+      <p className="max-w-md text-sm">{t('agent.empty_hint')}</p>
+    </div>
+  );
+}
+
+function ErrorBubble({ text }: { text: string }) {
+  return (
+    <div className="flex justify-start" data-testid="agent-bubble-error">
+      <div className="flex max-w-[85%] gap-2">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+          <AlertTriangle className="h-3.5 w-3.5" />
+        </div>
+        <div className="rounded-2xl rounded-tl-sm border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {text}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/agent/ChatBubble.tsx
+++ b/ui/src/features/agent/ChatBubble.tsx
@@ -1,0 +1,160 @@
+import * as React from 'react';
+import { Bot, User } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import AgentCitation from './AgentCitation';
+import type { AgentCitation as Citation } from './api';
+
+const CITE_REGEX = /<cite\s+id="([^"]+)"\s*\/?>/gi;
+
+interface UserBubbleProps {
+  variant: 'user';
+  text: string;
+}
+
+interface AgentBubbleProps {
+  variant: 'agent';
+  text: string;
+  citations: Citation[];
+}
+
+interface LoadingBubbleProps {
+  variant: 'loading';
+}
+
+type Props = UserBubbleProps | AgentBubbleProps | LoadingBubbleProps;
+
+export default function ChatBubble(props: Props) {
+  if (props.variant === 'user') {
+    return (
+      <div className="flex justify-end" data-testid="agent-bubble-user">
+        <div className="flex max-w-[85%] gap-2">
+          <div className="rounded-2xl rounded-tr-sm bg-primary px-3 py-2 text-sm text-primary-foreground">
+            {props.text}
+          </div>
+          <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <User className="h-3.5 w-3.5" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (props.variant === 'loading') {
+    return (
+      <AgentBubbleShell>
+        <Loader />
+      </AgentBubbleShell>
+    );
+  }
+
+  return (
+    <AgentBubbleShell>
+      <AnswerWithInlineCitations text={props.text} citations={props.citations} />
+      {props.citations.length > 0 ? (
+        <CitationsPanel citations={props.citations} />
+      ) : null}
+    </AgentBubbleShell>
+  );
+}
+
+function AgentBubbleShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex justify-start" data-testid="agent-bubble-agent">
+      <div className="flex max-w-[85%] gap-2">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+          <Bot className="h-3.5 w-3.5" />
+        </div>
+        <div className="min-w-0 rounded-2xl rounded-tl-sm border border-border bg-card px-3 py-2 text-sm text-foreground">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Loader() {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-center gap-2 text-muted-foreground" data-testid="agent-loader">
+      <span className="flex gap-1">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
+      </span>
+      <span>{t('agent.loading')}</span>
+    </div>
+  );
+}
+
+/**
+ * Replace each <cite id="entity:id"/> marker inline with a numbered chip linking
+ * to the cited entity. Numbers follow the order of citations as returned by the
+ * API (first appearance in the answer).
+ */
+function AnswerWithInlineCitations({
+  text,
+  citations,
+}: {
+  text: string;
+  citations: Citation[];
+}) {
+  const indexByTag = React.useMemo(() => {
+    const map = new Map<string, number>();
+    citations.forEach((c, i) => map.set(`${c.entity_type}:${c.id}`, i + 1));
+    return map;
+  }, [citations]);
+
+  const citationByTag = React.useMemo(() => {
+    const map = new Map<string, Citation>();
+    citations.forEach((c) => map.set(`${c.entity_type}:${c.id}`, c));
+    return map;
+  }, [citations]);
+
+  const parts = React.useMemo(() => {
+    const result: React.ReactNode[] = [];
+    const regex = new RegExp(CITE_REGEX.source, 'gi');
+    let lastIndex = 0;
+    let match: RegExpExecArray | null;
+    let key = 0;
+    while ((match = regex.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        result.push(
+          <React.Fragment key={`t-${key++}`}>{text.slice(lastIndex, match.index)}</React.Fragment>,
+        );
+      }
+      const tag = match[1];
+      const citation = citationByTag.get(tag);
+      const index = indexByTag.get(tag);
+      if (citation && index) {
+        result.push(
+          <span key={`c-${key++}`} className="mx-0.5 align-baseline">
+            <AgentCitation citation={citation} index={index} />
+          </span>,
+        );
+      }
+      lastIndex = regex.lastIndex;
+    }
+    if (lastIndex < text.length) {
+      result.push(<React.Fragment key={`t-${key++}`}>{text.slice(lastIndex)}</React.Fragment>);
+    }
+    return result;
+  }, [text, citationByTag, indexByTag]);
+
+  return <p className="whitespace-pre-wrap break-words">{parts}</p>;
+}
+
+function CitationsPanel({ citations }: { citations: Citation[] }) {
+  const { t } = useTranslation();
+  return (
+    <div className="mt-2 border-t border-border pt-2">
+      <p className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {t('agent.citations_label')}
+      </p>
+      <div className="flex flex-wrap gap-1.5">
+        {citations.map((c, i) => (
+          <AgentCitation key={`${c.entity_type}-${c.id}`} citation={c} index={i + 1} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/agent/PrivacyNotice.tsx
+++ b/ui/src/features/agent/PrivacyNotice.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter, DialogDescription,
+} from '@/design-system/dialog';
+import { Button } from '@/design-system/button';
+
+interface Props {
+  open: boolean;
+  onAccept: () => void;
+}
+
+export default function PrivacyNotice({ open, onAccept }: Props) {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        hideDefaultCloseButton
+        onEscapeKeyDown={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onInteractOutside={(e) => e.preventDefault()}
+        data-testid="agent-privacy-notice"
+      >
+        <DialogHeader>
+          <DialogTitle>{t('agent.privacy.title')}</DialogTitle>
+          <DialogDescription>{t('agent.privacy.intro')}</DialogDescription>
+        </DialogHeader>
+        <ul className="list-disc space-y-1 pl-5 text-sm text-foreground">
+          <li>{t('agent.privacy.point_provider')}</li>
+          <li>{t('agent.privacy.point_scope')}</li>
+          <li>{t('agent.privacy.point_retention')}</li>
+        </ul>
+        <DialogFooter>
+          <Button onClick={onAccept} data-testid="agent-privacy-accept">
+            {t('agent.privacy.accept')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -1,0 +1,30 @@
+import { api } from '@/lib/axios';
+
+export interface AgentCitation {
+  entity_type: string;
+  id: string;
+  label: string;
+  snippet: string;
+  url_path: string;
+}
+
+export interface AgentAnswerMetadata {
+  duration_ms?: number;
+  tokens_in?: number;
+  tokens_out?: number;
+  model?: string;
+  hits_count?: number;
+  reason?: string;
+  [key: string]: unknown;
+}
+
+export interface AgentAnswer {
+  answer: string;
+  citations: AgentCitation[];
+  metadata: AgentAnswerMetadata;
+}
+
+export async function askAgent(question: string): Promise<AgentAnswer> {
+  const { data } = await api.post<AgentAnswer>('/agent/ask/', { question });
+  return data;
+}

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { askAgent, type AgentAnswer } from './api';
+
+export function useAskAgent() {
+  return useMutation<AgentAnswer, unknown, string>({
+    mutationFn: (question: string) => askAgent(question),
+  });
+}

--- a/ui/src/features/agent/privacyStorage.ts
+++ b/ui/src/features/agent/privacyStorage.ts
@@ -1,0 +1,17 @@
+const STORAGE_KEY = 'agent.privacyAccepted.v1';
+
+export function hasAcceptedAgentPrivacy(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export function acceptAgentPrivacy(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, 'true');
+  } catch {
+    // ignore — best-effort
+  }
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1455,5 +1455,24 @@
     "warrantyExpiresIn_other": "Läuft in {{count}} Tagen ab ({{date}})",
     "maintenanceDueIn_one": "Wartung in {{count}} Tag ({{date}})",
     "maintenanceDueIn_other": "Wartung in {{count}} Tagen ({{date}})"
+  },
+  "agent": {
+    "title": "Agent",
+    "description": "Stell deinem Haushalt jede Frage.",
+    "input_placeholder": "Frag den Agenten…",
+    "send": "Senden",
+    "loading": "Durchsuche deinen Haushalt…",
+    "error": "Etwas ist schiefgelaufen, bitte erneut versuchen.",
+    "empty_title": "Stell jede Frage zu deinem Haushalt",
+    "empty_hint": "Der Agent durchsucht deine Dokumente, Geräte, Aufgaben, Verträge und mehr und nennt jede Quelle.",
+    "citations_label": "Quellen",
+    "privacy": {
+      "title": "Bevor du loslegst",
+      "intro": "Der Agent liest die Daten deines Haushalts, um deine Fragen zu beantworten. Wichtig zu wissen:",
+      "point_provider": "Deine Fragen und die passenden Auszüge werden an Anthropic (Claude) gesendet, um die Antwort zu erzeugen.",
+      "point_scope": "Es werden nur Daten deines Haushalts geteilt, niemals Daten eines anderen Haushalts.",
+      "point_retention": "Wir protokollieren Nutzungsstatistiken (Latenz, Erfolg), nicht aber den Inhalt deiner Unterhaltungen.",
+      "accept": "Verstanden"
+    }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1455,5 +1455,24 @@
     "warrantyExpiresIn_other": "Expires in {{count}} days ({{date}})",
     "maintenanceDueIn_one": "Maintenance due in {{count}} day ({{date}})",
     "maintenanceDueIn_other": "Maintenance due in {{count}} days ({{date}})"
+  },
+  "agent": {
+    "title": "Agent",
+    "description": "Ask anything about your household.",
+    "input_placeholder": "Ask the agent…",
+    "send": "Send",
+    "loading": "Searching your household…",
+    "error": "Something went wrong, please try again.",
+    "empty_title": "Ask anything about your household",
+    "empty_hint": "The agent searches your documents, equipment, tasks, contracts and more, and cites every source.",
+    "citations_label": "Sources",
+    "privacy": {
+      "title": "Before you start",
+      "intro": "The agent reads the data of your household to answer your questions. A few things to know:",
+      "point_provider": "Your questions and the matching excerpts are sent to Anthropic (Claude) to generate the answer.",
+      "point_scope": "Only data from your household is shared, never data from another household.",
+      "point_retention": "We log usage statistics (latency, success) but not the content of your conversations.",
+      "accept": "Got it"
+    }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1455,5 +1455,24 @@
     "warrantyExpiresIn_other": "Vence en {{count}} días ({{date}})",
     "maintenanceDueIn_one": "Mantenimiento en {{count}} día ({{date}})",
     "maintenanceDueIn_other": "Mantenimiento en {{count}} días ({{date}})"
+  },
+  "agent": {
+    "title": "Agente",
+    "description": "Pregunta lo que quieras sobre tu hogar.",
+    "input_placeholder": "Pregunta al agente…",
+    "send": "Enviar",
+    "loading": "Buscando en tu hogar…",
+    "error": "Algo salió mal, inténtalo de nuevo.",
+    "empty_title": "Pregunta lo que quieras sobre tu hogar",
+    "empty_hint": "El agente busca en tus documentos, equipos, tareas, contratos y más, y cita cada fuente.",
+    "citations_label": "Fuentes",
+    "privacy": {
+      "title": "Antes de empezar",
+      "intro": "El agente lee los datos de tu hogar para responder a tus preguntas. Algunas cosas a saber:",
+      "point_provider": "Tus preguntas y los extractos relevantes se envían a Anthropic (Claude) para generar la respuesta.",
+      "point_scope": "Solo se comparten datos de tu hogar, nunca de otro hogar.",
+      "point_retention": "Registramos estadísticas de uso (latencia, éxito) pero no el contenido de tus conversaciones.",
+      "accept": "Entendido"
+    }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1455,5 +1455,24 @@
     "warrantyExpiresIn_other": "Expire dans {{count}} jours ({{date}})",
     "maintenanceDueIn_one": "Maintenance dans {{count}} jour ({{date}})",
     "maintenanceDueIn_other": "Maintenance dans {{count}} jours ({{date}})"
+  },
+  "agent": {
+    "title": "Agent",
+    "description": "Pose toutes tes questions sur ton foyer.",
+    "input_placeholder": "Pose ta question à l'agent…",
+    "send": "Envoyer",
+    "loading": "Recherche dans ton foyer…",
+    "error": "Une erreur est survenue, réessaie.",
+    "empty_title": "Pose toutes tes questions sur ton foyer",
+    "empty_hint": "L'agent fouille tes documents, équipements, tâches, contrats… et cite chaque source utilisée.",
+    "citations_label": "Sources",
+    "privacy": {
+      "title": "Avant de commencer",
+      "intro": "L'agent lit les données de ton foyer pour répondre à tes questions. Quelques infos utiles :",
+      "point_provider": "Tes questions et les extraits pertinents sont envoyés à Anthropic (Claude) pour générer la réponse.",
+      "point_scope": "Seules les données de ton foyer sont transmises, jamais celles d'un autre foyer.",
+      "point_retention": "On enregistre les statistiques d'usage (latence, succès) mais pas le contenu de tes conversations.",
+      "accept": "J'ai compris"
+    }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -26,6 +26,7 @@ const DashboardPage = lazyWithReload(() => import('./features/dashboard/Dashboar
 const AlertsPage = lazyWithReload(() => import('./features/alerts/AlertsPage'));
 const NotificationsPage = lazyWithReload(() => import('./features/notifications/NotificationsPage'));
 const AdminUsersPage = lazyWithReload(() => import('./features/admin/AdminUsersPage'));
+const AgentPage = lazyWithReload(() => import('./features/agent/AgentPage'));
 
 export const router = createBrowserRouter([
   {
@@ -65,6 +66,7 @@ export const router = createBrowserRouter([
       { path: 'alerts', element: <AlertsPage /> },
       { path: 'notifications', element: <NotificationsPage /> },
       { path: 'settings', element: <SettingsPage /> },
+      { path: 'agent', element: <AgentPage /> },
       { path: 'admin/users', element: <AdminUsersPage /> },
     ],
   },


### PR DESCRIPTION
## Summary

Lot 3 du parcours 07 — surface UI de l'agent conversationnel.

- page dédiée \`/app/agent/\` (route + entrée sidebar Sparkles) — pas de widget global en V1
- \`AgentPage\` : input + textarea (Enter pour envoyer, Shift+Enter pour newline), bulles question/réponse, loader, hint d'accueil
- \`PrivacyNotice\` : modale au premier usage, acceptation persistée localStorage (\`agent.privacyAccepted.v1\`), input bloqué tant qu'elle n'est pas acceptée
- \`AgentCitation\` : chip cliquable avec icône par \`entity_type\`, navigation via \`url_path\` renvoyé par l'API lot 2 (10 entity types mappés)
- \`ChatBubble\` : marqueurs \`<cite id="entity:id"/>\` rendus inline en chips numérotés + panneau "Sources" sous la réponse
- i18n complet en/fr/de/es (namespace \`agent\`)
- E2E Playwright (\`e2e/agent.spec.ts\`) : 5 tests, mock du backend, golden path + edge cases

Closes #102.

## Test plan

- [x] \`npm run lint\` — 0 erreur (warnings pre-existants intacts)
- [x] \`npm run build\` — OK
- [x] \`npx tsc --noEmit -p ui/tsconfig.json\` — OK
- [x] \`pytest apps/agent/ apps/ai_usage/\` — 62 passed
- [x] \`npm run test:e2e\` — 75 passed (5 nouveaux tests agent + 70 préexistants)
- [x] Couverture E2E mise à jour dans \`e2e/COVERAGE.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)