### PR TITLE
feat(interactions): FK polymorphe + service helper pour auto-créer des interactions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,39 +81,63 @@ t('tasks.title')
 
 **Pourquoi :** les `defaultValue` masquent les traductions manquantes. Sans eux, une clé absente du fichier JSON affiche la clé brute, ce qui permet de repérer immédiatement ce qui n'est pas traduit.
 
-## Auto-création d'`Interaction` — pattern write-time
+## Auto-création d'`Interaction` — pattern write-time + service helper
 
-Quand une action utilisateur auto-crée une `Interaction` (ex: achat de stock → interaction `expense`), le titre est rendu **dans la langue de l'utilisateur au moment de la création**, puis stocké en clair dans `subject`. Pas de localisation à l'affichage — admin, RAG, citation, CSV, `__str__`, l'edit user : tout consomme `interaction.subject` brut.
+Quand une action utilisateur auto-crée une `Interaction` (ex: achat de stock ou d'équipement → interaction `expense`), le titre est rendu **dans la langue de l'utilisateur au moment de la création**, puis stocké en clair dans `subject`. Pas de localisation à l'affichage — admin, RAG, citation, CSV, `__str__`, edit user : tout consomme `interaction.subject` brut.
 
-**Convention** :
+### Liaison polymorphe
+
+`Interaction` est lié à son objet source via une FK polymorphe `(source_content_type, source_object_id)` + un `GenericForeignKey('source')`. Cela permet à n'importe quel modèle (`StockItem`, `Equipment`, `Project`, etc.) d'être source d'une interaction sans toucher au schéma.
+
+### Service helper `create_expense_interaction`
+
+Pour le cas standard « achat sur un objet », utiliser le service partagé :
 
 ```python
-# apps/<feature>/views.py
-from django.utils.translation import gettext_lazy as _
+from interactions.services import create_expense_interaction
 
-interaction = Interaction.objects.create(
-    household=...,
-    type="expense",
-    subject=_("Purchase — {name}").format(name=item.name),  # localisé write-time
-    metadata={
-        "kind": "stock_purchase",       # discriminateur pour traçabilité / filtres futurs
-        "stock_item_name": item.name,   # contexte structuré utile à l'agent
-        ...
-    },
-    ...
+interaction = create_expense_interaction(
+    source=stock_item_or_equipment,        # n'importe quel HouseholdScopedModel
+    user=request.user,
+    amount=Decimal("199.00"),
+    supplier="Wood Co.",
+    occurred_at=timezone.now(),
+    notes="...",
+    kind="stock_purchase",                 # optionnel, défaut = "<app_label>_purchase"
+    extra_metadata={"delta": "3.8", "unit": "stère"},  # contexte feature-spécifique
 )
 ```
 
-Puis :
-1. `python manage.py makemessages -l fr -l de -l es` — extrait la chaîne
-2. Éditer les 3 `.po` (`locale/fr|de|es/LC_MESSAGES/django.po`) pour ajouter la traduction
-3. `python manage.py compilemessages` — génère les `.mo`
+Le service :
+- localise le subject via `gettext_lazy` + le template enregistré dans `apps/interactions/services.py::AUTO_SUBJECT_TEMPLATES`
+- ajoute `metadata.kind` (discriminateur), `metadata.source_name`, `metadata.amount`, `metadata.unit_price`, `metadata.supplier`
+- lie via la FK polymorphe
+- attache la zone du source si elle existe
 
-**Pourquoi ce pattern plutôt qu'une localisation à l'affichage** :
+Les **side-effects** spécifiques au modèle source (ajuster une quantité, snapshot prix sur l'objet, etc.) restent dans la view appelante — le service ne touche pas à l'objet source.
+
+### Ajouter un nouveau template d'auto-subject
+
+1. Ajouter l'entrée dans `AUTO_SUBJECT_TEMPLATES` (`apps/interactions/services.py`)
+2. `python manage.py makemessages -l fr -l de -l es`
+3. Éditer les 3 `.po` (`locale/fr|de|es/LC_MESSAGES/django.po`) pour ajouter la traduction
+4. `python manage.py compilemessages`
+
+### Frontend — formulaire partagé
+
+Pour la partie UI, `ui/src/features/interactions/PurchaseForm.tsx` est le composant partagé (champs prix/fournisseur/date/notes + delta optionnel). Chaque feature wrappe ce form dans son propre dialog (`StockPurchaseDialog`, `EquipmentPurchaseDialog`, etc.) qui gère :
+- son contexte (item courant, mutation appelée)
+- le titre du dialog
+- les éventuels affichages spécifiques (quantité courante pour stock)
+
+Les clés i18n `purchase.*` (génériques au form) sont **shared** ; les clés `stock.purchase.*` / `equipment.purchase.*` sont **feature-spécifiques** (titre, message créé, libellé du bouton sur la card).
+
+### Pourquoi ce pattern
+
 - 1 user = 1 langue (pas de multi-langue par user dans le projet)
 - Le subject reste lisible dans la DB pour l'admin Django, l'agent RAG (search vector), les exports CSV
 - L'user édite son subject via `InteractionEditPage` → son texte écrase l'auto, sans logique de flag/snapshot
-- Mécanisme générique : toute feature qui auto-crée des interactions suit cette convention
+- FK polymorphe → toute feature peut auto-créer une interaction liée à n'importe quel objet, sans migration de schéma à chaque fois
 
 **Limite acceptée** : si l'user change sa langue plus tard, ses anciennes interactions auto-créées restent dans l'ancienne langue. Acceptable car rare.
 

--- a/apps/equipment/serializers.py
+++ b/apps/equipment/serializers.py
@@ -1,8 +1,21 @@
+from decimal import Decimal
+
 from rest_framework import serializers
 from django.utils.translation import gettext_lazy as _
 
 from .models import Equipment, EquipmentInteraction
 from .services import compute_next_service_due
+
+
+class EquipmentPurchaseSerializer(serializers.Serializer):
+    """Input for /equipment/{id}/register-purchase/."""
+
+    amount = serializers.DecimalField(
+        max_digits=12, decimal_places=2, required=False, allow_null=True, min_value=Decimal("0")
+    )
+    supplier = serializers.CharField(required=False, allow_blank=True, default="")
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/apps/equipment/tests/test_api_equipment_purchase.py
+++ b/apps/equipment/tests/test_api_equipment_purchase.py
@@ -1,0 +1,141 @@
+from decimal import Decimal
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from accounts.models import User
+from equipment.models import Equipment
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from zones.models import Zone
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(email="eq-purchase@test.dev", password="secret")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(email="eq-other@test.dev", password="secret")
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Eq home")
+
+
+@pytest.fixture
+def second_household(db):
+    return Household.objects.create(name="Other home")
+
+
+@pytest.fixture
+def membership(user, household):
+    HouseholdMember.objects.create(
+        user=user, household=household, role=HouseholdMember.Role.OWNER
+    )
+
+
+@pytest.fixture
+def zone(household, user):
+    return Zone.objects.create(household=household, name="Workshop", created_by=user)
+
+
+@pytest.fixture
+def drill(household, zone, user):
+    return Equipment.objects.create(
+        household=household,
+        zone=zone,
+        name="Cordless drill",
+        created_by=user,
+    )
+
+
+def _purchase_url(equipment):
+    return reverse("equipment-register-purchase", kwargs={"pk": equipment.id})
+
+
+@pytest.mark.django_db
+def test_register_purchase_snapshots_equipment_and_creates_expense(client, user, household, drill, membership):
+    client.force_login(user)
+
+    response = client.post(
+        _purchase_url(drill),
+        data={
+            "amount": "199.00",
+            "supplier": "ToolStore",
+            "occurred_at": "2026-04-15T10:00:00Z",
+            "notes": "Replacement for old drill",
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, response.content
+    payload = response.json()
+    assert payload["purchase_price"] == "199.00"
+    assert payload["purchase_vendor"] == "ToolStore"
+    assert payload["purchase_date"] == "2026-04-15"
+    assert "interaction_id" in payload
+
+    interaction = Interaction.objects.get(id=payload["interaction_id"])
+    assert interaction.type == "expense"
+    assert interaction.source == drill
+    assert interaction.source_content_type == ContentType.objects.get_for_model(Equipment)
+    assert interaction.source_object_id == drill.id
+    assert interaction.household_id == household.id
+    assert interaction.subject == "Purchase — Cordless drill"
+    assert interaction.metadata["kind"] == "equipment_purchase"
+    assert interaction.metadata["amount"] == "199.00"
+    assert interaction.metadata["supplier"] == "ToolStore"
+    assert interaction.metadata["equipment_name"] == "Cordless drill"
+    assert interaction.zones.count() == 1
+    assert interaction.zones.first().id == drill.zone_id
+
+
+@pytest.mark.django_db
+def test_register_purchase_without_amount_still_creates_interaction(client, user, drill, membership):
+    client.force_login(user)
+
+    response = client.post(
+        _purchase_url(drill),
+        data={"notes": "Free hand-me-down"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, response.content
+    payload = response.json()
+    assert payload["purchase_price"] is None
+    assert "interaction_id" in payload
+
+    interaction = Interaction.objects.get(id=payload["interaction_id"])
+    assert interaction.metadata["amount"] is None
+
+
+@pytest.mark.django_db
+def test_register_purchase_isolates_between_households(client, other_user, second_household, drill):
+    HouseholdMember.objects.create(
+        user=other_user, household=second_household, role=HouseholdMember.Role.OWNER
+    )
+    client.force_login(other_user)
+
+    response = client.post(
+        _purchase_url(drill),
+        data={"amount": "10"},
+        content_type="application/json",
+    )
+
+    assert response.status_code in (403, 404)
+    assert Interaction.objects.filter(source_object_id=drill.id).count() == 0
+
+
+@pytest.mark.django_db
+def test_register_purchase_requires_authentication(client, drill):
+    response = client.post(
+        _purchase_url(drill),
+        data={"amount": "10"},
+        content_type="application/json",
+    )
+    assert response.status_code in (401, 403)
+    assert Interaction.objects.filter(source_object_id=drill.id).count() == 0

--- a/apps/equipment/views.py
+++ b/apps/equipment/views.py
@@ -1,15 +1,22 @@
-from rest_framework import filters, viewsets
+from django.db import transaction
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from rest_framework.exceptions import ValidationError
-from django_filters.rest_framework import DjangoFilterBackend
-from django.utils.translation import gettext_lazy as _
 
 from core.permissions import IsHouseholdMember
 from interactions.models import Interaction
+from interactions.services import create_expense_interaction
 from .models import Equipment, EquipmentInteraction
-from .serializers import EquipmentSerializer, EquipmentInteractionSerializer
+from .serializers import (
+    EquipmentInteractionSerializer,
+    EquipmentPurchaseSerializer,
+    EquipmentSerializer,
+)
 
 
 class EquipmentViewSet(viewsets.ModelViewSet):
@@ -36,6 +43,50 @@ class EquipmentViewSet(viewsets.ModelViewSet):
 
     def perform_update(self, serializer):
         serializer.save(updated_by=self.request.user)
+
+    @action(detail=True, methods=["post"], url_path="register-purchase")
+    def register_purchase(self, request, pk=None):
+        """Snapshot purchase fields on the equipment + create an expense Interaction.
+
+        Single-action endpoint: writes amount/supplier/date on the equipment AND
+        creates an Interaction(type=expense) linked via the polymorphic source FK.
+        """
+        equipment = self.get_object()
+        serializer = EquipmentPurchaseSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        amount = serializer.validated_data.get("amount")
+        supplier = serializer.validated_data.get("supplier", "") or ""
+        occurred_at = serializer.validated_data.get("occurred_at") or timezone.now()
+        notes = serializer.validated_data.get("notes", "") or ""
+
+        with transaction.atomic():
+            # Equipment-specific snapshot of the most recent purchase
+            if amount is not None:
+                equipment.purchase_price = amount
+            if supplier:
+                equipment.purchase_vendor = supplier
+            equipment.purchase_date = occurred_at.date()
+            equipment.updated_by = request.user
+            equipment.save(update_fields=[
+                "purchase_price", "purchase_vendor", "purchase_date",
+                "updated_by", "updated_at",
+            ])
+
+            interaction = create_expense_interaction(
+                source=equipment,
+                user=request.user,
+                amount=amount,
+                supplier=supplier,
+                occurred_at=occurred_at,
+                notes=notes,
+                kind="equipment_purchase",
+                extra_metadata={"equipment_name": equipment.name},
+            )
+
+        payload = EquipmentSerializer(equipment, context={"request": request}).data
+        payload["interaction_id"] = str(interaction.id)
+        return Response(payload, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["get"])
     def audit(self, request, pk=None):

--- a/apps/interactions/migrations/0015_add_polymorphic_source.py
+++ b/apps/interactions/migrations/0015_add_polymorphic_source.py
@@ -1,0 +1,98 @@
+"""
+Replace `Interaction.stock_item` (specific FK) with a generic polymorphic source
+`(source_content_type, source_object_id)` so any module can link an interaction
+to its triggering object.
+
+Order matters: add the new fields, copy data, then drop the old FK + index.
+"""
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def copy_stock_item_to_source(apps, schema_editor):
+    Interaction = apps.get_model('interactions', 'Interaction')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+
+    # Resolve the ContentType for stock.StockItem once
+    stock_item_ct = ContentType.objects.filter(app_label='stock', model='stockitem').first()
+    if stock_item_ct is None:
+        return
+
+    # All interactions that already point to a StockItem via the legacy FK
+    candidates = Interaction.objects.filter(stock_item__isnull=False)
+    for interaction in candidates.iterator():
+        interaction.source_content_type = stock_item_ct
+        interaction.source_object_id = interaction.stock_item_id
+        interaction.save(update_fields=['source_content_type', 'source_object_id'])
+
+
+def restore_stock_item_from_source(apps, schema_editor):
+    """Reverse: only used if you migrate back. Best-effort."""
+    Interaction = apps.get_model('interactions', 'Interaction')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+
+    stock_item_ct = ContentType.objects.filter(app_label='stock', model='stockitem').first()
+    if stock_item_ct is None:
+        return
+
+    candidates = Interaction.objects.filter(source_content_type=stock_item_ct)
+    for interaction in candidates.iterator():
+        interaction.stock_item_id = interaction.source_object_id
+        interaction.save(update_fields=['stock_item_id'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('households', '0008_household_preferred_language'),
+        ('interactions', '0014_backfill_stock_purchase_subjects'),
+        ('projects', '0006_rename_user_pinned_househo_ce4d75_idx_project_mem_househo_b9a7c5_idx_and_more'),
+        ('zones', '0005_zone_one_root_constraint'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        # 1. Add the new generic FK columns
+        migrations.AddField(
+            model_name='interaction',
+            name='source_content_type',
+            field=models.ForeignKey(
+                blank=True,
+                help_text='Polymorphic source: type of the object that triggered this interaction.',
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='+',
+                to='contenttypes.contenttype',
+            ),
+        ),
+        migrations.AddField(
+            model_name='interaction',
+            name='source_object_id',
+            field=models.UUIDField(
+                blank=True,
+                help_text='Polymorphic source: id of the object that triggered this interaction.',
+                null=True,
+            ),
+        ),
+        # 2. Copy data from the legacy stock_item FK into the new generic columns
+        migrations.RunPython(copy_stock_item_to_source, reverse_code=restore_stock_item_from_source),
+        # 3. Drop the old FK + index now that data is moved
+        migrations.RemoveIndex(
+            model_name='interaction',
+            name='idx_int_stock_item',
+        ),
+        migrations.RemoveField(
+            model_name='interaction',
+            name='stock_item',
+        ),
+        # 4. Index the new generic columns for query performance
+        migrations.AddIndex(
+            model_name='interaction',
+            index=models.Index(
+                fields=['source_content_type', 'source_object_id'],
+                name='idx_int_source',
+            ),
+        ),
+    ]

--- a/apps/interactions/models.py
+++ b/apps/interactions/models.py
@@ -1,9 +1,10 @@
-""" 
+"""
 Interactions models - time-based entries (notes, todos, expenses, maintenance).
 """
 import uuid
 from django.db import models
-from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
+from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext_lazy as _
 from core.models import HouseholdScopedModel
 from core.managers import HouseholdScopedManager
@@ -87,15 +88,20 @@ class Interaction(HouseholdScopedModel):
         related_name='interactions',
         db_column='project_id'
     )
-    stock_item = models.ForeignKey(
-        'stock.StockItem',
+    source_content_type = models.ForeignKey(
+        ContentType,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        related_name='interactions',
-        db_column='stock_item_id',
-        help_text="Optional link to a stock item (e.g. an expense for restocking).",
+        related_name='+',
+        help_text="Polymorphic source: type of the object that triggered this interaction.",
     )
+    source_object_id = models.UUIDField(
+        null=True,
+        blank=True,
+        help_text="Polymorphic source: id of the object that triggered this interaction.",
+    )
+    source = GenericForeignKey('source_content_type', 'source_object_id')
     zones = models.ManyToManyField(
         'zones.Zone',
         through='InteractionZone',
@@ -113,7 +119,10 @@ class Interaction(HouseholdScopedModel):
             models.Index(fields=['household', 'type'], name='idx_int_hh_type'),
             models.Index(fields=['household', '-occurred_at'], name='idx_int_hh_date'),
             models.Index(fields=['project'], name='idx_int_project'),
-            models.Index(fields=['stock_item'], name='idx_int_stock_item'),
+            models.Index(
+                fields=['source_content_type', 'source_object_id'],
+                name='idx_int_source',
+            ),
             models.Index(fields=['status'], name='idx_int_status'),
             models.Index(fields=['is_private'], name='idx_int_private'),
         ]

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -28,7 +28,9 @@ class InteractionSerializer(serializers.ModelSerializer):
         required=True
     )
     project_title = serializers.SerializerMethodField()
-    stock_item_name = serializers.CharField(source='stock_item.name', read_only=True)
+    source_type = serializers.SerializerMethodField()
+    source_id = serializers.UUIDField(source='source_object_id', read_only=True)
+    source_label = serializers.SerializerMethodField()
     zone_names = serializers.SerializerMethodField()
     document_count = serializers.SerializerMethodField()
     tags = serializers.SerializerMethodField()
@@ -52,7 +54,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'id', 'household', 'subject', 'content', 'type', 'status',
             'is_private', 'occurred_at', 'tags', 'tags_input', 'metadata', 'enriched_text',
             'project', 'project_title',
-            'stock_item', 'stock_item_name',
+            'source_type', 'source_id', 'source_label',
             'zone_ids', 'zone_names', 'document_count', 'linked_document_ids', 'document_ids',
             'created_at', 'updated_at', 'created_by', 'created_by_name'
         ]
@@ -69,6 +71,18 @@ class InteractionSerializer(serializers.ModelSerializer):
         if obj.project_id:
             return obj.project.title if obj.project else None
         return None
+
+    def get_source_type(self, obj):
+        if obj.source_content_type_id is None:
+            return None
+        ct = obj.source_content_type
+        return f"{ct.app_label}.{ct.model}"
+
+    def get_source_label(self, obj):
+        source = obj.source
+        if source is None:
+            return None
+        return getattr(source, 'name', None) or getattr(source, 'title', None) or str(source)
 
     def get_zone_names(self, obj):
         return [zone.name for zone in obj.zones.all()]

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -1,0 +1,122 @@
+"""
+Service helpers used by other apps to auto-create Interactions linked to a
+domain object via the polymorphic `(source_content_type, source_object_id)` FK.
+
+The shared piece is the auto-subject (rendered write-time in the creator's
+locale via gettext) plus the kind discriminator in metadata. Side-effects
+specific to a source model (adjust stock quantity, snapshot equipment fields,
+etc.) stay in the calling view — the service only owns the Interaction.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from django.contrib.contenttypes.models import ContentType
+from django.db import transaction
+from django.utils import timezone
+from django.utils.translation import gettext_lazy as _
+
+from .models import Interaction, InteractionZone
+
+
+# Templates registry: maps a kind discriminator to a translatable subject template.
+# Templates use {name} as the source object's display name.
+AUTO_SUBJECT_TEMPLATES: dict[str, Any] = {
+    "stock_purchase": _("Purchase — {name}"),
+    "equipment_purchase": _("Purchase — {name}"),
+}
+
+
+def _purchase_kind_for_source(source) -> str:
+    """Return the kind discriminator for a purchase action on this source.
+
+    Convention: `<source_app_label>_purchase`. Examples: stock_purchase,
+    equipment_purchase. Callers can override with an explicit kind.
+    """
+    return f"{source._meta.app_label}_purchase"
+
+
+def _resolve_subject_template(kind: str) -> Any:
+    """Find a registered subject template for a kind, fall back to a generic one."""
+    if kind in AUTO_SUBJECT_TEMPLATES:
+        return AUTO_SUBJECT_TEMPLATES[kind]
+    return _("Interaction — {name}")
+
+
+def _source_name(source) -> str:
+    return getattr(source, "name", None) or getattr(source, "title", None) or str(source)
+
+
+def create_expense_interaction(
+    *,
+    source,
+    user,
+    amount: Decimal | None = None,
+    unit_price: Decimal | None = None,
+    supplier: str = "",
+    occurred_at: datetime | None = None,
+    notes: str = "",
+    extra_metadata: dict[str, Any] | None = None,
+    kind: str | None = None,
+) -> Interaction:
+    """Create an Interaction(type=expense) linked to `source` via polymorphic FK.
+
+    The subject is auto-localized at write time using the user's active locale
+    (set by `core.middleware.UserLocaleMiddleware`). The interaction inherits
+    the source's household and zone (if any).
+
+    Args:
+        source: any HouseholdScopedModel instance (StockItem, Equipment, etc.)
+        user: request.user (used as created_by + locale provider)
+        amount, unit_price, supplier, occurred_at, notes: expense details
+        extra_metadata: feature-specific metadata (delta, unit, etc.) merged
+            into the standard payload.
+        kind: override the auto-derived kind (e.g. "stock_purchase").
+
+    Side-effects on the source object (adjust quantity, snapshot purchase
+    fields, etc.) stay in the caller — this service owns the Interaction only.
+    """
+    if not hasattr(source, "household_id"):
+        raise ValueError(
+            "create_expense_interaction: source must be a HouseholdScopedModel "
+            f"(got {type(source).__name__})"
+        )
+
+    resolved_kind = kind or _purchase_kind_for_source(source)
+    template = _resolve_subject_template(resolved_kind)
+    name = _source_name(source)
+    subject = template.format(name=name)
+
+    # Always write the standard expense keys (None when missing) so consumers
+    # have a stable shape — extra_metadata can add feature-specific keys.
+    metadata: dict[str, Any] = {
+        "kind": resolved_kind,
+        "source_name": name,
+        "amount": str(amount) if amount is not None else None,
+        "unit_price": str(unit_price) if unit_price is not None else None,
+        "supplier": supplier or "",
+    }
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    source_ct = ContentType.objects.get_for_model(source.__class__)
+
+    with transaction.atomic():
+        interaction = Interaction.objects.create(
+            household_id=source.household_id,
+            created_by=user,
+            subject=subject,
+            content=notes,
+            type="expense",
+            occurred_at=occurred_at or timezone.now(),
+            metadata=metadata,
+            source_content_type=source_ct,
+            source_object_id=source.pk,
+        )
+        zone = getattr(source, "zone", None)
+        if zone is not None:
+            InteractionZone.objects.create(interaction=interaction, zone=zone)
+
+    return interaction

--- a/apps/interactions/tests/test_services.py
+++ b/apps/interactions/tests/test_services.py
@@ -1,0 +1,144 @@
+from decimal import Decimal
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.utils import timezone
+
+from accounts.models import User
+from equipment.models import Equipment
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from interactions.services import create_expense_interaction
+from stock.models import StockCategory, StockItem
+from zones.models import Zone
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(email="svc@test.dev", password="secret")
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Service test home")
+
+
+@pytest.fixture
+def membership(user, household):
+    HouseholdMember.objects.create(
+        user=user, household=household, role=HouseholdMember.Role.OWNER
+    )
+
+
+@pytest.fixture
+def zone(household, user):
+    return Zone.objects.create(household=household, name="Garage", created_by=user)
+
+
+@pytest.fixture
+def stock_item(household, user, zone):
+    category = StockCategory.objects.create(
+        household=household, name="Heating", created_by=user
+    )
+    return StockItem.objects.create(
+        household=household,
+        category=category,
+        zone=zone,
+        name="Pellets",
+        quantity=Decimal("0"),
+        unit="bag",
+        status="out_of_stock",
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def equipment(household, user, zone):
+    return Equipment.objects.create(
+        household=household,
+        zone=zone,
+        name="Drill",
+        created_by=user,
+    )
+
+
+@pytest.mark.django_db
+def test_creates_interaction_linked_to_stock_item(user, household, stock_item, membership):
+    interaction = create_expense_interaction(
+        source=stock_item,
+        user=user,
+        amount=Decimal("25.00"),
+        supplier="HardwareCo",
+        notes="Bought a bag",
+    )
+
+    assert interaction.type == "expense"
+    assert interaction.household_id == household.id
+    assert interaction.created_by_id == user.id
+    assert interaction.source == stock_item
+    assert interaction.source_content_type == ContentType.objects.get_for_model(StockItem)
+    assert interaction.source_object_id == stock_item.id
+    assert interaction.subject == "Purchase — Pellets"
+    assert interaction.metadata["kind"] == "stock_purchase"
+    assert interaction.metadata["source_name"] == "Pellets"
+    assert interaction.metadata["amount"] == "25.00"
+    assert interaction.metadata["supplier"] == "HardwareCo"
+    # zone of the source is attached
+    assert interaction.zones.count() == 1
+    assert interaction.zones.first().id == stock_item.zone_id
+
+
+@pytest.mark.django_db
+def test_creates_interaction_linked_to_equipment(user, household, equipment, membership):
+    interaction = create_expense_interaction(
+        source=equipment,
+        user=user,
+        amount=Decimal("199.00"),
+    )
+
+    assert interaction.source == equipment
+    assert interaction.source_content_type == ContentType.objects.get_for_model(Equipment)
+    assert interaction.subject == "Purchase — Drill"
+    assert interaction.metadata["kind"] == "equipment_purchase"
+
+
+@pytest.mark.django_db
+def test_kind_override_takes_precedence(user, household, stock_item, membership):
+    interaction = create_expense_interaction(
+        source=stock_item,
+        user=user,
+        kind="custom_kind",
+    )
+    assert interaction.metadata["kind"] == "custom_kind"
+
+
+@pytest.mark.django_db
+def test_extra_metadata_is_merged(user, stock_item, membership):
+    interaction = create_expense_interaction(
+        source=stock_item,
+        user=user,
+        amount=Decimal("10"),
+        extra_metadata={"delta": "2.5", "unit": "bag", "amount": "OVERRIDDEN"},
+    )
+    # extra_metadata can override standard keys (intentional escape hatch)
+    assert interaction.metadata["amount"] == "OVERRIDDEN"
+    assert interaction.metadata["delta"] == "2.5"
+    assert interaction.metadata["unit"] == "bag"
+
+
+@pytest.mark.django_db
+def test_uses_provided_occurred_at_else_now(user, stock_item, membership):
+    when = timezone.now().replace(year=2025, microsecond=0)
+    interaction = create_expense_interaction(
+        source=stock_item, user=user, occurred_at=when
+    )
+    assert interaction.occurred_at.replace(microsecond=0) == when
+
+
+@pytest.mark.django_db
+def test_rejects_source_without_household(user, db):
+    class FakeSource:
+        pk = "abc"
+
+    with pytest.raises(ValueError, match="HouseholdScopedModel"):
+        create_expense_interaction(source=FakeSource(), user=user)

--- a/apps/stock/tests/test_api_stock_purchase.py
+++ b/apps/stock/tests/test_api_stock_purchase.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
 from accounts.models import User
@@ -8,6 +9,11 @@ from households.models import Household, HouseholdMember
 from interactions.models import Interaction
 from stock.models import StockCategory, StockItem
 from zones.models import Zone
+
+
+def _interactions_for_item(item):
+    ct = ContentType.objects.get_for_model(StockItem)
+    return Interaction.objects.filter(source_content_type=ct, source_object_id=item.id)
 
 
 @pytest.fixture
@@ -90,7 +96,9 @@ def test_purchase_increments_quantity_and_creates_expense(client, user, househol
 
     interaction = Interaction.objects.get(id=payload["interaction_id"])
     assert interaction.type == "expense"
-    assert interaction.stock_item_id == firewood.id
+    assert interaction.source_object_id == firewood.id
+    assert interaction.source_content_type == ContentType.objects.get_for_model(StockItem)
+    assert interaction.source == firewood
     assert interaction.household_id == household.id
     assert interaction.created_by_id == user.id
     assert interaction.subject == "Purchase — Firewood"
@@ -144,7 +152,7 @@ def test_purchase_rejects_zero_or_negative_delta(client, user, firewood, members
 
     firewood.refresh_from_db()
     assert firewood.quantity == Decimal("0")
-    assert Interaction.objects.filter(stock_item=firewood).count() == 0
+    assert _interactions_for_item(firewood).count() == 0
 
 
 @pytest.mark.django_db
@@ -163,7 +171,7 @@ def test_purchase_isolates_between_households(client, other_user, second_househo
     assert response.status_code in (403, 404)
     firewood.refresh_from_db()
     assert firewood.quantity == Decimal("0")
-    assert Interaction.objects.filter(stock_item=firewood).count() == 0
+    assert _interactions_for_item(firewood).count() == 0
 
 
 @pytest.mark.django_db
@@ -174,7 +182,7 @@ def test_purchase_requires_authentication(client, firewood):
         content_type="application/json",
     )
     assert response.status_code in (401, 403)
-    assert Interaction.objects.filter(stock_item=firewood).count() == 0
+    assert _interactions_for_item(firewood).count() == 0
 
 
 @pytest.mark.django_db

--- a/apps/stock/views.py
+++ b/apps/stock/views.py
@@ -12,7 +12,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
-from interactions.models import Interaction, InteractionZone
+from interactions.services import create_expense_interaction
 
 from .models import StockCategory, StockItem
 from .serializers import (
@@ -138,6 +138,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
         unit_price = (amount / delta).quantize(Decimal("0.01")) if amount is not None and delta > 0 else None
 
         with transaction.atomic():
+            # Stock-specific side-effects on the item
             item.quantity = Decimal(item.quantity) + delta
             item.last_restocked_at = timezone.now()
             if unit_price is not None:
@@ -158,27 +159,21 @@ class StockItemViewSet(viewsets.ModelViewSet):
             item.updated_by = request.user
             item.save()
 
-            subject = _("Purchase — {name}").format(name=item.name)
-            metadata = {
-                "kind": "stock_purchase",
-                "stock_item_name": item.name,
-                "amount": str(amount) if amount is not None else None,
-                "unit_price": str(unit_price) if unit_price is not None else None,
-                "delta": str(delta),
-                "unit": item.unit,
-            }
-            interaction = Interaction.objects.create(
-                household=item.household,
-                created_by=request.user,
-                subject=subject,
-                content=notes,
-                type="expense",
+            interaction = create_expense_interaction(
+                source=item,
+                user=request.user,
+                amount=amount,
+                unit_price=unit_price,
+                supplier=supplier,
                 occurred_at=occurred_at,
-                metadata=metadata,
-                stock_item=item,
+                notes=notes,
+                kind="stock_purchase",
+                extra_metadata={
+                    "stock_item_name": item.name,
+                    "delta": str(delta),
+                    "unit": item.unit,
+                },
             )
-            if item.zone_id:
-                InteractionZone.objects.create(interaction=interaction, zone=item.zone)
 
         payload = StockItemSerializer(item, context={"request": request}).data
         payload["interaction_id"] = str(interaction.id)

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -131,6 +131,16 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 
 ---
 
+## Équipement (`equipment-purchase.spec.ts`)
+
+| Parcours | Statut |
+|---|---|
+| Création d'un équipement | ✅ |
+| Enregistrement d'un achat (prix + fournisseur, sans delta) en un seul geste | ✅ |
+| L'achat crée une `Interaction(type=expense)` liée via la FK polymorphe `source` et listée dans `/app/interactions` | ✅ |
+
+---
+
 ## Équipements
 
 | Parcours | Statut |

--- a/e2e/equipment-purchase.spec.ts
+++ b/e2e/equipment-purchase.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Parcours générique : enregistrer un achat sur un équipement.
+ *
+ * Issue: https://github.com/jammindev/house/issues/119 — généralisation du
+ * pattern "auto-création d'Interaction(expense) depuis n'importe quel module"
+ * via la FK polymorphe Interaction.source + le service create_expense_interaction.
+ */
+
+test('parcours achat d\'équipement — perceuse 199€', async ({ page }) => {
+  // 1. Créer un équipement « Perceuse E2E »
+  await page.goto('/app/equipment');
+  await expect(page).toHaveURL(/\/app\/equipment/);
+
+  await page.getByRole('button', { name: 'Nouveau' }).first().click();
+
+  let dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  const itemName = `Perceuse E2E ${Date.now()}`;
+  await page.locator('#eq-name').fill(itemName);
+
+  await dialog.getByRole('button', { name: /enregistrer|créer/i }).click();
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(itemName)).toBeVisible();
+
+  // 2. Cliquer sur l'action « Achat » de la card
+  const card = page.getByText(itemName, { exact: true }).locator('xpath=ancestor::li');
+  await card.getByRole('button', { name: 'Achat' }).click();
+
+  dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Enregistrer un achat');
+  await expect(dialog).toContainText(itemName);
+
+  // 3. Remplir : pas de delta (equipment), juste prix + fournisseur
+  await page.locator('#purchase-price').fill('199');
+  await page.locator('#purchase-supplier').fill('ToolStore');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+  await expect(dialog).toBeHidden();
+
+  // 4. Vérifier que l'interaction expense est listée dans /app/interactions
+  await page.goto('/app/interactions');
+  await expect(page.getByText(`Achat — ${itemName}`).first()).toBeVisible();
+});

--- a/e2e/stock-purchase.spec.ts
+++ b/e2e/stock-purchase.spec.ts
@@ -57,9 +57,9 @@ test('parcours achat de stock — bois de chauffage 3,8 stères', async ({ page 
   await expect(dialog).toContainText('Quantité actuelle');
 
   // 4. Remplir : 3,8 stères / 342 € / Wood Co.
-  await page.locator('#stock-purchase-delta').fill('3.8');
-  await page.locator('#stock-purchase-price').fill('342');
-  await page.locator('#stock-purchase-supplier').fill('Wood Co.');
+  await page.locator('#purchase-delta').fill('3.8');
+  await page.locator('#purchase-price').fill('342');
+  await page.locator('#purchase-supplier').fill('Wood Co.');
   await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
 
   await expect(dialog).toBeHidden();

--- a/ui/src/features/equipment/EquipmentCard.tsx
+++ b/ui/src/features/equipment/EquipmentCard.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
+import { Button } from '@/design-system/button';
 import { CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import type { EquipmentListItem } from '@/lib/api/equipment';
@@ -10,6 +11,7 @@ interface EquipmentCardProps {
   item: EquipmentListItem;
   onEdit: (item: EquipmentListItem) => void;
   onDelete: (itemId: string) => void;
+  onPurchase: (item: EquipmentListItem) => void;
 }
 
 function statusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
@@ -26,7 +28,7 @@ function formatDate(value?: string | null): string {
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
 }
 
-export default function EquipmentCard({ item, onEdit, onDelete }: EquipmentCardProps) {
+export default function EquipmentCard({ item, onEdit, onDelete, onPurchase }: EquipmentCardProps) {
   const { t } = useTranslation();
 
   const actions: CardAction[] = [
@@ -56,16 +58,28 @@ export default function EquipmentCard({ item, onEdit, onDelete }: EquipmentCardP
         </div>
       </div>
 
-      <div className="mt-2 grid gap-1 text-xs text-muted-foreground sm:grid-cols-3">
-        <p>
-          {t('equipment.zone')}: {item.zone_name || t('equipment.not_available')}
-        </p>
-        <p>
-          {t('equipment.warranty')}: {formatDate(item.warranty_expires_on)}
-        </p>
-        <p>
-          {t('equipment.next_service')}: {formatDate(item.next_service_due)}
-        </p>
+      <div className="mt-2 flex flex-wrap items-end justify-between gap-2">
+        <div className="grid gap-1 text-xs text-muted-foreground sm:grid-cols-3 sm:gap-x-4">
+          <p>
+            {t('equipment.zone')}: {item.zone_name || t('equipment.not_available')}
+          </p>
+          <p>
+            {t('equipment.warranty')}: {formatDate(item.warranty_expires_on)}
+          </p>
+          <p>
+            {t('equipment.next_service')}: {formatDate(item.next_service_due)}
+          </p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onPurchase(item)}
+          className="h-7 gap-1 px-2 text-xs"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          {t('equipment.purchase.actions.add')}
+        </Button>
       </div>
     </li>
   );

--- a/ui/src/features/equipment/EquipmentPage.tsx
+++ b/ui/src/features/equipment/EquipmentPage.tsx
@@ -10,6 +10,7 @@ import type { EquipmentListItem } from '@/lib/api/equipment';
 import { useEquipmentList, useDeleteEquipment, useZones, equipmentKeys } from './hooks';
 import EquipmentCard from './EquipmentCard';
 import EquipmentDialog from './EquipmentDialog';
+import EquipmentPurchaseDialog from './EquipmentPurchaseDialog';
 
 const STATUS_OPTIONS = ['', 'active', 'maintenance', 'storage', 'retired', 'lost', 'ordered'];
 
@@ -22,6 +23,7 @@ export default function EquipmentPage() {
   const [zone, setZone] = React.useState('');
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editingItem, setEditingItem] = React.useState<EquipmentListItem | null>(null);
+  const [purchasingItem, setPurchasingItem] = React.useState<EquipmentListItem | null>(null);
 
   const filters = React.useMemo(
     () => ({
@@ -167,6 +169,7 @@ export default function EquipmentPage() {
                   item={item}
                   onEdit={setEditingItem}
                   onDelete={handleDelete}
+                  onPurchase={setPurchasingItem}
                 />
               ))}
             </ul>
@@ -187,6 +190,12 @@ export default function EquipmentPage() {
         }}
         existingItem={editingItem ?? undefined}
         onSaved={handleSaved}
+      />
+
+      <EquipmentPurchaseDialog
+        open={purchasingItem !== null}
+        onOpenChange={(open) => { if (!open) setPurchasingItem(null); }}
+        equipment={purchasingItem}
       />
     </>
   );

--- a/ui/src/features/equipment/EquipmentPurchaseDialog.tsx
+++ b/ui/src/features/equipment/EquipmentPurchaseDialog.tsx
@@ -1,35 +1,38 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
-import type { StockItem } from '@/lib/api/stock';
+import type { EquipmentListItem } from '@/lib/api/equipment';
 import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
-import { usePurchaseStockItem } from './hooks';
+import { useRegisterEquipmentPurchase } from './hooks';
 
-interface StockPurchaseDialogProps {
+interface EquipmentPurchaseDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  item: StockItem | null;
+  equipment: EquipmentListItem | null;
 }
 
-export default function StockPurchaseDialog({ open, onOpenChange, item }: StockPurchaseDialogProps) {
+export default function EquipmentPurchaseDialog({
+  open,
+  onOpenChange,
+  equipment,
+}: EquipmentPurchaseDialogProps) {
   const { t } = useTranslation();
-  const purchaseMutation = usePurchaseStockItem();
+  const purchaseMutation = useRegisterEquipmentPurchase();
   const [error, setError] = React.useState<string | null>(null);
 
   React.useEffect(() => {
     if (!open) setError(null);
   }, [open]);
 
-  if (!item) return null;
+  if (!equipment) return null;
 
   async function handleSubmit(payload: PurchaseFormPayload) {
     setError(null);
-    if (!item || payload.delta === undefined) return;
+    if (!equipment) return;
     try {
       await purchaseMutation.mutateAsync({
-        id: item.id,
+        id: equipment.id,
         payload: {
-          delta: payload.delta,
           amount: payload.amount,
           supplier: payload.supplier,
           occurred_at: payload.occurred_at,
@@ -46,16 +49,10 @@ export default function StockPurchaseDialog({ open, onOpenChange, item }: StockP
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
         <DialogHeader>
-          <DialogTitle>{t('stock.purchase.title', { name: item.name })}</DialogTitle>
+          <DialogTitle>{t('equipment.purchase.title', { name: equipment.name })}</DialogTitle>
         </DialogHeader>
 
-        <p className="text-sm text-muted-foreground">
-          {t('stock.purchase.current_quantity', { quantity: item.quantity, unit: item.unit })}
-        </p>
-
         <PurchaseForm
-          withDelta
-          deltaUnit={item.unit}
           isPending={purchaseMutation.isPending}
           onSubmit={handleSubmit}
           onCancel={() => onOpenChange(false)}

--- a/ui/src/features/equipment/hooks.ts
+++ b/ui/src/features/equipment/hooks.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import {
   fetchEquipmentList,
   fetchEquipment,
@@ -6,9 +7,12 @@ import {
   createEquipment,
   updateEquipment,
   deleteEquipment,
+  registerEquipmentPurchase,
   type EquipmentPayload,
+  type EquipmentPurchasePayload,
 } from '@/lib/api/equipment';
 import { fetchZones } from '@/lib/api/zones';
+import { toast } from '@/lib/toast';
 
 interface EquipmentFilters {
   search?: string;
@@ -74,5 +78,20 @@ export function useDeleteEquipment() {
   return useMutation({
     mutationFn: (id: string) => deleteEquipment(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: equipmentKeys.all }),
+  });
+}
+
+export function useRegisterEquipmentPurchase() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: EquipmentPurchasePayload }) =>
+      registerEquipmentPurchase(id, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: equipmentKeys.all });
+      qc.invalidateQueries({ queryKey: ['interactions'] });
+      toast({ description: t('equipment.purchase.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }

--- a/ui/src/features/interactions/PurchaseForm.tsx
+++ b/ui/src/features/interactions/PurchaseForm.tsx
@@ -1,0 +1,224 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/design-system/input';
+import { Textarea } from '@/design-system/textarea';
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+
+export interface PurchaseFormPayload {
+  delta?: number;
+  amount: number | null;
+  supplier: string;
+  occurred_at: string | null;
+  notes: string;
+}
+
+interface PurchaseFormProps {
+  /** Show a "quantity added" input. Stock items use this; equipment doesn't. */
+  withDelta?: boolean;
+  /** Unit label shown next to the delta and as the "per X" toggle option. */
+  deltaUnit?: string;
+  /** True while the parent mutation is in flight. */
+  isPending: boolean;
+  onSubmit: (payload: PurchaseFormPayload) => void | Promise<void>;
+  onCancel: () => void;
+  /** Optional submit-time error message to display above the buttons. */
+  externalError?: string | null;
+}
+
+type PriceMode = 'total' | 'unit';
+
+interface FormState {
+  delta: string;
+  priceMode: PriceMode;
+  price: string;
+  supplier: string;
+  occurredAt: string;
+  notes: string;
+}
+
+function todayIsoDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function emptyState(): FormState {
+  return {
+    delta: '',
+    priceMode: 'total',
+    price: '',
+    supplier: '',
+    occurredAt: todayIsoDate(),
+    notes: '',
+  };
+}
+
+function parseDecimal(value: string): number | null {
+  const trimmed = value.trim().replace(',', '.');
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export default function PurchaseForm({
+  withDelta = false,
+  deltaUnit,
+  isPending,
+  onSubmit,
+  onCancel,
+  externalError,
+}: PurchaseFormProps) {
+  const { t } = useTranslation();
+  const [form, setForm] = React.useState<FormState>(emptyState);
+  const [internalError, setInternalError] = React.useState<string | null>(null);
+
+  const error = externalError ?? internalError;
+
+  function updateField<Key extends keyof FormState>(key: Key, value: FormState[Key]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setInternalError(null);
+
+    let delta: number | undefined;
+    if (withDelta) {
+      const parsedDelta = parseDecimal(form.delta);
+      if (parsedDelta === null || parsedDelta <= 0) {
+        setInternalError(t('purchase.errors.delta_required'));
+        return;
+      }
+      delta = parsedDelta;
+    }
+
+    const priceValue = parseDecimal(form.price);
+    let amount: number | null = null;
+    if (priceValue !== null) {
+      if (priceValue < 0) {
+        setInternalError(t('purchase.errors.price_invalid'));
+        return;
+      }
+      amount = withDelta && form.priceMode === 'unit' && delta !== undefined
+        ? priceValue * delta
+        : priceValue;
+    }
+
+    const occurredAt = form.occurredAt
+      ? new Date(`${form.occurredAt}T12:00:00`).toISOString()
+      : null;
+
+    await onSubmit({
+      delta,
+      amount,
+      supplier: form.supplier.trim(),
+      occurred_at: occurredAt,
+      notes: form.notes.trim(),
+    });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+      {withDelta ? (
+        <FormField
+          label={`${t('purchase.fields.delta', { unit: deltaUnit ?? '' })} *`}
+          htmlFor="purchase-delta"
+        >
+          <Input
+            id="purchase-delta"
+            type="number"
+            step="0.001"
+            min="0"
+            value={form.delta}
+            onChange={(e) => updateField('delta', e.target.value)}
+            required
+            autoFocus
+          />
+        </FormField>
+      ) : null}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium text-foreground">
+            {t('purchase.fields.price')}
+          </span>
+          {withDelta && deltaUnit ? (
+            <div className="inline-flex rounded-md border border-border p-0.5 text-xs">
+              <button
+                type="button"
+                onClick={() => updateField('priceMode', 'total')}
+                className={`rounded px-2 py-1 ${form.priceMode === 'total' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground'}`}
+              >
+                {t('purchase.price_mode.total')}
+              </button>
+              <button
+                type="button"
+                onClick={() => updateField('priceMode', 'unit')}
+                className={`rounded px-2 py-1 ${form.priceMode === 'unit' ? 'bg-primary text-primary-foreground' : 'text-muted-foreground'}`}
+              >
+                {t('purchase.price_mode.unit', { unit: deltaUnit })}
+              </button>
+            </div>
+          ) : null}
+        </div>
+        <Input
+          id="purchase-price"
+          type="number"
+          step="0.01"
+          min="0"
+          value={form.price}
+          onChange={(e) => updateField('price', e.target.value)}
+          placeholder={t('purchase.fields.price_placeholder')}
+          autoFocus={!withDelta}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <FormField label={t('purchase.fields.supplier')} htmlFor="purchase-supplier">
+          <Input
+            id="purchase-supplier"
+            value={form.supplier}
+            onChange={(e) => updateField('supplier', e.target.value)}
+            autoComplete="off"
+          />
+        </FormField>
+        <FormField label={t('purchase.fields.occurred_at')} htmlFor="purchase-date">
+          <Input
+            id="purchase-date"
+            type="date"
+            value={form.occurredAt}
+            onChange={(e) => updateField('occurredAt', e.target.value)}
+          />
+        </FormField>
+      </div>
+
+      <FormField label={t('purchase.fields.notes')} htmlFor="purchase-notes">
+        <Textarea
+          id="purchase-notes"
+          rows={3}
+          value={form.notes}
+          onChange={(e) => updateField('notes', e.target.value)}
+        />
+      </FormField>
+
+      {error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onCancel}
+          disabled={isPending}
+        >
+          {t('common.cancel')}
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending ? t('purchase.actions.saving') : t('purchase.actions.confirm')}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/ui/src/gen/api/models/Interaction.ts
+++ b/ui/src/gen/api/models/Interaction.ts
@@ -45,11 +45,9 @@ export type Interaction = {
     enriched_text?: string;
     project?: string | null;
     readonly project_title: string;
-    /**
-     * Optional link to a stock item (e.g. an expense for restocking).
-     */
-    stock_item?: string | null;
-    readonly stock_item_name: string;
+    readonly source_type: string;
+    readonly source_id: string;
+    readonly source_label: string;
     zone_ids: Array<string>;
     readonly zone_names: string;
     readonly document_count: string;

--- a/ui/src/gen/api/models/InteractionDetail.ts
+++ b/ui/src/gen/api/models/InteractionDetail.ts
@@ -45,11 +45,9 @@ export type InteractionDetail = {
     enriched_text?: string;
     project?: string | null;
     readonly project_title: string;
-    /**
-     * Optional link to a stock item (e.g. an expense for restocking).
-     */
-    stock_item?: string | null;
-    readonly stock_item_name: string;
+    readonly source_type: string;
+    readonly source_id: string;
+    readonly source_label: string;
     zone_ids: Array<string>;
     readonly zone_names: string;
     readonly document_count: string;

--- a/ui/src/gen/api/models/PatchedInteraction.ts
+++ b/ui/src/gen/api/models/PatchedInteraction.ts
@@ -45,11 +45,9 @@ export type PatchedInteraction = {
     enriched_text?: string;
     project?: string | null;
     readonly project_title?: string;
-    /**
-     * Optional link to a stock item (e.g. an expense for restocking).
-     */
-    stock_item?: string | null;
-    readonly stock_item_name?: string;
+    readonly source_type?: string;
+    readonly source_id?: string;
+    readonly source_label?: string;
     zone_ids?: Array<string>;
     readonly zone_names?: string;
     readonly document_count?: string;

--- a/ui/src/gen/api/services/EquipmentService.ts
+++ b/ui/src/gen/api/services/EquipmentService.ts
@@ -133,6 +133,30 @@ export class EquipmentService {
         });
     }
     /**
+     * Snapshot purchase fields on the equipment + create an expense Interaction.
+     *
+     * Single-action endpoint: writes amount/supplier/date on the equipment AND
+     * creates an Interaction(type=expense) linked via the polymorphic source FK.
+     * @param id
+     * @param requestBody
+     * @returns Equipment
+     * @throws ApiError
+     */
+    public static equipmentRegisterPurchaseCreate(
+        id: string,
+        requestBody: Equipment,
+    ): CancelablePromise<Equipment> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/equipment/{id}/register-purchase/',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * @param ordering Which field to use when ordering the results.
      * @returns EquipmentInteraction
      * @throws ApiError

--- a/ui/src/lib/api/equipment.ts
+++ b/ui/src/lib/api/equipment.ts
@@ -184,6 +184,30 @@ export async function linkEquipmentInteraction(
   return data as EquipmentInteractionItem;
 }
 
+export interface EquipmentPurchasePayload {
+  amount?: number | null;
+  supplier?: string;
+  occurred_at?: string | null;
+  notes?: string;
+}
+
+export interface EquipmentPurchaseResponse extends EquipmentListItem {
+  interaction_id: string;
+}
+
+export async function registerEquipmentPurchase(
+  equipmentId: string,
+  payload: EquipmentPurchasePayload,
+): Promise<EquipmentPurchaseResponse> {
+  const { data } = await api.post(`/equipment/${equipmentId}/register-purchase/`, {
+    amount: payload.amount ?? null,
+    supplier: payload.supplier ?? '',
+    occurred_at: payload.occurred_at ?? null,
+    notes: payload.notes ?? '',
+  });
+  return data as EquipmentPurchaseResponse;
+}
+
 export function zoneLabel(zoneId: string | null | undefined, zones: ZoneOption[]): string {
   if (!zoneId) return '—';
   return zones.find((zone) => zone.id === zoneId)?.full_path ?? zones.find((zone) => zone.id === zoneId)?.name ?? '—';

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -962,7 +962,14 @@
       "archived": "Archiviert"
     },
     "deleted": "Gerät gelöscht",
-    "empty_description": "Fügen Sie Ihr erstes Gerät hinzu, um Ihre Haushaltsgeräte und Werkzeuge zu verwalten."
+    "empty_description": "Fügen Sie Ihr erstes Gerät hinzu, um Ihre Haushaltsgeräte und Werkzeuge zu verwalten.",
+    "purchase": {
+      "title": "Kauf erfassen — {{name}}",
+      "created": "Einkauf gespeichert",
+      "actions": {
+        "add": "Kauf"
+      }
+    }
   },
   "dashboard": {
     "title": "Übersicht",
@@ -1214,28 +1221,32 @@
       "title": "Auffüllen — {{name}}",
       "current_quantity": "Aktuelle Menge: {{quantity}} {{unit}}",
       "created": "Einkauf gespeichert",
-      "fields": {
-        "delta": "Hinzugefügte Menge ({{unit}})",
-        "price": "Preis",
-        "price_placeholder": "Optional",
-        "supplier": "Lieferant",
-        "occurred_at": "Kaufdatum",
-        "notes": "Notizen"
-      },
-      "price_mode": {
-        "total": "Gesamt",
-        "unit": "Pro {{unit}}"
-      },
       "actions": {
-        "add": "Kauf",
-        "confirm": "Einkauf speichern",
-        "saving": "Speichern..."
-      },
-      "errors": {
-        "delta_required": "Gib eine gekaufte Menge größer als 0 an.",
-        "price_invalid": "Der Preis muss positiv sein.",
-        "save_failed": "Einkauf konnte nicht gespeichert werden."
+        "add": "Kauf"
       }
+    }
+  },
+  "purchase": {
+    "fields": {
+      "delta": "Hinzugefügte Menge ({{unit}})",
+      "price": "Preis",
+      "price_placeholder": "Optional",
+      "supplier": "Lieferant",
+      "occurred_at": "Kaufdatum",
+      "notes": "Notizen"
+    },
+    "price_mode": {
+      "total": "Gesamt",
+      "unit": "Pro {{unit}}"
+    },
+    "actions": {
+      "confirm": "Einkauf speichern",
+      "saving": "Speichern..."
+    },
+    "errors": {
+      "delta_required": "Gib eine gekaufte Menge größer als 0 an.",
+      "price_invalid": "Der Preis muss positiv sein.",
+      "save_failed": "Einkauf konnte nicht gespeichert werden."
     }
   },
   "admin": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -962,7 +962,14 @@
       "archived": "Archived"
     },
     "deleted": "Equipment deleted",
-    "empty_description": "Add your first piece of equipment to start tracking your home appliances and tools."
+    "empty_description": "Add your first piece of equipment to start tracking your home appliances and tools.",
+    "purchase": {
+      "title": "Register purchase — {{name}}",
+      "created": "Purchase recorded",
+      "actions": {
+        "add": "Buy"
+      }
+    }
   },
   "dashboard": {
     "title": "Dashboard",
@@ -1214,28 +1221,32 @@
       "title": "Restock — {{name}}",
       "current_quantity": "Current quantity: {{quantity}} {{unit}}",
       "created": "Purchase recorded",
-      "fields": {
-        "delta": "Quantity added ({{unit}})",
-        "price": "Price",
-        "price_placeholder": "Optional",
-        "supplier": "Supplier",
-        "occurred_at": "Purchase date",
-        "notes": "Notes"
-      },
-      "price_mode": {
-        "total": "Total",
-        "unit": "Per {{unit}}"
-      },
       "actions": {
-        "add": "Buy",
-        "confirm": "Save purchase",
-        "saving": "Saving..."
-      },
-      "errors": {
-        "delta_required": "Enter a purchased quantity greater than 0.",
-        "price_invalid": "Price must be positive.",
-        "save_failed": "Could not save the purchase."
+        "add": "Buy"
       }
+    }
+  },
+  "purchase": {
+    "fields": {
+      "delta": "Quantity added ({{unit}})",
+      "price": "Price",
+      "price_placeholder": "Optional",
+      "supplier": "Supplier",
+      "occurred_at": "Purchase date",
+      "notes": "Notes"
+    },
+    "price_mode": {
+      "total": "Total",
+      "unit": "Per {{unit}}"
+    },
+    "actions": {
+      "confirm": "Save purchase",
+      "saving": "Saving..."
+    },
+    "errors": {
+      "delta_required": "Enter a purchased quantity greater than 0.",
+      "price_invalid": "Price must be positive.",
+      "save_failed": "Could not save the purchase."
     }
   },
   "admin": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -962,7 +962,14 @@
       "archived": "Archivado"
     },
     "deleted": "Equipo eliminado",
-    "empty_description": "Añade tu primer equipo para comenzar a registrar tus electrodomésticos y herramientas."
+    "empty_description": "Añade tu primer equipo para comenzar a registrar tus electrodomésticos y herramientas.",
+    "purchase": {
+      "title": "Registrar compra — {{name}}",
+      "created": "Compra registrada",
+      "actions": {
+        "add": "Comprar"
+      }
+    }
   },
   "dashboard": {
     "title": "Panel de control",
@@ -1214,28 +1221,32 @@
       "title": "Reabastecer — {{name}}",
       "current_quantity": "Cantidad actual: {{quantity}} {{unit}}",
       "created": "Compra registrada",
-      "fields": {
-        "delta": "Cantidad añadida ({{unit}})",
-        "price": "Precio",
-        "price_placeholder": "Opcional",
-        "supplier": "Proveedor",
-        "occurred_at": "Fecha de compra",
-        "notes": "Notas"
-      },
-      "price_mode": {
-        "total": "Total",
-        "unit": "Por {{unit}}"
-      },
       "actions": {
-        "add": "Comprar",
-        "confirm": "Guardar compra",
-        "saving": "Guardando..."
-      },
-      "errors": {
-        "delta_required": "Indica una cantidad comprada mayor que 0.",
-        "price_invalid": "El precio debe ser positivo.",
-        "save_failed": "No se pudo guardar la compra."
+        "add": "Comprar"
       }
+    }
+  },
+  "purchase": {
+    "fields": {
+      "delta": "Cantidad añadida ({{unit}})",
+      "price": "Precio",
+      "price_placeholder": "Opcional",
+      "supplier": "Proveedor",
+      "occurred_at": "Fecha de compra",
+      "notes": "Notas"
+    },
+    "price_mode": {
+      "total": "Total",
+      "unit": "Por {{unit}}"
+    },
+    "actions": {
+      "confirm": "Guardar compra",
+      "saving": "Guardando..."
+    },
+    "errors": {
+      "delta_required": "Indica una cantidad comprada mayor que 0.",
+      "price_invalid": "El precio debe ser positivo.",
+      "save_failed": "No se pudo guardar la compra."
     }
   },
   "admin": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -962,7 +962,14 @@
       "archived": "Archivé"
     },
     "deleted": "Équipement supprimé",
-    "empty_description": "Ajoutez votre premier équipement pour commencer à suivre vos appareils et outils."
+    "empty_description": "Ajoutez votre premier équipement pour commencer à suivre vos appareils et outils.",
+    "purchase": {
+      "title": "Enregistrer un achat — {{name}}",
+      "created": "Achat enregistré",
+      "actions": {
+        "add": "Achat"
+      }
+    }
   },
   "dashboard": {
     "title": "Tableau de bord",
@@ -1214,28 +1221,32 @@
       "title": "Approvisionner — {{name}}",
       "current_quantity": "Quantité actuelle : {{quantity}} {{unit}}",
       "created": "Achat enregistré",
-      "fields": {
-        "delta": "Quantité ajoutée ({{unit}})",
-        "price": "Prix",
-        "price_placeholder": "Optionnel",
-        "supplier": "Fournisseur",
-        "occurred_at": "Date d'achat",
-        "notes": "Notes"
-      },
-      "price_mode": {
-        "total": "Total",
-        "unit": "Par {{unit}}"
-      },
       "actions": {
-        "add": "Achat",
-        "confirm": "Enregistrer l'achat",
-        "saving": "Enregistrement..."
-      },
-      "errors": {
-        "delta_required": "Indique une quantité achetée supérieure à 0.",
-        "price_invalid": "Le prix doit être positif.",
-        "save_failed": "Impossible d'enregistrer l'achat."
+        "add": "Achat"
       }
+    }
+  },
+  "purchase": {
+    "fields": {
+      "delta": "Quantité ajoutée ({{unit}})",
+      "price": "Prix",
+      "price_placeholder": "Optionnel",
+      "supplier": "Fournisseur",
+      "occurred_at": "Date d'achat",
+      "notes": "Notes"
+    },
+    "price_mode": {
+      "total": "Total",
+      "unit": "Par {{unit}}"
+    },
+    "actions": {
+      "confirm": "Enregistrer l'achat",
+      "saving": "Enregistrement..."
+    },
+    "errors": {
+      "delta_required": "Indique une quantité achetée supérieure à 0.",
+      "price_invalid": "Le prix doit être positif.",
+      "save_failed": "Impossible d'enregistrer l'achat."
     }
   },
   "admin": {


### PR DESCRIPTION
Closes #119

## Summary

Généralise la mécanique posée pour stock à n'importe quel module qui veut auto-créer des `Interaction` liées à son objet source. Premier consommateur ajouté : equipment.

## Architecture

### FK polymorphe
- Migration `0015` : `Interaction.stock_item` (FK spécifique) → `source_content_type` + `source_object_id` + `GenericForeignKey('source')`. Data migration copie les liens existants. Index polymorphe.
- N'importe quel `HouseholdScopedModel` peut désormais être source d'une interaction sans toucher au schéma.

### Service helper partagé
- `apps/interactions/services.py::create_expense_interaction(source, user, amount, ...)`
- Localise le subject via gettext write-time (registry `AUTO_SUBJECT_TEMPLATES`)
- Écrit un metadata normalisé : `{kind, source_name, amount, unit_price, supplier}` + `extra_metadata` pour le feature-spécifique
- Lie via la FK polymorphe + attache la zone du source si elle existe
- Side-effects sur l'objet source restent dans la view appelante

### Equipment register-purchase
- `POST /equipment/{id}/register-purchase/` snapshot `purchase_price`/`vendor`/`date` et crée l'interaction expense via le service
- Action « Achat » sur la card equipment, dialog dédié, hook mutation

### Front partagé
- `ui/src/features/interactions/PurchaseForm.tsx` : composant unique avec `withDelta` configurable
- Stock le consomme avec `withDelta=true`, equipment avec `withDelta=false`

## What changed

### Backend
- `apps/interactions/models.py` : FK polymorphe
- `apps/interactions/services.py` : nouveau service + registry
- `apps/interactions/serializers.py` : expose `source_type`/`source_id`/`source_label` génériques
- `apps/stock/views.py` : refactoré pour utiliser le service
- `apps/equipment/views.py` : nouvel endpoint `register-purchase`
- `apps/equipment/serializers.py` : nouveau `EquipmentPurchaseSerializer`
- 7 tests pytest pour le service + 4 pour l'endpoint equipment

### Frontend
- `ui/src/features/interactions/PurchaseForm.tsx` (nouveau)
- `ui/src/features/stock/StockPurchaseDialog.tsx` refactoré
- `ui/src/features/equipment/EquipmentPurchaseDialog.tsx` (nouveau)
- `ui/src/features/equipment/EquipmentCard.tsx` : action « Achat »
- `ui/src/features/equipment/hooks.ts` : `useRegisterEquipmentPurchase`
- `ui/src/lib/api/equipment.ts` : `registerEquipmentPurchase`
- Régénération des types API

### i18n
- `purchase.*` (form partagé) en en/fr/de/es
- `stock.purchase.*` slimmé
- `equipment.purchase.*` (nouveau) en 4 locales

### E2E
- `e2e/equipment-purchase.spec.ts` (nouveau)
- `e2e/stock-purchase.spec.ts` ajusté aux nouveaux ids `#purchase-*`
- `COVERAGE.md` à jour

### Doc
- `CLAUDE.md` : section « Auto-création d'Interaction » étoffée (FK polymorphe, service helper, registry templates, pattern PurchaseForm)

## Test plan

- [x] `pytest apps/interactions/tests/ apps/stock/tests/ apps/equipment/tests/` → 17/17 verts (services + stock + equipment)
- [x] `pytest -q` complet → 726/728 (2 skipped attendus)
- [x] `npm run lint` → 0 erreur
- [x] `npx playwright test` → 4/4 verts (stock-purchase + equipment-purchase + setup + auth)

## Hors scope (suivi)

- **Catégorisation des dépenses** (champ `nature`, découplage `kind` business, etc.) → délibérément différée tant qu'on n'a pas 20-30 dépenses réelles à classer pour faire émerger la bonne taxonomie. Tracé en #120.
- Vue agrégée `features/expenses/ExpensesPage.tsx` + endpoint `/expenses/summary/` → Phase 1 d'un module Budget, à attaquer après merge.
- Endpoint `/interactions/expense/` pour dépenses ad-hoc sans source.
- Extension `PurchaseForm` à project / project-group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)