### PR TITLE
fix(expenses): corrige le préfixe d'URL côté frontend (404 en prod)

### DIFF
--- a/ui/src/lib/api/expenses.ts
+++ b/ui/src/lib/api/expenses.ts
@@ -40,7 +40,7 @@ export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): 
   if (filters.to) params.to = filters.to;
   if (filters.supplier) params.supplier = filters.supplier;
   if (filters.kind) params.kind = filters.kind;
-  const { data } = await api.get<ExpenseSummary>('/interactions/expenses/summary/', { params });
+  const { data } = await api.get<ExpenseSummary>('/interactions/interactions/expenses/summary/', { params });
   return data;
 }
 
@@ -60,6 +60,6 @@ export async function createManualExpense(payload: ManualExpensePayload): Promis
   if (payload.occurred_at) body.occurred_at = payload.occurred_at;
   if (payload.notes) body.notes = payload.notes;
   if (payload.zone_ids && payload.zone_ids.length > 0) body.zone_ids = payload.zone_ids;
-  const { data } = await api.post('/interactions/expenses/manual/', body);
+  const { data } = await api.post('/interactions/interactions/expenses/manual/', body);
   return data as { id: string };
 }


### PR DESCRIPTION
## Summary

Hotfix — la vue dépense et la dépense ad-hoc renvoyaient 404 en prod parce que le client axios appelait `/api/interactions/expenses/...` au lieu de `/api/interactions/interactions/expenses/...`.

## Cause

Le router DRF de l'app `interactions` est mounté sous `/api/interactions/` puis le router lui-même ajoute son propre préfixe `interactions/`. Les autres appels (`fetchInteractions`, etc.) utilisent déjà le double préfixe `/interactions/interactions/`. Mes nouveaux endpoints utilisaient un seul niveau.

Les tests pytest passaient parce qu'ils utilisent `reverse(\"interaction-expenses-summary\")` qui résout correctement à `/api/interactions/interactions/expenses/summary/` — mais le client axios était hardcodé sur le mauvais path.

## Fix

`ui/src/lib/api/expenses.ts` :
- `/interactions/expenses/summary/` → `/interactions/interactions/expenses/summary/`
- `/interactions/expenses/manual/` → `/interactions/interactions/expenses/manual/`

## Test plan

- [x] `npm run build` (0 erreurs)
- [x] `pytest apps/interactions/` (59 tests verts — pas de régression)
- [ ] Vérification manuelle sur prod après merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)