### PR TITLE
feat(interactions): bouton créer une tâche depuis une interaction (#76)

### DIFF
--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -1,13 +1,16 @@
 import * as React from 'react';
-import { Clock3 } from 'lucide-react';
+import { Clock3, ListTodo } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+import { toast } from '@/lib/toast';
 import PageHeader from '@/components/PageHeader';
 import { Button } from '@/design-system/button';
 import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { fetchZones, type ZoneOption } from '@/lib/api/zones';
 import { updateInteraction } from '@/lib/api/interactions';
+import { fetchHouseholdMembers, type HouseholdMember } from '@/lib/api/tasks';
+import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 import { useInteraction } from './hooks';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import ExpenseFields from './ExpenseFields';
@@ -67,7 +70,13 @@ export default function InteractionEditPage() {
   const [formError, setFormError] = React.useState<string | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
   const [initialised, setInitialised] = React.useState(false);
+  const [taskDialogOpen, setTaskDialogOpen] = React.useState(false);
+  const [householdMembers, setHouseholdMembers] = React.useState<HouseholdMember[]>([]);
   const showSkeleton = useDelayedLoading(isLoading);
+
+  React.useEffect(() => {
+    fetchHouseholdMembers().then(setHouseholdMembers).catch(() => {});
+  }, []);
 
   const metadata = (interaction?.metadata ?? {}) as Record<string, string | null | undefined>;
 
@@ -181,12 +190,34 @@ export default function InteractionEditPage() {
         <Button
           type="button"
           variant="outline"
+          onClick={() => setTaskDialogOpen(true)}
+          disabled={submitting}
+        >
+          <ListTodo className="mr-2 h-4 w-4" />
+          {t('interactions.createTaskFromHere')}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
           onClick={() => navigate(-1)}
           disabled={submitting}
         >
           {t('common.cancel')}
         </Button>
       </PageHeader>
+
+      <NewTaskDialog
+        open={taskDialogOpen}
+        onOpenChange={setTaskDialogOpen}
+        onCreated={() => {
+          toast({ description: t('interactions.taskCreatedFromInteraction'), variant: 'success' });
+          setTaskDialogOpen(false);
+        }}
+        householdMembers={householdMembers}
+        defaultSubject={subject}
+        defaultZoneIds={zoneId ? [zoneId] : []}
+        sourceInteractionId={id}
+      />
 
       <form className="space-y-5" onSubmit={handleSubmit}>
         {/* Subject */}

--- a/ui/src/features/tasks/NewTaskDialog.tsx
+++ b/ui/src/features/tasks/NewTaskDialog.tsx
@@ -27,6 +27,12 @@ interface NewTaskDialogProps {
   householdMembers?: HouseholdMember[];
   /** Pre-fill project when opening from a project page */
   defaultProjectId?: string;
+  /** Pre-fill subject (e.g. when opening from an interaction) */
+  defaultSubject?: string;
+  /** Pre-fill zones (e.g. when opening from an interaction) */
+  defaultZoneIds?: string[];
+  /** Link the new task to the source interaction it was created from */
+  sourceInteractionId?: string;
 }
 
 export default function NewTaskDialog({
@@ -37,6 +43,9 @@ export default function NewTaskDialog({
   onUpdated,
   householdMembers = [],
   defaultProjectId,
+  defaultSubject,
+  defaultZoneIds,
+  sourceInteractionId,
 }: NewTaskDialogProps) {
   const { t } = useTranslation();
   const isEditing = Boolean(existingTask);
@@ -109,13 +118,13 @@ export default function NewTaskDialog({
       setProjectId(existingTask.project ?? defaultProjectId ?? '');
       setIsPrivate(existingTask.is_private ?? false);
     } else {
-      setSubject('');
+      setSubject(defaultSubject ?? '');
       setContent('');
       setDueDate('');
       setPriority('2');
       setStatus('pending');
       setAssignedToId('');
-      setZoneIds([]);
+      setZoneIds(defaultZoneIds ?? []);
       setProjectId(defaultProjectId ?? '');
       setIsPrivate(false);
       setSelectedDocumentIds([]);
@@ -134,8 +143,9 @@ export default function NewTaskDialog({
       return;
     }
     if (existingTask) return;
-    // Création : si on vient d'un projet avec des zones, on les hérite ;
-    // sinon on retombe sur la racine du household.
+    // Création : si l'appelant a déjà fourni des zones (ex: depuis une interaction), on ne touche pas.
+    if (defaultZoneIds && defaultZoneIds.length > 0) return;
+    // Si on vient d'un projet avec des zones, on les hérite ; sinon on retombe sur la racine du household.
     if (defaultProjectId && projects.length > 0) {
       const project = projects.find((p) => p.id === defaultProjectId);
       if (project?.zones?.length) {
@@ -184,6 +194,7 @@ export default function NewTaskDialog({
         status: status as TaskStatus,
         document_ids: selectedDocumentIds.length > 0 ? selectedDocumentIds : undefined,
         interaction_ids: selectedInteractionIds.length > 0 ? selectedInteractionIds : undefined,
+        source_interaction: sourceInteractionId ?? undefined,
       } as Parameters<typeof createTask>[0])
         .then(() => {
           setLoading(false);

--- a/ui/src/lib/api/tasks.ts
+++ b/ui/src/lib/api/tasks.ts
@@ -160,6 +160,7 @@ export async function createTask(
     is_private?: boolean;
     document_ids?: string[];
     interaction_ids?: string[];
+    source_interaction?: string | null;
   },
 ): Promise<Task> {
   const { data } = await api.post('/tasks/tasks/', { status: 'pending', ...payload });

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -286,6 +286,8 @@
     "edit_title": "Aktivität bearbeiten",
     "update_label": "Änderungen speichern",
     "update_failed": "Änderungen konnten nicht gespeichert werden.",
+    "createTaskFromHere": "Aufgabe erstellen",
+    "taskCreatedFromInteraction": "Aufgabe aus dieser Aktivität erstellt.",
     "delete_confirm": "Diese Aktivität löschen?",
     "detail_title": "Aktivitätsdetail",
     "type": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -286,6 +286,8 @@
     "edit_title": "Edit activity",
     "update_label": "Save changes",
     "update_failed": "Failed to save changes.",
+    "createTaskFromHere": "Create task",
+    "taskCreatedFromInteraction": "Task created from this activity.",
     "delete_confirm": "Delete this activity?",
     "detail_title": "Activity detail",
     "type": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -286,6 +286,8 @@
     "edit_title": "Editar actividad",
     "update_label": "Guardar cambios",
     "update_failed": "No se pudieron guardar los cambios.",
+    "createTaskFromHere": "Crear tarea",
+    "taskCreatedFromInteraction": "Tarea creada desde esta actividad.",
     "delete_confirm": "¿Eliminar esta actividad?",
     "detail_title": "Detalle de actividad",
     "type": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -286,6 +286,8 @@
     "edit_title": "Modifier l'activité",
     "update_label": "Enregistrer les modifications",
     "update_failed": "Impossible d'enregistrer les modifications.",
+    "createTaskFromHere": "Créer une tâche",
+    "taskCreatedFromInteraction": "Tâche créée depuis cette activité.",
     "delete_confirm": "Supprimer cette activité ?",
     "detail_title": "Détail de l'activité",
     "type": {


### PR DESCRIPTION
## Summary
- Bouton **« Créer une tâche »** dans l'entête de `InteractionEditPage`
- Ouvre `NewTaskDialog` avec :
  - `subject` = sujet de l'interaction
  - `zone_ids` = zone de l'interaction (fallback racine si vide)
  - `source_interaction` = id de l'interaction → FK posée à la création
- Toast de confirmation après création
- i18n FR/EN/DE/ES (`interactions.createTaskFromHere`, `interactions.taskCreatedFromInteraction`)

Closes #76

## Avant
Pour créer une tâche en partant du contexte d'une interaction, il fallait re-saisir le sujet à la main et la zone — le champ `Task.source_interaction` existait déjà côté backend mais n'était jamais alimenté depuis l'UI.

## Après
Workflow utilisateur : ouvrir l'interaction → clic « Créer une tâche » → dialog pré-rempli → enregistrer. Le lien `source_interaction` permet ensuite de retrouver la chaîne « problème observé → action décidée ».

## Test plan
- [x] Bouton apparaît bien dans l'entête de l'éditeur d'interaction
- [x] Le sujet est pré-rempli
- [x] La création passe (`POST /api/tasks/tasks/` → 201)
- [x] `source_interaction` est bien stocké côté DB (vérifié via GET)
- [x] Lint passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)