### PR TITLE
feat(stock): alertes stock faible et rupture (#74)

### DIFF
--- a/apps/notifications/models.py
+++ b/apps/notifications/models.py
@@ -18,6 +18,8 @@ class Notification(models.Model):
 
     class Type(models.TextChoices):
         HOUSEHOLD_INVITATION = "household_invitation", _("Household invitation")
+        STOCK_LOW = "stock_low", _("Low stock")
+        STOCK_OUT = "stock_out", _("Out of stock")
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     user = models.ForeignKey(

--- a/apps/stock/notifications.py
+++ b/apps/stock/notifications.py
@@ -1,0 +1,58 @@
+"""
+Stock low/out-of-stock notifications.
+
+Side-effect of stock-altering views (adjust, purchase). Detects transitions
+to LOW_STOCK or OUT_OF_STOCK and sends a notification to every active
+household member.
+"""
+from __future__ import annotations
+
+from django.utils.translation import gettext as _
+
+from households.models import HouseholdMember
+from notifications.models import Notification
+from notifications.service import send
+
+from .models import StockItem
+
+
+def notify_stock_status_change(item: StockItem, old_status: str, new_status: str) -> int:
+    """
+    Send a notification when a stock item transitions to LOW_STOCK or OUT_OF_STOCK.
+
+    Returns the number of notifications created (0 if no transition).
+    No-op when the status didn't change or moved back up.
+    """
+    if old_status == new_status:
+        return 0
+    if new_status == StockItem.Status.OUT_OF_STOCK:
+        notif_type = Notification.Type.STOCK_OUT
+        title = _("Out of stock: %(name)s") % {"name": item.name}
+        body = _("This item is now out of stock. Restock or update its status.")
+    elif new_status == StockItem.Status.LOW_STOCK:
+        notif_type = Notification.Type.STOCK_LOW
+        title = _("Low stock: %(name)s") % {"name": item.name}
+        body = _("This item has crossed its minimum quantity threshold.")
+    else:
+        return 0
+
+    payload = {
+        "item_id": str(item.id),
+        "item_name": item.name,
+        "quantity": str(item.quantity),
+        "min_quantity": str(item.min_quantity) if item.min_quantity is not None else None,
+        "unit": item.unit,
+    }
+
+    members = HouseholdMember.objects.filter(household=item.household).select_related("user")
+    created = 0
+    for member in members:
+        send(
+            member.user,
+            notification_type=notif_type,
+            title=title,
+            body=body,
+            payload=payload,
+        )
+        created += 1
+    return created

--- a/apps/stock/tests/test_api_stock_extra.py
+++ b/apps/stock/tests/test_api_stock_extra.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 
 from accounts.models import User
 from households.models import Household, HouseholdMember
+from notifications.models import Notification
 from stock.models import StockCategory, StockItem
 from zones.models import Zone
 
@@ -42,6 +43,64 @@ def test_stock_summary_returns_counts(client, user, household, dual_membership):
     assert payload["item_count"] == 2
     assert payload["low_stock_count"] == 1
     assert payload["out_of_stock_count"] == 1
+
+
+@pytest.mark.django_db
+def test_stock_adjust_emits_low_stock_notification_on_transition(client, user, household, dual_membership):
+    """Crossing the min_quantity threshold sends a STOCK_LOW notification to household members."""
+    category = StockCategory.objects.create(household=household, name="Food", created_by=user)
+    item = StockItem.objects.create(
+        household=household, category=category, name="Bread",
+        quantity=5, min_quantity=2, unit="pcs", status="in_stock", created_by=user,
+    )
+    client.force_login(user)
+    response = client.post(
+        reverse("stock-item-adjust-quantity", kwargs={"pk": item.id}),
+        data={"delta": -4},  # 5 - 4 = 1 ≤ 2 → low_stock
+        content_type="application/json",
+    )
+    assert response.status_code == 200
+    item.refresh_from_db()
+    assert item.status == StockItem.Status.LOW_STOCK
+    notifs = Notification.objects.filter(user=user, type=Notification.Type.STOCK_LOW)
+    assert notifs.count() == 1
+    assert notifs.first().payload["item_id"] == str(item.id)
+
+
+@pytest.mark.django_db
+def test_stock_adjust_emits_out_of_stock_notification_on_transition(client, user, household, dual_membership):
+    """Dropping to zero sends a STOCK_OUT notification."""
+    category = StockCategory.objects.create(household=household, name="Food", created_by=user)
+    item = StockItem.objects.create(
+        household=household, category=category, name="Eggs",
+        quantity=2, min_quantity=1, unit="pcs", status="in_stock", created_by=user,
+    )
+    client.force_login(user)
+    client.post(
+        reverse("stock-item-adjust-quantity", kwargs={"pk": item.id}),
+        data={"delta": -2},
+        content_type="application/json",
+    )
+    item.refresh_from_db()
+    assert item.status == StockItem.Status.OUT_OF_STOCK
+    assert Notification.objects.filter(user=user, type=Notification.Type.STOCK_OUT).count() == 1
+
+
+@pytest.mark.django_db
+def test_stock_adjust_no_notification_when_status_unchanged(client, user, household, dual_membership):
+    """Adjusting quantity without a status transition does not emit a notification."""
+    category = StockCategory.objects.create(household=household, name="Food", created_by=user)
+    item = StockItem.objects.create(
+        household=household, category=category, name="Rice",
+        quantity=10, min_quantity=2, unit="kg", status="in_stock", created_by=user,
+    )
+    client.force_login(user)
+    client.post(
+        reverse("stock-item-adjust-quantity", kwargs={"pk": item.id}),
+        data={"delta": -1},  # 10 - 1 = 9, still in_stock
+        content_type="application/json",
+    )
+    assert Notification.objects.filter(user=user).count() == 0
 
 
 @pytest.mark.django_db

--- a/apps/stock/views.py
+++ b/apps/stock/views.py
@@ -15,6 +15,7 @@ from core.permissions import IsHouseholdMember
 from interactions.services import create_expense_interaction
 
 from .models import StockCategory, StockItem
+from .notifications import notify_stock_status_change
 from .serializers import (
     StockCategorySerializer,
     StockCategorySummarySerializer,
@@ -99,6 +100,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
         if new_quantity < 0:
             raise ValidationError({"delta": _("Adjustment would produce a negative quantity.")})
 
+        old_status = item.status
         item.quantity = new_quantity
         item.last_restocked_at = timezone.now() if delta > 0 else item.last_restocked_at
 
@@ -113,6 +115,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
 
         item.updated_by = request.user
         item.save(update_fields=["quantity", "last_restocked_at", "status", "updated_by", "updated_at"])
+        notify_stock_status_change(item, old_status, item.status)
 
         return Response(StockItemSerializer(item, context={"request": request}).data, status=status.HTTP_200_OK)
 
@@ -139,6 +142,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
 
         with transaction.atomic():
             # Stock-specific side-effects on the item
+            old_status = item.status
             item.quantity = Decimal(item.quantity) + delta
             item.last_restocked_at = timezone.now()
             if unit_price is not None:
@@ -158,6 +162,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
                 item.status = StockItem.Status.IN_STOCK
             item.updated_by = request.user
             item.save()
+            notify_stock_status_change(item, old_status, item.status)
 
             interaction = create_expense_interaction(
                 source=item,

--- a/ui/src/features/stock/StockPage.tsx
+++ b/ui/src/features/stock/StockPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Package, Tag } from 'lucide-react';
+import { Package, Tag, AlertTriangle, PackageX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import ListPage from '@/components/ListPage';
@@ -157,6 +157,8 @@ export default function StockPage() {
                 }}
               >
                 <div className="space-y-4">
+                  <StockAlertsBanner items={items} onFilterStatus={setStatus} />
+
                   <FilterBar
                     fields={[
                       {
@@ -354,5 +356,41 @@ export default function StockPage() {
         loading={deleteCategoryMutation.isPending}
       />
     </>
+  );
+}
+
+interface StockAlertsBannerProps {
+  items: StockItem[];
+  onFilterStatus: (status: string) => void;
+}
+
+function StockAlertsBanner({ items, onFilterStatus }: StockAlertsBannerProps) {
+  const { t } = useTranslation();
+  const lowCount = items.filter((i) => i.status === 'low_stock').length;
+  const outCount = items.filter((i) => i.status === 'out_of_stock').length;
+  if (lowCount === 0 && outCount === 0) return null;
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm">
+      {outCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => onFilterStatus('out_of_stock')}
+          className="inline-flex items-center gap-2 rounded-md px-2 py-1 font-medium text-destructive hover:bg-destructive/10"
+        >
+          <PackageX className="h-4 w-4" />
+          {t('stock.alerts.out_of_stock_count', { count: outCount })}
+        </button>
+      ) : null}
+      {lowCount > 0 ? (
+        <button
+          type="button"
+          onClick={() => onFilterStatus('low_stock')}
+          className="inline-flex items-center gap-2 rounded-md px-2 py-1 font-medium text-foreground hover:bg-muted"
+        >
+          <AlertTriangle className="h-4 w-4 text-amber-500" />
+          {t('stock.alerts.low_stock_count', { count: lowCount })}
+        </button>
+      ) : null}
+    </div>
   );
 }

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1148,6 +1148,12 @@
   },
   "stock": {
     "title": "Bestand",
+    "alerts": {
+      "low_stock_count_one": "{{count}} Artikel mit niedrigem Bestand",
+      "low_stock_count_other": "{{count}} Artikel mit niedrigem Bestand",
+      "out_of_stock_count_one": "{{count}} Artikel vergriffen",
+      "out_of_stock_count_other": "{{count}} Artikel vergriffen"
+    },
     "tabs": {
       "items": "Artikel",
       "categories": "Kategorien"

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1148,6 +1148,12 @@
   },
   "stock": {
     "title": "Stock",
+    "alerts": {
+      "low_stock_count_one": "{{count}} item low in stock",
+      "low_stock_count_other": "{{count}} items low in stock",
+      "out_of_stock_count_one": "{{count}} item out of stock",
+      "out_of_stock_count_other": "{{count}} items out of stock"
+    },
     "tabs": {
       "items": "Items",
       "categories": "Categories"

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1148,6 +1148,12 @@
   },
   "stock": {
     "title": "Inventario",
+    "alerts": {
+      "low_stock_count_one": "{{count}} artículo con stock bajo",
+      "low_stock_count_other": "{{count}} artículos con stock bajo",
+      "out_of_stock_count_one": "{{count}} artículo agotado",
+      "out_of_stock_count_other": "{{count}} artículos agotados"
+    },
     "tabs": {
       "items": "Artículos",
       "categories": "Categorías"

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1148,6 +1148,12 @@
   },
   "stock": {
     "title": "Stock",
+    "alerts": {
+      "low_stock_count_one": "{{count}} article en stock faible",
+      "low_stock_count_other": "{{count}} articles en stock faible",
+      "out_of_stock_count_one": "{{count}} article en rupture",
+      "out_of_stock_count_other": "{{count}} articles en rupture"
+    },
     "tabs": {
       "items": "Articles",
       "categories": "Catégories"


### PR DESCRIPTION
## Summary

### Backend
- `Notification.Type` : 2 nouveaux types `STOCK_LOW` et `STOCK_OUT`
- `apps/stock/notifications.py` : helper `notify_stock_status_change(item, old_status, new_status)` qui pousse une notif à **chaque membre du foyer** quand un item transite vers `low_stock` ou `out_of_stock`
- Wire dans les vues `adjust` et `purchase` : capture l'ancien statut avant le save, appelle le helper après
- Pas de notif si le statut ne change pas, ni si on remonte vers `in_stock`

### Frontend
- `StockAlertsBanner` au-dessus du `FilterBar` (onglet articles) : indique combien d'items sont en rupture / faible
- Clic = applique le filtre status correspondant pour zoomer sur la liste
- Banner masqué quand counts = 0

### i18n
- FR/EN/DE/ES (clés `stock.alerts.low_stock_count`, `stock.alerts.out_of_stock_count`, formes plurielles)

Closes #74

## Test plan
- [x] `pytest apps/stock/tests/test_api_stock_extra.py` — **7 passed**
  - nouveau : transition in_stock → low_stock crée 1 notification STOCK_LOW
  - nouveau : transition in_stock → out_of_stock crée 1 notification STOCK_OUT
  - nouveau : ajustement sans transition de statut → 0 notification
- [x] Bannière visible quand il y a au moins 1 article low/out
- [x] Lint passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)