### PR TITLE
fix(zones): bouton supprimer désactivé si sous-zones + erreur claire (#71)

### DIFF
--- a/ui/src/features/zones/ZoneItem.tsx
+++ b/ui/src/features/zones/ZoneItem.tsx
@@ -66,7 +66,9 @@ export default function ZoneItem({ zone, depth, onDelete }: ZoneItemProps) {
             size="icon"
             className="h-7 w-7 text-muted-foreground hover:text-destructive"
             onClick={() => onDelete(zone)}
+            disabled={childCount > 0}
             aria-label={t('common.delete')}
+            title={childCount > 0 ? t('zones.cannotDeleteWithChildrenTooltip') : undefined}
             type="button"
           >
             <Trash2 className="h-3.5 w-3.5" />

--- a/ui/src/features/zones/ZonesPage.tsx
+++ b/ui/src/features/zones/ZonesPage.tsx
@@ -3,6 +3,7 @@ import { MapPin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import ListPage from '@/components/ListPage';
+import { toast } from '@/lib/toast';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useZones, useDeleteZone, zoneKeys, buildZoneTree } from './hooks';
 import ZoneItem from './ZoneItem';
@@ -26,6 +27,13 @@ export default function ZonesPage() {
 
   const handleDelete = React.useCallback(
     (zone: Zone) => {
+      if ((zone.children_count ?? 0) > 0) {
+        toast({
+          description: t('zones.cannotDeleteWithChildren'),
+          variant: 'destructive',
+        });
+        return;
+      }
       deleteWithUndo(zone.id, {
         onRemove: () =>
           qc.setQueryData<Zone[]>(zoneKeys.list(), (old = []) =>
@@ -34,7 +42,7 @@ export default function ZonesPage() {
         onRestore: () => qc.invalidateQueries({ queryKey: zoneKeys.all }),
       });
     },
-    [deleteWithUndo, qc]
+    [deleteWithUndo, qc, t]
   );
 
   const { sortedZones, depthMap } = React.useMemo(

--- a/ui/src/features/zones/hooks.ts
+++ b/ui/src/features/zones/hooks.ts
@@ -65,9 +65,17 @@ export function useUpdateZone() {
 
 export function useDeleteZone() {
   const qc = useQueryClient();
+  const { t } = useTranslation();
   return useMutation({
     mutationFn: (id: string) => deleteZone(id),
     onSuccess: () => { void qc.invalidateQueries({ queryKey: zoneKeys.all }); },
+    onError: (err) => {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      toast({
+        description: detail || t('zones.deleteFailed'),
+        variant: 'destructive',
+      });
+    },
   });
 }
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -377,6 +377,8 @@
     "updateFailed": "Zone konnte nicht aktualisiert werden",
     "saveInProgress": "Wird gespeichert…",
     "deleteFailed": "Zone konnte nicht gelöscht werden",
+    "cannotDeleteWithChildren": "Diese Zone enthält Unterzonen. Verschiebe oder lösche sie zuerst.",
+    "cannotDeleteWithChildrenTooltip": "Lösche zuerst die Unterzonen",
     "loading_error_title": "Ladefehler",
     "colorLabel": "Zonenfarbe",
     "colorHelper": "Wähle die Basisfarbe für diese Zone der ersten Ebene. Unterzonen werden automatisch aufgehellt.",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -377,6 +377,8 @@
     "updateFailed": "Failed to update zone",
     "saveInProgress": "Saving…",
     "deleteFailed": "Failed to delete zone",
+    "cannotDeleteWithChildren": "This zone contains sub-zones. Move or delete them first.",
+    "cannotDeleteWithChildrenTooltip": "Delete sub-zones first",
     "loading_error_title": "Loading error",
     "colorLabel": "Zone color",
     "colorHelper": "Select the base color for this first-level zone. Its children will automatically use lighter shades.",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -377,6 +377,8 @@
     "updateFailed": "No se pudo actualizar la zona",
     "saveInProgress": "Guardando…",
     "deleteFailed": "No se pudo eliminar la zona",
+    "cannotDeleteWithChildren": "Esta zona contiene sub-zonas. Muévelas o elimínalas primero.",
+    "cannotDeleteWithChildrenTooltip": "Elimina primero las sub-zonas",
     "loading_error_title": "Error de carga",
     "colorLabel": "Color de la zona",
     "colorHelper": "Selecciona el color base para esta zona de primer nivel. Sus hijas usarán tonos más claros automáticamente.",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -377,6 +377,8 @@
     "updateFailed": "Échec de la mise à jour de la zone",
     "saveInProgress": "Enregistrement…",
     "deleteFailed": "Échec de la suppression de la zone",
+    "cannotDeleteWithChildren": "Cette zone contient des sous-zones. Déplacez-les ou supprimez-les d'abord.",
+    "cannotDeleteWithChildrenTooltip": "Supprimez d'abord les sous-zones",
     "loading_error_title": "Erreur de chargement",
     "colorLabel": "Couleur",
     "colorHelper": "Choisissez la couleur de base de cette zone de premier niveau. Les sous-zones seront automatiquement éclaircies.",


### PR DESCRIPTION
## Summary
- Désactive le bouton supprimer quand `children_count > 0`, avec tooltip explicatif
- Pré-check côté client : toast d'erreur explicite si l'action est déclenchée malgré tout (race condition)
- Fallback `onError` sur la mutation : affiche le `detail` renvoyé par le backend (409) ou un message générique
- Supprime le toast \"Zone supprimée\" optimiste mensonger pour les zones avec enfants

Closes #71

## Avant
1. Clic sur supprimer → toast \"Zone supprimée\" + bouton Annuler
2. 5s plus tard → API renvoie 409, la zone réapparaît silencieusement
3. L'utilisateur pense avoir réussi mais rien n'a bougé

## Après
- Zones avec sous-zones : bouton supprimer grisé + tooltip \"Supprimez d'abord les sous-zones\"
- Échec API inattendu : toast d'erreur avec le message backend ou générique

## Test plan
- [x] Page Zones charge correctement
- [x] Boutons supprimer désactivés sur zones avec badge enfants (vérifié sur \"Les Petits Bonheurs\" 7, \"Dépendances\" 5, \"Maison\" 3, \"Étage\" 1)
- [x] Boutons supprimer actifs sur zones feuilles (vérifié sur \"Barbecue\", \"Atelier Bois\", etc.)
- [x] Lint passe
- [ ] Traductions FR/EN/DE/ES ajoutées (`zones.cannotDeleteWithChildren`, `zones.cannotDeleteWithChildrenTooltip`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)