### PR TITLE
feat(interactions): champ équipement concerné dans le form (#78)

### DIFF
--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -64,7 +64,14 @@ class InteractionSerializer(serializers.ModelSerializer):
         required=False,
         allow_empty=True,
     )
-    
+    equipments = serializers.SerializerMethodField()
+    equipment_ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        write_only=True,
+        required=False,
+        allow_empty=True,
+    )
+
     class Meta:
         model = Interaction
         fields = [
@@ -73,6 +80,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'project', 'project_title',
             'source_type', 'source_id', 'source_label',
             'zone_ids', 'zone_names', 'document_count', 'linked_document_ids', 'document_ids',
+            'equipments', 'equipment_ids',
             'created_at', 'updated_at', 'created_by', 'created_by_name'
         ]
         read_only_fields = ['id', 'household', 'created_at', 'updated_at', 'created_by']
@@ -118,6 +126,12 @@ class InteractionSerializer(serializers.ModelSerializer):
     def get_linked_document_ids(self, obj):
         return self._get_linked_document_ids(obj)
 
+    def get_equipments(self, obj):
+        return [
+            {'id': str(link.equipment_id), 'name': link.equipment.name}
+            for link in obj.equipment_interactions.select_related('equipment').all()
+        ]
+
     def _sync_tags(self, interaction, tag_names):
         if tag_names is None:
             return
@@ -154,10 +168,21 @@ class InteractionSerializer(serializers.ModelSerializer):
                 defaults={'created_by': interaction.created_by},
             )
     
+    def _sync_equipments(self, interaction, equipment_ids):
+        if equipment_ids is None:
+            return
+        from equipment.models import Equipment, EquipmentInteraction
+        interaction.equipment_interactions.all().delete()
+        for equipment_id in equipment_ids:
+            equipment = Equipment.objects.filter(id=equipment_id, household=interaction.household).first()
+            if equipment is not None:
+                EquipmentInteraction.objects.create(equipment=equipment, interaction=interaction)
+
     def create(self, validated_data):
         tag_names = validated_data.pop('tags_input', [])
         zone_ids = validated_data.pop('zone_ids', [])
         document_ids = validated_data.pop('document_ids', [])
+        equipment_ids = validated_data.pop('equipment_ids', [])
 
         with transaction.atomic():
             interaction = Interaction.objects.create(**validated_data)
@@ -172,19 +197,21 @@ class InteractionSerializer(serializers.ModelSerializer):
                 InteractionDocument.objects.create(interaction=interaction, document=document)
 
             self._sync_tags(interaction, tag_names)
+            self._sync_equipments(interaction, equipment_ids)
 
         return interaction
-    
+
     def update(self, instance, validated_data):
         tag_names = validated_data.pop('tags_input', None)
         zone_ids = validated_data.pop('zone_ids', None)
         validated_data.pop('document_ids', None)
-        
+        equipment_ids = validated_data.pop('equipment_ids', None)
+
         # Update interaction fields
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         instance.save()
-        
+
         # Update zones if provided
         if zone_ids is not None:
             from zones.models import Zone
@@ -194,7 +221,8 @@ class InteractionSerializer(serializers.ModelSerializer):
                 InteractionZone.objects.create(interaction=instance, zone=zone)
 
         self._sync_tags(instance, tag_names)
-        
+        self._sync_equipments(instance, equipment_ids)
+
         return instance
 
 

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/design-system/button';
 import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { fetchZones, type ZoneOption } from '@/lib/api/zones';
+import { fetchEquipmentList, type EquipmentListItem } from '@/lib/api/equipment';
 import { updateInteraction } from '@/lib/api/interactions';
 import { fetchHouseholdMembers, type HouseholdMember } from '@/lib/api/tasks';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
@@ -65,6 +66,8 @@ export default function InteractionEditPage() {
   const [tagsInput, setTagsInput] = React.useState('');
   const [zoneId, setZoneId] = React.useState('');
   const [zones, setZones] = React.useState<ZoneOption[]>([]);
+  const [equipmentId, setEquipmentId] = React.useState('');
+  const [equipmentList, setEquipmentList] = React.useState<EquipmentListItem[]>([]);
   const [amount, setAmount] = React.useState('');
   const [supplier, setSupplier] = React.useState('');
   const [formError, setFormError] = React.useState<string | null>(null);
@@ -95,13 +98,13 @@ export default function InteractionEditPage() {
     const md = (interaction.metadata ?? {}) as Record<string, string | null | undefined>;
     setAmount(md.amount ?? '');
     setSupplier(md.supplier ?? '');
+    setEquipmentId(interaction.equipments?.[0]?.id ?? '');
     setInitialised(true);
   }, [interaction, initialised]);
 
   React.useEffect(() => {
-    fetchZones()
-      .then(setZones)
-      .catch(() => {});
+    fetchZones().then(setZones).catch(() => {});
+    fetchEquipmentList().then(setEquipmentList).catch(() => {});
   }, []);
 
   const isTodo = type === 'todo';
@@ -155,6 +158,7 @@ export default function InteractionEditPage() {
         occurred_at: occurredAt.toISOString(),
         zone_ids: zoneId ? [zoneId] : [],
         tags_input: tags,
+        equipment_ids: equipmentId ? [equipmentId] : [],
         ...(nextMetadata ? { metadata: nextMetadata } : {}),
       });
       navigate(-1);
@@ -344,6 +348,26 @@ export default function InteractionEditPage() {
             {zones.map((z) => (
               <option key={z.id} value={z.id}>
                 {z.full_path ?? z.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Equipment */}
+        <div className="space-y-2">
+          <label htmlFor="interaction-equipment" className="text-sm font-medium">
+            {t('interactions.equipment_label')}
+          </label>
+          <select
+            id="interaction-equipment"
+            className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            value={equipmentId}
+            onChange={(e) => setEquipmentId(e.target.value)}
+          >
+            <option value="">{t('interactions.equipment_placeholder')}</option>
+            {equipmentList.map((eq) => (
+              <option key={eq.id} value={eq.id}>
+                {eq.name}
               </option>
             ))}
           </select>

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/design-system/button';
 import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { fetchZones, type ZoneOption } from '@/lib/api/zones';
-import { linkEquipmentInteraction } from '@/lib/api/equipment';
+import { fetchEquipmentList, type EquipmentListItem } from '@/lib/api/equipment';
 import { useCreateInteraction } from './hooks';
 import ExpenseFields from './ExpenseFields';
 
@@ -63,6 +63,8 @@ export default function InteractionNewPage() {
   const [tagsInput, setTagsInput] = React.useState('');
   const [zoneId, setZoneId] = React.useState(paramZoneId);
   const [zones, setZones] = React.useState<ZoneOption[]>([]);
+  const [equipmentId, setEquipmentId] = React.useState(paramEquipmentId);
+  const [equipmentList, setEquipmentList] = React.useState<EquipmentListItem[]>([]);
   const [amount, setAmount] = React.useState('');
   const [supplier, setSupplier] = React.useState('');
   const [formError, setFormError] = React.useState<string | null>(null);
@@ -72,9 +74,8 @@ export default function InteractionNewPage() {
   const zoneIsLocked = !!paramZoneId;
 
   React.useEffect(() => {
-    fetchZones()
-      .then(setZones)
-      .catch(() => {});
+    fetchZones().then(setZones).catch(() => {});
+    fetchEquipmentList().then(setEquipmentList).catch(() => {});
   }, []);
 
   // Pré-sélection de la racine si rien n'est imposé via le query param.
@@ -133,7 +134,7 @@ export default function InteractionNewPage() {
     }
 
     try {
-      const newInteraction = await createMutation.mutateAsync({
+      await createMutation.mutateAsync({
         subject: subject.trim(),
         content: description,
         type,
@@ -142,11 +143,11 @@ export default function InteractionNewPage() {
         zone_ids: [zoneId],
         tags_input: tags,
         project: paramProjectId || null,
+        equipment_ids: equipmentId ? [equipmentId] : [],
         ...(metadata ? { metadata } : {}),
       });
 
       if (paramEquipmentId) {
-        await linkEquipmentInteraction(paramEquipmentId, newInteraction.id, {});
         navigate(`/app/equipment/${paramEquipmentId}`);
       } else if (paramProjectId) {
         navigate(`/app/projects/${paramProjectId}`);
@@ -304,6 +305,32 @@ export default function InteractionNewPage() {
               {zones.map((z) => (
                 <option key={z.id} value={z.id}>
                   {z.full_path ?? z.name}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        {/* Equipment */}
+        <div className="space-y-2">
+          <label htmlFor="interaction-equipment" className="text-sm font-medium">
+            {t('interactions.equipment_label')}
+          </label>
+          {paramEquipmentId ? (
+            <div className="flex h-10 w-full items-center rounded-md border border-input bg-muted px-3 py-2 text-sm text-muted-foreground">
+              {equipmentList.find((eq) => eq.id === equipmentId)?.name ?? equipmentId}
+            </div>
+          ) : (
+            <select
+              id="interaction-equipment"
+              className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={equipmentId}
+              onChange={(e) => setEquipmentId(e.target.value)}
+            >
+              <option value="">{t('interactions.equipment_placeholder')}</option>
+              {equipmentList.map((eq) => (
+                <option key={eq.id} value={eq.id}>
+                  {eq.name}
                 </option>
               ))}
             </select>

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -1,5 +1,10 @@
 import { api } from '@/lib/axios';
 
+export interface InteractionEquipmentSummary {
+  id: string;
+  name: string;
+}
+
 export interface InteractionListItem {
   id: string;
   subject: string;
@@ -17,6 +22,7 @@ export interface InteractionListItem {
   source_type?: string | null;
   source_id?: string | null;
   source_label?: string | null;
+  equipments?: InteractionEquipmentSummary[];
 }
 
 export interface CreateInteractionInput {
@@ -30,6 +36,7 @@ export interface CreateInteractionInput {
   metadata?: Record<string, unknown>;
   document_ids?: string[];
   project?: string | null;
+  equipment_ids?: string[];
 }
 
 export interface LinkDocumentToInteractionInput {

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -278,6 +278,8 @@
     "deleted": "Ereignis gelöscht",
     "zone_label": "Zone",
     "zone_placeholder": "Zone auswählen",
+    "equipment_label": "Betroffenes Gerät",
+    "equipment_placeholder": "Kein Gerät",
     "tags_input_placeholder": "Tag1, Tag2, Tag3",
     "tags_input_help": "Tags durch Kommas trennen.",
     "project_label": "Projekt",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -278,6 +278,8 @@
     "deleted": "Event deleted",
     "zone_label": "Zone",
     "zone_placeholder": "Select a zone",
+    "equipment_label": "Related equipment",
+    "equipment_placeholder": "No equipment",
     "tags_input_placeholder": "tag1, tag2, tag3",
     "tags_input_help": "Separate tags with commas.",
     "project_label": "Project",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -278,6 +278,8 @@
     "deleted": "Evento eliminado",
     "zone_label": "Zona",
     "zone_placeholder": "Seleccionar una zona",
+    "equipment_label": "Equipo relacionado",
+    "equipment_placeholder": "Sin equipo",
     "tags_input_placeholder": "etiqueta1, etiqueta2",
     "tags_input_help": "Separa las etiquetas con comas.",
     "project_label": "Proyecto",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -278,6 +278,8 @@
     "deleted": "Événement supprimé",
     "zone_label": "Zone",
     "zone_placeholder": "Sélectionner une zone",
+    "equipment_label": "Équipement concerné",
+    "equipment_placeholder": "Aucun équipement",
     "tags_input_placeholder": "tag1, tag2, tag3",
     "tags_input_help": "Séparez les tags par des virgules.",
     "project_label": "Projet",


### PR DESCRIPTION
## Summary
- **Backend** : `InteractionSerializer` accepte `equipment_ids` en write, expose `equipments` (list of `{id, name}`) en read. La méthode `_sync_equipments` maintient le M2M `EquipmentInteraction`.
- **Frontend** : select d'équipement dans `InteractionNewPage` et `InteractionEditPage`.
- Quand on arrive depuis la fiche équipement (`?equipment_id=…`), le champ est **locké** sur cet équipement.
- L'ancien appel `linkEquipmentInteraction` post-création est remplacé par le flow unifié via `equipment_ids` côté serializer.
- i18n FR/EN/DE/ES.

Closes #78

## Test plan
- [x] `pytest apps/interactions/` — 59 passed
- [x] Création d'interaction avec un équipement → `POST` puis `GET` renvoie `equipments: [{id, name}]`
- [x] Pas de régression sur le flow depuis la fiche équipement (param locked)
- [x] Lint passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)