### PR TITLE
fix(auth): valider le mot de passe à l'inscription (#60)

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -1,4 +1,6 @@
 from django.contrib.auth import get_user_model
+from django.contrib.auth.password_validation import validate_password
+from django.core.exceptions import ValidationError as DjangoValidationError
 from rest_framework import serializers
 
 User = get_user_model()
@@ -32,6 +34,10 @@ class UserSerializer(serializers.ModelSerializer):
         password = validated_data.pop("password", None)
         user = User(**validated_data)
         if password:
+            try:
+                validate_password(password, user=user)
+            except DjangoValidationError as exc:
+                raise serializers.ValidationError({"password": list(exc.messages)})
             user.set_password(password)
         else:
             user.set_unusable_password()
@@ -43,6 +49,10 @@ class UserSerializer(serializers.ModelSerializer):
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
         if password:
+            try:
+                validate_password(password, user=instance)
+            except DjangoValidationError as exc:
+                raise serializers.ValidationError({"password": list(exc.messages)})
             instance.set_password(password)
         instance.save()
         return instance

--- a/apps/accounts/tests/test_api.py
+++ b/apps/accounts/tests/test_api.py
@@ -99,17 +99,41 @@ class TestUserViewSet:
     def test_create_user_no_auth(self, api_client):
         """Test creating user without authentication (registration)."""
         url = reverse("user-list")
-        
+
         response = api_client.post(url, {
             "email": "newuser@example.com",
             "password": "newpass123",
             "first_name": "New",
             "last_name": "User",
         })
-        
+
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data["email"] == "newuser@example.com"
         assert "password" not in response.data
+
+    def test_create_user_rejects_short_password(self, api_client):
+        """Registration must reject passwords that fail Django validators."""
+        url = reverse("user-list")
+        response = api_client.post(url, {
+            "email": "short@example.com",
+            "password": "abc",
+            "first_name": "Short",
+            "last_name": "Pwd",
+        })
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "password" in response.data
+
+    def test_create_user_rejects_too_common_password(self, api_client):
+        """Registration must reject common passwords listed by Django."""
+        url = reverse("user-list")
+        response = api_client.post(url, {
+            "email": "common@example.com",
+            "password": "password123",
+            "first_name": "Common",
+            "last_name": "Pwd",
+        })
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "password" in response.data
     
     def test_retrieve_user_detail(self, authenticated_client, user):
         """Test retrieving user detail."""


### PR DESCRIPTION
## Summary
- `UserSerializer.create()` appelle désormais `validate_password()` **avant** `set_password()`, exposant les validateurs Django (`MinimumLengthValidator`, `CommonPasswordValidator`, etc.) aux signups.
- `update()` reçoit le même garde-fou par cohérence (idempotent vs. l'endpoint `change-password` qui valide déjà).
- En cas d'échec, `serializers.ValidationError({\"password\": [...]})` → 400 avec liste des messages.

Closes #60

## Avant
```python
user = User(**validated_data)
user.set_password(password)  # \"abc\" accepté
```

## Après
```python
user = User(**validated_data)
try:
    validate_password(password, user=user)
except DjangoValidationError as exc:
    raise serializers.ValidationError({\"password\": list(exc.messages)})
user.set_password(password)
```

## Test plan
- [x] `pytest apps/accounts/tests/test_api.py` — 54 passed
  - nouveau : `test_create_user_rejects_short_password` (password \"abc\" → 400)
  - nouveau : `test_create_user_rejects_too_common_password` (password \"password123\" → 400)

🤖 Generated with [Claude Code](https://claude.com/claude-code)