### PR TITLE
feat(directory): voir l'activité d'un contact / d'une structure (#77)

### DIFF
--- a/ui/src/features/directory/ContactCard.tsx
+++ b/ui/src/features/directory/ContactCard.tsx
@@ -1,4 +1,6 @@
-import { Mail, Phone, Pencil, Trash2 } from 'lucide-react';
+import { Mail, Phone, Pencil, Trash2, MessageSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Card, CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import type { Contact } from '@/lib/api/contacts';
@@ -20,13 +22,20 @@ function getPrimaryPhone(contact: Contact): string | null {
 }
 
 export default function ContactCard({ contact, onEdit, onDelete }: ContactCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
   const fullName = [contact.first_name, contact.last_name].filter(Boolean).join(' ').trim() || '—';
   const email = getPrimaryEmail(contact);
   const phone = getPrimaryPhone(contact);
 
   const actions: CardAction[] = [
-    { label: 'Modifier', icon: Pencil, onClick: () => onEdit(contact) },
-    { label: 'Supprimer', icon: Trash2, onClick: () => onDelete(contact.id), variant: 'danger' },
+    {
+      label: t('directory.contact.view_activity'),
+      icon: MessageSquare,
+      onClick: () => navigate(`/app/interactions?contact=${contact.id}`),
+    },
+    { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(contact) },
+    { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(contact.id), variant: 'danger' },
   ];
 
   return (

--- a/ui/src/features/directory/StructureCard.tsx
+++ b/ui/src/features/directory/StructureCard.tsx
@@ -1,4 +1,6 @@
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, MessageSquare } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import CardActions, { type CardAction } from '@/components/CardActions';
@@ -17,9 +19,16 @@ export default function StructureCard({
   onEdit,
   onDelete,
 }: StructureCardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
   const actions: CardAction[] = [
-    { label: 'Modifier', icon: Pencil, onClick: () => onEdit(structure) },
-    { label: 'Supprimer', icon: Trash2, onClick: () => onDelete(structure.id), variant: 'danger' },
+    {
+      label: t('directory.contact.view_activity'),
+      icon: MessageSquare,
+      onClick: () => navigate(`/app/interactions?structure=${structure.id}`),
+    },
+    { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(structure) },
+    { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(structure.id), variant: 'danger' },
   ];
 
   return (

--- a/ui/src/features/interactions/InteractionsPage.tsx
+++ b/ui/src/features/interactions/InteractionsPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { MessageSquare } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import ListPage from '@/components/ListPage';
 import { FilterBar } from '@/design-system/filter-bar';
@@ -34,12 +34,14 @@ export default function InteractionsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const qc = useQueryClient();
+  const [searchParams] = useSearchParams();
 
   const [search, setSearch] = React.useState('');
   const [type, setType] = React.useState('');
   const [status, setStatus] = React.useState('');
   const [zone, setZone] = React.useState('');
-  const [contact, setContact] = React.useState('');
+  const [contact, setContact] = React.useState(searchParams.get('contact') ?? '');
+  const [structure, setStructure] = React.useState(searchParams.get('structure') ?? '');
   const [tagsFilter, setTagsFilter] = React.useState('');
   const [startDate, setStartDate] = React.useState('');
   const [endDate, setEndDate] = React.useState('');
@@ -59,11 +61,12 @@ export default function InteractionsPage() {
       ...(status ? { status } : {}),
       ...(zone ? { zone } : {}),
       ...(contact ? { contact } : {}),
+      ...(structure ? { structure } : {}),
       ...(tagsFilter ? { tags: tagsFilter } : {}),
       ...(startDate ? { start_date: startDate } : {}),
       ...(endDate ? { end_date: endDate } : {}),
     }),
-    [search, type, status, zone, contact, tagsFilter, startDate, endDate],
+    [search, type, status, zone, contact, structure, tagsFilter, startDate, endDate],
   );
 
   const { data, isLoading, error } = useInteractions(filters);
@@ -104,6 +107,7 @@ export default function InteractionsPage() {
     setStatus('');
     setZone('');
     setContact('');
+    setStructure('');
     setTagsFilter('');
     setStartDate('');
     setEndDate('');
@@ -220,7 +224,7 @@ export default function InteractionsPage() {
             },
           ]}
           onReset={resetFilters}
-          hasActiveFilters={!!(search || type || status || zone || contact || tagsFilter || startDate || endDate)}
+          hasActiveFilters={!!(search || type || status || zone || contact || structure || tagsFilter || startDate || endDate)}
           resetLabel={t('interactions.reset_filters')}
           applyLabel={t('interactions.apply_filters')}
         />

--- a/ui/src/features/interactions/hooks.ts
+++ b/ui/src/features/interactions/hooks.ts
@@ -14,6 +14,7 @@ interface InteractionFilters {
   status?: string;
   zone?: string;
   contact?: string;
+  structure?: string;
   tags?: string;
   start_date?: string;
   end_date?: string;

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -45,6 +45,7 @@ interface FetchInteractionsOptions {
   status?: string;
   zone?: string;
   contact?: string;
+  structure?: string;
   tags?: string;
   start_date?: string;
   end_date?: string;
@@ -108,6 +109,7 @@ export async function fetchInteractions(
     status,
     zone,
     contact,
+    structure,
     tags,
     start_date,
     end_date,
@@ -123,6 +125,7 @@ export async function fetchInteractions(
   if (status) params.status = status;
   if (zone) params.zone = zone;
   if (contact) params.contact = contact;
+  if (structure) params.structure = structure;
   if (tags) params.tags = tags;
   if (start_date) params.start_date = start_date;
   if (end_date) params.end_date = end_date;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -676,7 +676,10 @@
   "directory": {
     "title": "Verzeichnis",
     "tabContacts": "Kontakte",
-    "tabStructures": "Strukturen"
+    "tabStructures": "Strukturen",
+    "contact": {
+      "view_activity": "Aktivität ansehen"
+    }
   },
   "contacts": {
     "app_title": "Kontakte-Mini-App",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -676,7 +676,10 @@
   "directory": {
     "title": "Directory",
     "tabContacts": "Contacts",
-    "tabStructures": "Structures"
+    "tabStructures": "Structures",
+    "contact": {
+      "view_activity": "View activity"
+    }
   },
   "contacts": {
     "app_title": "Contacts mini-app",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -676,7 +676,10 @@
   "directory": {
     "title": "Directorio",
     "tabContacts": "Contactos",
-    "tabStructures": "Estructuras"
+    "tabStructures": "Estructuras",
+    "contact": {
+      "view_activity": "Ver actividad"
+    }
   },
   "contacts": {
     "app_title": "Mini-app Contactos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -676,7 +676,10 @@
   "directory": {
     "title": "Répertoire",
     "tabContacts": "Contacts",
-    "tabStructures": "Structures"
+    "tabStructures": "Structures",
+    "contact": {
+      "view_activity": "Voir l'activité"
+    }
   },
   "contacts": {
     "app_title": "Mini-app Contacts",


### PR DESCRIPTION
## Summary
- `ContactCard` et `StructureCard` exposent une action **« Voir l'activité »** dans leur menu
- L'action navigue vers `/app/interactions?contact=<id>` (ou `?structure=<id>`)
- `InteractionsPage` lit les query params `contact` et `structure` au montage et pré-remplit l'état du filtre
- Le filtre **structure** est ajouté en state (sans select UI pour l'instant — déjà supporté côté backend, on l'expose si besoin plus tard)
- API client + hook propagent maintenant `structure`
- i18n FR/EN/DE/ES (`directory.contact.view_activity`)

Closes #77

## Test plan
- [x] Naviguer vers `/app/interactions?contact=<id>` → le select contact se pré-remplit
- [x] Requête API contient bien `?contact=<id>` (200)
- [x] Bouton Réinitialiser vide aussi le filtre contact et structure
- [x] Lint passe

## Notes
Pas de page de détail contact dédiée (`ContactDetailPage`) — c'est une suite naturelle si on veut consolider documents/notes/etc. liés à un contact en un seul endroit. Pour l'instant l'action « Voir l'activité » suffit à délivrer la valeur de l'issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)