### PR TITLE
feat(auth): page d'inscription frontend (#59)

### DIFF
--- a/ui/src/features/auth/LoginPage.tsx
+++ b/ui/src/features/auth/LoginPage.tsx
@@ -11,6 +11,7 @@ export default function LoginPage() {
   const navigate = useNavigate();
   const location = useLocation();
   const resetSuccess = (location.state as { resetSuccess?: boolean } | null)?.resetSuccess;
+  const signupSuccess = (location.state as { signupSuccess?: boolean } | null)?.signupSuccess;
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -40,6 +41,7 @@ export default function LoginPage() {
       <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
         <h1 className="text-2xl font-semibold">{t('auth.login')}</h1>
         {resetSuccess && <p className="text-sm text-primary">{t('auth.passwordResetSuccess')}</p>}
+        {signupSuccess && <p className="text-sm text-primary">{t('auth.signupSuccess')}</p>}
         {error && <p className="text-sm text-destructive">{error}</p>}
         <Input type="email" placeholder={t('auth.email')} value={email} onChange={(e) => setEmail(e.target.value)} required autoComplete="email" inputMode="email" />
         <Input type="password" placeholder={t('auth.password')} value={password} onChange={(e) => setPassword(e.target.value)} required autoComplete="current-password" />
@@ -48,6 +50,9 @@ export default function LoginPage() {
         </Button>
         <Link to="/forgot-password" className="block text-center text-sm text-primary hover:underline">
           {t('auth.forgotPassword')}
+        </Link>
+        <Link to="/signup" className="block text-center text-sm text-primary hover:underline">
+          {t('auth.noAccountYet')} {t('auth.createAccount')}
         </Link>
       </form>
     </div>

--- a/ui/src/features/auth/SignupPage.tsx
+++ b/ui/src/features/auth/SignupPage.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/lib/auth/useAuth';
+import { signup } from '@/lib/api/users';
+import { Button } from '@/design-system/button';
+import { Input } from '@/design-system/input';
+
+export default function SignupPage() {
+  const { t } = useTranslation();
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  if (user) {
+    navigate('/app/dashboard');
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (password !== confirmPassword) {
+      setError(t('auth.passwordMismatch'));
+      return;
+    }
+    setLoading(true);
+    try {
+      await signup({
+        email: email.trim(),
+        password,
+        first_name: firstName.trim() || undefined,
+        last_name: lastName.trim() || undefined,
+      });
+      navigate('/login', { state: { signupSuccess: true } });
+    } catch (err) {
+      const data = (err as { response?: { data?: Record<string, string[] | string> } })?.response?.data;
+      const firstFieldError = data
+        ? Object.entries(data)
+            .map(([_, v]) => (Array.isArray(v) ? v[0] : v))
+            .find(Boolean)
+        : null;
+      setError(firstFieldError || t('auth.signupError'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-dvh items-center justify-center pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)]">
+      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-semibold">{t('auth.signupTitle')}</h1>
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <Input
+          type="email"
+          placeholder={t('auth.email')}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          inputMode="email"
+        />
+        <Input
+          type="text"
+          placeholder={t('auth.firstName')}
+          value={firstName}
+          onChange={(e) => setFirstName(e.target.value)}
+          autoComplete="given-name"
+        />
+        <Input
+          type="text"
+          placeholder={t('auth.lastName')}
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          autoComplete="family-name"
+        />
+        <Input
+          type="password"
+          placeholder={t('auth.password')}
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+        />
+        <Input
+          type="password"
+          placeholder={t('auth.confirmPassword')}
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+        />
+        <Button type="submit" className="w-full" disabled={loading}>
+          {loading ? t('auth.signupInProgress') : t('auth.signupSubmit')}
+        </Button>
+        <Link to="/login" className="block text-center text-sm text-primary hover:underline">
+          {t('auth.alreadyHaveAccount')}
+        </Link>
+      </form>
+    </div>
+  );
+}

--- a/ui/src/lib/api/users.ts
+++ b/ui/src/lib/api/users.ts
@@ -47,6 +47,18 @@ export interface UpdateProfileInput {
   color_theme?: ColorTheme;
 }
 
+export interface SignupInput {
+  email: string;
+  password: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+export async function signup(input: SignupInput): Promise<UserProfile> {
+  const { data } = await api.post('/accounts/users/', input);
+  return data as UserProfile;
+}
+
 export async function fetchMe(): Promise<UserProfile> {
   const { data } = await api.get('/accounts/users/me/');
   return data as UserProfile;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1322,7 +1322,17 @@
     "resetSubmit": "Passwort zurücksetzen",
     "resetting": "Zurücksetzen…",
     "tokenInvalid": "Dieser Link ist ungültig oder abgelaufen. Bitte fordern Sie einen neuen an.",
-    "passwordResetSuccess": "Passwort zurückgesetzt. Sie können sich jetzt anmelden."
+    "passwordResetSuccess": "Passwort zurückgesetzt. Sie können sich jetzt anmelden.",
+    "signupTitle": "Konto erstellen",
+    "signupSubmit": "Konto erstellen",
+    "signupInProgress": "Konto wird erstellt…",
+    "signupSuccess": "Konto erstellt. Du kannst dich jetzt anmelden.",
+    "signupError": "Konto konnte nicht erstellt werden. Überprüfe die Felder und versuche es erneut.",
+    "firstName": "Vorname",
+    "lastName": "Nachname",
+    "alreadyHaveAccount": "Schon ein Konto?",
+    "noAccountYet": "Noch kein Konto?",
+    "createAccount": "Konto erstellen"
   },
   "projects": {
     "app_title": "Projekte-Mini-App",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1322,7 +1322,17 @@
     "resetSubmit": "Reset password",
     "resetting": "Resetting…",
     "tokenInvalid": "This link is invalid or has expired. Please request a new one.",
-    "passwordResetSuccess": "Password reset. You can now sign in."
+    "passwordResetSuccess": "Password reset. You can now sign in.",
+    "signupTitle": "Create an account",
+    "signupSubmit": "Create account",
+    "signupInProgress": "Creating account…",
+    "signupSuccess": "Account created. You can now sign in.",
+    "signupError": "Could not create the account. Check the fields and try again.",
+    "firstName": "First name",
+    "lastName": "Last name",
+    "alreadyHaveAccount": "Already have an account?",
+    "noAccountYet": "Don't have an account yet?",
+    "createAccount": "Create an account"
   },
   "projects": {
     "app_title": "Projects mini-app",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1322,7 +1322,17 @@
     "resetSubmit": "Restablecer contraseña",
     "resetting": "Restableciendo…",
     "tokenInvalid": "Este enlace no es válido o ha expirado. Solicita uno nuevo.",
-    "passwordResetSuccess": "Contraseña restablecida. Ahora puedes iniciar sesión."
+    "passwordResetSuccess": "Contraseña restablecida. Ahora puedes iniciar sesión.",
+    "signupTitle": "Crear una cuenta",
+    "signupSubmit": "Crear cuenta",
+    "signupInProgress": "Creando cuenta…",
+    "signupSuccess": "Cuenta creada. Ahora puedes iniciar sesión.",
+    "signupError": "No se pudo crear la cuenta. Revisa los campos e inténtalo de nuevo.",
+    "firstName": "Nombre",
+    "lastName": "Apellido",
+    "alreadyHaveAccount": "¿Ya tienes cuenta?",
+    "noAccountYet": "¿Aún no tienes cuenta?",
+    "createAccount": "Crear una cuenta"
   },
   "projects": {
     "app_title": "Mini-app Proyectos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1322,7 +1322,17 @@
     "resetSubmit": "Réinitialiser",
     "resetting": "Réinitialisation…",
     "tokenInvalid": "Ce lien est invalide ou a expiré. Demandez un nouveau lien.",
-    "passwordResetSuccess": "Mot de passe réinitialisé. Vous pouvez maintenant vous connecter."
+    "passwordResetSuccess": "Mot de passe réinitialisé. Vous pouvez maintenant vous connecter.",
+    "signupTitle": "Créer un compte",
+    "signupSubmit": "Créer le compte",
+    "signupInProgress": "Création du compte…",
+    "signupSuccess": "Compte créé. Vous pouvez maintenant vous connecter.",
+    "signupError": "Impossible de créer le compte. Vérifiez les champs et réessayez.",
+    "firstName": "Prénom",
+    "lastName": "Nom",
+    "alreadyHaveAccount": "Déjà inscrit ?",
+    "noAccountYet": "Pas encore de compte ?",
+    "createAccount": "Créer un compte"
   },
   "projects": {
     "app_title": "Mini-app Projets",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import ProtectedLayout from './components/ProtectedLayout';
 import LoginPage from './features/auth/LoginPage';
+import SignupPage from './features/auth/SignupPage';
 import ForgotPasswordPage from './features/auth/ForgotPasswordPage';
 import ResetPasswordPage from './features/auth/ResetPasswordPage';
 import NotFoundPage from './features/general/NotFoundPage';
@@ -34,6 +35,10 @@ export const router = createBrowserRouter([
   {
     path: '/login',
     element: <LoginPage />,
+  },
+  {
+    path: '/signup',
+    element: <SignupPage />,
   },
   {
     path: '/forgot-password',


### PR DESCRIPTION
## Summary
- Nouvelle page `SignupPage` (email, prénom, nom, mot de passe, confirmation)
- Route `/signup` côté router
- Lien « Pas encore de compte ? Créer un compte » sur `LoginPage`
- Bannière de succès affichée sur `LoginPage` après création (via `location.state.signupSuccess`)
- `signup()` ajouté à `lib/api/users.ts`
- Validation client : passwords matching → message d'erreur
- Remontée des erreurs backend par champ (premier message affiché)
- i18n FR/EN/DE/ES

Closes #59

## Pairing avec #60
PR [#140](https://github.com/jammindev/house/pull/140) ajoute la validation des mots de passe à l'inscription côté backend. Combinées, ces deux PR rendent le flow signup complet et sûr.

## Test plan
- [x] `/signup` charge la page hors authentification
- [x] Soumission avec passwords mismatch → message d'erreur en haut du form
- [x] Soumission valide → POST 201, redirect `/login` avec bannière succès
- [x] Lint passe
- [x] Lien de retour `/login` fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)