### PR TITLE
feat(general): page 404 + ErrorBoundary global (#69)

### DIFF
--- a/ui/src/components/ErrorBoundary.tsx
+++ b/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { withTranslation, type WithTranslation } from 'react-i18next';
+import { Button } from '@/design-system/button';
+
+interface ErrorBoundaryProps extends WithTranslation {
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ErrorBoundaryBase extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, info);
+  }
+
+  handleReload = () => {
+    window.location.reload();
+  };
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+    const { t } = this.props;
+    return (
+      <div className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-lg border border-destructive/30 bg-destructive/10 p-8 text-center">
+        <h2 className="text-lg font-semibold text-foreground">{t('errors.unexpectedTitle')}</h2>
+        <p className="text-sm text-muted-foreground">{t('errors.unexpectedDescription')}</p>
+        <Button type="button" onClick={this.handleReload}>
+          {t('errors.reload')}
+        </Button>
+      </div>
+    );
+  }
+}
+
+const ErrorBoundary = withTranslation()(ErrorBoundaryBase);
+export default ErrorBoundary;

--- a/ui/src/components/ProtectedLayout.tsx
+++ b/ui/src/components/ProtectedLayout.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/lib/auth/useAuth';
 import { useMe } from '../features/settings/hooks';
 import { applyDarkMode, applyColorTheme } from '../lib/theme';
 import AppShell from './AppShell';
+import ErrorBoundary from './ErrorBoundary';
 
 export default function ProtectedLayout() {
   const { user, isLoading } = useAuth();
@@ -20,9 +21,11 @@ export default function ProtectedLayout() {
 
   return (
     <AppShell>
-      <Suspense fallback={null}>
-        {isLoading ? null : <Outlet />}
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={null}>
+          {isLoading ? null : <Outlet />}
+        </Suspense>
+      </ErrorBoundary>
     </AppShell>
   );
 }

--- a/ui/src/features/general/NotFoundPage.tsx
+++ b/ui/src/features/general/NotFoundPage.tsx
@@ -1,0 +1,21 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Compass } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { buttonVariants } from '@/design-system/button';
+
+export default function NotFoundPage() {
+  const { t } = useTranslation();
+  return (
+    <div className="mx-auto flex max-w-md flex-col items-center gap-4 rounded-lg border border-dashed border-border bg-card p-10 text-center">
+      <Compass className="h-10 w-10 text-muted-foreground/40" aria-hidden />
+      <div>
+        <h1 className="text-lg font-semibold text-foreground">{t('errors.notFoundTitle')}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t('errors.notFoundDescription')}</p>
+      </div>
+      <Link to="/app/dashboard" className={cn(buttonVariants({ size: 'sm' }))}>
+        {t('errors.backToDashboard')}
+      </Link>
+    </div>
+  );
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -20,6 +20,14 @@
     "error_loading": "Laden fehlgeschlagen.",
     "loading": "Wird geladen…"
   },
+  "errors": {
+    "notFoundTitle": "Seite nicht gefunden",
+    "notFoundDescription": "Die angeforderte Seite existiert nicht oder wurde verschoben.",
+    "backToDashboard": "Zurück zum Dashboard",
+    "unexpectedTitle": "Hoppla, etwas ist schiefgelaufen",
+    "unexpectedDescription": "Die App hat ein unerwartetes Problem festgestellt. Lade die Seite neu, um es erneut zu versuchen.",
+    "reload": "Seite neu laden"
+  },
   "sidebar": {
     "open": "Menü öffnen",
     "groupHome": "Zuhause",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -20,6 +20,14 @@
     "error_loading": "Failed to load.",
     "loading": "Loading…"
   },
+  "errors": {
+    "notFoundTitle": "Page not found",
+    "notFoundDescription": "The page you're looking for doesn't exist or has been moved.",
+    "backToDashboard": "Back to dashboard",
+    "unexpectedTitle": "Oops, something went wrong",
+    "unexpectedDescription": "The app ran into an unexpected problem. Reload the page to try again.",
+    "reload": "Reload page"
+  },
   "sidebar": {
     "open": "Open menu",
     "groupHome": "Home",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -20,6 +20,14 @@
     "error_loading": "Error al cargar.",
     "loading": "Cargando…"
   },
+  "errors": {
+    "notFoundTitle": "Página no encontrada",
+    "notFoundDescription": "La página que buscas no existe o se ha movido.",
+    "backToDashboard": "Volver al panel",
+    "unexpectedTitle": "Vaya, algo salió mal",
+    "unexpectedDescription": "La aplicación encontró un problema inesperado. Recarga la página para volver a intentarlo.",
+    "reload": "Recargar la página"
+  },
   "sidebar": {
     "open": "Abrir menú",
     "groupHome": "Hogar",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -20,6 +20,14 @@
     "error_loading": "Erreur lors du chargement.",
     "loading": "Chargement…"
   },
+  "errors": {
+    "notFoundTitle": "Page introuvable",
+    "notFoundDescription": "L'adresse demandée n'existe pas ou a été déplacée.",
+    "backToDashboard": "Retour au tableau de bord",
+    "unexpectedTitle": "Oups, une erreur est survenue",
+    "unexpectedDescription": "L'application a rencontré un problème inattendu. Rechargez la page pour réessayer.",
+    "reload": "Recharger la page"
+  },
   "sidebar": {
     "open": "Ouvrir le menu",
     "groupHome": "Maison",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -3,6 +3,7 @@ import ProtectedLayout from './components/ProtectedLayout';
 import LoginPage from './features/auth/LoginPage';
 import ForgotPasswordPage from './features/auth/ForgotPasswordPage';
 import ResetPasswordPage from './features/auth/ResetPasswordPage';
+import NotFoundPage from './features/general/NotFoundPage';
 import { lazyWithReload } from './lib/lazyWithReload';
 
 const TasksPage = lazyWithReload(() => import('./features/tasks/TasksPage'));
@@ -70,10 +71,15 @@ export const router = createBrowserRouter([
       { path: 'settings', element: <SettingsPage /> },
       { path: 'agent', element: <AgentPage /> },
       { path: 'admin/users', element: <AdminUsersPage /> },
+      { path: '*', element: <NotFoundPage /> },
     ],
   },
   {
     path: '/',
+    element: <Navigate to="/app" replace />,
+  },
+  {
+    path: '*',
     element: <Navigate to="/app" replace />,
   },
 ]);


### PR DESCRIPTION
## Summary
- `NotFoundPage` rendue dans l'AppShell pour toute route inconnue sous `/app/*`
- `ErrorBoundary` global wrappant l'Outlet dans `ProtectedLayout` : capture les erreurs runtime + bouton recharger
- URL invalides hors `/app` redirigées vers `/app` (qui mène au dashboard ou login selon auth)
- Nouveau namespace i18n `errors` dans les 4 locales (FR/EN/DE/ES)

Closes #69

## Avant
URL invalide → écran React Router brut :
> Unexpected Application Error! 404 Not Found — 💿 Hey developer 👋

## Après
- `/app/foo` → page \"Page introuvable\" avec sidebar + lien vers dashboard
- `/foo` (hors `/app`) → redirige sur `/app` (dashboard si auth, login sinon)
- Erreur runtime dans n'importe quelle page → ErrorBoundary affiche \"Oups, une erreur est survenue\" + bouton Recharger

## Test plan
- [x] Lint passe
- [x] `/app/route-inexistante` affiche la page 404 brandée dans le shell
- [x] `/route-hors-app` redirige sur `/app/dashboard`
- [x] Lien \"Retour au tableau de bord\" fonctionne
- [ ] Vérifier l'ErrorBoundary en provoquant une vraie erreur (todo follow-up éventuel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)