### PR TITLE
feat(projects): quick-add d'une dépense depuis un projet (#123)

### DIFF
--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -26,6 +26,7 @@ from .models import Interaction, InteractionZone
 AUTO_SUBJECT_TEMPLATES: dict[str, Any] = {
     "stock_purchase": _("Purchase — {name}"),
     "equipment_purchase": _("Purchase — {name}"),
+    "project_purchase": _("Purchase — {name}"),
 }
 
 

--- a/apps/projects/serializers.py
+++ b/apps/projects/serializers.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from rest_framework import serializers
 
 from .models import (
@@ -8,6 +10,17 @@ from .models import (
     ProjectAIMessage,
     UserPinnedProject,
 )
+
+
+class ProjectPurchaseSerializer(serializers.Serializer):
+    """Input for /projects/{id}/register-purchase/."""
+
+    amount = serializers.DecimalField(
+        max_digits=12, decimal_places=2, required=False, allow_null=True, min_value=Decimal("0")
+    )
+    supplier = serializers.CharField(required=False, allow_blank=True, default="")
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
 
 
 class ProjectGroupPickerSerializer(serializers.ModelSerializer):

--- a/apps/projects/tests/test_api_project_purchase.py
+++ b/apps/projects/tests/test_api_project_purchase.py
@@ -1,0 +1,167 @@
+"""Tests for POST /projects/{id}/register-purchase/."""
+from decimal import Decimal
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from accounts.models import User
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from projects.models import Project
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(email="proj-purchase@test.dev", password="secret")
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(email="proj-other@test.dev", password="secret")
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Project home")
+
+
+@pytest.fixture
+def second_household(db):
+    return Household.objects.create(name="Other project home")
+
+
+@pytest.fixture
+def membership(user, household):
+    HouseholdMember.objects.create(
+        user=user, household=household, role=HouseholdMember.Role.OWNER
+    )
+
+
+@pytest.fixture
+def project(household, user):
+    return Project.objects.create(
+        household=household,
+        title="Kitchen reno",
+        planned_budget=Decimal("5000.00"),
+        actual_cost_cached=Decimal("0.00"),
+        created_by=user,
+    )
+
+
+def _purchase_url(project):
+    return reverse("project-register-purchase", kwargs={"pk": project.id})
+
+
+@pytest.mark.django_db
+def test_register_purchase_increments_actual_cost_and_creates_expense(
+    client, user, household, project, membership
+):
+    client.force_login(user)
+
+    response = client.post(
+        _purchase_url(project),
+        data={
+            "amount": "450.00",
+            "supplier": "Leroy Merlin",
+            "occurred_at": "2026-04-15T10:00:00Z",
+            "notes": "Tiles for the floor",
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201, response.content
+    payload = response.json()
+    assert payload["actual_cost_cached"] == "450.00"
+    assert "interaction_id" in payload
+
+    interaction = Interaction.objects.get(id=payload["interaction_id"])
+    assert interaction.type == "expense"
+    assert interaction.source == project
+    assert interaction.source_content_type == ContentType.objects.get_for_model(Project)
+    assert interaction.source_object_id == project.id
+    assert interaction.household_id == household.id
+    assert interaction.subject == "Purchase — Kitchen reno"
+    assert interaction.metadata["kind"] == "project_purchase"
+    assert interaction.metadata["amount"] == "450.00"
+    assert interaction.metadata["supplier"] == "Leroy Merlin"
+    assert interaction.metadata["project_title"] == "Kitchen reno"
+
+    project.refresh_from_db()
+    assert project.actual_cost_cached == Decimal("450.00")
+
+
+@pytest.mark.django_db
+def test_register_purchase_accumulates_actual_cost(client, user, project, membership):
+    client.force_login(user)
+    project.actual_cost_cached = Decimal("100.00")
+    project.save(update_fields=["actual_cost_cached"])
+
+    response = client.post(
+        _purchase_url(project),
+        data={"amount": "50.50"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201, response.content
+    project.refresh_from_db()
+    assert project.actual_cost_cached == Decimal("150.50")
+
+
+@pytest.mark.django_db
+def test_register_purchase_without_amount_does_not_touch_cost(client, user, project, membership):
+    client.force_login(user)
+    project.actual_cost_cached = Decimal("100.00")
+    project.save(update_fields=["actual_cost_cached"])
+
+    response = client.post(
+        _purchase_url(project),
+        data={"notes": "Free donation, only logging it"},
+        content_type="application/json",
+    )
+    assert response.status_code == 201, response.content
+    payload = response.json()
+    assert "interaction_id" in payload
+    project.refresh_from_db()
+    assert project.actual_cost_cached == Decimal("100.00")
+    interaction = Interaction.objects.get(id=payload["interaction_id"])
+    assert interaction.metadata["amount"] is None
+
+
+@pytest.mark.django_db
+def test_register_purchase_isolates_between_households(
+    client, other_user, second_household, project
+):
+    HouseholdMember.objects.create(
+        user=other_user, household=second_household, role=HouseholdMember.Role.OWNER
+    )
+    client.force_login(other_user)
+
+    response = client.post(
+        _purchase_url(project),
+        data={"amount": "10"},
+        content_type="application/json",
+    )
+    assert response.status_code in (403, 404)
+    assert Interaction.objects.filter(source_object_id=project.id).count() == 0
+
+
+@pytest.mark.django_db
+def test_register_purchase_requires_authentication(client, project):
+    response = client.post(
+        _purchase_url(project),
+        data={"amount": "10"},
+        content_type="application/json",
+    )
+    assert response.status_code in (401, 403)
+    assert Interaction.objects.filter(source_object_id=project.id).count() == 0
+
+
+@pytest.mark.django_db
+def test_register_purchase_rejects_invalid_amount(client, user, project, membership):
+    client.force_login(user)
+    response = client.post(
+        _purchase_url(project),
+        data={"amount": "-50"},
+        content_type="application/json",
+    )
+    assert response.status_code == 400

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -1,3 +1,7 @@
+from decimal import Decimal
+
+from django.db import transaction
+from django.utils import timezone
 from rest_framework import status as drf_status, viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
@@ -6,6 +10,7 @@ from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
 from documents.models import Document
+from interactions.services import create_expense_interaction
 from .models import (
     Project,
     ProjectDocument,
@@ -18,6 +23,7 @@ from .models import (
 from .serializers import (
     ProjectSerializer,
     ProjectGroupSerializer,
+    ProjectPurchaseSerializer,
     ProjectZoneSerializer,
     ProjectAIThreadSerializer,
     ProjectAIMessageSerializer,
@@ -91,6 +97,44 @@ class ProjectViewSet(_HouseholdScopedViewSet):
             raise ValidationError({"cover_interaction": "Cover interaction household must match selected household."})
 
         serializer.save(updated_by=self.request.user)
+
+    @action(detail=True, methods=["post"], url_path="register-purchase")
+    def register_purchase(self, request, pk=None):
+        """Increment Project.actual_cost_cached + create an expense Interaction.
+
+        Single-action endpoint: increments the project's cached actual cost
+        AND creates an Interaction(type=expense) linked via the polymorphic
+        source FK.
+        """
+        project = self.get_object()
+        serializer = ProjectPurchaseSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        amount = serializer.validated_data.get("amount")
+        supplier = serializer.validated_data.get("supplier", "") or ""
+        occurred_at = serializer.validated_data.get("occurred_at") or timezone.now()
+        notes = serializer.validated_data.get("notes", "") or ""
+
+        with transaction.atomic():
+            if amount is not None:
+                project.actual_cost_cached = (project.actual_cost_cached or Decimal("0")) + amount
+                project.updated_by = request.user
+                project.save(update_fields=["actual_cost_cached", "updated_by", "updated_at"])
+
+            interaction = create_expense_interaction(
+                source=project,
+                user=request.user,
+                amount=amount,
+                supplier=supplier,
+                occurred_at=occurred_at,
+                notes=notes,
+                kind="project_purchase",
+                extra_metadata={"project_title": project.title},
+            )
+
+        payload = ProjectSerializer(project, context={"request": request}).data
+        payload["interaction_id"] = str(interaction.id)
+        return Response(payload, status=drf_status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"], url_path="pin")
     def pin(self, request, pk=None):

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -141,13 +141,15 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 
 ---
 
-## Dépenses (`expenses-summary.spec.ts`)
+## Dépenses (`expenses-summary.spec.ts`, `project-purchase.spec.ts`)
 
 | Parcours | Statut |
 |---|---|
 | `/app/expenses` affiche le titre, le total mensuel et le breakdown par type/fournisseur | ✅ |
 | Un achat de stock alimente bien la vue dépense (Total + by_kind + by_supplier) | ✅ |
 | L'`Interaction(type=expense)` est listée dans la liste des dépenses de la vue | ✅ |
+| Quick-add d'une dépense depuis la card d'un projet (« + Dépense ») crée une `Interaction(type=expense, kind='project_purchase')` | ✅ |
+| L'expense projet apparaît dans `/app/interactions` ET dans `/app/expenses` | ✅ |
 
 ---
 

--- a/e2e/project-purchase.spec.ts
+++ b/e2e/project-purchase.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Parcours 08 — Lot 1.1 : enregistrer une dépense liée à un projet.
+ *
+ * Issue: https://github.com/jammindev/house/issues/123
+ *
+ * Le test crée un projet, déclenche le quick-add depuis sa card, vérifie que
+ * l'`Interaction(type=expense, kind='project_purchase')` est créée et listée
+ * dans /app/interactions, et que `actual_cost_cached` est incrémenté côté
+ * card (BudgetBar visible).
+ */
+
+test('parcours achat projet — Rénovation cuisine 450€ Leroy Merlin', async ({ page }) => {
+  await page.goto('/app/projects');
+  await expect(page).toHaveURL(/\/app\/projects/);
+
+  // Créer un projet
+  await page.getByRole('button', { name: /nouveau|créer/i }).first().click();
+  let dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  const projectTitle = `Rénovation cuisine E2E ${Date.now()}`;
+  await page.locator('#project-title').fill(projectTitle);
+  // planned_budget for the BudgetBar to render
+  const budgetInput = page.locator('#project-planned-budget');
+  if (await budgetInput.count()) {
+    await budgetInput.fill('1000');
+  }
+  await dialog.getByRole('button', { name: /enregistrer|créer/i }).click();
+  await expect(dialog).toBeHidden();
+  await expect(page.getByText(projectTitle)).toBeVisible();
+
+  // Cliquer sur l'action « + Dépense » de la card
+  const card = page.getByText(projectTitle, { exact: true })
+    .locator('xpath=ancestor::*[contains(@class, "rounded")][1]');
+  await card.getByRole('button', { name: 'Dépense' }).click();
+
+  dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Enregistrer une dépense');
+  await expect(dialog).toContainText(projectTitle);
+
+  // Saisir prix + fournisseur
+  await page.locator('#purchase-price').fill('450');
+  await page.locator('#purchase-supplier').fill('Leroy Merlin E2E');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+  await expect(dialog).toBeHidden();
+
+  // Vérifier que l'interaction expense est listée dans /app/interactions
+  await page.goto('/app/interactions');
+  await expect(page.getByText(`Achat — ${projectTitle}`).first()).toBeVisible();
+
+  // Vérifier qu'elle apparaît aussi dans la vue dépense
+  await page.goto('/app/expenses');
+  await expect(page.getByText(`Achat — ${projectTitle}`).first()).toBeVisible();
+  await expect(page.getByText('Leroy Merlin E2E').first()).toBeVisible();
+});

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: House Backend 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 04:46+0000\n"
+"POT-Creation-Date: 2026-05-03 05:57+0000\n"
 "PO-Revision-Date: 2026-03-08 00:00+0000\n"
 "Last-Translator: House Team\n"
 "Language-Team: German\n"
@@ -16,344 +16,450 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: apps/accounts/models.py:44
 msgid "Display name shown in the UI"
 msgstr "In der UI angezeigter Name"
 
+#: apps/accounts/models.py:48 apps/households/models.py:38
 msgid "English"
 msgstr "Englisch"
 
+#: apps/accounts/models.py:49
 msgid "Français"
 msgstr "Französisch"
 
+#: apps/accounts/models.py:50
 msgid "Deutsch"
 msgstr "Deutsch"
 
+#: apps/accounts/models.py:51
 msgid "Español"
 msgstr "Spanisch"
 
+#: apps/accounts/models.py:56
 msgid "User's preferred language. Null means use browser detection."
 msgstr ""
 
+#: apps/accounts/models.py:65
 msgid "User's avatar image file"
 msgstr "URL zum Avatar-Bild des Benutzers"
 
+#: apps/accounts/models.py:77
 msgid "User's preferred theme (light/dark/system)"
 msgstr "Bevorzugtes Thema des Benutzers (hell/dunkel/system)"
 
+#: apps/accounts/models.py:103
 msgid "User's preferred color palette"
 msgstr "Bevorzugte Farbpalette des Benutzers"
 
+#: apps/accounts/models.py:111
 msgid "User's currently active household"
 msgstr "Derzeit aktiver Haushalt des Benutzers"
 
+#: apps/accounts/models.py:112
 msgid "active household"
 msgstr "aktiver Haushalt"
 
+#: apps/accounts/models.py:125
 msgid "user"
 msgstr "Benutzer"
 
+#: apps/accounts/models.py:126
 msgid "users"
 msgstr "Benutzer"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:3
 #, fuzzy
 #| msgid "Password"
 msgid "Password reset"
 msgstr "Passwort"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:5
+#: apps/accounts/templates/accounts/emails/password_reset.txt:1
 msgid "Hello,"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:6
+#: apps/accounts/templates/accounts/emails/password_reset.txt:3
 msgid "You requested a password reset for your House account."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:9
 msgid "Reset my password"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:12
 msgid "Or copy and paste this URL into your browser:"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:15
+#: apps/accounts/templates/accounts/emails/password_reset.txt:9
 msgid ""
 "This link will expire in 3 days. If you did not request a password reset, "
 "you can safely ignore this email."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:16
+#: apps/accounts/templates/accounts/emails/password_reset.txt:11
 msgid "— House"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.txt:5
 msgid "Click the link below to set a new password:"
 msgstr ""
 
+#: apps/accounts/views/api.py:60
 msgid "Email and password are required."
 msgstr "E-Mail und Passwort sind erforderlich."
 
+#: apps/accounts/views/api.py:66
 msgid "Invalid credentials."
 msgstr "Ungültige Anmeldedaten."
 
+#: apps/accounts/views/api.py:71
 msgid "Login successful."
 msgstr "Anmeldung erfolgreich."
 
+#: apps/accounts/views/api.py:81
 msgid "Logout successful."
 msgstr "Abmeldung erfolgreich."
 
+#: apps/accounts/views/api.py:101 apps/households/views.py:164
 msgid "Email is required."
 msgstr "E-Mail ist erforderlich."
 
+#: apps/accounts/views/api.py:120
 msgid "Reset your House password"
 msgstr ""
 
+#: apps/accounts/views/api.py:130
 msgid "If an account with that email exists, a reset link has been sent."
 msgstr ""
 
+#: apps/accounts/views/api.py:151
 #, fuzzy
 #| msgid "Email and password are required."
 msgid "uid, token and new_password are required."
 msgstr "E-Mail und Passwort sind erforderlich."
 
+#: apps/accounts/views/api.py:160 apps/accounts/views/api.py:166
 #, fuzzy
 #| msgid "Invalid credentials."
 msgid "Invalid or expired reset link."
 msgstr "Ungültige Anmeldedaten."
 
+#: apps/accounts/views/api.py:182
 #, fuzzy
 #| msgid "Password updated successfully."
 msgid "Password has been reset successfully."
 msgstr "Passwort erfolgreich aktualisiert."
 
+#: apps/accounts/views/api.py:242
 msgid "new_password and confirm_password are required."
 msgstr "new_password und confirm_password sind erforderlich."
 
+#: apps/accounts/views/api.py:248
 msgid "Password must be at least 8 characters."
 msgstr "Das Passwort muss mindestens 8 Zeichen lang sein."
 
+#: apps/accounts/views/api.py:254
 msgid "Passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
+#: apps/accounts/views/api.py:268
 msgid "Password updated successfully."
 msgstr "Passwort erfolgreich aktualisiert."
 
+#: apps/accounts/views/api.py:280
 msgid "You cannot impersonate yourself."
 msgstr ""
 
+#: apps/accounts/views/api.py:307
 msgid "No avatar to delete."
 msgstr "Kein Avatar zum Löschen."
 
+#: apps/accounts/views/api.py:319
 msgid "Avatar removed."
 msgstr "Avatar entfernt."
 
+#: apps/accounts/views/api.py:325
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:641
 msgid "No file was submitted."
 msgstr "Es wurde keine Datei übermittelt."
 
+#: apps/ai_usage/models.py:21
 msgid "OCR — upload"
 msgstr ""
 
+#: apps/ai_usage/models.py:22
 msgid "OCR — backfill"
 msgstr ""
 
+#: apps/ai_usage/models.py:23
 msgid "Agent — ask"
 msgstr ""
 
+#: apps/core/file_validation.py:15
 msgid "JPEG image"
 msgstr ""
 
+#: apps/core/file_validation.py:20
 msgid "PNG image"
 msgstr ""
 
+#: apps/core/file_validation.py:25
 msgid "GIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:30
 msgid "WebP image"
 msgstr ""
 
+#: apps/core/file_validation.py:35
 msgid "HEIC image"
 msgstr ""
 
+#: apps/core/file_validation.py:40
 msgid "HEIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:45
 #, fuzzy
 #| msgid "document"
 msgid "PDF document"
 msgstr "Dokument"
 
+#: apps/core/file_validation.py:85
 #, python-format
 msgid "File too large (%(size)d MB). Maximum allowed: %(max)d MB."
 msgstr ""
 
+#: apps/core/file_validation.py:99
 #, python-format
 msgid "Unsupported file type. Allowed: %(types)s."
 msgstr ""
 
+#: apps/directory/models.py:49
 msgid "contact"
 msgstr "Kontakt"
 
+#: apps/directory/models.py:50
 msgid "contacts"
 msgstr "Kontakte"
 
+#: apps/documents/models.py:80
 msgid "document"
 msgstr "Dokument"
 
+#: apps/documents/models.py:81
 msgid "documents"
 msgstr "Dokumente"
 
+#: apps/electricity/models.py:16
 msgid "Single phase"
 msgstr "Einphasig"
 
+#: apps/electricity/models.py:17
 msgid "Three phase"
 msgstr "Dreiphasig"
 
+#: apps/electricity/models.py:27
 msgid "Socket"
 msgstr "Steckdose"
 
+#: apps/electricity/models.py:28
 msgid "Light"
 msgstr "Beleuchtung"
 
+#: apps/electricity/models.py:115
 msgid "electricity board"
 msgstr "Stromverteilerkasten"
 
+#: apps/electricity/models.py:116
 msgid "electricity boards"
 msgstr "Stromverteilerkästen"
 
+#: apps/electricity/models.py:208
 msgid "protective device"
 msgstr ""
 
+#: apps/electricity/models.py:209
 msgid "protective devices"
 msgstr ""
 
+#: apps/electricity/models.py:267
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "curve_type must be empty for device_type=rcd."
 msgstr "Die Phase muss für ein einphasiges Tableau leer sein."
 
+#: apps/electricity/models.py:272
 msgid "sensitivity_ma must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:276
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "type_code must be empty for device_type=breaker."
 msgstr "Die Phase muss für ein einphasiges Tableau leer sein."
 
+#: apps/electricity/models.py:280
 msgid "phase_coverage must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:310
 msgid "circuit"
 msgstr "Stromkreis"
 
+#: apps/electricity/models.py:311
 msgid "circuits"
 msgstr "Stromkreise"
 
+#: apps/electricity/models.py:329
 msgid ""
 "A circuit cannot be directly protected by a pure RCD (device_type=rcd). Use "
 "a breaker, combined, or main device."
 msgstr ""
 
+#: apps/electricity/models.py:358
 msgid "usage point"
 msgstr "Nutzungspunkt"
 
+#: apps/electricity/models.py:359
 msgid "usage points"
 msgstr "Nutzungspunkte"
 
+#: apps/electricity/models.py:468
 msgid "maintenance event"
 msgstr ""
 
+#: apps/electricity/models.py:469
 msgid "maintenance events"
 msgstr ""
 
+#: apps/electricity/serializers.py:42
 msgid "Household cannot be changed."
 msgstr "Der Haushalt kann nicht geändert werden."
 
+#: apps/electricity/serializers.py:56
 msgid "Label must be unique across electricity entities in household."
 msgstr ""
 "Das Etikett muss unter den Elektroentitäten im Haushalt eindeutig sein.Das "
 "Etikett muss unter den Elektroentitäten im Haushalt eindeutig sein."
 
+#: apps/electricity/serializers.py:100
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent board must belong to the same household."
 msgstr "Die übergeordnete Zone muss zum selben Haushalt gehören"
 
+#: apps/electricity/serializers.py:102 apps/electricity/serializers.py:292
 #, fuzzy
 #| msgid "Email is required."
 msgid "Zone is required."
 msgstr "E-Mail ist erforderlich."
 
+#: apps/electricity/serializers.py:104 apps/electricity/serializers.py:294
 msgid "Zone must belong to the same household."
 msgstr "Die Zone muss zum selben Haushalt gehören."
 
+#: apps/electricity/serializers.py:124
 #, fuzzy
 #| msgid "Only one active board is allowed per household."
 msgid "Only one active root board is allowed per household."
 msgstr "Pro Haushalt ist nur ein aktives Tableau erlaubt."
 
+#: apps/electricity/serializers.py:176 apps/electricity/serializers.py:364
 msgid "Board must belong to the same household."
 msgstr "Das Tableau muss zum selben Haushalt gehören."
 
+#: apps/electricity/serializers.py:178
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent device must belong to the same household."
 msgstr "Die übergeordnete Zone muss zum selben Haushalt gehören"
 
+#: apps/electricity/serializers.py:182
 msgid "Phase must be empty for single-phase board."
 msgstr "Die Phase muss für ein einphasiges Tableau leer sein."
 
+#: apps/electricity/serializers.py:184
 msgid "Phase is required for three-phase board."
 msgstr "Die Phase ist für ein dreiphasiges Tableau erforderlich."
 
+#: apps/electricity/serializers.py:186
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "phase_coverage must be null for single-phase board."
 msgstr "Die Phase muss für ein einphasiges Tableau leer sein."
 
+#: apps/electricity/serializers.py:190
 msgid "pole_count must be 2 or 4 for rcd and combined devices."
 msgstr ""
 
+#: apps/electricity/serializers.py:197
 msgid "row and position must both be set or both be empty."
 msgstr ""
 
+#: apps/electricity/serializers.py:203
 msgid "position_end requires position to be set."
 msgstr ""
 
+#: apps/electricity/serializers.py:207
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "position_end must be greater than or equal to position."
 msgstr "Das Enddatum muss am oder nach dem Startdatum liegen."
 
+#: apps/electricity/serializers.py:224
 msgid "Position range overlaps with an existing device on the same row."
 msgstr ""
 
+#: apps/electricity/serializers.py:254
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Protective device must belong to the same household."
 msgstr "Die übergeordnete Zone muss zum selben Haushalt gehören"
 
+#: apps/electricity/serializers.py:257
 msgid "A circuit cannot be directly protected by a pure RCD (device_type=rcd)."
 msgstr ""
 
+#: apps/electricity/serializers.py:261
 msgid "A spare device cannot protect a circuit."
 msgstr ""
 
+#: apps/electricity/serializers.py:264
 #, fuzzy
 #| msgid "Breaker must belong to the selected board."
 msgid "Protective device must belong to the selected board."
 msgstr "Der Leitungsschutzschalter muss zum ausgewählten Tableau gehören."
 
+#: apps/electricity/serializers.py:322
 msgid "Circuit must belong to the same household."
 msgstr "Der Stromkreis muss zum selben Haushalt gehören."
 
+#: apps/electricity/serializers.py:324
 msgid "Usage point must belong to the same household."
 msgstr "Der Nutzungspunkt muss zum selben Haushalt gehören."
 
+#: apps/electricity/serializers.py:326
 msgid "Usage point and circuit must be in the same household."
 msgstr "Nutzungspunkt und Stromkreis müssen im selben Haushalt sein."
 
+#: apps/electricity/serializers.py:333
 msgid "Usage point already has an active circuit link."
 msgstr "Der Nutzungspunkt hat bereits eine aktive Stromkreisverbindung."
 
+#: apps/electricity/serializers.py:389
 msgid "Actor is required."
 msgstr "Der Akteur ist erforderlich."
 
+#: apps/electricity/serializers.py:391
 msgid "Actor must be a member of the household."
 msgstr "Der Akteur muss Mitglied des Haushalts sein."
 
+#: apps/electricity/views.py:83
 #, fuzzy
 #| msgid "Cannot delete breaker with active circuits."
 msgid "Cannot delete protective device with active circuits."
@@ -361,314 +467,416 @@ msgstr ""
 "Ein Leitungsschutzschalter mit aktiven Stromkreisen kann nicht gelöscht "
 "werden."
 
+#: apps/electricity/views.py:94
 msgid "Cannot delete circuit with active usage point links."
 msgstr ""
 "Ein Stromkreis mit aktiven Nutzungspunktverbindungen kann nicht gelöscht "
 "werden."
 
+#: apps/electricity/views.py:105
 msgid "Cannot delete usage point with active circuit link."
 msgstr ""
 "Ein Nutzungspunkt mit aktiver Stromkreisverbindung kann nicht gelöscht "
 "werden."
 
+#: apps/electricity/views.py:113
 msgid "Cannot delete resource with active dependencies."
 msgstr "Eine Ressource mit aktiven Abhängigkeiten kann nicht gelöscht werden."
 
+#: apps/electricity/views.py:162 apps/equipment/views.py:41
+#: apps/insurance/serializers.py:57 apps/insurance/views.py:32
+#: apps/stock/views.py:46 apps/stock/views.py:81
 msgid "A valid household context is required."
 msgstr "Ein gültiger Haushaltskontext ist erforderlich."
 
+#: apps/electricity/views.py:167
 msgid "Must be an integer."
 msgstr ""
 
+#: apps/electricity/views.py:169
 msgid "Must be between 1 and 50."
 msgstr ""
 
+#: apps/electricity/views.py:175
 msgid "A label prefix is required when creating multiple usage points."
 msgstr ""
 
+#: apps/equipment/models.py:12 apps/insurance/models.py:20
 #, fuzzy
 #| msgid "Activity"
 msgid "Active"
 msgstr "Aktivität"
 
+#: apps/equipment/models.py:13
 msgid "Maintenance"
 msgstr ""
 
+#: apps/equipment/models.py:14
 msgid "Storage"
 msgstr ""
 
+#: apps/equipment/models.py:15
 msgid "Retired"
 msgstr ""
 
+#: apps/equipment/models.py:16
 msgid "Lost"
 msgstr ""
 
+#: apps/equipment/models.py:17 apps/stock/models.py:37
 msgid "Ordered"
 msgstr ""
 
+#: apps/equipment/models.py:45 apps/equipment/models.py:46
 msgid "equipment"
 msgstr "Gerät"
 
+#: apps/equipment/serializers.py:71 apps/stock/serializers.py:108
 msgid "Invalid zone or access denied."
 msgstr "Ungültige Zone oder Zugriff verweigert."
 
+#: apps/equipment/serializers.py:88
 msgid "Zone must belong to the same household as equipment."
 msgstr "Die Zone muss zum selben Haushalt wie die Ausstattung gehören."
 
+#: apps/equipment/views.py:133
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid equipment or access denied."
 msgstr "Ungültige Zone oder Zugriff verweigert."
 
+#: apps/equipment/views.py:135
 msgid "Interaction household must match equipment household."
 msgstr ""
 "Der Haushalt der Interaktion muss mit dem Haushalt der Ausstattung "
 "übereinstimmen."
 
+#: apps/equipment/views.py:137
 msgid "Invalid interaction or access denied."
 msgstr "Ungültige Interaktion oder Zugriff verweigert."
 
+#: apps/households/models.py:26
 msgid "ISO 3166-1 alpha-2 country code (e.g. FR, DE, US)"
 msgstr ""
 
+#: apps/households/models.py:28
 msgid "IANA timezone (e.g. Europe/Paris). Leave blank for UTC."
 msgstr ""
 
+#: apps/households/models.py:37
 msgid "French"
 msgstr ""
 
+#: apps/households/models.py:39
 msgid "German"
 msgstr ""
 
+#: apps/households/models.py:40
 msgid "Spanish"
 msgstr ""
 
+#: apps/households/models.py:56
 msgid "household"
 msgstr "Haushalt"
 
+#: apps/households/models.py:57
 msgid "households"
 msgstr "Haushalte"
 
+#: apps/households/models.py:117
 #, fuzzy
 #| msgid "Pending tasks"
 msgid "Pending"
 msgstr "Ausstehende Aufgaben"
 
+#: apps/households/models.py:118
 msgid "Accepted"
 msgstr ""
 
+#: apps/households/models.py:119
 msgid "Declined"
 msgstr ""
 
+#: apps/households/views.py:99
 #, fuzzy
 #| msgid "household_id required"
 msgid "household_id is required."
 msgstr "household_id erforderlich"
 
+#: apps/households/views.py:104
 #, fuzzy
 #| msgid "You are not a member of this household."
 msgid "Not a member of this household."
 msgstr "Sie sind kein Mitglied dieses Haushalts."
 
+#: apps/households/views.py:134
 msgid "You are not a member of this household."
 msgstr "Sie sind kein Mitglied dieses Haushalts."
 
+#: apps/households/views.py:147
 msgid "Cannot leave household as the last owner."
 msgstr "Als letzter Inhaber kann der Haushalt nicht verlassen werden."
 
+#: apps/households/views.py:173
 msgid "No user found with that email address."
 msgstr "Kein Benutzer mit dieser E-Mail-Adresse gefunden."
 
+#: apps/households/views.py:179
 msgid "User is already a member of this household."
 msgstr "Der Benutzer ist bereits Mitglied dieses Haushalts."
 
+#: apps/households/views.py:189
 msgid "An invitation is already pending for this user."
 msgstr ""
 
+#: apps/households/views.py:206
 #, python-format
 msgid "You've been invited to join %(name)s"
 msgstr "Sie wurden eingeladen, %(name)s beizutreten"
 
+#: apps/households/views.py:207
 #, python-format
 msgid "%(inviter)s invited you to join their household."
 msgstr "%(inviter)s hat Sie eingeladen, seinem Haushalt beizutreten."
 
+#: apps/households/views.py:221
 #, fuzzy
 #| msgid "Interactions"
 msgid "Invitation sent."
 msgstr "Interaktionen"
 
+#: apps/households/views.py:232
 msgid "user_id is required."
 msgstr "user_id ist erforderlich."
 
+#: apps/households/views.py:239 apps/households/views.py:279
 msgid "User is not a member of this household."
 msgstr "Der Benutzer ist kein Mitglied dieses Haushalts."
 
+#: apps/households/views.py:250
 msgid "Cannot remove the last owner of the household."
 msgstr "Der letzte Inhaber des Haushalts kann nicht entfernt werden."
 
+#: apps/households/views.py:266
 msgid "user_id and role are required."
 msgstr "user_id und role sind erforderlich."
 
+#: apps/households/views.py:272
 msgid "Invalid role. Must be owner or member."
 msgstr "Ungültige Rolle. Muss owner oder member sein."
 
+#: apps/households/views.py:290
 msgid "Cannot demote the last owner of the household."
 msgstr "Der letzte Inhaber des Haushalts kann nicht herabgestuft werden."
 
+#: apps/households/views.py:324 apps/households/views.py:368
 msgid "This invitation is no longer pending."
 msgstr ""
 
+#: apps/households/views.py:353
 #, fuzzy, python-format
 #| msgid "You've been invited to join %(name)s"
 msgid "You have joined %(name)s."
 msgstr "Sie wurden eingeladen, %(name)s beizutreten"
 
+#: apps/households/views.py:380
 msgid "Invitation declined."
 msgstr ""
 
+#: apps/insurance/models.py:12
 msgid "Health"
 msgstr ""
 
+#: apps/insurance/models.py:13
 msgid "Home"
 msgstr ""
 
+#: apps/insurance/models.py:14
 msgid "Car"
 msgstr ""
 
+#: apps/insurance/models.py:15
 msgid "Life"
 msgstr ""
 
+#: apps/insurance/models.py:16
 msgid "Liability"
 msgstr ""
 
+#: apps/insurance/models.py:17
 msgid "Other"
 msgstr ""
 
+#: apps/insurance/models.py:21
 msgid "Suspended"
 msgstr ""
 
+#: apps/insurance/models.py:22
 msgid "Terminated"
 msgstr ""
 
+#: apps/insurance/models.py:25
 #, fuzzy
 #| msgid "Monthly cost"
 msgid "Monthly"
 msgstr "Monatliche Kosten"
 
+#: apps/insurance/models.py:26
 msgid "Quarterly"
 msgstr ""
 
+#: apps/insurance/models.py:27
 #, fuzzy
 #| msgid "Yearly cost"
 msgid "Yearly"
 msgstr "Jährliche Kosten"
 
+#: apps/insurance/models.py:49
 msgid "insurance contract"
 msgstr "Versicherungsvertrag"
 
+#: apps/insurance/models.py:50
 msgid "insurance contracts"
 msgstr "Versicherungsverträge"
 
+#: apps/insurance/serializers.py:43
 msgid "End date must be after or equal to start date."
 msgstr "Das Enddatum muss am oder nach dem Startdatum liegen."
 
+#: apps/insurance/serializers.py:46
 msgid "Monthly cost must be non-negative."
 msgstr "Die monatlichen Kosten müssen größer oder gleich null sein."
 
+#: apps/insurance/serializers.py:49
 msgid "Yearly cost must be non-negative."
 msgstr "Die jährlichen Kosten müssen größer oder gleich null sein."
 
+#: apps/interactions/migrations/0014_backfill_stock_purchase_subjects.py:37
+#: apps/interactions/services.py:27 apps/interactions/services.py:28
+#: apps/interactions/services.py:29
+#, python-brace-format
+msgid "Purchase — {name}"
+msgstr "Einkauf — {name}"
+
+#: apps/interactions/models.py:115
 msgid "interaction"
 msgstr "Interaktion"
 
+#: apps/interactions/models.py:116
 msgid "interactions"
 msgstr "Interaktionen"
 
+#: apps/interactions/services.py:46
+#, fuzzy, python-brace-format
+#| msgid "Interactions"
+msgid "Interaction — {name}"
+msgstr "Interaktionen"
+
+#: apps/notifications/models.py:20
 msgid "Household invitation"
 msgstr "Haushalt-Einladung"
 
+#: apps/stock/models.py:23
 msgid "stock category"
 msgstr ""
 
+#: apps/stock/models.py:24
 msgid "stock categories"
 msgstr ""
 
+#: apps/stock/models.py:34
 msgid "In stock"
 msgstr ""
 
+#: apps/stock/models.py:35
 msgid "Low stock"
 msgstr ""
 
+#: apps/stock/models.py:36
 msgid "Out of stock"
 msgstr ""
 
+#: apps/stock/models.py:38
 msgid "Expired"
 msgstr ""
 
+#: apps/stock/models.py:39
 msgid "Reserved"
 msgstr ""
 
+#: apps/stock/models.py:65
 msgid "stock item"
 msgstr ""
 
+#: apps/stock/models.py:66
 msgid "stock items"
 msgstr ""
 
+#: apps/stock/serializers.py:95
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid category or access denied."
 msgstr "Ungültige Zone oder Zugriff verweigert."
 
+#: apps/stock/serializers.py:123
 #, fuzzy
 #| msgid "Breaker must belong to the same household."
 msgid "Category must belong to the same household as item."
 msgstr "Der Leitungsschutzschalter muss zum selben Haushalt gehören."
 
+#: apps/stock/serializers.py:126
 #, fuzzy
 #| msgid "Zone must belong to the same household as equipment."
 msgid "Zone must belong to the same household as item."
 msgstr "Die Zone muss zum selben Haushalt wie die Ausstattung gehören."
 
+#: apps/stock/serializers.py:131
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "Max quantity must be greater than or equal to min quantity."
 msgstr "Das Enddatum muss am oder nach dem Startdatum liegen."
 
+#: apps/stock/serializers.py:141
 msgid "Delta must not be zero."
 msgstr ""
 
+#: apps/stock/views.py:100
 msgid "Adjustment would produce a negative quantity."
 msgstr ""
 
-#, python-brace-format
-msgid "Purchase — {name}"
-msgstr "Einkauf — {name}"
-
+#: apps/zones/models.py:52
 msgid "zone"
 msgstr "Zone"
 
+#: apps/zones/models.py:53
 msgid "zones"
 msgstr "Zonen"
 
+#: apps/zones/serializers.py:53
 msgid "Parent zone must belong to the same household"
 msgstr "Die übergeordnete Zone muss zum selben Haushalt gehören"
 
+#: templates/home.html:4
 msgid "House — Manage your home"
 msgstr "Haus — Verwalten Sie Ihr Zuhause"
 
+#: templates/home.html:17 templates/login.html:6 templates/login.html:82
 msgid "Sign in"
 msgstr "Anmelden"
 
+#: templates/home.html:25
 msgid "Beta — In development"
 msgstr "Beta — In Entwicklung"
 
+#: templates/home.html:29
 msgid "Your home,"
 msgstr "Ihr Zuhause,"
 
+#: templates/home.html:31
 msgid "organized."
 msgstr "organisiert."
 
+#: templates/home.html:36
 msgid ""
 "Track interventions, documents, equipment and contacts related to your home "
 "— all in one place."
@@ -676,152 +884,201 @@ msgstr ""
 "Verfolgen Sie Eingriffe, Dokumente, Geräte und Kontakte rund um Ihr Zuhause "
 "— alles an einem Ort."
 
+#: templates/home.html:42
 msgid "Open the app"
 msgstr "App öffnen"
 
+#: templates/home.html:55
 msgid "Interaction log"
 msgstr "Interaktionsprotokoll"
 
+#: templates/home.html:56
 msgid "Notes, interventions, expenses — the full history of your home."
 msgstr ""
 "Notizen, Eingriffe, Ausgaben — die vollständige Geschichte Ihres "
 "Zuhauses.Notizen, Eingriffe, Ausgaben — die vollständige Geschichte Ihres "
 "Zuhauses."
 
+#: templates/home.html:61
 msgid "Documents"
 msgstr "Dokumente"
 
+#: templates/home.html:62
 msgid "Invoices, warranties, plans — centralized and easy to find."
 msgstr "Rechnungen, Garantien, Pläne — zentralisiert und leicht auffindbar."
 
+#: templates/home.html:67
 msgid "Equipment"
 msgstr "Geräte"
 
+#: templates/home.html:68
 msgid "Track the status and maintenance of each piece of equipment."
 msgstr "Verfolgen Sie den Status und die Wartung jedes Geräts."
 
+#: templates/home.html:73
 msgid "Zones"
 msgstr "Zonen"
 
+#: templates/home.html:74
 msgid "Organize by room, floor or outdoor space."
 msgstr "Organisieren Sie nach Raum, Etage oder Außenbereich."
 
+#: templates/home.html:79
 msgid "Contacts & Contractors"
 msgstr "Kontakte und Handwerker"
 
+#: templates/home.html:80
 msgid "Craftspeople, neighbors, agencies — your home address book."
 msgstr "Handwerker, Nachbarn, Agenturen — Ihr Adressbuch."
 
+#: templates/home.html:85
 msgid "And more to come…"
 msgstr "Und noch mehr kommt…"
 
+#: templates/home.html:86
 msgid "Photos, projects, AI — in development."
 msgstr "Fotos, Projekte, KI — in Entwicklung."
 
+#: templates/home.html:94
 msgid "All rights reserved"
 msgstr "Alle Rechte vorbehalten"
 
+#: templates/login.html:19
 msgid "Sign in to your workspace"
 msgstr "Melden Sie sich in Ihrem Arbeitsbereich an"
 
+#: templates/login.html:46
 msgid "Email"
 msgstr "E-Mail"
 
+#: templates/login.html:64
 msgid "Password"
 msgstr "Passwort"
 
+#: templates/login.html:88
 msgid "Back to home"
 msgstr "Zurück zur Startseite"
 
+#: venv/lib/python3.12/site-packages/django/contrib/messages/apps.py:16
 msgid "Messages"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/sitemaps/apps.py:8
 msgid "Site Maps"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/staticfiles/apps.py:9
 msgid "Static Files"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/syndication/apps.py:7
 msgid "Syndication"
 msgstr ""
 
 #. Translators: String used to replace omitted page numbers in elided page
 #. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:30
 msgid "…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:32
 msgid "That page number is not an integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:33
 msgid "That page number is less than 1"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:34
 msgid "That page contains no results"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:22
 msgid "Enter a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:70
 msgid "Enter a valid domain name."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:153
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:775
 msgid "Enter a valid URL."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:200
 msgid "Enter a valid integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:211
 msgid "Enter a valid email address."
 msgstr ""
 
 #. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.12/site-packages/django/core/validators.py:289
 msgid ""
 "Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:297
 msgid ""
 "Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
 "hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:309
+#: venv/lib/python3.12/site-packages/django/core/validators.py:318
+#: venv/lib/python3.12/site-packages/django/core/validators.py:332
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2220
 #, python-format
 msgid "Enter a valid %(protocol)s address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:311
 msgid "IPv4"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:320
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:43
 msgid "IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:334
 msgid "IPv4 or IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:375
 msgid "Enter only digits separated by commas."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:381
 #, python-format
 msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:416
 #, python-format
 msgid "Ensure this value is less than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:425
 #, python-format
 msgid "Ensure this value is greater than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:434
 #, python-format
 msgid "Ensure this value is a multiple of step size %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:441
 #, python-format
 msgid ""
 "Ensure this value is a multiple of step size %(limit_value)s, starting from "
 "%(offset)s, e.g. %(offset)s, %(valid_value1)s, %(valid_value2)s, and so on."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:473
 #, python-format
 msgid ""
 "Ensure this value has at least %(limit_value)d character (it has "
@@ -832,6 +1089,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:491
 #, python-format
 msgid ""
 "Ensure this value has at most %(limit_value)d character (it has "
@@ -842,21 +1100,27 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:514
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:366
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:405
 msgid "Enter a number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:516
 #, python-format
 msgid "Ensure that there are no more than %(max)s digit in total."
 msgid_plural "Ensure that there are no more than %(max)s digits in total."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:521
 #, python-format
 msgid "Ensure that there are no more than %(max)s decimal place."
 msgid_plural "Ensure that there are no more than %(max)s decimal places."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:526
 #, python-format
 msgid ""
 "Ensure that there are no more than %(max)s digit before the decimal point."
@@ -865,267 +1129,344 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:597
 #, python-format
 msgid ""
 "File extension “%(extension)s” is not allowed. Allowed extensions are: "
 "%(allowed_extensions)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:659
 msgid "Null characters are not allowed."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1600
+#: venv/lib/python3.12/site-packages/django/forms/models.py:908
 msgid "and"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1602
 #, python-format
 msgid "%(model_name)s with this %(field_labels)s already exists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/constraints.py:22
 #, python-format
 msgid "Constraint “%(name)s” is violated."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:134
 #, python-format
 msgid "Value %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:135
 msgid "This field cannot be null."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:136
 msgid "This field cannot be blank."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:137
 #, python-format
 msgid "%(model_name)s with this %(field_label)s already exists."
 msgstr ""
 
 #. Translators: The 'lookup_type' is one of 'date', 'year' or
 #. 'month'. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:141
 #, python-format
 msgid ""
 "%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:180
 #, python-format
 msgid "Field of type: %(field_type)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1162
 #, python-format
 msgid "“%(value)s” value must be either True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1163
 #, python-format
 msgid "“%(value)s” value must be either True, False, or None."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1165
 msgid "Boolean (Either True or False)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1215
 #, python-format
 msgid "String (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1217
 msgid "String (unlimited)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1326
 msgid "Comma-separated integers"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1427
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1431
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1566
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
 "date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1435
 msgid "Date (without time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1562
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in YYYY-MM-DD "
 "HH:MM[:ss[.uuuuuu]][TZ] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1570
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
 "[TZ]) but it is an invalid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1575
 msgid "Date (with time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1702
 #, python-format
 msgid "“%(value)s” value must be a decimal number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1704
 msgid "Decimal number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1864
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in [DD] "
 "[[HH:]MM:]ss[.uuuuuu] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1868
 msgid "Duration"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1920
 msgid "Email address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1945
 msgid "File path"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2023
 #, python-format
 msgid "“%(value)s” value must be a float."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2025
 msgid "Floating point number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2065
 #, python-format
 msgid "“%(value)s” value must be an integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2067
 msgid "Integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2163
 msgid "Big (8 byte) integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2180
 msgid "Small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2188
 msgid "IPv4 address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2219
 msgid "IP address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2310
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2311
 #, python-format
 msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2313
 msgid "Boolean (Either True, False or None)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2364
 msgid "Positive big integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2379
 msgid "Positive integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2394
 msgid "Positive small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2410
 #, python-format
 msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2446
 msgid "Text"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2526
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2530
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
 "invalid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2534
 msgid "Time"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2642
 msgid "URL"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2666
 msgid "Raw binary data"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2731
 #, python-format
 msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2733
 msgid "Universally unique identifier"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:244
 msgid "File"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:420
 msgid "Image"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:24
 msgid "A JSON object"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:26
 msgid "Value must be valid JSON."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:979
 #, python-format
 msgid "%(model)s instance with %(field)s %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:982
 msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1276
 msgid "One-to-one relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1333
 #, python-format
 msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1335
 #, python-format
 msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1383
 msgid "Many-to-many relationship"
 msgstr ""
 
 #. Translators: If found as last label character, these punctuation
 #. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.12/site-packages/django/forms/boundfield.py:185
 msgid ":?.!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:95
 msgid "This field is required."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:315
 msgid "Enter a whole number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:486
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1267
 msgid "Enter a valid date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:509
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1268
 msgid "Enter a valid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:536
 msgid "Enter a valid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:570
 msgid "Enter a valid duration."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:571
 #, python-brace-format
 msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:640
 msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:642
 msgid "The submitted file is empty."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:644
 #, python-format
 msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
 msgid_plural ""
@@ -1133,428 +1474,551 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:649
 msgid "Please either submit a file or check the clear checkbox, not both."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:717
 msgid ""
 "Upload a valid image. The file you uploaded was either not an image or a "
 "corrupted image."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:889
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:975
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1592
 #, python-format
 msgid "Select a valid choice. %(value)s is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:977
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1096
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1590
 msgid "Enter a list of values."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1097
 msgid "Enter a complete value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1339
 msgid "Enter a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1369
 msgid "Enter a valid JSON."
 msgstr ""
 
 #. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:97
 msgid ":"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:239
 #, python-format
 msgid "(Hidden field %(name)s) %(error)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:61
 #, python-format
 msgid ""
 "ManagementForm data is missing or has been tampered with. Missing fields: "
 "%(field_names)s. You may need to file a bug report if the issue persists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:65
 #, python-format
 msgid "Please submit at most %(num)d form."
 msgid_plural "Please submit at most %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:70
 #, python-format
 msgid "Please submit at least %(num)d form."
 msgid_plural "Please submit at least %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:484
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:491
 msgid "Order"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:499
 msgid "Delete"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:901
 #, python-format
 msgid "Please correct the duplicate data for %(field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:906
 #, python-format
 msgid "Please correct the duplicate data for %(field)s, which must be unique."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:913
 #, python-format
 msgid ""
 "Please correct the duplicate data for %(field_name)s which must be unique "
 "for the %(lookup)s in %(date_field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:922
 msgid "Please correct the duplicate values below."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1359
 msgid "The inline value did not match the parent instance."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1450
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1594
 #, python-format
 msgid "“%(pk)s” is not a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/utils.py:229
 #, python-format
 msgid ""
 "%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
 "may be ambiguous or it may not exist."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:527
 msgid "Clear"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:528
 msgid "Currently"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:529
 msgid "Change"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:866
 msgid "Unknown"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:867
 msgid "Yes"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:868
 msgid "No"
 msgstr ""
 
 #. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:873
 msgid "yes,no,maybe"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:903
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:920
 #, python-format
 msgid "%(size)d byte"
 msgid_plural "%(size)d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:922
 #, python-format
 msgid "%s KB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:924
 #, python-format
 msgid "%s MB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:926
 #, python-format
 msgid "%s GB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:928
 #, python-format
 msgid "%s TB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:930
 #, python-format
 msgid "%s PB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:74
 msgid "p.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:75
 msgid "a.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:80
 msgid "PM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:81
 msgid "AM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:153
 msgid "midnight"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:155
 msgid "noon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:7
 msgid "Monday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:8
 msgid "Tuesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:9
 msgid "Wednesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:10
 msgid "Thursday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:11
 msgid "Friday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:12
 msgid "Saturday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:13
 msgid "Sunday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:16
 msgid "Mon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:17
 msgid "Tue"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:18
 msgid "Wed"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:19
 msgid "Thu"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:20
 msgid "Fri"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:21
 msgid "Sat"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:22
 msgid "Sun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:25
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:26
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:27
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:28
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:29
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:30
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:31
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:32
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:33
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:34
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:35
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:36
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:39
 msgid "jan"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:40
 msgid "feb"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:41
 msgid "mar"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:42
 msgid "apr"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:43
 msgid "may"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:44
 msgid "jun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:45
 msgid "jul"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:46
 msgid "aug"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:47
 msgid "sep"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:48
 msgid "oct"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:49
 msgid "nov"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:50
 msgid "dec"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:53
 msgctxt "abbrev. month"
 msgid "Jan."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:54
 msgctxt "abbrev. month"
 msgid "Feb."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:55
 msgctxt "abbrev. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:56
 msgctxt "abbrev. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:57
 msgctxt "abbrev. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:58
 msgctxt "abbrev. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:59
 msgctxt "abbrev. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:60
 msgctxt "abbrev. month"
 msgid "Aug."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:61
 msgctxt "abbrev. month"
 msgid "Sept."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:62
 msgctxt "abbrev. month"
 msgid "Oct."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:63
 msgctxt "abbrev. month"
 msgid "Nov."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:64
 msgctxt "abbrev. month"
 msgid "Dec."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:67
 msgctxt "alt. month"
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:68
 msgctxt "alt. month"
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:69
 msgctxt "alt. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:70
 msgctxt "alt. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:71
 msgctxt "alt. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:72
 msgctxt "alt. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:73
 msgctxt "alt. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:74
 msgctxt "alt. month"
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:75
 msgctxt "alt. month"
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:76
 msgctxt "alt. month"
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:77
 msgctxt "alt. month"
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:78
 msgctxt "alt. month"
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:20
 msgid "This is not a valid IPv6 address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:76
 #, python-format
 msgctxt "String to return when truncating text"
 msgid "%(truncated_text)s…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:288
 msgid "or"
 msgstr ""
 
 #. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.12/site-packages/django/utils/text.py:307
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:135
 msgid ", "
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:8
 #, python-format
 msgid "%(num)d year"
 msgid_plural "%(num)d years"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:9
 #, python-format
 msgid "%(num)d month"
 msgid_plural "%(num)d months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:10
 #, python-format
 msgid "%(num)d week"
 msgid_plural "%(num)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:11
 #, python-format
 msgid "%(num)d day"
 msgid_plural "%(num)d days"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:12
 #, python-format
 msgid "%(num)d hour"
 msgid_plural "%(num)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:13
 #, python-format
 msgid "%(num)d minute"
 msgid_plural "%(num)d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:29
 msgid "Forbidden"
 msgstr "Verboten"
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:30
 msgid "CSRF verification failed. Request aborted."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:34
 msgid ""
 "You are seeing this message because this HTTPS site requires a “Referer "
 "header” to be sent by your web browser, but none was sent. This header is "
@@ -1562,12 +2026,14 @@ msgid ""
 "hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:40
 msgid ""
 "If you have configured your browser to disable “Referer” headers, please re-"
 "enable them, at least for this site, or for HTTPS connections, or for “same-"
 "origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:45
 msgid ""
 "If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
 "including the “Referrer-Policy: no-referrer” header, please remove them. The "
@@ -1576,84 +2042,111 @@ msgid ""
 "rel=\"noreferrer\" …> for links to third-party sites."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:54
 msgid ""
 "You are seeing this message because this site requires a CSRF cookie when "
 "submitting forms. This cookie is required for security reasons, to ensure "
 "that your browser is not being hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:60
 msgid ""
 "If you have configured your browser to disable cookies, please re-enable "
 "them, at least for this site, or for “same-origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:66
 msgid "More information is available with DEBUG=True."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:44
 msgid "No year specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:64
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:115
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:214
 msgid "Date out of range"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:94
 msgid "No month specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:147
 msgid "No day specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:194
 msgid "No week specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:353
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:384
 #, python-format
 msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:680
 #, python-format
 msgid ""
 "Future %(verbose_name_plural)s not available because "
 "%(class_name)s.allow_future is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:720
 #, python-format
 msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/detail.py:56
 #, python-format
 msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:70
 msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:77
 #, python-format
 msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:173
 #, python-format
 msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:49
 msgid "Directory indexes are not allowed here."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:51
 #, python-format
 msgid "“%(path)s” does not exist"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:68
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:8
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:11
 #, python-format
 msgid "Index of %(directory)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:204
 msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:206
 #, python-format
 msgid ""
 "View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
 "target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:208
 #, python-format
 msgid ""
 "You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
@@ -1662,34 +2155,48 @@ msgid ""
 "configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:217
 msgid "Django Documentation"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:218
 msgid "Topics, references, &amp; how-to’s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:226
 msgid "Tutorial: A Polling App"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:227
 msgid "Get started with Django"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:235
 msgid "Django Community"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:236
 msgid "Connect, get help, or contribute"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1404
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1457
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1461
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1465
 msgid "No response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1429
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1483
 msgid "Unspecified response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/plumbing.py:488
 #, python-format
 msgid "Token-based authentication with required prefix \"%s\""
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/views.py:45
 msgid ""
 "\n"
 "    OpenApi3 schema for this API. Format can be selected via content "
@@ -1723,11 +2230,6 @@ msgstr ""
 
 #~ msgid "Actual cost"
 #~ msgstr "Tatsächliche Kosten"
-
-#, fuzzy
-#~| msgid "Interactions"
-#~ msgid "Interaction"
-#~ msgstr "Interaktionen"
 
 #~ msgid "Dashboard"
 #~ msgstr "Übersicht"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: House Backend 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 04:46+0000\n"
+"POT-Creation-Date: 2026-05-03 05:57+0000\n"
 "PO-Revision-Date: 2026-03-08 00:00+0000\n"
 "Last-Translator: House Team\n"
 "Language-Team: Spanish\n"
@@ -17,652 +17,860 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
 "1 : 2;\n"
 
+#: apps/accounts/models.py:44
 msgid "Display name shown in the UI"
 msgstr "Nombre mostrado en la interfaz"
 
+#: apps/accounts/models.py:48 apps/households/models.py:38
 msgid "English"
 msgstr "Inglés"
 
+#: apps/accounts/models.py:49
 msgid "Français"
 msgstr "Francés"
 
+#: apps/accounts/models.py:50
 msgid "Deutsch"
 msgstr "Alemán"
 
+#: apps/accounts/models.py:51
 msgid "Español"
 msgstr "Español"
 
+#: apps/accounts/models.py:56
 msgid "User's preferred language. Null means use browser detection."
 msgstr ""
 
+#: apps/accounts/models.py:65
 msgid "User's avatar image file"
 msgstr "URL de la imagen de avatar del usuario"
 
+#: apps/accounts/models.py:77
 msgid "User's preferred theme (light/dark/system)"
 msgstr "Tema preferido del usuario (claro/oscuro/sistema)"
 
+#: apps/accounts/models.py:103
 msgid "User's preferred color palette"
 msgstr "Paleta de colores preferida del usuario"
 
+#: apps/accounts/models.py:111
 msgid "User's currently active household"
 msgstr "Hogar activo actual del usuario"
 
+#: apps/accounts/models.py:112
 msgid "active household"
 msgstr "hogar activo"
 
+#: apps/accounts/models.py:125
 msgid "user"
 msgstr "usuario"
 
+#: apps/accounts/models.py:126
 msgid "users"
 msgstr "usuarios"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:3
 #, fuzzy
 #| msgid "Password"
 msgid "Password reset"
 msgstr "Contraseña"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:5
+#: apps/accounts/templates/accounts/emails/password_reset.txt:1
 msgid "Hello,"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:6
+#: apps/accounts/templates/accounts/emails/password_reset.txt:3
 msgid "You requested a password reset for your House account."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:9
 msgid "Reset my password"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:12
 msgid "Or copy and paste this URL into your browser:"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:15
+#: apps/accounts/templates/accounts/emails/password_reset.txt:9
 msgid ""
 "This link will expire in 3 days. If you did not request a password reset, "
 "you can safely ignore this email."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:16
+#: apps/accounts/templates/accounts/emails/password_reset.txt:11
 msgid "— House"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.txt:5
 msgid "Click the link below to set a new password:"
 msgstr ""
 
+#: apps/accounts/views/api.py:60
 msgid "Email and password are required."
 msgstr "El correo electrónico y la contraseña son obligatorios."
 
+#: apps/accounts/views/api.py:66
 msgid "Invalid credentials."
 msgstr "Credenciales inválidas."
 
+#: apps/accounts/views/api.py:71
 msgid "Login successful."
 msgstr "Inicio de sesión exitoso."
 
+#: apps/accounts/views/api.py:81
 msgid "Logout successful."
 msgstr "Cierre de sesión exitoso."
 
+#: apps/accounts/views/api.py:101 apps/households/views.py:164
 msgid "Email is required."
 msgstr "El correo electrónico es obligatorio."
 
+#: apps/accounts/views/api.py:120
 msgid "Reset your House password"
 msgstr ""
 
+#: apps/accounts/views/api.py:130
 msgid "If an account with that email exists, a reset link has been sent."
 msgstr ""
 
+#: apps/accounts/views/api.py:151
 #, fuzzy
 #| msgid "Email and password are required."
 msgid "uid, token and new_password are required."
 msgstr "El correo electrónico y la contraseña son obligatorios."
 
+#: apps/accounts/views/api.py:160 apps/accounts/views/api.py:166
 #, fuzzy
 #| msgid "Invalid credentials."
 msgid "Invalid or expired reset link."
 msgstr "Credenciales inválidas."
 
+#: apps/accounts/views/api.py:182
 #, fuzzy
 #| msgid "Password updated successfully."
 msgid "Password has been reset successfully."
 msgstr "Contraseña actualizada correctamente."
 
+#: apps/accounts/views/api.py:242
 msgid "new_password and confirm_password are required."
 msgstr "new_password y confirm_password son obligatorios."
 
+#: apps/accounts/views/api.py:248
 msgid "Password must be at least 8 characters."
 msgstr "La contraseña debe tener al menos 8 caracteres."
 
+#: apps/accounts/views/api.py:254
 msgid "Passwords do not match."
 msgstr "Las contraseñas no coinciden."
 
+#: apps/accounts/views/api.py:268
 msgid "Password updated successfully."
 msgstr "Contraseña actualizada correctamente."
 
+#: apps/accounts/views/api.py:280
 msgid "You cannot impersonate yourself."
 msgstr ""
 
+#: apps/accounts/views/api.py:307
 msgid "No avatar to delete."
 msgstr "No hay avatar que eliminar."
 
+#: apps/accounts/views/api.py:319
 msgid "Avatar removed."
 msgstr "Avatar eliminado."
 
+#: apps/accounts/views/api.py:325
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:641
 msgid "No file was submitted."
 msgstr "No se envió ningún archivo."
 
+#: apps/ai_usage/models.py:21
 msgid "OCR — upload"
 msgstr ""
 
+#: apps/ai_usage/models.py:22
 msgid "OCR — backfill"
 msgstr ""
 
+#: apps/ai_usage/models.py:23
 msgid "Agent — ask"
 msgstr ""
 
+#: apps/core/file_validation.py:15
 msgid "JPEG image"
 msgstr ""
 
+#: apps/core/file_validation.py:20
 msgid "PNG image"
 msgstr ""
 
+#: apps/core/file_validation.py:25
 msgid "GIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:30
 msgid "WebP image"
 msgstr ""
 
+#: apps/core/file_validation.py:35
 msgid "HEIC image"
 msgstr ""
 
+#: apps/core/file_validation.py:40
 msgid "HEIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:45
 #, fuzzy
 #| msgid "document"
 msgid "PDF document"
 msgstr "documento"
 
+#: apps/core/file_validation.py:85
 #, python-format
 msgid "File too large (%(size)d MB). Maximum allowed: %(max)d MB."
 msgstr ""
 
+#: apps/core/file_validation.py:99
 #, python-format
 msgid "Unsupported file type. Allowed: %(types)s."
 msgstr ""
 
+#: apps/directory/models.py:49
 msgid "contact"
 msgstr "contacto"
 
+#: apps/directory/models.py:50
 msgid "contacts"
 msgstr "contactos"
 
+#: apps/documents/models.py:80
 msgid "document"
 msgstr "documento"
 
+#: apps/documents/models.py:81
 msgid "documents"
 msgstr "documentos"
 
+#: apps/electricity/models.py:16
 msgid "Single phase"
 msgstr "Monofásico"
 
+#: apps/electricity/models.py:17
 msgid "Three phase"
 msgstr "Trifásico"
 
+#: apps/electricity/models.py:27
 msgid "Socket"
 msgstr "Enchufe"
 
+#: apps/electricity/models.py:28
 msgid "Light"
 msgstr "Iluminación"
 
+#: apps/electricity/models.py:115
 msgid "electricity board"
 msgstr "cuadro eléctrico"
 
+#: apps/electricity/models.py:116
 msgid "electricity boards"
 msgstr "cuadros eléctricos"
 
+#: apps/electricity/models.py:208
 msgid "protective device"
 msgstr ""
 
+#: apps/electricity/models.py:209
 msgid "protective devices"
 msgstr ""
 
+#: apps/electricity/models.py:267
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "curve_type must be empty for device_type=rcd."
 msgstr "La fase debe estar vacía para un cuadro monofásico."
 
+#: apps/electricity/models.py:272
 msgid "sensitivity_ma must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:276
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "type_code must be empty for device_type=breaker."
 msgstr "La fase debe estar vacía para un cuadro monofásico."
 
+#: apps/electricity/models.py:280
 msgid "phase_coverage must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:310
 msgid "circuit"
 msgstr "circuito"
 
+#: apps/electricity/models.py:311
 msgid "circuits"
 msgstr "circuitos"
 
+#: apps/electricity/models.py:329
 msgid ""
 "A circuit cannot be directly protected by a pure RCD (device_type=rcd). Use "
 "a breaker, combined, or main device."
 msgstr ""
 
+#: apps/electricity/models.py:358
 msgid "usage point"
 msgstr "punto de uso"
 
+#: apps/electricity/models.py:359
 msgid "usage points"
 msgstr "puntos de uso"
 
+#: apps/electricity/models.py:468
 msgid "maintenance event"
 msgstr ""
 
+#: apps/electricity/models.py:469
 msgid "maintenance events"
 msgstr ""
 
+#: apps/electricity/serializers.py:42
 msgid "Household cannot be changed."
 msgstr "El hogar no puede ser cambiado."
 
+#: apps/electricity/serializers.py:56
 msgid "Label must be unique across electricity entities in household."
 msgstr "La etiqueta debe ser única entre las entidades eléctricas del hogar."
 
+#: apps/electricity/serializers.py:100
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent board must belong to the same household."
 msgstr "La zona padre debe pertenecer al mismo hogar"
 
+#: apps/electricity/serializers.py:102 apps/electricity/serializers.py:292
 #, fuzzy
 #| msgid "Email is required."
 msgid "Zone is required."
 msgstr "El correo electrónico es obligatorio."
 
+#: apps/electricity/serializers.py:104 apps/electricity/serializers.py:294
 msgid "Zone must belong to the same household."
 msgstr "La zona debe pertenecer al mismo hogar."
 
+#: apps/electricity/serializers.py:124
 #, fuzzy
 #| msgid "Only one active board is allowed per household."
 msgid "Only one active root board is allowed per household."
 msgstr "Solo se permite un cuadro activo por hogar."
 
+#: apps/electricity/serializers.py:176 apps/electricity/serializers.py:364
 msgid "Board must belong to the same household."
 msgstr "El cuadro debe pertenecer al mismo hogar."
 
+#: apps/electricity/serializers.py:178
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent device must belong to the same household."
 msgstr "La zona padre debe pertenecer al mismo hogar"
 
+#: apps/electricity/serializers.py:182
 msgid "Phase must be empty for single-phase board."
 msgstr "La fase debe estar vacía para un cuadro monofásico."
 
+#: apps/electricity/serializers.py:184
 msgid "Phase is required for three-phase board."
 msgstr "La fase es requerida para un cuadro trifásico."
 
+#: apps/electricity/serializers.py:186
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "phase_coverage must be null for single-phase board."
 msgstr "La fase debe estar vacía para un cuadro monofásico."
 
+#: apps/electricity/serializers.py:190
 msgid "pole_count must be 2 or 4 for rcd and combined devices."
 msgstr ""
 
+#: apps/electricity/serializers.py:197
 msgid "row and position must both be set or both be empty."
 msgstr ""
 
+#: apps/electricity/serializers.py:203
 msgid "position_end requires position to be set."
 msgstr ""
 
+#: apps/electricity/serializers.py:207
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "position_end must be greater than or equal to position."
 msgstr ""
 "La fecha de finalización debe ser posterior o igual a la fecha de inicio."
 
+#: apps/electricity/serializers.py:224
 msgid "Position range overlaps with an existing device on the same row."
 msgstr ""
 
+#: apps/electricity/serializers.py:254
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Protective device must belong to the same household."
 msgstr "La zona padre debe pertenecer al mismo hogar"
 
+#: apps/electricity/serializers.py:257
 msgid "A circuit cannot be directly protected by a pure RCD (device_type=rcd)."
 msgstr ""
 
+#: apps/electricity/serializers.py:261
 msgid "A spare device cannot protect a circuit."
 msgstr ""
 
+#: apps/electricity/serializers.py:264
 #, fuzzy
 #| msgid "Breaker must belong to the selected board."
 msgid "Protective device must belong to the selected board."
 msgstr "El disyuntor debe pertenecer al cuadro seleccionado."
 
+#: apps/electricity/serializers.py:322
 msgid "Circuit must belong to the same household."
 msgstr "El circuito debe pertenecer al mismo hogar."
 
+#: apps/electricity/serializers.py:324
 msgid "Usage point must belong to the same household."
 msgstr "El punto de uso debe pertenecer al mismo hogar."
 
+#: apps/electricity/serializers.py:326
 msgid "Usage point and circuit must be in the same household."
 msgstr "El punto de uso y el circuito deben estar en el mismo hogar."
 
+#: apps/electricity/serializers.py:333
 msgid "Usage point already has an active circuit link."
 msgstr "El punto de uso ya tiene un enlace de circuito activo."
 
+#: apps/electricity/serializers.py:389
 msgid "Actor is required."
 msgstr "El actor es requerido."
 
+#: apps/electricity/serializers.py:391
 msgid "Actor must be a member of the household."
 msgstr "El actor debe ser miembro del hogar."
 
+#: apps/electricity/views.py:83
 #, fuzzy
 #| msgid "Cannot delete breaker with active circuits."
 msgid "Cannot delete protective device with active circuits."
 msgstr "No se puede eliminar un disyuntor con circuitos activos."
 
+#: apps/electricity/views.py:94
 msgid "Cannot delete circuit with active usage point links."
 msgstr "No se puede eliminar un circuito con enlaces de puntos de uso activos."
 
+#: apps/electricity/views.py:105
 msgid "Cannot delete usage point with active circuit link."
 msgstr "No se puede eliminar un punto de uso con un enlace de circuito activo."
 
+#: apps/electricity/views.py:113
 msgid "Cannot delete resource with active dependencies."
 msgstr "No se puede eliminar un recurso con dependencias activas."
 
+#: apps/electricity/views.py:162 apps/equipment/views.py:41
+#: apps/insurance/serializers.py:57 apps/insurance/views.py:32
+#: apps/stock/views.py:46 apps/stock/views.py:81
 msgid "A valid household context is required."
 msgstr "Se requiere un contexto de hogar válido."
 
+#: apps/electricity/views.py:167
 msgid "Must be an integer."
 msgstr ""
 
+#: apps/electricity/views.py:169
 msgid "Must be between 1 and 50."
 msgstr ""
 
+#: apps/electricity/views.py:175
 msgid "A label prefix is required when creating multiple usage points."
 msgstr ""
 
+#: apps/equipment/models.py:12 apps/insurance/models.py:20
 #, fuzzy
 #| msgid "Activity"
 msgid "Active"
 msgstr "Actividad"
 
+#: apps/equipment/models.py:13
 msgid "Maintenance"
 msgstr ""
 
+#: apps/equipment/models.py:14
 msgid "Storage"
 msgstr ""
 
+#: apps/equipment/models.py:15
 msgid "Retired"
 msgstr ""
 
+#: apps/equipment/models.py:16
 msgid "Lost"
 msgstr ""
 
+#: apps/equipment/models.py:17 apps/stock/models.py:37
 msgid "Ordered"
 msgstr ""
 
+#: apps/equipment/models.py:45 apps/equipment/models.py:46
 msgid "equipment"
 msgstr "equipo"
 
+#: apps/equipment/serializers.py:71 apps/stock/serializers.py:108
 msgid "Invalid zone or access denied."
 msgstr "Zona no válida o acceso denegado."
 
+#: apps/equipment/serializers.py:88
 msgid "Zone must belong to the same household as equipment."
 msgstr "La zona debe pertenecer al mismo hogar que el equipo."
 
+#: apps/equipment/views.py:133
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid equipment or access denied."
 msgstr "Zona no válida o acceso denegado."
 
+#: apps/equipment/views.py:135
 msgid "Interaction household must match equipment household."
 msgstr "El hogar de la interacción debe coincidir con el hogar del equipo."
 
+#: apps/equipment/views.py:137
 msgid "Invalid interaction or access denied."
 msgstr "Interacción no válida o acceso denegado."
 
+#: apps/households/models.py:26
 msgid "ISO 3166-1 alpha-2 country code (e.g. FR, DE, US)"
 msgstr ""
 
+#: apps/households/models.py:28
 msgid "IANA timezone (e.g. Europe/Paris). Leave blank for UTC."
 msgstr ""
 
+#: apps/households/models.py:37
 msgid "French"
 msgstr ""
 
+#: apps/households/models.py:39
 msgid "German"
 msgstr ""
 
+#: apps/households/models.py:40
 msgid "Spanish"
 msgstr ""
 
+#: apps/households/models.py:56
 msgid "household"
 msgstr "hogar"
 
+#: apps/households/models.py:57
 msgid "households"
 msgstr "hogares"
 
+#: apps/households/models.py:117
 #, fuzzy
 #| msgid "Pending tasks"
 msgid "Pending"
 msgstr "Tareas pendientes"
 
+#: apps/households/models.py:118
 msgid "Accepted"
 msgstr ""
 
+#: apps/households/models.py:119
 msgid "Declined"
 msgstr ""
 
+#: apps/households/views.py:99
 #, fuzzy
 #| msgid "household_id required"
 msgid "household_id is required."
 msgstr "household_id es obligatorio"
 
+#: apps/households/views.py:104
 #, fuzzy
 #| msgid "You are not a member of this household."
 msgid "Not a member of this household."
 msgstr "No es miembro de este hogar."
 
+#: apps/households/views.py:134
 msgid "You are not a member of this household."
 msgstr "No es miembro de este hogar."
 
+#: apps/households/views.py:147
 msgid "Cannot leave household as the last owner."
 msgstr "No puede abandonar el hogar siendo el último propietario."
 
+#: apps/households/views.py:173
 msgid "No user found with that email address."
 msgstr "No se encontró ningún usuario con esa dirección de correo electrónico."
 
+#: apps/households/views.py:179
 msgid "User is already a member of this household."
 msgstr "El usuario ya es miembro de este hogar."
 
+#: apps/households/views.py:189
 msgid "An invitation is already pending for this user."
 msgstr ""
 
+#: apps/households/views.py:206
 #, python-format
 msgid "You've been invited to join %(name)s"
 msgstr "Has sido invitado/a a unirte a %(name)s"
 
+#: apps/households/views.py:207
 #, python-format
 msgid "%(inviter)s invited you to join their household."
 msgstr "%(inviter)s te ha invitado a unirte a su hogar."
 
+#: apps/households/views.py:221
 #, fuzzy
 #| msgid "Interactions"
 msgid "Invitation sent."
 msgstr "Interacciones"
 
+#: apps/households/views.py:232
 msgid "user_id is required."
 msgstr "user_id es obligatorio."
 
+#: apps/households/views.py:239 apps/households/views.py:279
 msgid "User is not a member of this household."
 msgstr "El usuario no es miembro de este hogar."
 
+#: apps/households/views.py:250
 msgid "Cannot remove the last owner of the household."
 msgstr "No se puede eliminar al último propietario del hogar."
 
+#: apps/households/views.py:266
 msgid "user_id and role are required."
 msgstr "user_id y role son obligatorios."
 
+#: apps/households/views.py:272
 msgid "Invalid role. Must be owner or member."
 msgstr "Rol inválido. Debe ser owner o member."
 
+#: apps/households/views.py:290
 msgid "Cannot demote the last owner of the household."
 msgstr "No se puede degradar al último propietario del hogar."
 
+#: apps/households/views.py:324 apps/households/views.py:368
 msgid "This invitation is no longer pending."
 msgstr ""
 
+#: apps/households/views.py:353
 #, fuzzy, python-format
 #| msgid "You've been invited to join %(name)s"
 msgid "You have joined %(name)s."
 msgstr "Has sido invitado/a a unirte a %(name)s"
 
+#: apps/households/views.py:380
 msgid "Invitation declined."
 msgstr ""
 
+#: apps/insurance/models.py:12
 msgid "Health"
 msgstr ""
 
+#: apps/insurance/models.py:13
 msgid "Home"
 msgstr ""
 
+#: apps/insurance/models.py:14
 msgid "Car"
 msgstr ""
 
+#: apps/insurance/models.py:15
 msgid "Life"
 msgstr ""
 
+#: apps/insurance/models.py:16
 msgid "Liability"
 msgstr ""
 
+#: apps/insurance/models.py:17
 msgid "Other"
 msgstr ""
 
+#: apps/insurance/models.py:21
 msgid "Suspended"
 msgstr ""
 
+#: apps/insurance/models.py:22
 msgid "Terminated"
 msgstr ""
 
+#: apps/insurance/models.py:25
 #, fuzzy
 #| msgid "Monthly cost"
 msgid "Monthly"
 msgstr "Coste mensual"
 
+#: apps/insurance/models.py:26
 msgid "Quarterly"
 msgstr ""
 
+#: apps/insurance/models.py:27
 #, fuzzy
 #| msgid "Yearly cost"
 msgid "Yearly"
 msgstr "Coste anual"
 
+#: apps/insurance/models.py:49
 msgid "insurance contract"
 msgstr "contrato de seguro"
 
+#: apps/insurance/models.py:50
 msgid "insurance contracts"
 msgstr "contratos de seguro"
 
+#: apps/insurance/serializers.py:43
 msgid "End date must be after or equal to start date."
 msgstr ""
 "La fecha de finalización debe ser posterior o igual a la fecha de inicio."
 
+#: apps/insurance/serializers.py:46
 msgid "Monthly cost must be non-negative."
 msgstr "El coste mensual debe ser mayor o igual que cero."
 
+#: apps/insurance/serializers.py:49
 msgid "Yearly cost must be non-negative."
 msgstr "El coste anual debe ser mayor o igual que cero."
 
+#: apps/interactions/migrations/0014_backfill_stock_purchase_subjects.py:37
+#: apps/interactions/services.py:27 apps/interactions/services.py:28
+#: apps/interactions/services.py:29
+#, python-brace-format
+msgid "Purchase — {name}"
+msgstr "Compra — {name}"
+
+#: apps/interactions/models.py:115
 msgid "interaction"
 msgstr "interacción"
 
+#: apps/interactions/models.py:116
 msgid "interactions"
 msgstr "interacciones"
 
+#: apps/interactions/services.py:46
+#, fuzzy, python-brace-format
+#| msgid "Interactions"
+msgid "Interaction — {name}"
+msgstr "Interacciones"
+
+#: apps/notifications/models.py:20
 msgid "Household invitation"
 msgstr "Invitación al hogar"
 
+#: apps/stock/models.py:23
 msgid "stock category"
 msgstr ""
 
+#: apps/stock/models.py:24
 msgid "stock categories"
 msgstr ""
 
+#: apps/stock/models.py:34
 msgid "In stock"
 msgstr ""
 
+#: apps/stock/models.py:35
 msgid "Low stock"
 msgstr ""
 
+#: apps/stock/models.py:36
 msgid "Out of stock"
 msgstr ""
 
+#: apps/stock/models.py:38
 msgid "Expired"
 msgstr ""
 
+#: apps/stock/models.py:39
 msgid "Reserved"
 msgstr ""
 
+#: apps/stock/models.py:65
 msgid "stock item"
 msgstr ""
 
+#: apps/stock/models.py:66
 msgid "stock items"
 msgstr ""
 
+#: apps/stock/serializers.py:95
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid category or access denied."
 msgstr "Zona no válida o acceso denegado."
 
+#: apps/stock/serializers.py:123
 #, fuzzy
 #| msgid "Breaker must belong to the same household."
 msgid "Category must belong to the same household as item."
 msgstr "El disyuntor debe pertenecer al mismo hogar."
 
+#: apps/stock/serializers.py:126
 #, fuzzy
 #| msgid "Zone must belong to the same household as equipment."
 msgid "Zone must belong to the same household as item."
 msgstr "La zona debe pertenecer al mismo hogar que el equipo."
 
+#: apps/stock/serializers.py:131
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "Max quantity must be greater than or equal to min quantity."
 msgstr ""
 "La fecha de finalización debe ser posterior o igual a la fecha de inicio."
 
+#: apps/stock/serializers.py:141
 msgid "Delta must not be zero."
 msgstr ""
 
+#: apps/stock/views.py:100
 msgid "Adjustment would produce a negative quantity."
 msgstr ""
 
-#, python-brace-format
-msgid "Purchase — {name}"
-msgstr "Compra — {name}"
-
+#: apps/zones/models.py:52
 msgid "zone"
 msgstr "zona"
 
+#: apps/zones/models.py:53
 msgid "zones"
 msgstr "zonas"
 
+#: apps/zones/serializers.py:53
 msgid "Parent zone must belong to the same household"
 msgstr "La zona padre debe pertenecer al mismo hogar"
 
+#: templates/home.html:4
 msgid "House — Manage your home"
 msgstr "Casa — Gestione su hogar"
 
+#: templates/home.html:17 templates/login.html:6 templates/login.html:82
 msgid "Sign in"
 msgstr "Iniciar sesión"
 
+#: templates/home.html:25
 msgid "Beta — In development"
 msgstr "Beta — En desarrollo"
 
+#: templates/home.html:29
 msgid "Your home,"
 msgstr "Su hogar,"
 
+#: templates/home.html:31
 msgid "organized."
 msgstr "organizado."
 
+#: templates/home.html:36
 msgid ""
 "Track interventions, documents, equipment and contacts related to your home "
 "— all in one place."
@@ -670,149 +878,198 @@ msgstr ""
 "Rastree intervenciones, documentos, equipos y contactos relacionados con su "
 "hogar — todo en un solo lugar."
 
+#: templates/home.html:42
 msgid "Open the app"
 msgstr "Abrir la aplicación"
 
+#: templates/home.html:55
 msgid "Interaction log"
 msgstr "Registro de interacciones"
 
+#: templates/home.html:56
 msgid "Notes, interventions, expenses — the full history of your home."
 msgstr "Notas, intervenciones, gastos — el historial completo de su hogar."
 
+#: templates/home.html:61
 msgid "Documents"
 msgstr "Documentos"
 
+#: templates/home.html:62
 msgid "Invoices, warranties, plans — centralized and easy to find."
 msgstr "Facturas, garantías, planos — centralizados y fáciles de encontrar."
 
+#: templates/home.html:67
 msgid "Equipment"
 msgstr "Equipos"
 
+#: templates/home.html:68
 msgid "Track the status and maintenance of each piece of equipment."
 msgstr "Rastree el estado y mantenimiento de cada equipo."
 
+#: templates/home.html:73
 msgid "Zones"
 msgstr "Zonas"
 
+#: templates/home.html:74
 msgid "Organize by room, floor or outdoor space."
 msgstr "Organice por habitación, piso o espacio exterior."
 
+#: templates/home.html:79
 msgid "Contacts & Contractors"
 msgstr "Contactos y contratistas"
 
+#: templates/home.html:80
 msgid "Craftspeople, neighbors, agencies — your home address book."
 msgstr "Artesanos, vecinos, agencias — su libreta de direcciones."
 
+#: templates/home.html:85
 msgid "And more to come…"
 msgstr "Y más por venir…"
 
+#: templates/home.html:86
 msgid "Photos, projects, AI — in development."
 msgstr "Fotos, proyectos, IA — en desarrollo."
 
+#: templates/home.html:94
 msgid "All rights reserved"
 msgstr "Todos los derechos reservados"
 
+#: templates/login.html:19
 msgid "Sign in to your workspace"
 msgstr "Inicie sesión en su espacio de trabajo"
 
+#: templates/login.html:46
 msgid "Email"
 msgstr "Correo electrónico"
 
+#: templates/login.html:64
 msgid "Password"
 msgstr "Contraseña"
 
+#: templates/login.html:88
 msgid "Back to home"
 msgstr "Volver al inicio"
 
+#: venv/lib/python3.12/site-packages/django/contrib/messages/apps.py:16
 msgid "Messages"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/sitemaps/apps.py:8
 msgid "Site Maps"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/staticfiles/apps.py:9
 msgid "Static Files"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/syndication/apps.py:7
 msgid "Syndication"
 msgstr ""
 
 #. Translators: String used to replace omitted page numbers in elided page
 #. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:30
 msgid "…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:32
 msgid "That page number is not an integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:33
 msgid "That page number is less than 1"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:34
 msgid "That page contains no results"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:22
 msgid "Enter a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:70
 msgid "Enter a valid domain name."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:153
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:775
 msgid "Enter a valid URL."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:200
 msgid "Enter a valid integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:211
 msgid "Enter a valid email address."
 msgstr ""
 
 #. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.12/site-packages/django/core/validators.py:289
 msgid ""
 "Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:297
 msgid ""
 "Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
 "hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:309
+#: venv/lib/python3.12/site-packages/django/core/validators.py:318
+#: venv/lib/python3.12/site-packages/django/core/validators.py:332
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2220
 #, python-format
 msgid "Enter a valid %(protocol)s address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:311
 msgid "IPv4"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:320
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:43
 msgid "IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:334
 msgid "IPv4 or IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:375
 msgid "Enter only digits separated by commas."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:381
 #, python-format
 msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:416
 #, python-format
 msgid "Ensure this value is less than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:425
 #, python-format
 msgid "Ensure this value is greater than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:434
 #, python-format
 msgid "Ensure this value is a multiple of step size %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:441
 #, python-format
 msgid ""
 "Ensure this value is a multiple of step size %(limit_value)s, starting from "
 "%(offset)s, e.g. %(offset)s, %(valid_value1)s, %(valid_value2)s, and so on."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:473
 #, python-format
 msgid ""
 "Ensure this value has at least %(limit_value)d character (it has "
@@ -823,6 +1080,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:491
 #, python-format
 msgid ""
 "Ensure this value has at most %(limit_value)d character (it has "
@@ -833,21 +1091,27 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:514
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:366
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:405
 msgid "Enter a number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:516
 #, python-format
 msgid "Ensure that there are no more than %(max)s digit in total."
 msgid_plural "Ensure that there are no more than %(max)s digits in total."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:521
 #, python-format
 msgid "Ensure that there are no more than %(max)s decimal place."
 msgid_plural "Ensure that there are no more than %(max)s decimal places."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:526
 #, python-format
 msgid ""
 "Ensure that there are no more than %(max)s digit before the decimal point."
@@ -856,267 +1120,344 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:597
 #, python-format
 msgid ""
 "File extension “%(extension)s” is not allowed. Allowed extensions are: "
 "%(allowed_extensions)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:659
 msgid "Null characters are not allowed."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1600
+#: venv/lib/python3.12/site-packages/django/forms/models.py:908
 msgid "and"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1602
 #, python-format
 msgid "%(model_name)s with this %(field_labels)s already exists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/constraints.py:22
 #, python-format
 msgid "Constraint “%(name)s” is violated."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:134
 #, python-format
 msgid "Value %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:135
 msgid "This field cannot be null."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:136
 msgid "This field cannot be blank."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:137
 #, python-format
 msgid "%(model_name)s with this %(field_label)s already exists."
 msgstr ""
 
 #. Translators: The 'lookup_type' is one of 'date', 'year' or
 #. 'month'. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:141
 #, python-format
 msgid ""
 "%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:180
 #, python-format
 msgid "Field of type: %(field_type)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1162
 #, python-format
 msgid "“%(value)s” value must be either True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1163
 #, python-format
 msgid "“%(value)s” value must be either True, False, or None."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1165
 msgid "Boolean (Either True or False)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1215
 #, python-format
 msgid "String (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1217
 msgid "String (unlimited)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1326
 msgid "Comma-separated integers"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1427
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1431
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1566
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
 "date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1435
 msgid "Date (without time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1562
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in YYYY-MM-DD "
 "HH:MM[:ss[.uuuuuu]][TZ] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1570
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
 "[TZ]) but it is an invalid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1575
 msgid "Date (with time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1702
 #, python-format
 msgid "“%(value)s” value must be a decimal number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1704
 msgid "Decimal number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1864
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in [DD] "
 "[[HH:]MM:]ss[.uuuuuu] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1868
 msgid "Duration"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1920
 msgid "Email address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1945
 msgid "File path"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2023
 #, python-format
 msgid "“%(value)s” value must be a float."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2025
 msgid "Floating point number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2065
 #, python-format
 msgid "“%(value)s” value must be an integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2067
 msgid "Integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2163
 msgid "Big (8 byte) integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2180
 msgid "Small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2188
 msgid "IPv4 address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2219
 msgid "IP address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2310
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2311
 #, python-format
 msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2313
 msgid "Boolean (Either True, False or None)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2364
 msgid "Positive big integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2379
 msgid "Positive integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2394
 msgid "Positive small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2410
 #, python-format
 msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2446
 msgid "Text"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2526
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2530
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
 "invalid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2534
 msgid "Time"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2642
 msgid "URL"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2666
 msgid "Raw binary data"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2731
 #, python-format
 msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2733
 msgid "Universally unique identifier"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:244
 msgid "File"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:420
 msgid "Image"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:24
 msgid "A JSON object"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:26
 msgid "Value must be valid JSON."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:979
 #, python-format
 msgid "%(model)s instance with %(field)s %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:982
 msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1276
 msgid "One-to-one relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1333
 #, python-format
 msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1335
 #, python-format
 msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1383
 msgid "Many-to-many relationship"
 msgstr ""
 
 #. Translators: If found as last label character, these punctuation
 #. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.12/site-packages/django/forms/boundfield.py:185
 msgid ":?.!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:95
 msgid "This field is required."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:315
 msgid "Enter a whole number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:486
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1267
 msgid "Enter a valid date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:509
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1268
 msgid "Enter a valid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:536
 msgid "Enter a valid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:570
 msgid "Enter a valid duration."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:571
 #, python-brace-format
 msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:640
 msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:642
 msgid "The submitted file is empty."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:644
 #, python-format
 msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
 msgid_plural ""
@@ -1124,428 +1465,551 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:649
 msgid "Please either submit a file or check the clear checkbox, not both."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:717
 msgid ""
 "Upload a valid image. The file you uploaded was either not an image or a "
 "corrupted image."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:889
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:975
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1592
 #, python-format
 msgid "Select a valid choice. %(value)s is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:977
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1096
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1590
 msgid "Enter a list of values."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1097
 msgid "Enter a complete value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1339
 msgid "Enter a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1369
 msgid "Enter a valid JSON."
 msgstr ""
 
 #. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:97
 msgid ":"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:239
 #, python-format
 msgid "(Hidden field %(name)s) %(error)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:61
 #, python-format
 msgid ""
 "ManagementForm data is missing or has been tampered with. Missing fields: "
 "%(field_names)s. You may need to file a bug report if the issue persists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:65
 #, python-format
 msgid "Please submit at most %(num)d form."
 msgid_plural "Please submit at most %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:70
 #, python-format
 msgid "Please submit at least %(num)d form."
 msgid_plural "Please submit at least %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:484
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:491
 msgid "Order"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:499
 msgid "Delete"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:901
 #, python-format
 msgid "Please correct the duplicate data for %(field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:906
 #, python-format
 msgid "Please correct the duplicate data for %(field)s, which must be unique."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:913
 #, python-format
 msgid ""
 "Please correct the duplicate data for %(field_name)s which must be unique "
 "for the %(lookup)s in %(date_field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:922
 msgid "Please correct the duplicate values below."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1359
 msgid "The inline value did not match the parent instance."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1450
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1594
 #, python-format
 msgid "“%(pk)s” is not a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/utils.py:229
 #, python-format
 msgid ""
 "%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
 "may be ambiguous or it may not exist."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:527
 msgid "Clear"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:528
 msgid "Currently"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:529
 msgid "Change"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:866
 msgid "Unknown"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:867
 msgid "Yes"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:868
 msgid "No"
 msgstr ""
 
 #. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:873
 msgid "yes,no,maybe"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:903
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:920
 #, python-format
 msgid "%(size)d byte"
 msgid_plural "%(size)d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:922
 #, python-format
 msgid "%s KB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:924
 #, python-format
 msgid "%s MB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:926
 #, python-format
 msgid "%s GB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:928
 #, python-format
 msgid "%s TB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:930
 #, python-format
 msgid "%s PB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:74
 msgid "p.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:75
 msgid "a.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:80
 msgid "PM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:81
 msgid "AM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:153
 msgid "midnight"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:155
 msgid "noon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:7
 msgid "Monday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:8
 msgid "Tuesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:9
 msgid "Wednesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:10
 msgid "Thursday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:11
 msgid "Friday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:12
 msgid "Saturday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:13
 msgid "Sunday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:16
 msgid "Mon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:17
 msgid "Tue"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:18
 msgid "Wed"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:19
 msgid "Thu"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:20
 msgid "Fri"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:21
 msgid "Sat"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:22
 msgid "Sun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:25
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:26
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:27
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:28
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:29
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:30
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:31
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:32
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:33
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:34
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:35
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:36
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:39
 msgid "jan"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:40
 msgid "feb"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:41
 msgid "mar"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:42
 msgid "apr"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:43
 msgid "may"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:44
 msgid "jun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:45
 msgid "jul"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:46
 msgid "aug"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:47
 msgid "sep"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:48
 msgid "oct"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:49
 msgid "nov"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:50
 msgid "dec"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:53
 msgctxt "abbrev. month"
 msgid "Jan."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:54
 msgctxt "abbrev. month"
 msgid "Feb."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:55
 msgctxt "abbrev. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:56
 msgctxt "abbrev. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:57
 msgctxt "abbrev. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:58
 msgctxt "abbrev. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:59
 msgctxt "abbrev. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:60
 msgctxt "abbrev. month"
 msgid "Aug."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:61
 msgctxt "abbrev. month"
 msgid "Sept."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:62
 msgctxt "abbrev. month"
 msgid "Oct."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:63
 msgctxt "abbrev. month"
 msgid "Nov."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:64
 msgctxt "abbrev. month"
 msgid "Dec."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:67
 msgctxt "alt. month"
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:68
 msgctxt "alt. month"
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:69
 msgctxt "alt. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:70
 msgctxt "alt. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:71
 msgctxt "alt. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:72
 msgctxt "alt. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:73
 msgctxt "alt. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:74
 msgctxt "alt. month"
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:75
 msgctxt "alt. month"
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:76
 msgctxt "alt. month"
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:77
 msgctxt "alt. month"
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:78
 msgctxt "alt. month"
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:20
 msgid "This is not a valid IPv6 address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:76
 #, python-format
 msgctxt "String to return when truncating text"
 msgid "%(truncated_text)s…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:288
 msgid "or"
 msgstr ""
 
 #. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.12/site-packages/django/utils/text.py:307
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:135
 msgid ", "
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:8
 #, python-format
 msgid "%(num)d year"
 msgid_plural "%(num)d years"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:9
 #, python-format
 msgid "%(num)d month"
 msgid_plural "%(num)d months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:10
 #, python-format
 msgid "%(num)d week"
 msgid_plural "%(num)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:11
 #, python-format
 msgid "%(num)d day"
 msgid_plural "%(num)d days"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:12
 #, python-format
 msgid "%(num)d hour"
 msgid_plural "%(num)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:13
 #, python-format
 msgid "%(num)d minute"
 msgid_plural "%(num)d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:29
 msgid "Forbidden"
 msgstr "Prohibido"
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:30
 msgid "CSRF verification failed. Request aborted."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:34
 msgid ""
 "You are seeing this message because this HTTPS site requires a “Referer "
 "header” to be sent by your web browser, but none was sent. This header is "
@@ -1553,12 +2017,14 @@ msgid ""
 "hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:40
 msgid ""
 "If you have configured your browser to disable “Referer” headers, please re-"
 "enable them, at least for this site, or for HTTPS connections, or for “same-"
 "origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:45
 msgid ""
 "If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
 "including the “Referrer-Policy: no-referrer” header, please remove them. The "
@@ -1567,84 +2033,111 @@ msgid ""
 "rel=\"noreferrer\" …> for links to third-party sites."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:54
 msgid ""
 "You are seeing this message because this site requires a CSRF cookie when "
 "submitting forms. This cookie is required for security reasons, to ensure "
 "that your browser is not being hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:60
 msgid ""
 "If you have configured your browser to disable cookies, please re-enable "
 "them, at least for this site, or for “same-origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:66
 msgid "More information is available with DEBUG=True."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:44
 msgid "No year specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:64
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:115
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:214
 msgid "Date out of range"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:94
 msgid "No month specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:147
 msgid "No day specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:194
 msgid "No week specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:353
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:384
 #, python-format
 msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:680
 #, python-format
 msgid ""
 "Future %(verbose_name_plural)s not available because "
 "%(class_name)s.allow_future is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:720
 #, python-format
 msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/detail.py:56
 #, python-format
 msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:70
 msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:77
 #, python-format
 msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:173
 #, python-format
 msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:49
 msgid "Directory indexes are not allowed here."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:51
 #, python-format
 msgid "“%(path)s” does not exist"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:68
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:8
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:11
 #, python-format
 msgid "Index of %(directory)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:204
 msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:206
 #, python-format
 msgid ""
 "View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
 "target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:208
 #, python-format
 msgid ""
 "You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
@@ -1653,34 +2146,48 @@ msgid ""
 "configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:217
 msgid "Django Documentation"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:218
 msgid "Topics, references, &amp; how-to’s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:226
 msgid "Tutorial: A Polling App"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:227
 msgid "Get started with Django"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:235
 msgid "Django Community"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:236
 msgid "Connect, get help, or contribute"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1404
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1457
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1461
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1465
 msgid "No response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1429
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1483
 msgid "Unspecified response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/plumbing.py:488
 #, python-format
 msgid "Token-based authentication with required prefix \"%s\""
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/views.py:45
 msgid ""
 "\n"
 "    OpenApi3 schema for this API. Format can be selected via content "
@@ -1714,11 +2221,6 @@ msgstr ""
 
 #~ msgid "Actual cost"
 #~ msgstr "Coste real"
-
-#, fuzzy
-#~| msgid "Interactions"
-#~ msgid "Interaction"
-#~ msgstr "Interacciones"
 
 #~ msgid "Dashboard"
 #~ msgstr "Panel de control"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: House Backend 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-05-03 04:46+0000\n"
+"POT-Creation-Date: 2026-05-03 05:57+0000\n"
 "PO-Revision-Date: 2026-02-11 21:22+0000\n"
 "Last-Translator: House Team\n"
 "Language-Team: French\n"
@@ -16,651 +16,859 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
+#: apps/accounts/models.py:44
 msgid "Display name shown in the UI"
 msgstr "Nom affiché dans l'interface"
 
+#: apps/accounts/models.py:48 apps/households/models.py:38
 msgid "English"
 msgstr "Anglais"
 
+#: apps/accounts/models.py:49
 msgid "Français"
 msgstr "Français"
 
+#: apps/accounts/models.py:50
 msgid "Deutsch"
 msgstr "Allemand"
 
+#: apps/accounts/models.py:51
 msgid "Español"
 msgstr "Espagnol"
 
+#: apps/accounts/models.py:56
 msgid "User's preferred language. Null means use browser detection."
 msgstr ""
 
+#: apps/accounts/models.py:65
 msgid "User's avatar image file"
 msgstr "URL de l'image d'avatar de l'utilisateur"
 
+#: apps/accounts/models.py:77
 msgid "User's preferred theme (light/dark/system)"
 msgstr "Thème préféré de l'utilisateur (clair/sombre/système)"
 
+#: apps/accounts/models.py:103
 msgid "User's preferred color palette"
 msgstr "Palette de couleurs préférée de l'utilisateur"
 
+#: apps/accounts/models.py:111
 msgid "User's currently active household"
 msgstr "Foyer actuellement actif de l'utilisateur"
 
+#: apps/accounts/models.py:112
 msgid "active household"
 msgstr "foyer actif"
 
+#: apps/accounts/models.py:125
 msgid "user"
 msgstr "utilisateur"
 
+#: apps/accounts/models.py:126
 msgid "users"
 msgstr "utilisateurs"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:3
 #, fuzzy
 #| msgid "Password"
 msgid "Password reset"
 msgstr "Mot de passe"
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:5
+#: apps/accounts/templates/accounts/emails/password_reset.txt:1
 msgid "Hello,"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:6
+#: apps/accounts/templates/accounts/emails/password_reset.txt:3
 msgid "You requested a password reset for your House account."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:9
 msgid "Reset my password"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:12
 msgid "Or copy and paste this URL into your browser:"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:15
+#: apps/accounts/templates/accounts/emails/password_reset.txt:9
 msgid ""
 "This link will expire in 3 days. If you did not request a password reset, "
 "you can safely ignore this email."
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.html:16
+#: apps/accounts/templates/accounts/emails/password_reset.txt:11
 msgid "— House"
 msgstr ""
 
+#: apps/accounts/templates/accounts/emails/password_reset.txt:5
 msgid "Click the link below to set a new password:"
 msgstr ""
 
+#: apps/accounts/views/api.py:60
 msgid "Email and password are required."
 msgstr "L'email et le mot de passe sont requis."
 
+#: apps/accounts/views/api.py:66
 msgid "Invalid credentials."
 msgstr "Identifiants invalides."
 
+#: apps/accounts/views/api.py:71
 msgid "Login successful."
 msgstr "Connexion réussie."
 
+#: apps/accounts/views/api.py:81
 msgid "Logout successful."
 msgstr "Déconnexion réussie."
 
+#: apps/accounts/views/api.py:101 apps/households/views.py:164
 msgid "Email is required."
 msgstr "L'email est requis."
 
+#: apps/accounts/views/api.py:120
 msgid "Reset your House password"
 msgstr ""
 
+#: apps/accounts/views/api.py:130
 msgid "If an account with that email exists, a reset link has been sent."
 msgstr ""
 
+#: apps/accounts/views/api.py:151
 #, fuzzy
 #| msgid "Email and password are required."
 msgid "uid, token and new_password are required."
 msgstr "L'email et le mot de passe sont requis."
 
+#: apps/accounts/views/api.py:160 apps/accounts/views/api.py:166
 #, fuzzy
 #| msgid "Invalid credentials."
 msgid "Invalid or expired reset link."
 msgstr "Identifiants invalides."
 
+#: apps/accounts/views/api.py:182
 #, fuzzy
 #| msgid "Password updated successfully."
 msgid "Password has been reset successfully."
 msgstr "Mot de passe mis à jour avec succès."
 
+#: apps/accounts/views/api.py:242
 msgid "new_password and confirm_password are required."
 msgstr "new_password et confirm_password sont requis."
 
+#: apps/accounts/views/api.py:248
 msgid "Password must be at least 8 characters."
 msgstr "Le mot de passe doit contenir au moins 8 caractères."
 
+#: apps/accounts/views/api.py:254
 msgid "Passwords do not match."
 msgstr "Les mots de passe ne correspondent pas."
 
+#: apps/accounts/views/api.py:268
 msgid "Password updated successfully."
 msgstr "Mot de passe mis à jour avec succès."
 
+#: apps/accounts/views/api.py:280
 msgid "You cannot impersonate yourself."
 msgstr ""
 
+#: apps/accounts/views/api.py:307
 msgid "No avatar to delete."
 msgstr "Aucun avatar à supprimer."
 
+#: apps/accounts/views/api.py:319
 msgid "Avatar removed."
 msgstr "Avatar supprimé."
 
+#: apps/accounts/views/api.py:325
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:641
 msgid "No file was submitted."
 msgstr "Aucun fichier n'a été soumis."
 
+#: apps/ai_usage/models.py:21
 msgid "OCR — upload"
 msgstr ""
 
+#: apps/ai_usage/models.py:22
 msgid "OCR — backfill"
 msgstr ""
 
+#: apps/ai_usage/models.py:23
 msgid "Agent — ask"
 msgstr ""
 
+#: apps/core/file_validation.py:15
 msgid "JPEG image"
 msgstr ""
 
+#: apps/core/file_validation.py:20
 msgid "PNG image"
 msgstr ""
 
+#: apps/core/file_validation.py:25
 msgid "GIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:30
 msgid "WebP image"
 msgstr ""
 
+#: apps/core/file_validation.py:35
 msgid "HEIC image"
 msgstr ""
 
+#: apps/core/file_validation.py:40
 msgid "HEIF image"
 msgstr ""
 
+#: apps/core/file_validation.py:45
 #, fuzzy
 #| msgid "document"
 msgid "PDF document"
 msgstr "document"
 
+#: apps/core/file_validation.py:85
 #, python-format
 msgid "File too large (%(size)d MB). Maximum allowed: %(max)d MB."
 msgstr ""
 
+#: apps/core/file_validation.py:99
 #, python-format
 msgid "Unsupported file type. Allowed: %(types)s."
 msgstr ""
 
+#: apps/directory/models.py:49
 msgid "contact"
 msgstr "contact"
 
+#: apps/directory/models.py:50
 msgid "contacts"
 msgstr "contacts"
 
+#: apps/documents/models.py:80
 msgid "document"
 msgstr "document"
 
+#: apps/documents/models.py:81
 msgid "documents"
 msgstr "documents"
 
+#: apps/electricity/models.py:16
 msgid "Single phase"
 msgstr "Monophasé"
 
+#: apps/electricity/models.py:17
 msgid "Three phase"
 msgstr "Triphasé"
 
+#: apps/electricity/models.py:27
 msgid "Socket"
 msgstr "Prise"
 
+#: apps/electricity/models.py:28
 msgid "Light"
 msgstr "Luminaire"
 
+#: apps/electricity/models.py:115
 msgid "electricity board"
 msgstr "tableau électrique"
 
+#: apps/electricity/models.py:116
 msgid "electricity boards"
 msgstr "tableaux électriques"
 
+#: apps/electricity/models.py:208
 msgid "protective device"
 msgstr ""
 
+#: apps/electricity/models.py:209
 msgid "protective devices"
 msgstr ""
 
+#: apps/electricity/models.py:267
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "curve_type must be empty for device_type=rcd."
 msgstr "La phase doit être vide pour un tableau monophasé."
 
+#: apps/electricity/models.py:272
 msgid "sensitivity_ma must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:276
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "type_code must be empty for device_type=breaker."
 msgstr "La phase doit être vide pour un tableau monophasé."
 
+#: apps/electricity/models.py:280
 msgid "phase_coverage must be null for device_type=breaker."
 msgstr ""
 
+#: apps/electricity/models.py:310
 msgid "circuit"
 msgstr "circuit"
 
+#: apps/electricity/models.py:311
 msgid "circuits"
 msgstr "circuits"
 
+#: apps/electricity/models.py:329
 msgid ""
 "A circuit cannot be directly protected by a pure RCD (device_type=rcd). Use "
 "a breaker, combined, or main device."
 msgstr ""
 
+#: apps/electricity/models.py:358
 msgid "usage point"
 msgstr "point d'usage"
 
+#: apps/electricity/models.py:359
 msgid "usage points"
 msgstr "points d'usage"
 
+#: apps/electricity/models.py:468
 msgid "maintenance event"
 msgstr ""
 
+#: apps/electricity/models.py:469
 msgid "maintenance events"
 msgstr ""
 
+#: apps/electricity/serializers.py:42
 msgid "Household cannot be changed."
 msgstr "Le foyer ne peut pas être modifié."
 
+#: apps/electricity/serializers.py:56
 msgid "Label must be unique across electricity entities in household."
 msgstr "L'étiquette doit être unique parmi les entités électriques du foyer."
 
+#: apps/electricity/serializers.py:100
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent board must belong to the same household."
 msgstr "La zone parente doit appartenir au même foyer"
 
+#: apps/electricity/serializers.py:102 apps/electricity/serializers.py:292
 #, fuzzy
 #| msgid "Email is required."
 msgid "Zone is required."
 msgstr "L'email est requis."
 
+#: apps/electricity/serializers.py:104 apps/electricity/serializers.py:294
 msgid "Zone must belong to the same household."
 msgstr "La zone doit appartenir au même foyer."
 
+#: apps/electricity/serializers.py:124
 #, fuzzy
 #| msgid "Only one active board is allowed per household."
 msgid "Only one active root board is allowed per household."
 msgstr "Un seul tableau actif est autorisé par foyer."
 
+#: apps/electricity/serializers.py:176 apps/electricity/serializers.py:364
 msgid "Board must belong to the same household."
 msgstr "Le tableau doit appartenir au même foyer."
 
+#: apps/electricity/serializers.py:178
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Parent device must belong to the same household."
 msgstr "La zone parente doit appartenir au même foyer"
 
+#: apps/electricity/serializers.py:182
 msgid "Phase must be empty for single-phase board."
 msgstr "La phase doit être vide pour un tableau monophasé."
 
+#: apps/electricity/serializers.py:184
 msgid "Phase is required for three-phase board."
 msgstr "La phase est requise pour un tableau triphasé."
 
+#: apps/electricity/serializers.py:186
 #, fuzzy
 #| msgid "Phase must be empty for single-phase board."
 msgid "phase_coverage must be null for single-phase board."
 msgstr "La phase doit être vide pour un tableau monophasé."
 
+#: apps/electricity/serializers.py:190
 msgid "pole_count must be 2 or 4 for rcd and combined devices."
 msgstr ""
 
+#: apps/electricity/serializers.py:197
 msgid "row and position must both be set or both be empty."
 msgstr ""
 
+#: apps/electricity/serializers.py:203
 msgid "position_end requires position to be set."
 msgstr ""
 
+#: apps/electricity/serializers.py:207
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "position_end must be greater than or equal to position."
 msgstr "La date de fin doit être postérieure ou égale à la date de début."
 
+#: apps/electricity/serializers.py:224
 msgid "Position range overlaps with an existing device on the same row."
 msgstr ""
 
+#: apps/electricity/serializers.py:254
 #, fuzzy
 #| msgid "Parent zone must belong to the same household"
 msgid "Protective device must belong to the same household."
 msgstr "La zone parente doit appartenir au même foyer"
 
+#: apps/electricity/serializers.py:257
 msgid "A circuit cannot be directly protected by a pure RCD (device_type=rcd)."
 msgstr ""
 
+#: apps/electricity/serializers.py:261
 msgid "A spare device cannot protect a circuit."
 msgstr ""
 
+#: apps/electricity/serializers.py:264
 #, fuzzy
 #| msgid "Breaker must belong to the selected board."
 msgid "Protective device must belong to the selected board."
 msgstr "Le disjoncteur doit appartenir au tableau sélectionné."
 
+#: apps/electricity/serializers.py:322
 msgid "Circuit must belong to the same household."
 msgstr "Le circuit doit appartenir au même foyer."
 
+#: apps/electricity/serializers.py:324
 msgid "Usage point must belong to the same household."
 msgstr "Le point d'usage doit appartenir au même foyer."
 
+#: apps/electricity/serializers.py:326
 msgid "Usage point and circuit must be in the same household."
 msgstr "Le point d'usage et le circuit doivent appartenir au même foyer."
 
+#: apps/electricity/serializers.py:333
 msgid "Usage point already has an active circuit link."
 msgstr "Le point d'usage a déjà un lien de circuit actif."
 
+#: apps/electricity/serializers.py:389
 msgid "Actor is required."
 msgstr "L'acteur est requis."
 
+#: apps/electricity/serializers.py:391
 msgid "Actor must be a member of the household."
 msgstr "L'acteur doit être membre du foyer."
 
+#: apps/electricity/views.py:83
 #, fuzzy
 #| msgid "Cannot delete breaker with active circuits."
 msgid "Cannot delete protective device with active circuits."
 msgstr "Impossible de supprimer un disjoncteur avec des circuits actifs."
 
+#: apps/electricity/views.py:94
 msgid "Cannot delete circuit with active usage point links."
 msgstr ""
 "Impossible de supprimer un circuit avec des liens de points d'usage actifs."
 
+#: apps/electricity/views.py:105
 msgid "Cannot delete usage point with active circuit link."
 msgstr ""
 "Impossible de supprimer un point d'usage avec un lien de circuit actif."
 
+#: apps/electricity/views.py:113
 msgid "Cannot delete resource with active dependencies."
 msgstr "Impossible de supprimer une ressource avec des dépendances actives."
 
+#: apps/electricity/views.py:162 apps/equipment/views.py:41
+#: apps/insurance/serializers.py:57 apps/insurance/views.py:32
+#: apps/stock/views.py:46 apps/stock/views.py:81
 msgid "A valid household context is required."
 msgstr "Un contexte de foyer valide est requis."
 
+#: apps/electricity/views.py:167
 msgid "Must be an integer."
 msgstr ""
 
+#: apps/electricity/views.py:169
 msgid "Must be between 1 and 50."
 msgstr ""
 
+#: apps/electricity/views.py:175
 msgid "A label prefix is required when creating multiple usage points."
 msgstr ""
 
+#: apps/equipment/models.py:12 apps/insurance/models.py:20
 #, fuzzy
 #| msgid "Activity"
 msgid "Active"
 msgstr "Activité"
 
+#: apps/equipment/models.py:13
 msgid "Maintenance"
 msgstr ""
 
+#: apps/equipment/models.py:14
 msgid "Storage"
 msgstr ""
 
+#: apps/equipment/models.py:15
 msgid "Retired"
 msgstr ""
 
+#: apps/equipment/models.py:16
 msgid "Lost"
 msgstr ""
 
+#: apps/equipment/models.py:17 apps/stock/models.py:37
 msgid "Ordered"
 msgstr ""
 
+#: apps/equipment/models.py:45 apps/equipment/models.py:46
 msgid "equipment"
 msgstr "équipement"
 
+#: apps/equipment/serializers.py:71 apps/stock/serializers.py:108
 msgid "Invalid zone or access denied."
 msgstr "Zone invalide ou accès refusé."
 
+#: apps/equipment/serializers.py:88
 msgid "Zone must belong to the same household as equipment."
 msgstr "La zone doit appartenir au même foyer que l'équipement."
 
+#: apps/equipment/views.py:133
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid equipment or access denied."
 msgstr "Zone invalide ou accès refusé."
 
+#: apps/equipment/views.py:135
 msgid "Interaction household must match equipment household."
 msgstr "Le foyer de l'interaction doit correspondre au foyer de l'équipement."
 
+#: apps/equipment/views.py:137
 msgid "Invalid interaction or access denied."
 msgstr "Interaction invalide ou accès refusé."
 
+#: apps/households/models.py:26
 msgid "ISO 3166-1 alpha-2 country code (e.g. FR, DE, US)"
 msgstr ""
 
+#: apps/households/models.py:28
 msgid "IANA timezone (e.g. Europe/Paris). Leave blank for UTC."
 msgstr ""
 
+#: apps/households/models.py:37
 msgid "French"
 msgstr ""
 
+#: apps/households/models.py:39
 msgid "German"
 msgstr ""
 
+#: apps/households/models.py:40
 msgid "Spanish"
 msgstr ""
 
+#: apps/households/models.py:56
 msgid "household"
 msgstr "foyer"
 
+#: apps/households/models.py:57
 msgid "households"
 msgstr "foyers"
 
+#: apps/households/models.py:117
 #, fuzzy
 #| msgid "Pending tasks"
 msgid "Pending"
 msgstr "Tâches en attente"
 
+#: apps/households/models.py:118
 msgid "Accepted"
 msgstr ""
 
+#: apps/households/models.py:119
 msgid "Declined"
 msgstr ""
 
+#: apps/households/views.py:99
 #, fuzzy
 #| msgid "household_id required"
 msgid "household_id is required."
 msgstr "household_id requis"
 
+#: apps/households/views.py:104
 #, fuzzy
 #| msgid "You are not a member of this household."
 msgid "Not a member of this household."
 msgstr "Vous n'êtes pas membre de ce foyer."
 
+#: apps/households/views.py:134
 msgid "You are not a member of this household."
 msgstr "Vous n'êtes pas membre de ce foyer."
 
+#: apps/households/views.py:147
 msgid "Cannot leave household as the last owner."
 msgstr "Impossible de quitter le foyer en tant que dernier propriétaire."
 
+#: apps/households/views.py:173
 msgid "No user found with that email address."
 msgstr "Aucun utilisateur trouvé avec cette adresse email."
 
+#: apps/households/views.py:179
 msgid "User is already a member of this household."
 msgstr "L'utilisateur est déjà membre de ce foyer."
 
+#: apps/households/views.py:189
 msgid "An invitation is already pending for this user."
 msgstr ""
 
+#: apps/households/views.py:206
 #, python-format
 msgid "You've been invited to join %(name)s"
 msgstr "Vous avez été invité(e) à rejoindre %(name)s"
 
+#: apps/households/views.py:207
 #, python-format
 msgid "%(inviter)s invited you to join their household."
 msgstr "%(inviter)s vous a invité(e) à rejoindre son foyer."
 
+#: apps/households/views.py:221
 #, fuzzy
 #| msgid "Interactions"
 msgid "Invitation sent."
 msgstr "Interactions"
 
+#: apps/households/views.py:232
 msgid "user_id is required."
 msgstr "user_id est requis."
 
+#: apps/households/views.py:239 apps/households/views.py:279
 msgid "User is not a member of this household."
 msgstr "L'utilisateur n'est pas membre de ce foyer."
 
+#: apps/households/views.py:250
 msgid "Cannot remove the last owner of the household."
 msgstr "Impossible de supprimer le dernier propriétaire du foyer."
 
+#: apps/households/views.py:266
 msgid "user_id and role are required."
 msgstr "user_id et role sont requis."
 
+#: apps/households/views.py:272
 msgid "Invalid role. Must be owner or member."
 msgstr "Rôle invalide. Doit être owner ou member."
 
+#: apps/households/views.py:290
 msgid "Cannot demote the last owner of the household."
 msgstr "Impossible de rétrograder le dernier propriétaire du foyer."
 
+#: apps/households/views.py:324 apps/households/views.py:368
 msgid "This invitation is no longer pending."
 msgstr ""
 
+#: apps/households/views.py:353
 #, fuzzy, python-format
 #| msgid "You've been invited to join %(name)s"
 msgid "You have joined %(name)s."
 msgstr "Vous avez été invité(e) à rejoindre %(name)s"
 
+#: apps/households/views.py:380
 msgid "Invitation declined."
 msgstr ""
 
+#: apps/insurance/models.py:12
 msgid "Health"
 msgstr ""
 
+#: apps/insurance/models.py:13
 msgid "Home"
 msgstr ""
 
+#: apps/insurance/models.py:14
 msgid "Car"
 msgstr ""
 
+#: apps/insurance/models.py:15
 msgid "Life"
 msgstr ""
 
+#: apps/insurance/models.py:16
 msgid "Liability"
 msgstr ""
 
+#: apps/insurance/models.py:17
 msgid "Other"
 msgstr ""
 
+#: apps/insurance/models.py:21
 msgid "Suspended"
 msgstr ""
 
+#: apps/insurance/models.py:22
 msgid "Terminated"
 msgstr ""
 
+#: apps/insurance/models.py:25
 #, fuzzy
 #| msgid "Monthly cost"
 msgid "Monthly"
 msgstr "Coût mensuel"
 
+#: apps/insurance/models.py:26
 msgid "Quarterly"
 msgstr ""
 
+#: apps/insurance/models.py:27
 #, fuzzy
 #| msgid "Yearly cost"
 msgid "Yearly"
 msgstr "Coût annuel"
 
+#: apps/insurance/models.py:49
 msgid "insurance contract"
 msgstr "contrat d'assurance"
 
+#: apps/insurance/models.py:50
 msgid "insurance contracts"
 msgstr "contrats d'assurance"
 
+#: apps/insurance/serializers.py:43
 msgid "End date must be after or equal to start date."
 msgstr "La date de fin doit être postérieure ou égale à la date de début."
 
+#: apps/insurance/serializers.py:46
 msgid "Monthly cost must be non-negative."
 msgstr "Le coût mensuel doit être positif ou nul."
 
+#: apps/insurance/serializers.py:49
 msgid "Yearly cost must be non-negative."
 msgstr "Le coût annuel doit être positif ou nul."
 
+#: apps/interactions/migrations/0014_backfill_stock_purchase_subjects.py:37
+#: apps/interactions/services.py:27 apps/interactions/services.py:28
+#: apps/interactions/services.py:29
+#, python-brace-format
+msgid "Purchase — {name}"
+msgstr "Achat — {name}"
+
+#: apps/interactions/models.py:115
 msgid "interaction"
 msgstr "interaction"
 
+#: apps/interactions/models.py:116
 msgid "interactions"
 msgstr "interactions"
 
+#: apps/interactions/services.py:46
+#, fuzzy, python-brace-format
+#| msgid "Interactions"
+msgid "Interaction — {name}"
+msgstr "Interactions"
+
+#: apps/notifications/models.py:20
 msgid "Household invitation"
 msgstr "Invitation au foyer"
 
+#: apps/stock/models.py:23
 msgid "stock category"
 msgstr ""
 
+#: apps/stock/models.py:24
 msgid "stock categories"
 msgstr ""
 
+#: apps/stock/models.py:34
 msgid "In stock"
 msgstr ""
 
+#: apps/stock/models.py:35
 msgid "Low stock"
 msgstr ""
 
+#: apps/stock/models.py:36
 msgid "Out of stock"
 msgstr ""
 
+#: apps/stock/models.py:38
 msgid "Expired"
 msgstr ""
 
+#: apps/stock/models.py:39
 msgid "Reserved"
 msgstr ""
 
+#: apps/stock/models.py:65
 msgid "stock item"
 msgstr ""
 
+#: apps/stock/models.py:66
 msgid "stock items"
 msgstr ""
 
+#: apps/stock/serializers.py:95
 #, fuzzy
 #| msgid "Invalid zone or access denied."
 msgid "Invalid category or access denied."
 msgstr "Zone invalide ou accès refusé."
 
+#: apps/stock/serializers.py:123
 #, fuzzy
 #| msgid "Breaker must belong to the same household."
 msgid "Category must belong to the same household as item."
 msgstr "Le disjoncteur doit appartenir au même foyer."
 
+#: apps/stock/serializers.py:126
 #, fuzzy
 #| msgid "Zone must belong to the same household as equipment."
 msgid "Zone must belong to the same household as item."
 msgstr "La zone doit appartenir au même foyer que l'équipement."
 
+#: apps/stock/serializers.py:131
 #, fuzzy
 #| msgid "End date must be after or equal to start date."
 msgid "Max quantity must be greater than or equal to min quantity."
 msgstr "La date de fin doit être postérieure ou égale à la date de début."
 
+#: apps/stock/serializers.py:141
 msgid "Delta must not be zero."
 msgstr ""
 
+#: apps/stock/views.py:100
 msgid "Adjustment would produce a negative quantity."
 msgstr ""
 
-#, python-brace-format
-msgid "Purchase — {name}"
-msgstr "Achat — {name}"
-
+#: apps/zones/models.py:52
 msgid "zone"
 msgstr "zone"
 
+#: apps/zones/models.py:53
 msgid "zones"
 msgstr "zones"
 
+#: apps/zones/serializers.py:53
 msgid "Parent zone must belong to the same household"
 msgstr "La zone parente doit appartenir au même foyer"
 
+#: templates/home.html:4
 msgid "House — Manage your home"
 msgstr "Maison — Gérez votre maison"
 
+#: templates/home.html:17 templates/login.html:6 templates/login.html:82
 msgid "Sign in"
 msgstr "Se connecter"
 
+#: templates/home.html:25
 msgid "Beta — In development"
 msgstr "Bêta — En développement"
 
+#: templates/home.html:29
 msgid "Your home,"
 msgstr "Votre maison,"
 
+#: templates/home.html:31
 msgid "organized."
 msgstr "organisée."
 
+#: templates/home.html:36
 msgid ""
 "Track interventions, documents, equipment and contacts related to your home "
 "— all in one place."
@@ -668,149 +876,198 @@ msgstr ""
 "Suivez les interventions, documents, équipements et contacts liés à votre "
 "maison — tout en un seul endroit."
 
+#: templates/home.html:42
 msgid "Open the app"
 msgstr "Ouvrir l'application"
 
+#: templates/home.html:55
 msgid "Interaction log"
 msgstr "Journal d'interactions"
 
+#: templates/home.html:56
 msgid "Notes, interventions, expenses — the full history of your home."
 msgstr "Notes, interventions, dépenses — l'historique complet de votre maison."
 
+#: templates/home.html:61
 msgid "Documents"
 msgstr "Documents"
 
+#: templates/home.html:62
 msgid "Invoices, warranties, plans — centralized and easy to find."
 msgstr "Factures, garanties, plans — centralisés et faciles à retrouver."
 
+#: templates/home.html:67
 msgid "Equipment"
 msgstr "Équipements"
 
+#: templates/home.html:68
 msgid "Track the status and maintenance of each piece of equipment."
 msgstr "Suivez l'état et la maintenance de chaque équipement."
 
+#: templates/home.html:73
 msgid "Zones"
 msgstr "Zones"
 
+#: templates/home.html:74
 msgid "Organize by room, floor or outdoor space."
 msgstr "Organisez par pièce, étage ou espace extérieur."
 
+#: templates/home.html:79
 msgid "Contacts & Contractors"
 msgstr "Contacts et prestataires"
 
+#: templates/home.html:80
 msgid "Craftspeople, neighbors, agencies — your home address book."
 msgstr "Artisans, voisins, agences — votre carnet d'adresses."
 
+#: templates/home.html:85
 msgid "And more to come…"
 msgstr "Et bien plus à venir…"
 
+#: templates/home.html:86
 msgid "Photos, projects, AI — in development."
 msgstr "Photos, projets, IA — en développement."
 
+#: templates/home.html:94
 msgid "All rights reserved"
 msgstr "Tous droits réservés"
 
+#: templates/login.html:19
 msgid "Sign in to your workspace"
 msgstr "Connectez-vous à votre espace"
 
+#: templates/login.html:46
 msgid "Email"
 msgstr "Email"
 
+#: templates/login.html:64
 msgid "Password"
 msgstr "Mot de passe"
 
+#: templates/login.html:88
 msgid "Back to home"
 msgstr "Retour à l'accueil"
 
+#: venv/lib/python3.12/site-packages/django/contrib/messages/apps.py:16
 msgid "Messages"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/sitemaps/apps.py:8
 msgid "Site Maps"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/staticfiles/apps.py:9
 msgid "Static Files"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/contrib/syndication/apps.py:7
 msgid "Syndication"
 msgstr ""
 
 #. Translators: String used to replace omitted page numbers in elided page
 #. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:30
 msgid "…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:32
 msgid "That page number is not an integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:33
 msgid "That page number is less than 1"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/paginator.py:34
 msgid "That page contains no results"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:22
 msgid "Enter a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:70
 msgid "Enter a valid domain name."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:153
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:775
 msgid "Enter a valid URL."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:200
 msgid "Enter a valid integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:211
 msgid "Enter a valid email address."
 msgstr ""
 
 #. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.12/site-packages/django/core/validators.py:289
 msgid ""
 "Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:297
 msgid ""
 "Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
 "hyphens."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:309
+#: venv/lib/python3.12/site-packages/django/core/validators.py:318
+#: venv/lib/python3.12/site-packages/django/core/validators.py:332
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2220
 #, python-format
 msgid "Enter a valid %(protocol)s address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:311
 msgid "IPv4"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:320
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:43
 msgid "IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:334
 msgid "IPv4 or IPv6"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:375
 msgid "Enter only digits separated by commas."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:381
 #, python-format
 msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:416
 #, python-format
 msgid "Ensure this value is less than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:425
 #, python-format
 msgid "Ensure this value is greater than or equal to %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:434
 #, python-format
 msgid "Ensure this value is a multiple of step size %(limit_value)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:441
 #, python-format
 msgid ""
 "Ensure this value is a multiple of step size %(limit_value)s, starting from "
 "%(offset)s, e.g. %(offset)s, %(valid_value1)s, %(valid_value2)s, and so on."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:473
 #, python-format
 msgid ""
 "Ensure this value has at least %(limit_value)d character (it has "
@@ -821,6 +1078,7 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:491
 #, python-format
 msgid ""
 "Ensure this value has at most %(limit_value)d character (it has "
@@ -831,21 +1089,27 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:514
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:366
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:405
 msgid "Enter a number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:516
 #, python-format
 msgid "Ensure that there are no more than %(max)s digit in total."
 msgid_plural "Ensure that there are no more than %(max)s digits in total."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:521
 #, python-format
 msgid "Ensure that there are no more than %(max)s decimal place."
 msgid_plural "Ensure that there are no more than %(max)s decimal places."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:526
 #, python-format
 msgid ""
 "Ensure that there are no more than %(max)s digit before the decimal point."
@@ -854,267 +1118,344 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:597
 #, python-format
 msgid ""
 "File extension “%(extension)s” is not allowed. Allowed extensions are: "
 "%(allowed_extensions)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/core/validators.py:659
 msgid "Null characters are not allowed."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1600
+#: venv/lib/python3.12/site-packages/django/forms/models.py:908
 msgid "and"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/base.py:1602
 #, python-format
 msgid "%(model_name)s with this %(field_labels)s already exists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/constraints.py:22
 #, python-format
 msgid "Constraint “%(name)s” is violated."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:134
 #, python-format
 msgid "Value %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:135
 msgid "This field cannot be null."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:136
 msgid "This field cannot be blank."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:137
 #, python-format
 msgid "%(model_name)s with this %(field_label)s already exists."
 msgstr ""
 
 #. Translators: The 'lookup_type' is one of 'date', 'year' or
 #. 'month'. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:141
 #, python-format
 msgid ""
 "%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:180
 #, python-format
 msgid "Field of type: %(field_type)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1162
 #, python-format
 msgid "“%(value)s” value must be either True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1163
 #, python-format
 msgid "“%(value)s” value must be either True, False, or None."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1165
 msgid "Boolean (Either True or False)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1215
 #, python-format
 msgid "String (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1217
 msgid "String (unlimited)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1326
 msgid "Comma-separated integers"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1427
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1431
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1566
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
 "date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1435
 msgid "Date (without time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1562
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in YYYY-MM-DD "
 "HH:MM[:ss[.uuuuuu]][TZ] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1570
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
 "[TZ]) but it is an invalid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1575
 msgid "Date (with time)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1702
 #, python-format
 msgid "“%(value)s” value must be a decimal number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1704
 msgid "Decimal number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1864
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in [DD] "
 "[[HH:]MM:]ss[.uuuuuu] format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1868
 msgid "Duration"
 msgstr "Durée"
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1920
 msgid "Email address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:1945
 msgid "File path"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2023
 #, python-format
 msgid "“%(value)s” value must be a float."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2025
 msgid "Floating point number"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2065
 #, python-format
 msgid "“%(value)s” value must be an integer."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2067
 msgid "Integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2163
 msgid "Big (8 byte) integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2180
 msgid "Small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2188
 msgid "IPv4 address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2219
 msgid "IP address"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2310
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2311
 #, python-format
 msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2313
 msgid "Boolean (Either True, False or None)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2364
 msgid "Positive big integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2379
 msgid "Positive integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2394
 msgid "Positive small integer"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2410
 #, python-format
 msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2446
 msgid "Text"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2526
 #, python-format
 msgid ""
 "“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
 "format."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2530
 #, python-format
 msgid ""
 "“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
 "invalid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2534
 msgid "Time"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2642
 msgid "URL"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2666
 msgid "Raw binary data"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2731
 #, python-format
 msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/__init__.py:2733
 msgid "Universally unique identifier"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:244
 msgid "File"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/files.py:420
 msgid "Image"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:24
 msgid "A JSON object"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/json.py:26
 msgid "Value must be valid JSON."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:979
 #, python-format
 msgid "%(model)s instance with %(field)s %(value)r is not a valid choice."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:982
 msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1276
 msgid "One-to-one relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1333
 #, python-format
 msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1335
 #, python-format
 msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/db/models/fields/related.py:1383
 msgid "Many-to-many relationship"
 msgstr ""
 
 #. Translators: If found as last label character, these punctuation
 #. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.12/site-packages/django/forms/boundfield.py:185
 msgid ":?.!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:95
 msgid "This field is required."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:315
 msgid "Enter a whole number."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:486
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1267
 msgid "Enter a valid date."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:509
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1268
 msgid "Enter a valid time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:536
 msgid "Enter a valid date/time."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:570
 msgid "Enter a valid duration."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:571
 #, python-brace-format
 msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:640
 msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:642
 msgid "The submitted file is empty."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:644
 #, python-format
 msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
 msgid_plural ""
@@ -1122,428 +1463,551 @@ msgid_plural ""
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:649
 msgid "Please either submit a file or check the clear checkbox, not both."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:717
 msgid ""
 "Upload a valid image. The file you uploaded was either not an image or a "
 "corrupted image."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:889
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:975
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1592
 #, python-format
 msgid "Select a valid choice. %(value)s is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:977
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1096
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1590
 msgid "Enter a list of values."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1097
 msgid "Enter a complete value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1339
 msgid "Enter a valid UUID."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/fields.py:1369
 msgid "Enter a valid JSON."
 msgstr ""
 
 #. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:97
 msgid ":"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/forms.py:239
 #, python-format
 msgid "(Hidden field %(name)s) %(error)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:61
 #, python-format
 msgid ""
 "ManagementForm data is missing or has been tampered with. Missing fields: "
 "%(field_names)s. You may need to file a bug report if the issue persists."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:65
 #, python-format
 msgid "Please submit at most %(num)d form."
 msgid_plural "Please submit at most %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:70
 #, python-format
 msgid "Please submit at least %(num)d form."
 msgid_plural "Please submit at least %(num)d forms."
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:484
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:491
 msgid "Order"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/formsets.py:499
 msgid "Delete"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:901
 #, python-format
 msgid "Please correct the duplicate data for %(field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:906
 #, python-format
 msgid "Please correct the duplicate data for %(field)s, which must be unique."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:913
 #, python-format
 msgid ""
 "Please correct the duplicate data for %(field_name)s which must be unique "
 "for the %(lookup)s in %(date_field)s."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:922
 msgid "Please correct the duplicate values below."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1359
 msgid "The inline value did not match the parent instance."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1450
 msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/models.py:1594
 #, python-format
 msgid "“%(pk)s” is not a valid value."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/utils.py:229
 #, python-format
 msgid ""
 "%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
 "may be ambiguous or it may not exist."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:527
 msgid "Clear"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:528
 msgid "Currently"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:529
 msgid "Change"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:866
 msgid "Unknown"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:867
 msgid "Yes"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/forms/widgets.py:868
 msgid "No"
 msgstr ""
 
 #. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:873
 msgid "yes,no,maybe"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:903
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:920
 #, python-format
 msgid "%(size)d byte"
 msgid_plural "%(size)d bytes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:922
 #, python-format
 msgid "%s KB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:924
 #, python-format
 msgid "%s MB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:926
 #, python-format
 msgid "%s GB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:928
 #, python-format
 msgid "%s TB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/template/defaultfilters.py:930
 #, python-format
 msgid "%s PB"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:74
 msgid "p.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:75
 msgid "a.m."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:80
 msgid "PM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:81
 msgid "AM"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:153
 msgid "midnight"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dateformat.py:155
 msgid "noon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:7
 msgid "Monday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:8
 msgid "Tuesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:9
 msgid "Wednesday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:10
 msgid "Thursday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:11
 msgid "Friday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:12
 msgid "Saturday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:13
 msgid "Sunday"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:16
 msgid "Mon"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:17
 msgid "Tue"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:18
 msgid "Wed"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:19
 msgid "Thu"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:20
 msgid "Fri"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:21
 msgid "Sat"
 msgstr "sam."
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:22
 msgid "Sun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:25
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:26
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:27
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:28
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:29
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:30
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:31
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:32
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:33
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:34
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:35
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:36
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:39
 msgid "jan"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:40
 msgid "feb"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:41
 msgid "mar"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:42
 msgid "apr"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:43
 msgid "may"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:44
 msgid "jun"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:45
 msgid "jul"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:46
 msgid "aug"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:47
 msgid "sep"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:48
 msgid "oct"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:49
 msgid "nov"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:50
 msgid "dec"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:53
 msgctxt "abbrev. month"
 msgid "Jan."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:54
 msgctxt "abbrev. month"
 msgid "Feb."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:55
 msgctxt "abbrev. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:56
 msgctxt "abbrev. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:57
 msgctxt "abbrev. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:58
 msgctxt "abbrev. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:59
 msgctxt "abbrev. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:60
 msgctxt "abbrev. month"
 msgid "Aug."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:61
 msgctxt "abbrev. month"
 msgid "Sept."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:62
 msgctxt "abbrev. month"
 msgid "Oct."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:63
 msgctxt "abbrev. month"
 msgid "Nov."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:64
 msgctxt "abbrev. month"
 msgid "Dec."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:67
 msgctxt "alt. month"
 msgid "January"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:68
 msgctxt "alt. month"
 msgid "February"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:69
 msgctxt "alt. month"
 msgid "March"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:70
 msgctxt "alt. month"
 msgid "April"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:71
 msgctxt "alt. month"
 msgid "May"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:72
 msgctxt "alt. month"
 msgid "June"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:73
 msgctxt "alt. month"
 msgid "July"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:74
 msgctxt "alt. month"
 msgid "August"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:75
 msgctxt "alt. month"
 msgid "September"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:76
 msgctxt "alt. month"
 msgid "October"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:77
 msgctxt "alt. month"
 msgid "November"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/dates.py:78
 msgctxt "alt. month"
 msgid "December"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/ipv6.py:20
 msgid "This is not a valid IPv6 address."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:76
 #, python-format
 msgctxt "String to return when truncating text"
 msgid "%(truncated_text)s…"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/text.py:288
 msgid "or"
 msgstr ""
 
 #. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.12/site-packages/django/utils/text.py:307
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:135
 msgid ", "
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:8
 #, python-format
 msgid "%(num)d year"
 msgid_plural "%(num)d years"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:9
 #, python-format
 msgid "%(num)d month"
 msgid_plural "%(num)d months"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:10
 #, python-format
 msgid "%(num)d week"
 msgid_plural "%(num)d weeks"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:11
 #, python-format
 msgid "%(num)d day"
 msgid_plural "%(num)d days"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:12
 #, python-format
 msgid "%(num)d hour"
 msgid_plural "%(num)d hours"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/utils/timesince.py:13
 #, python-format
 msgid "%(num)d minute"
 msgid_plural "%(num)d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:29
 msgid "Forbidden"
 msgstr "Interdit"
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:30
 msgid "CSRF verification failed. Request aborted."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:34
 msgid ""
 "You are seeing this message because this HTTPS site requires a “Referer "
 "header” to be sent by your web browser, but none was sent. This header is "
@@ -1551,12 +2015,14 @@ msgid ""
 "hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:40
 msgid ""
 "If you have configured your browser to disable “Referer” headers, please re-"
 "enable them, at least for this site, or for HTTPS connections, or for “same-"
 "origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:45
 msgid ""
 "If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
 "including the “Referrer-Policy: no-referrer” header, please remove them. The "
@@ -1565,84 +2031,111 @@ msgid ""
 "rel=\"noreferrer\" …> for links to third-party sites."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:54
 msgid ""
 "You are seeing this message because this site requires a CSRF cookie when "
 "submitting forms. This cookie is required for security reasons, to ensure "
 "that your browser is not being hijacked by third parties."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:60
 msgid ""
 "If you have configured your browser to disable cookies, please re-enable "
 "them, at least for this site, or for “same-origin” requests."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/csrf.py:66
 msgid "More information is available with DEBUG=True."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:44
 msgid "No year specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:64
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:115
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:214
 msgid "Date out of range"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:94
 msgid "No month specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:147
 msgid "No day specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:194
 msgid "No week specified"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:353
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:384
 #, python-format
 msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:680
 #, python-format
 msgid ""
 "Future %(verbose_name_plural)s not available because "
 "%(class_name)s.allow_future is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/dates.py:720
 #, python-format
 msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/detail.py:56
 #, python-format
 msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:70
 msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:77
 #, python-format
 msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/generic/list.py:173
 #, python-format
 msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:49
 msgid "Directory indexes are not allowed here."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:51
 #, python-format
 msgid "“%(path)s” does not exist"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/static.py:68
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:8
+#: venv/lib/python3.12/site-packages/django/views/templates/directory_index.html:11
 #, python-format
 msgid "Index of %(directory)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:204
 msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:206
 #, python-format
 msgid ""
 "View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
 "target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:208
 #, python-format
 msgid ""
 "You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
@@ -1651,34 +2144,48 @@ msgid ""
 "configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:217
 msgid "Django Documentation"
 msgstr "Documentation"
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:218
 msgid "Topics, references, &amp; how-to’s"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:226
 msgid "Tutorial: A Polling App"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:227
 msgid "Get started with Django"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:235
 msgid "Django Community"
 msgstr "Admin Django"
 
+#: venv/lib/python3.12/site-packages/django/views/templates/default_urlconf.html:236
 msgid "Connect, get help, or contribute"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1404
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1457
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1461
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1465
 msgid "No response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1429
+#: venv/lib/python3.12/site-packages/drf_spectacular/openapi.py:1483
 msgid "Unspecified response body"
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/plumbing.py:488
 #, python-format
 msgid "Token-based authentication with required prefix \"%s\""
 msgstr ""
 
+#: venv/lib/python3.12/site-packages/drf_spectacular/views.py:45
 msgid ""
 "\n"
 "    OpenApi3 schema for this API. Format can be selected via content "
@@ -1712,11 +2219,6 @@ msgstr ""
 
 #~ msgid "Actual cost"
 #~ msgstr "Coût réel"
-
-#, fuzzy
-#~| msgid "Interactions"
-#~ msgid "Interaction"
-#~ msgstr "Interactions"
 
 #~ msgid "Dashboard"
 #~ msgstr "Tableau de bord"

--- a/ui/src/features/projects/ProjectCard.tsx
+++ b/ui/src/features/projects/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Pencil, Star, Trash2 } from 'lucide-react';
+import { Pencil, Plus, Star, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
@@ -74,6 +74,7 @@ interface ProjectCardProps {
   onEdit: (project: ProjectListItem) => void;
   onDelete: (projectId: string) => void;
   onTogglePin?: (project: ProjectListItem) => void;
+  onPurchase?: (project: ProjectListItem) => void;
   pinLoading?: boolean;
 }
 
@@ -82,6 +83,7 @@ export default function ProjectCard({
   onEdit,
   onDelete,
   onTogglePin,
+  onPurchase,
   pinLoading = false,
 }: ProjectCardProps) {
   const { t } = useTranslation();
@@ -185,6 +187,21 @@ export default function ProjectCard({
             planned={Number(project.planned_budget)}
             actual={Number(project.actual_cost_cached)}
           />
+        </div>
+      ) : null}
+
+      {onPurchase ? (
+        <div className="mt-3 flex justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => onPurchase(project)}
+            className="h-7 gap-1 px-2 text-xs"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t('projects.purchase.actions.add')}
+          </Button>
         </div>
       ) : null}
     </Card>

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -19,6 +19,7 @@ import {
 } from './hooks';
 import ProjectDialog from './ProjectDialog';
 import ProjectDocumentsTab from './ProjectDocumentsTab';
+import ProjectPurchaseDialog from './ProjectPurchaseDialog';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Helpers ────────────────────────────────────────────────
@@ -234,6 +235,7 @@ export default function ProjectDetailPage() {
 
   const [editOpen, setEditOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
+  const [purchaseOpen, setPurchaseOpen] = React.useState(false);
 
   const { data: project, isLoading, error } = useProject(id ?? '');
   const deleteProjectMutation = useDeleteProject();
@@ -325,6 +327,15 @@ export default function ProjectDetailPage() {
                 className="h-4 w-4"
                 fill={project.is_pinned ? 'currentColor' : 'none'}
               />
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 gap-1 px-3 text-sm"
+              onClick={() => setPurchaseOpen(true)}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {t('projects.purchase.actions.add')}
             </Button>
             <Button
               type="button"
@@ -443,6 +454,12 @@ export default function ProjectDetailPage() {
         description={t('projects.delete_confirm', { title: project.title })}
         onConfirm={handleDelete}
         loading={deleteProjectMutation.isPending}
+      />
+
+      <ProjectPurchaseDialog
+        open={purchaseOpen}
+        onOpenChange={setPurchaseOpen}
+        project={project}
       />
     </>
   );

--- a/ui/src/features/projects/ProjectPurchaseDialog.tsx
+++ b/ui/src/features/projects/ProjectPurchaseDialog.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
+import type { ProjectListItem } from '@/lib/api/projects';
+import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
+import { useRegisterProjectPurchase } from './hooks';
+
+interface ProjectPurchaseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: ProjectListItem | null;
+}
+
+export default function ProjectPurchaseDialog({
+  open,
+  onOpenChange,
+  project,
+}: ProjectPurchaseDialogProps) {
+  const { t } = useTranslation();
+  const purchaseMutation = useRegisterProjectPurchase();
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) setError(null);
+  }, [open]);
+
+  if (!project) return null;
+
+  async function handleSubmit(payload: PurchaseFormPayload) {
+    setError(null);
+    if (!project) return;
+    try {
+      await purchaseMutation.mutateAsync({
+        id: project.id,
+        payload: {
+          amount: payload.amount,
+          supplier: payload.supplier,
+          occurred_at: payload.occurred_at,
+          notes: payload.notes,
+        },
+      });
+      onOpenChange(false);
+    } catch {
+      setError(t('purchase.errors.save_failed'));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{t('projects.purchase.title', { name: project.title })}</DialogTitle>
+        </DialogHeader>
+
+        <PurchaseForm
+          isPending={purchaseMutation.isPending}
+          onSubmit={handleSubmit}
+          onCancel={() => onOpenChange(false)}
+          externalError={error}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/projects/ProjectsPage.tsx
+++ b/ui/src/features/projects/ProjectsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from './hooks';
 import ProjectCard from './ProjectCard';
 import ProjectDialog from './ProjectDialog';
+import ProjectPurchaseDialog from './ProjectPurchaseDialog';
 import GroupCard from './GroupCard';
 import GroupDialog from './GroupDialog';
 
@@ -46,6 +47,15 @@ export default function ProjectsPage() {
   const [groupDialogOpen, setGroupDialogOpen] = React.useState(false);
   const [editingGroup, setEditingGroup] = React.useState<ProjectGroupItem | null>(null);
   const [deletingGroupId, setDeletingGroupId] = React.useState<string | null>(null);
+
+  // Purchase dialog
+  const [purchaseDialogOpen, setPurchaseDialogOpen] = React.useState(false);
+  const [purchasingProject, setPurchasingProject] = React.useState<ProjectListItem | null>(null);
+
+  const handleOpenPurchase = React.useCallback((project: ProjectListItem) => {
+    setPurchasingProject(project);
+    setPurchaseDialogOpen(true);
+  }, []);
 
   const filters = React.useMemo(
     () => ({
@@ -251,6 +261,7 @@ export default function ProjectsPage() {
                           project={project}
                           onEdit={setEditingProject}
                           onDelete={handleDeleteProject}
+                          onPurchase={handleOpenPurchase}
                         />
                       ))}
                     </div>
@@ -354,6 +365,15 @@ export default function ProjectsPage() {
         })}
         onConfirm={handleConfirmDeleteGroup}
         loading={deleteGroupMutation.isPending}
+      />
+
+      <ProjectPurchaseDialog
+        open={purchaseDialogOpen}
+        onOpenChange={(open) => {
+          setPurchaseDialogOpen(open);
+          if (!open) setPurchasingProject(null);
+        }}
+        project={purchasingProject}
       />
     </>
   );

--- a/ui/src/features/projects/hooks.ts
+++ b/ui/src/features/projects/hooks.ts
@@ -1,4 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
 import {
   fetchProjects,
   fetchProject,
@@ -14,13 +15,16 @@ import {
   unpinProject,
   attachProjectDocument,
   detachProjectDocument,
+  registerProjectPurchase,
   type ProjectListItem,
   type ProjectInteractionItem,
   type ProjectPayload,
   type ProjectGroupPayload,
+  type ProjectPurchasePayload,
 } from '@/lib/api/projects';
 import { documentKeys } from '@/features/documents/hooks';
 import { fetchZones } from '@/lib/api/zones';
+import { toast } from '@/lib/toast';
 
 interface ProjectFilters {
   search?: string;
@@ -142,6 +146,22 @@ export function useDetachProjectDocument(projectId: string) {
   return useMutation({
     mutationFn: (documentId: string) => detachProjectDocument(projectId, documentId),
     onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
+  });
+}
+
+export function useRegisterProjectPurchase() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: ProjectPurchasePayload }) =>
+      registerProjectPurchase(id, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: projectKeys.all });
+      qc.invalidateQueries({ queryKey: ['interactions'] });
+      qc.invalidateQueries({ queryKey: ['expenses'] });
+      toast({ description: t('projects.purchase.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }
 

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -70,6 +70,13 @@ export interface ProjectGroupPayload {
   tags?: string[];
 }
 
+export interface ProjectPurchasePayload {
+  amount: number | null;
+  supplier?: string;
+  occurred_at?: string | null;
+  notes?: string;
+}
+
 interface PaginatedResponse<T> {
   count?: number;
   next?: string | null;
@@ -163,6 +170,22 @@ export async function attachProjectDocument(projectId: string, documentId: strin
 
 export async function detachProjectDocument(projectId: string, documentId: string): Promise<void> {
   await api.post(`/projects/projects/${projectId}/detach_document/`, { document_id: documentId });
+}
+
+export async function registerProjectPurchase(
+  projectId: string,
+  payload: ProjectPurchasePayload,
+): Promise<ProjectListItem & { interaction_id?: string }> {
+  const body: Record<string, unknown> = {};
+  if (payload.amount !== undefined && payload.amount !== null) body.amount = payload.amount;
+  if (payload.supplier) body.supplier = payload.supplier;
+  if (payload.occurred_at) body.occurred_at = payload.occurred_at;
+  if (payload.notes) body.notes = payload.notes;
+  const { data } = await api.post(
+    `/projects/projects/${projectId}/register-purchase/`,
+    body,
+  );
+  return data as ProjectListItem & { interaction_id?: string };
 }
 
 export interface ProjectInteractionItem {

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1435,6 +1435,13 @@
         "saving": "Wird gespeichert...",
         "create": "Gruppe erstellen"
       }
+    },
+    "purchase": {
+      "title": "Ausgabe erfassen — {{name}}",
+      "created": "Ausgabe erfasst",
+      "actions": {
+        "add": "Ausgabe"
+      }
     }
   },
   "notifications": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1435,6 +1435,13 @@
         "saving": "Saving...",
         "create": "Create group"
       }
+    },
+    "purchase": {
+      "title": "Record an expense — {{name}}",
+      "created": "Expense recorded",
+      "actions": {
+        "add": "Expense"
+      }
     }
   },
   "notifications": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1435,6 +1435,13 @@
         "saving": "Guardando...",
         "create": "Crear grupo"
       }
+    },
+    "purchase": {
+      "title": "Registrar un gasto — {{name}}",
+      "created": "Gasto registrado",
+      "actions": {
+        "add": "Gasto"
+      }
     }
   },
   "notifications": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1435,6 +1435,13 @@
         "saving": "Enregistrement...",
         "create": "Créer le groupe"
       }
+    },
+    "purchase": {
+      "title": "Enregistrer une dépense — {{name}}",
+      "created": "Dépense enregistrée",
+      "actions": {
+        "add": "Dépense"
+      }
     }
   },
   "notifications": {


### PR DESCRIPTION
## Summary

Deuxième lot du parcours 08. Ferme #123.

Permet d'enregistrer une dépense liée à un projet directement depuis sa fiche, comme c'est déjà possible pour stock (#116) et equipment (#119). Met à jour `Project.actual_cost_cached` en cohérence (incrément, pas remplacement).

## Backend

- `AUTO_SUBJECT_TEMPLATES[\"project_purchase\"] = _(\"Purchase — {name}\")` — réutilise le template déjà traduit pour stock/equipment, gettext partage la chaîne source donc **pas de nouvelle traduction à ajouter**.
- `ProjectPurchaseSerializer` (amount, supplier, occurred_at, notes).
- `@action register_purchase` sur `ProjectViewSet` :
  - `POST /api/projects/{id}/register-purchase/`
  - Incrémente `actual_cost_cached` en transaction (best-effort, atomique avec la création de l'interaction)
  - Crée `Interaction(type=expense, source=project, kind='project_purchase')` via `create_expense_interaction`
- **6 tests pytest** : snapshot, accumulation cumulée, sans `amount`, isolation tenant, auth required, validation `amount<0` refusée.

## Frontend

- `ProjectPurchaseDialog` wrappe `PurchaseForm` (sans `withDelta`, miroir d'`EquipmentPurchaseDialog`).
- Bouton « + Dépense » sur `ProjectCard` (en bas, prop `onPurchase` optionnelle) et sur `ProjectDetailPage` (PageHeader, à côté de Edit).
- Hook `useRegisterProjectPurchase` avec invalidation `projects` + `interactions` + `expenses` keys.
- `registerProjectPurchase` API wrapper.
- i18n `projects.purchase.{title,created,actions.add}` en/fr/de/es.

## Tests E2E

- `e2e/project-purchase.spec.ts` — parcours complet : création projet → « + Dépense » → vérification dans `/app/interactions` ET dans `/app/expenses`.
- `COVERAGE.md` mis à jour.

## Test plan

- [x] `pytest apps/projects apps/interactions` (74 tests verts)
- [x] `pytest --no-cov -q` (744 passed, 2 skipped)
- [x] `npm run build` (0 erreurs)
- [x] Subject auto-localisé en fr/de/es via gettext partagé

## Hors scope

- Lien automatique entre `Project.planned_budget` et la somme des dépenses (parcours budget ultérieur)
- Édition / suppression des dépenses projet — à généraliser plus tard
- Décomposition des dépenses par groupe de projet
- Catégorisation (`nature`, `category`) — différée (cf. #120)

## Suite

Le lot 1.2 (#124) ajoute le mode ad-hoc et extrait `_build_expense_metadata` du service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)