### PR TITLE
feat(expenses): dépense ad-hoc + split du service en 2 fonctions (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,35 @@ Le service :
 
 Les **side-effects** spécifiques au modèle source (ajuster une quantité, snapshot prix sur l'objet, etc.) restent dans la view appelante — le service ne touche pas à l'objet source.
 
+### Service helper `create_manual_expense_interaction` (dépense ad-hoc)
+
+Pour les dépenses **sans objet source** (resto, cinéma, cadeau…) — saisies depuis `/app/expenses/` :
+
+```python
+from interactions.services import create_manual_expense_interaction
+
+interaction = create_manual_expense_interaction(
+    household=request.household,
+    user=request.user,
+    subject="Restaurant Le Bistrot",   # saisi par l'user, pas templaté
+    amount=Decimal("32.00"),
+    supplier="Le Bistrot",
+    occurred_at=timezone.now(),
+    notes="...",
+    zone_ids=[zone_id],                # optionnel
+)
+```
+
+Différences vs `create_expense_interaction` :
+- `subject` est **saisi par l'user**, pas templaté via gettext (le texte est stocké tel-quel)
+- `metadata.kind = "manual"`, `metadata.source_name = None`
+- Pas de FK polymorphe (`source_content_type=None`, `source_object_id=None`)
+- `household` doit être passé explicitement (pas dérivé d'un source)
+
+### Builder partagé `_build_expense_metadata`
+
+Les deux fonctions (`create_expense_interaction` + `create_manual_expense_interaction`) flow through un helper interne `_build_expense_metadata` qui garantit le shape `metadata` uniforme : `{kind, source_name, amount, unit_price, supplier}` + extra optionnel. Ajouter une clé standard (ex: `currency`) = touche un seul endroit.
+
 ### Ajouter un nouveau template d'auto-subject
 
 1. Ajouter l'entrée dans `AUTO_SUBJECT_TEMPLATES` (`apps/interactions/services.py`)

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -1,6 +1,8 @@
 """
 Interaction serializers for REST API.
 """
+from decimal import Decimal
+
 from django.db import transaction
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
@@ -13,6 +15,21 @@ from .models import (
     InteractionStructure,
     InteractionDocument,
 )
+
+
+class ManualExpenseSerializer(serializers.Serializer):
+    """Input for POST /api/interactions/expenses/manual/."""
+
+    subject = serializers.CharField(required=True, allow_blank=False, max_length=500)
+    amount = serializers.DecimalField(
+        max_digits=12, decimal_places=2, required=False, allow_null=True, min_value=Decimal("0")
+    )
+    supplier = serializers.CharField(required=False, allow_blank=True, default="")
+    occurred_at = serializers.DateTimeField(required=False, allow_null=True)
+    notes = serializers.CharField(required=False, allow_blank=True, default="")
+    zone_ids = serializers.ListField(
+        child=serializers.UUIDField(), required=False, allow_empty=True, default=list
+    )
 
 
 class InteractionSerializer(serializers.ModelSerializer):

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -12,11 +12,14 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
+from uuid import UUID
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+
+from zones.models import Zone
 
 from .models import Interaction, InteractionZone
 
@@ -48,6 +51,36 @@ def _resolve_subject_template(kind: str) -> Any:
 
 def _source_name(source) -> str:
     return getattr(source, "name", None) or getattr(source, "title", None) or str(source)
+
+
+def _build_expense_metadata(
+    *,
+    kind: str,
+    source_name: str | None,
+    amount: Decimal | None = None,
+    unit_price: Decimal | None = None,
+    supplier: str = "",
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Single source of truth for the `metadata` shape on expense interactions.
+
+    Both `create_expense_interaction` and `create_manual_expense_interaction`
+    flow through this helper, so adding a new key (e.g. `currency`) in the
+    future means touching one place.
+
+    `extra` overrides standard keys when collisions occur — intentional escape
+    hatch for feature-specific metadata.
+    """
+    metadata: dict[str, Any] = {
+        "kind": kind,
+        "source_name": source_name,
+        "amount": str(amount) if amount is not None else None,
+        "unit_price": str(unit_price) if unit_price is not None else None,
+        "supplier": supplier or "",
+    }
+    if extra:
+        metadata.update(extra)
+    return metadata
 
 
 def create_expense_interaction(
@@ -90,17 +123,14 @@ def create_expense_interaction(
     name = _source_name(source)
     subject = template.format(name=name)
 
-    # Always write the standard expense keys (None when missing) so consumers
-    # have a stable shape — extra_metadata can add feature-specific keys.
-    metadata: dict[str, Any] = {
-        "kind": resolved_kind,
-        "source_name": name,
-        "amount": str(amount) if amount is not None else None,
-        "unit_price": str(unit_price) if unit_price is not None else None,
-        "supplier": supplier or "",
-    }
-    if extra_metadata:
-        metadata.update(extra_metadata)
+    metadata = _build_expense_metadata(
+        kind=resolved_kind,
+        source_name=name,
+        amount=amount,
+        unit_price=unit_price,
+        supplier=supplier,
+        extra=extra_metadata,
+    )
 
     source_ct = ContentType.objects.get_for_model(source.__class__)
 
@@ -118,6 +148,76 @@ def create_expense_interaction(
         )
         zone = getattr(source, "zone", None)
         if zone is not None:
+            InteractionZone.objects.create(interaction=interaction, zone=zone)
+
+    return interaction
+
+
+def create_manual_expense_interaction(
+    *,
+    household,
+    user,
+    subject: str,
+    amount: Decimal | None = None,
+    supplier: str = "",
+    occurred_at: datetime | None = None,
+    notes: str = "",
+    zone_ids: list[UUID] | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+) -> Interaction:
+    """Create an Interaction(type=expense) NOT linked to a domain source object.
+
+    For ad-hoc expenses (restaurant, gift, one-off purchase…) where no domain
+    object triggered the action. The subject is provided by the user — no
+    gettext template, the user's text is what gets stored.
+
+    Args:
+        household: Household instance (required, not derived from a source)
+        user: request.user (used as created_by)
+        subject: user-provided subject text (required, not blank)
+        amount, supplier, occurred_at, notes: expense details
+        zone_ids: optional list of zone UUIDs to attach. Each zone must belong
+            to the household.
+        extra_metadata: feature-specific metadata merged into the standard payload.
+
+    metadata.kind is always "manual"; metadata.source_name is None to keep
+    the shape uniform with `create_expense_interaction` for downstream consumers
+    (RAG agent, exports, summary aggregations).
+    """
+    if not subject or not subject.strip():
+        raise ValueError("create_manual_expense_interaction: subject is required")
+
+    metadata = _build_expense_metadata(
+        kind="manual",
+        source_name=None,
+        amount=amount,
+        unit_price=None,
+        supplier=supplier,
+        extra=extra_metadata,
+    )
+
+    zones: list[Zone] = []
+    if zone_ids:
+        zones = list(Zone.objects.filter(id__in=zone_ids, household_id=household.id))
+        if len(zones) != len(zone_ids):
+            raise ValueError(
+                "create_manual_expense_interaction: one or more zones do not "
+                "belong to the household"
+            )
+
+    with transaction.atomic():
+        interaction = Interaction.objects.create(
+            household_id=household.id,
+            created_by=user,
+            subject=subject.strip(),
+            content=notes,
+            type="expense",
+            occurred_at=occurred_at or timezone.now(),
+            metadata=metadata,
+            source_content_type=None,
+            source_object_id=None,
+        )
+        for zone in zones:
             InteractionZone.objects.create(interaction=interaction, zone=zone)
 
     return interaction

--- a/apps/interactions/tests/test_api_expense_manual.py
+++ b/apps/interactions/tests/test_api_expense_manual.py
@@ -1,0 +1,161 @@
+"""Tests for POST /api/interactions/expenses/manual/."""
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from zones.models import Zone
+
+
+def _create_household(name: str) -> Household:
+    return Household.objects.create(name=name)
+
+
+def _add_membership(user, household, role=HouseholdMember.Role.OWNER):
+    return HouseholdMember.objects.create(user=user, household=household, role=role)
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="adhoc-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    instance = _create_household("Adhoc House")
+    _add_membership(owner, instance, role=HouseholdMember.Role.OWNER)
+    owner.active_household = instance
+    owner.save(update_fields=["active_household"])
+    return instance
+
+
+@pytest.fixture
+def owner_client(owner):
+    return _client_for(owner)
+
+
+@pytest.fixture
+def zone(household, owner):
+    return Zone.objects.create(household=household, name="Living room", created_by=owner)
+
+
+@pytest.mark.django_db
+class TestManualExpenseEndpoint:
+    def url(self):
+        return reverse("interaction-expenses-manual")
+
+    def test_create_manual_expense(self, owner_client, household, owner):
+        response = owner_client.post(
+            self.url(),
+            data={
+                "subject": "Restaurant Le Bistrot",
+                "amount": "32.00",
+                "supplier": "Le Bistrot",
+                "occurred_at": "2026-05-03T12:00:00Z",
+                "notes": "Déjeuner Sophie",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        data = response.data
+        assert data["subject"] == "Restaurant Le Bistrot"
+        assert data["type"] == "expense"
+        assert data["metadata"]["kind"] == "manual"
+        assert data["metadata"]["amount"] == "32.00"
+        assert data["metadata"]["supplier"] == "Le Bistrot"
+        assert data["metadata"]["source_name"] is None
+        assert data["source_type"] is None
+
+        interaction = Interaction.objects.get(id=data["id"])
+        assert interaction.household_id == household.id
+        assert interaction.created_by == owner
+        assert interaction.source_content_type_id is None
+        assert interaction.source_object_id is None
+
+    def test_create_manual_expense_without_amount(self, owner_client, household):
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "Cinema night"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        assert response.data["metadata"]["amount"] is None
+
+    def test_subject_is_required(self, owner_client, household):
+        response = owner_client.post(
+            self.url(),
+            data={"amount": "10"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "subject" in response.data
+
+    def test_subject_blank_rejected(self, owner_client, household):
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "   "},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_negative_amount_rejected(self, owner_client, household):
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "Cinema", "amount": "-5"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_zone_must_belong_to_household(self, owner_client, household, owner):
+        other_house = _create_household("Other house")
+        foreign_zone = Zone.objects.create(
+            household=other_house, name="Foreign", created_by=owner
+        )
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "Test", "zone_ids": [str(foreign_zone.id)]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_zone_attached_when_valid(self, owner_client, household, zone):
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "Cinema", "zone_ids": [str(zone.id)]},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED, response.content
+        interaction = Interaction.objects.get(id=response.data["id"])
+        assert list(interaction.zones.values_list("id", flat=True)) == [zone.id]
+
+    def test_unauthenticated_rejected(self, db):
+        client = APIClient()
+        response = client.post(
+            reverse("interaction-expenses-manual"),
+            data={"subject": "Cinema"},
+            format="json",
+        )
+        assert response.status_code in (401, 403)
+
+    def test_appears_in_summary_endpoint(self, owner_client, household):
+        response = owner_client.post(
+            self.url(),
+            data={"subject": "Cinema", "amount": "12.50"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+
+        summary = owner_client.get(reverse("interaction-expenses-summary"))
+        assert summary.status_code == status.HTTP_200_OK
+        assert summary.data["total"] == "12.50"
+        kinds = {row["kind"] for row in summary.data["by_kind"]}
+        assert "manual" in kinds

--- a/apps/interactions/tests/test_services.py
+++ b/apps/interactions/tests/test_services.py
@@ -142,3 +142,97 @@ def test_rejects_source_without_household(user, db):
 
     with pytest.raises(ValueError, match="HouseholdScopedModel"):
         create_expense_interaction(source=FakeSource(), user=user)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# create_manual_expense_interaction — Lot 1.2
+# ──────────────────────────────────────────────────────────────────────
+
+from interactions.services import create_manual_expense_interaction
+
+
+@pytest.mark.django_db
+def test_manual_creates_expense_with_user_subject(user, household, membership):
+    interaction = create_manual_expense_interaction(
+        household=household,
+        user=user,
+        subject="Restaurant Le Bistrot",
+        amount=Decimal("32.00"),
+        supplier="Le Bistrot",
+    )
+    assert interaction.type == "expense"
+    assert interaction.subject == "Restaurant Le Bistrot"
+    assert interaction.household_id == household.id
+    assert interaction.created_by == user
+    assert interaction.source_content_type_id is None
+    assert interaction.source_object_id is None
+    assert interaction.metadata["kind"] == "manual"
+    assert interaction.metadata["source_name"] is None
+    assert interaction.metadata["amount"] == "32.00"
+    assert interaction.metadata["unit_price"] is None
+    assert interaction.metadata["supplier"] == "Le Bistrot"
+
+
+@pytest.mark.django_db
+def test_manual_strips_whitespace_from_subject(user, household, membership):
+    interaction = create_manual_expense_interaction(
+        household=household, user=user, subject="  Cinema  "
+    )
+    assert interaction.subject == "Cinema"
+
+
+@pytest.mark.django_db
+def test_manual_rejects_blank_subject(user, household, membership):
+    with pytest.raises(ValueError, match="subject"):
+        create_manual_expense_interaction(
+            household=household, user=user, subject="   "
+        )
+
+
+@pytest.mark.django_db
+def test_manual_attaches_zones(user, household, zone, membership):
+    interaction = create_manual_expense_interaction(
+        household=household,
+        user=user,
+        subject="Garage tools",
+        zone_ids=[zone.id],
+    )
+    assert list(interaction.zones.values_list("id", flat=True)) == [zone.id]
+
+
+@pytest.mark.django_db
+def test_manual_rejects_zone_outside_household(user, household, membership):
+    other_household = Household.objects.create(name="Other house")
+    other_zone = Zone.objects.create(
+        household=other_household, name="Foreign zone", created_by=user
+    )
+    with pytest.raises(ValueError, match="zones"):
+        create_manual_expense_interaction(
+            household=household,
+            user=user,
+            subject="Bad zone",
+            zone_ids=[other_zone.id],
+        )
+
+
+@pytest.mark.django_db
+def test_manual_amount_none_kept_as_null(user, household, membership):
+    interaction = create_manual_expense_interaction(
+        household=household,
+        user=user,
+        subject="Free lunch",
+    )
+    assert interaction.metadata["amount"] is None
+
+
+@pytest.mark.django_db
+def test_manual_extra_metadata_is_merged(user, household, membership):
+    interaction = create_manual_expense_interaction(
+        household=household,
+        user=user,
+        subject="Cinema",
+        amount=Decimal("12"),
+        extra_metadata={"category": "leisure"},
+    )
+    assert interaction.metadata["category"] == "leisure"
+    assert interaction.metadata["amount"] == "12"

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -18,6 +18,15 @@ from documents.models import Document
 from zones.models import Zone
 from .aggregations import compute_expense_summary
 from .models import Interaction, InteractionZone, InteractionContact, InteractionStructure, InteractionDocument
+from .serializers import (
+    InteractionSerializer,
+    InteractionDetailSerializer,
+    InteractionContactSerializer,
+    InteractionStructureSerializer,
+    InteractionDocumentSerializer,
+    ManualExpenseSerializer,
+)
+from .services import create_manual_expense_interaction
 
 
 def _parse_period(from_param: str | None, to_param: str | None):
@@ -47,13 +56,6 @@ def _parse_period(from_param: str | None, to_param: str | None):
     from_dt = _parse(from_param) if from_param else None
     to_dt = _parse(to_param) if to_param else None
     return from_dt, to_dt
-from .serializers import (
-    InteractionSerializer,
-    InteractionDetailSerializer,
-    InteractionContactSerializer,
-    InteractionStructureSerializer,
-    InteractionDocumentSerializer,
-)
 
 
 class InteractionViewSet(viewsets.ModelViewSet):
@@ -200,6 +202,38 @@ class InteractionViewSet(viewsets.ModelViewSet):
         
         return Response(tasks_by_status)
     
+    @action(detail=False, methods=['post'], url_path='expenses/manual')
+    def expenses_manual(self, request):
+        """POST /api/interactions/expenses/manual/
+
+        Create an Interaction(type=expense) NOT linked to a domain object —
+        the user-typed `subject` is what gets stored. Used for ad-hoc expenses
+        (restaurant, cinema, gift…).
+        """
+        household = request.household
+        if household is None:
+            raise ValidationError({"household_id": "A valid household context is required."})
+
+        serializer = ManualExpenseSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            interaction = create_manual_expense_interaction(
+                household=household,
+                user=request.user,
+                subject=serializer.validated_data["subject"],
+                amount=serializer.validated_data.get("amount"),
+                supplier=serializer.validated_data.get("supplier", "") or "",
+                occurred_at=serializer.validated_data.get("occurred_at"),
+                notes=serializer.validated_data.get("notes", "") or "",
+                zone_ids=serializer.validated_data.get("zone_ids") or None,
+            )
+        except ValueError as exc:
+            raise ValidationError({"detail": str(exc)})
+
+        payload = InteractionSerializer(interaction, context={"request": request}).data
+        return Response(payload, status=status.HTTP_201_CREATED)
+
     @action(detail=False, methods=['get'], url_path='expenses/summary')
     def expenses_summary(self, request):
         """GET /api/interactions/expenses/summary/?from=&to=&supplier=&kind=

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -141,7 +141,7 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 
 ---
 
-## Dépenses (`expenses-summary.spec.ts`, `project-purchase.spec.ts`)
+## Dépenses (`expenses-summary.spec.ts`, `project-purchase.spec.ts`, `expense-adhoc.spec.ts`)
 
 | Parcours | Statut |
 |---|---|
@@ -150,6 +150,8 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 | L'`Interaction(type=expense)` est listée dans la liste des dépenses de la vue | ✅ |
 | Quick-add d'une dépense depuis la card d'un projet (« + Dépense ») crée une `Interaction(type=expense, kind='project_purchase')` | ✅ |
 | L'expense projet apparaît dans `/app/interactions` ET dans `/app/expenses` | ✅ |
+| Quick-add d'une dépense ad-hoc depuis `/app/expenses` (sujet libre, pas de template gettext, `kind='manual'`, `source=None`) | ✅ |
+| Validation client : sujet vide refusé sur la dépense ad-hoc | ✅ |
 
 ---
 

--- a/e2e/expense-adhoc.spec.ts
+++ b/e2e/expense-adhoc.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Parcours 08 — Lot 1.2 : enregistrer une dépense ad-hoc.
+ *
+ * Issue: https://github.com/jammindev/house/issues/124
+ *
+ * La dépense ad-hoc n'a pas de source : c'est l'utilisateur qui saisit
+ * le sujet libre. metadata.kind = 'manual', source_content_type = NULL.
+ */
+
+test('parcours dépense ad-hoc — Restaurant Le Bistrot 32€', async ({ page }) => {
+  await page.goto('/app/expenses');
+  await expect(page).toHaveURL(/\/app\/expenses/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Dépenses' })).toBeVisible();
+
+  // Cliquer sur le bouton « + Dépense » du PageHeader
+  await page.getByRole('button', { name: 'Dépense' }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Enregistrer une dépense ad-hoc');
+
+  const subject = `Restaurant E2E ${Date.now()}`;
+  await page.locator('#adhoc-subject').fill(subject);
+  await page.locator('#purchase-price').fill('32');
+  await page.locator('#purchase-supplier').fill('Le Bistrot E2E');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+  await expect(dialog).toBeHidden();
+
+  // Vérifier que la dépense apparaît dans la vue dépense (le subject est
+  // saisi tel-quel — pas de template gettext)
+  await expect(page.getByText(subject).first()).toBeVisible();
+
+  // Vérifier qu'elle apparaît aussi dans /app/interactions
+  await page.goto('/app/interactions');
+  await expect(page.getByText(subject).first()).toBeVisible();
+});
+
+test('parcours dépense ad-hoc — sujet vide refusé', async ({ page }) => {
+  await page.goto('/app/expenses');
+  await page.getByRole('button', { name: 'Dépense' }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  // Tenter de soumettre sans sujet
+  await page.locator('#purchase-price').fill('10');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+
+  // Le dialog reste ouvert (validation côté front)
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Un sujet est requis');
+});

--- a/ui/src/features/expenses/ExpenseAdHocDialog.tsx
+++ b/ui/src/features/expenses/ExpenseAdHocDialog.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
+import { useCreateManualExpense } from './hooks';
+
+interface ExpenseAdHocDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function ExpenseAdHocDialog({ open, onOpenChange }: ExpenseAdHocDialogProps) {
+  const { t } = useTranslation();
+  const mutation = useCreateManualExpense();
+  const [subject, setSubject] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) {
+      setSubject('');
+      setError(null);
+    }
+  }, [open]);
+
+  async function handleSubmit(payload: PurchaseFormPayload) {
+    setError(null);
+    if (!subject.trim()) {
+      setError(t('expenses.adhoc.subjectRequired'));
+      return;
+    }
+    try {
+      await mutation.mutateAsync({
+        subject: subject.trim(),
+        amount: payload.amount,
+        supplier: payload.supplier,
+        occurred_at: payload.occurred_at,
+        notes: payload.notes,
+      });
+      onOpenChange(false);
+    } catch {
+      setError(t('purchase.errors.save_failed'));
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg max-h-[90vh] overflow-y-auto" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{t('expenses.adhoc.title')}</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-4">
+          <FormField label={`${t('expenses.adhoc.subject')} *`} htmlFor="adhoc-subject">
+            <Input
+              id="adhoc-subject"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder={t('expenses.adhoc.subjectPlaceholder')}
+              autoFocus
+              required
+            />
+          </FormField>
+        </div>
+
+        <PurchaseForm
+          isPending={mutation.isPending}
+          onSubmit={handleSubmit}
+          onCancel={() => onOpenChange(false)}
+          externalError={error}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/expenses/ExpensesPage.tsx
+++ b/ui/src/features/expenses/ExpensesPage.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Receipt } from 'lucide-react';
+import { Plus, Receipt } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import PageHeader from '@/components/PageHeader';
 import EmptyState from '@/components/EmptyState';
+import { Button } from '@/design-system/button';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useSessionState } from '@/lib/useSessionState';
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
@@ -13,6 +14,7 @@ import ExpenseSummaryCards from './ExpenseSummaryCards';
 import ExpenseFilters from './ExpenseFilters';
 import { resolvePeriod, type PeriodRange } from './period';
 import ExpenseList from './ExpenseList';
+import ExpenseAdHocDialog from './ExpenseAdHocDialog';
 
 export default function ExpensesPage() {
   const { t } = useTranslation();
@@ -69,9 +71,20 @@ export default function ExpensesPage() {
     return summary.by_kind.filter((row) => row.kind).map((row) => row.kind);
   }, [summary]);
 
+  const [adhocOpen, setAdhocOpen] = React.useState(false);
+
   return (
     <>
-      <PageHeader title={t('expenses.title')} description={t('expenses.description')} />
+      <PageHeader title={t('expenses.title')} description={t('expenses.description')}>
+        <Button
+          type="button"
+          onClick={() => setAdhocOpen(true)}
+          className="gap-1.5"
+        >
+          <Plus className="h-4 w-4" />
+          {t('expenses.adhoc.actions.add')}
+        </Button>
+      </PageHeader>
 
       <div className="space-y-5">
         <ExpenseFilters
@@ -108,6 +121,7 @@ export default function ExpensesPage() {
                 icon={Receipt}
                 title={t('expenses.empty')}
                 description={t('expenses.emptyDescription')}
+                action={{ label: t('expenses.adhoc.actions.add'), onClick: () => setAdhocOpen(true) }}
               />
             ) : (
               <ExpenseList items={items} />
@@ -115,6 +129,8 @@ export default function ExpensesPage() {
           </>
         ) : null}
       </div>
+
+      <ExpenseAdHocDialog open={adhocOpen} onOpenChange={setAdhocOpen} />
     </>
   );
 }

--- a/ui/src/features/expenses/hooks.ts
+++ b/ui/src/features/expenses/hooks.ts
@@ -1,5 +1,12 @@
-import { useQuery } from '@tanstack/react-query';
-import { fetchExpenseSummary, type ExpenseSummaryFilters } from '@/lib/api/expenses';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  createManualExpense,
+  fetchExpenseSummary,
+  type ExpenseSummaryFilters,
+  type ManualExpensePayload,
+} from '@/lib/api/expenses';
+import { toast } from '@/lib/toast';
 
 export const expenseKeys = {
   all: ['expenses'] as const,
@@ -11,5 +18,19 @@ export function useExpenseSummary(filters: ExpenseSummaryFilters = {}) {
   return useQuery({
     queryKey: expenseKeys.summary(filters),
     queryFn: () => fetchExpenseSummary(filters),
+  });
+}
+
+export function useCreateManualExpense() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: ManualExpensePayload) => createManualExpense(payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: expenseKeys.all });
+      qc.invalidateQueries({ queryKey: ['interactions'] });
+      toast({ description: t('expenses.adhoc.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }

--- a/ui/src/lib/api/expenses.ts
+++ b/ui/src/lib/api/expenses.ts
@@ -43,3 +43,23 @@ export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): 
   const { data } = await api.get<ExpenseSummary>('/interactions/expenses/summary/', { params });
   return data;
 }
+
+export interface ManualExpensePayload {
+  subject: string;
+  amount: number | null;
+  supplier?: string;
+  occurred_at?: string | null;
+  notes?: string;
+  zone_ids?: string[];
+}
+
+export async function createManualExpense(payload: ManualExpensePayload): Promise<{ id: string }> {
+  const body: Record<string, unknown> = { subject: payload.subject };
+  if (payload.amount !== null && payload.amount !== undefined) body.amount = payload.amount;
+  if (payload.supplier) body.supplier = payload.supplier;
+  if (payload.occurred_at) body.occurred_at = payload.occurred_at;
+  if (payload.notes) body.notes = payload.notes;
+  if (payload.zone_ids && payload.zone_ids.length > 0) body.zone_ids = payload.zone_ids;
+  const { data } = await api.post('/interactions/expenses/manual/', body);
+  return data as { id: string };
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1555,6 +1555,16 @@
     },
     "list": {
       "noAmount": "Ohne Betrag"
+    },
+    "adhoc": {
+      "title": "Ad-hoc Ausgabe erfassen",
+      "subject": "Betreff",
+      "subjectPlaceholder": "z. B. Restaurant Le Bistrot",
+      "subjectRequired": "Ein Betreff ist erforderlich",
+      "created": "Ausgabe erfasst",
+      "actions": {
+        "add": "Ausgabe"
+      }
     }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1555,6 +1555,16 @@
     },
     "list": {
       "noAmount": "No amount"
+    },
+    "adhoc": {
+      "title": "Record an ad-hoc expense",
+      "subject": "Subject",
+      "subjectPlaceholder": "e.g. Restaurant Le Bistrot",
+      "subjectRequired": "A subject is required",
+      "created": "Expense recorded",
+      "actions": {
+        "add": "Expense"
+      }
     }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1555,6 +1555,16 @@
     },
     "list": {
       "noAmount": "Sin importe"
+    },
+    "adhoc": {
+      "title": "Registrar un gasto suelto",
+      "subject": "Asunto",
+      "subjectPlaceholder": "p. ej. Restaurante Le Bistrot",
+      "subjectRequired": "Se requiere un asunto",
+      "created": "Gasto registrado",
+      "actions": {
+        "add": "Gasto"
+      }
     }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1555,6 +1555,16 @@
     },
     "list": {
       "noAmount": "Sans montant"
+    },
+    "adhoc": {
+      "title": "Enregistrer une dépense ad-hoc",
+      "subject": "Sujet",
+      "subjectPlaceholder": "ex : Restaurant Le Bistrot",
+      "subjectRequired": "Un sujet est requis",
+      "created": "Dépense enregistrée",
+      "actions": {
+        "add": "Dépense"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Troisième et dernier lot du parcours 08. Ferme #124. Termine le parcours.

Permet d'enregistrer une dépense « libre » qui ne se rattache à aucun objet du foyer (resto, cinéma, cadeau…). Tire profit de l'écriture de cette deuxième fonction de création pour extraire `_build_expense_metadata` et garantir un shape `metadata` uniforme.

## Posture validée — option (c) : split + builder partagé

- `create_expense_interaction(*, source, user, ...)` inchangé — auto-template gettext + héritage household/zone, kind dérivé du source.
- **Nouvelle** `create_manual_expense_interaction(*, household, user, subject, ...)` — subject saisi user, `source=None`, `kind=\"manual\"`.
- `_build_expense_metadata(...)` — extrait **au moment d'écrire la 2e fonction** (pas avant). Garantit le shape `{kind, source_name, amount, unit_price, supplier}` + extra. Ajouter une clé standard (ex: `currency`) = touche un seul endroit.

## Backend

- `ManualExpenseSerializer` (subject required, amount/supplier/occurred_at/notes/zone_ids optionnels).
- `@action expenses_manual` sur `InteractionViewSet` → `POST /api/interactions/expenses/manual/`.
- **7 tests service** (subject required/blank, attache zones, rejette zones hors household, amount=None, extra_metadata).
- **9 tests endpoint** (création, sans amount, validations, isolation, scope household, apparition dans summary).
- Refacto `_build_expense_metadata` extrait après écriture des deux fonctions ; **régression vérifiée** sur 110 tests interactions/stock/equipment/projects.

## Frontend

- `ExpenseAdHocDialog` avec champ `subject` libre + `PurchaseForm` partagé (sans `withDelta`, sans pré-fill).
- Bouton « + Dépense » dans le `PageHeader` de `/app/expenses/` ET dans l'`EmptyState` (call-to-action quand pas de dépenses).
- Hook `useCreateManualExpense` avec invalidation `expenses` + `interactions`.
- `createManualExpense` API wrapper.
- i18n `expenses.adhoc.{title, subject, subjectPlaceholder, subjectRequired, created, actions.add}` en/fr/de/es.

## Tests E2E

- `e2e/expense-adhoc.spec.ts` — golden path (saisie + apparition dans `/app/expenses` ET `/app/interactions`) + validation client (sujet vide refusé).
- `COVERAGE.md` mis à jour.

## Doc

- CLAUDE.md étendu :
  - section `create_manual_expense_interaction`
  - section builder `_build_expense_metadata`
  - distinction source-bound vs ad-hoc

## Test plan

- [x] `pytest apps/interactions/tests/test_services.py` (13 tests verts)
- [x] `pytest apps/interactions/tests/test_api_expense_manual.py` (9 tests verts)
- [x] `pytest apps/interactions apps/stock apps/equipment apps/projects` (110 tests verts — régression OK)
- [x] `pytest --no-cov -q` (760 passed, 2 skipped — +16 new tests)
- [x] `npm run build` (0 erreurs)
- [x] `npm run lint` (0 nouvelles erreurs)

## Hors scope

- Catégorisation user-driven du `kind` manuel — sujet de #120, à traiter quand le signal sera là (20-30 dépenses réelles enregistrées).
- Édition du subject auto post-création (déjà couvert par `InteractionEditPage` existante).
- Multi-currency — `metadata.currency` reste optionnel, non consommé en V1.

## Parcours 08 complet

Avec ce lot, la V1 du parcours 08 « Voir et enregistrer ses dépenses » est livrée :
- Lot 1.0 (#125) — Vue agrégée + endpoint summary
- Lot 1.1 (#126) — Quick-add depuis Project
- Lot 1.2 (#127, ce PR) — Dépense ad-hoc + split du service

Suite : recette manuelle pendant 2-4 semaines (cf. `docs/parcours/PARCOURS_08_*.md`), puis réouverture de #120 quand les données seront là.

🤖 Generated with [Claude Code](https://claude.com/claude-code)