### PR TITLE
feat(insurance): page Assurances frontend (#65)

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 import {
   LayoutDashboard, ListTodo, FolderKanban, Wrench, Box,
   Zap, MapPin, Users, FileText, Image, Notebook, User,
-  ShieldCheck, X, AlertCircle, Sparkles, Receipt,
+  ShieldCheck, X, AlertCircle, Sparkles, Receipt, Umbrella,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/lib/auth/useAuth';
@@ -21,10 +21,11 @@ const NAV_GROUPS = [
   {
     labelKey: 'sidebar.groupHome',
     items: [
-      { to: '/app/zones',       labelKey: 'zones.title',       Icon: MapPin },
-      { to: '/app/equipment',   labelKey: 'equipment.title',   Icon: Wrench },
-      { to: '/app/electricity', labelKey: 'electricity.title', Icon: Zap    },
-      { to: '/app/stock',       labelKey: 'stock.title',       Icon: Box    },
+      { to: '/app/zones',       labelKey: 'zones.title',       Icon: MapPin   },
+      { to: '/app/equipment',   labelKey: 'equipment.title',   Icon: Wrench   },
+      { to: '/app/electricity', labelKey: 'electricity.title', Icon: Zap      },
+      { to: '/app/stock',       labelKey: 'stock.title',       Icon: Box      },
+      { to: '/app/insurance',   labelKey: 'insurance.title',   Icon: Umbrella },
     ],
   },
   {

--- a/ui/src/features/insurance/InsuranceCard.tsx
+++ b/ui/src/features/insurance/InsuranceCard.tsx
@@ -1,0 +1,82 @@
+import { Pencil, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Card, CardTitle } from '@/design-system/card';
+import { Badge } from '@/design-system/badge';
+import CardActions, { type CardAction } from '@/components/CardActions';
+import type { InsuranceContract } from '@/lib/api/insurance';
+
+interface InsuranceCardProps {
+  contract: InsuranceContract;
+  onEdit: (contract: InsuranceContract) => void;
+  onDelete: (id: string) => void;
+}
+
+const TYPE_EMOJI: Record<string, string> = {
+  health: '🩺',
+  home: '🏠',
+  car: '🚗',
+  life: '🌱',
+  liability: '⚖️',
+  other: '📄',
+};
+
+function statusVariant(status: string): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'active') return 'secondary';
+  if (status === 'suspended') return 'outline';
+  return 'destructive';
+}
+
+export default function InsuranceCard({ contract, onEdit, onDelete }: InsuranceCardProps) {
+  const { t } = useTranslation();
+  const emoji = TYPE_EMOJI[contract.type] ?? '📄';
+
+  const actions: CardAction[] = [
+    { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(contract) },
+    { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(contract.id), variant: 'danger' },
+  ];
+
+  const yearlyValue = Number(contract.yearly_cost);
+  const monthlyValue = Number(contract.monthly_cost);
+  const hasCost = yearlyValue > 0 || monthlyValue > 0;
+
+  return (
+    <Card className="p-3 transition-shadow hover:shadow-md">
+      <div className="flex items-start gap-2">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <CardTitle>{`${emoji} ${contract.name}`}</CardTitle>
+            <Badge variant="outline" className="text-[11px]">
+              {t(`insurance.type.${contract.type}`)}
+            </Badge>
+            <Badge variant={statusVariant(contract.status)} className="text-[11px]">
+              {t(`insurance.status.${contract.status}`)}
+            </Badge>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+            {contract.provider ? <span>{contract.provider}</span> : null}
+            {contract.insured_item ? <span>· {contract.insured_item}</span> : null}
+            {contract.contract_number ? <span>· N° {contract.contract_number}</span> : null}
+          </div>
+          {hasCost ? (
+            <div className="text-xs text-muted-foreground">
+              {yearlyValue > 0 ? (
+                <span>{t('insurance.yearly_cost_value', { value: yearlyValue.toFixed(2) })}</span>
+              ) : null}
+              {yearlyValue > 0 && monthlyValue > 0 ? <span> · </span> : null}
+              {monthlyValue > 0 ? (
+                <span>{t('insurance.monthly_cost_value', { value: monthlyValue.toFixed(2) })}</span>
+              ) : null}
+            </div>
+          ) : null}
+          {contract.renewal_date ? (
+            <div className="text-xs text-muted-foreground">
+              {t('insurance.renewal_on', { date: contract.renewal_date })}
+            </div>
+          ) : null}
+        </div>
+
+        <CardActions actions={actions} />
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/features/insurance/InsuranceDialog.tsx
+++ b/ui/src/features/insurance/InsuranceDialog.tsx
@@ -1,0 +1,314 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { Textarea } from '@/design-system/textarea';
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import type {
+  InsuranceContract,
+  InsurancePayload,
+  InsuranceType,
+  InsuranceStatus,
+  PaymentFrequency,
+} from '@/lib/api/insurance';
+import { useCreateInsurance, useUpdateInsurance } from './hooks';
+
+interface InsuranceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: () => void;
+  existing?: InsuranceContract;
+}
+
+const TYPE_OPTIONS: InsuranceType[] = ['health', 'home', 'car', 'life', 'liability', 'other'];
+const STATUS_OPTIONS: InsuranceStatus[] = ['active', 'suspended', 'terminated'];
+const FREQUENCY_OPTIONS: PaymentFrequency[] = ['monthly', 'quarterly', 'yearly'];
+
+type FormState = {
+  name: string;
+  provider: string;
+  contract_number: string;
+  type: InsuranceType;
+  insured_item: string;
+  start_date: string;
+  end_date: string;
+  renewal_date: string;
+  status: InsuranceStatus;
+  payment_frequency: PaymentFrequency;
+  monthly_cost: string;
+  yearly_cost: string;
+  coverage_summary: string;
+  notes: string;
+};
+
+const EMPTY_STATE: FormState = {
+  name: '',
+  provider: '',
+  contract_number: '',
+  type: 'other',
+  insured_item: '',
+  start_date: '',
+  end_date: '',
+  renewal_date: '',
+  status: 'active',
+  payment_frequency: 'monthly',
+  monthly_cost: '',
+  yearly_cost: '',
+  coverage_summary: '',
+  notes: '',
+};
+
+export default function InsuranceDialog({ open, onOpenChange, onSaved, existing }: InsuranceDialogProps) {
+  const { t } = useTranslation();
+  const isEditing = Boolean(existing);
+
+  const [form, setForm] = React.useState<FormState>(EMPTY_STATE);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createMutation = useCreateInsurance();
+  const updateMutation = useUpdateInsurance();
+
+  React.useEffect(() => {
+    if (!open) return;
+    if (existing) {
+      setForm({
+        name: existing.name,
+        provider: existing.provider,
+        contract_number: existing.contract_number,
+        type: existing.type,
+        insured_item: existing.insured_item,
+        start_date: existing.start_date ?? '',
+        end_date: existing.end_date ?? '',
+        renewal_date: existing.renewal_date ?? '',
+        status: existing.status,
+        payment_frequency: existing.payment_frequency,
+        monthly_cost: Number(existing.monthly_cost) > 0 ? existing.monthly_cost : '',
+        yearly_cost: Number(existing.yearly_cost) > 0 ? existing.yearly_cost : '',
+        coverage_summary: existing.coverage_summary,
+        notes: existing.notes,
+      });
+    } else {
+      setForm(EMPTY_STATE);
+    }
+    setError(null);
+  }, [open, existing]);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+
+    if (!form.name.trim()) {
+      setError(t('insurance.name_required'));
+      return;
+    }
+    if (form.start_date && form.end_date && form.end_date < form.start_date) {
+      setError(t('insurance.dates_inconsistent'));
+      return;
+    }
+
+    const payload: InsurancePayload = {
+      name: form.name.trim(),
+      provider: form.provider.trim(),
+      contract_number: form.contract_number.trim(),
+      type: form.type,
+      insured_item: form.insured_item.trim(),
+      start_date: form.start_date || null,
+      end_date: form.end_date || null,
+      renewal_date: form.renewal_date || null,
+      status: form.status,
+      payment_frequency: form.payment_frequency,
+      monthly_cost: form.monthly_cost || '0',
+      yearly_cost: form.yearly_cost || '0',
+      coverage_summary: form.coverage_summary,
+      notes: form.notes,
+    };
+
+    try {
+      if (existing) {
+        await updateMutation.mutateAsync({ id: existing.id, payload });
+      } else {
+        await createMutation.mutateAsync(payload);
+      }
+      onOpenChange(false);
+      onSaved();
+    } catch {
+      setError(t(existing ? 'insurance.update_failed' : 'insurance.create_failed'));
+    }
+  }
+
+  const submitting = createMutation.isPending || updateMutation.isPending;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{isEditing ? t('insurance.edit_title') : t('insurance.new_title')}</DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <FormField label={t('insurance.field.name')} htmlFor="insurance-name">
+            <Input
+              id="insurance-name"
+              value={form.name}
+              onChange={(e) => update('name', e.target.value)}
+              placeholder={t('insurance.field.name_placeholder')}
+              required
+              autoFocus
+            />
+          </FormField>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField label={t('insurance.field.type')} htmlFor="insurance-type">
+              <Select
+                id="insurance-type"
+                value={form.type}
+                onChange={(e) => update('type', e.target.value as InsuranceType)}
+                options={TYPE_OPTIONS.map((v) => ({ value: v, label: t(`insurance.type.${v}`) }))}
+              />
+            </FormField>
+            <FormField label={t('insurance.field.status')} htmlFor="insurance-status">
+              <Select
+                id="insurance-status"
+                value={form.status}
+                onChange={(e) => update('status', e.target.value as InsuranceStatus)}
+                options={STATUS_OPTIONS.map((v) => ({ value: v, label: t(`insurance.status.${v}`) }))}
+              />
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <FormField label={t('insurance.field.provider')} htmlFor="insurance-provider">
+              <Input
+                id="insurance-provider"
+                value={form.provider}
+                onChange={(e) => update('provider', e.target.value)}
+                placeholder={t('insurance.field.provider_placeholder')}
+              />
+            </FormField>
+            <FormField label={t('insurance.field.contract_number')} htmlFor="insurance-contract-number">
+              <Input
+                id="insurance-contract-number"
+                value={form.contract_number}
+                onChange={(e) => update('contract_number', e.target.value)}
+                placeholder={t('insurance.field.contract_number_placeholder')}
+              />
+            </FormField>
+          </div>
+
+          <FormField label={t('insurance.field.insured_item')} htmlFor="insurance-insured-item">
+            <Input
+              id="insurance-insured-item"
+              value={form.insured_item}
+              onChange={(e) => update('insured_item', e.target.value)}
+              placeholder={t('insurance.field.insured_item_placeholder')}
+            />
+          </FormField>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <FormField label={t('insurance.field.start_date')} htmlFor="insurance-start-date">
+              <Input
+                id="insurance-start-date"
+                type="date"
+                value={form.start_date}
+                onChange={(e) => update('start_date', e.target.value)}
+              />
+            </FormField>
+            <FormField label={t('insurance.field.end_date')} htmlFor="insurance-end-date">
+              <Input
+                id="insurance-end-date"
+                type="date"
+                value={form.end_date}
+                onChange={(e) => update('end_date', e.target.value)}
+              />
+            </FormField>
+            <FormField label={t('insurance.field.renewal_date')} htmlFor="insurance-renewal-date">
+              <Input
+                id="insurance-renewal-date"
+                type="date"
+                value={form.renewal_date}
+                onChange={(e) => update('renewal_date', e.target.value)}
+              />
+            </FormField>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-3">
+            <FormField label={t('insurance.field.payment_frequency')} htmlFor="insurance-frequency">
+              <Select
+                id="insurance-frequency"
+                value={form.payment_frequency}
+                onChange={(e) => update('payment_frequency', e.target.value as PaymentFrequency)}
+                options={FREQUENCY_OPTIONS.map((v) => ({
+                  value: v,
+                  label: t(`insurance.frequency.${v}`),
+                }))}
+              />
+            </FormField>
+            <FormField label={t('insurance.field.monthly_cost')} htmlFor="insurance-monthly-cost">
+              <Input
+                id="insurance-monthly-cost"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.monthly_cost}
+                onChange={(e) => update('monthly_cost', e.target.value)}
+                placeholder="0.00"
+              />
+            </FormField>
+            <FormField label={t('insurance.field.yearly_cost')} htmlFor="insurance-yearly-cost">
+              <Input
+                id="insurance-yearly-cost"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.yearly_cost}
+                onChange={(e) => update('yearly_cost', e.target.value)}
+                placeholder="0.00"
+              />
+            </FormField>
+          </div>
+
+          <FormField label={t('insurance.field.coverage_summary')} htmlFor="insurance-coverage">
+            <Textarea
+              id="insurance-coverage"
+              rows={3}
+              value={form.coverage_summary}
+              onChange={(e) => update('coverage_summary', e.target.value)}
+              placeholder={t('insurance.field.coverage_summary_placeholder')}
+            />
+          </FormField>
+
+          <FormField label={t('insurance.field.notes')} htmlFor="insurance-notes">
+            <Textarea
+              id="insurance-notes"
+              rows={3}
+              value={form.notes}
+              onChange={(e) => update('notes', e.target.value)}
+              placeholder={t('insurance.field.notes_placeholder')}
+            />
+          </FormField>
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? t('common.saving') : t('common.save')}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/features/insurance/InsurancePage.tsx
+++ b/ui/src/features/insurance/InsurancePage.tsx
@@ -1,0 +1,185 @@
+import * as React from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import ListPage from '@/components/ListPage';
+import { FilterBar } from '@/design-system/filter-bar';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import type { InsuranceContract } from '@/lib/api/insurance';
+import { useInsuranceList, useDeleteInsurance, insuranceKeys } from './hooks';
+import InsuranceCard from './InsuranceCard';
+import InsuranceDialog from './InsuranceDialog';
+
+const TYPE_OPTIONS = ['health', 'home', 'car', 'life', 'liability', 'other'];
+const STATUS_OPTIONS = ['active', 'suspended', 'terminated'];
+
+export default function InsurancePage() {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+
+  const [search, setSearch] = React.useState('');
+  const [type, setType] = React.useState('');
+  const [status, setStatus] = React.useState('');
+
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<InsuranceContract | null>(null);
+
+  const filters = React.useMemo(
+    () => ({
+      ...(search ? { search } : {}),
+      ...(type ? { type } : {}),
+      ...(status ? { status } : {}),
+    }),
+    [search, type, status],
+  );
+
+  const { data: items = [], isLoading, error } = useInsuranceList(filters);
+  const deleteMutation = useDeleteInsurance();
+
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('insurance.deleted'),
+    onDelete: (id) => deleteMutation.mutateAsync(id),
+  });
+
+  const handleDelete = React.useCallback(
+    (id: string) => {
+      const item = items.find((i) => i.id === id);
+      if (!item) return;
+      deleteWithUndo(id, {
+        onRemove: () =>
+          qc.setQueryData<InsuranceContract[]>(
+            insuranceKeys.list(filters),
+            (old) => old?.filter((i) => i.id !== id),
+          ),
+        onRestore: () =>
+          qc.setQueryData<InsuranceContract[]>(
+            insuranceKeys.list(filters),
+            (old) => (old ? [...old, item] : [item]),
+          ),
+      });
+    },
+    [items, deleteWithUndo, qc, filters],
+  );
+
+  function resetFilters() {
+    setSearch('');
+    setType('');
+    setStatus('');
+  }
+
+  const isEmpty = !isLoading && !error && items.length === 0;
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  return (
+    <>
+      <ListPage
+        title={t('insurance.title')}
+        isEmpty={isEmpty}
+        emptyState={{
+          icon: ShieldCheck,
+          title: t('insurance.empty'),
+          description: t('insurance.empty_description'),
+          action: { label: t('insurance.new'), onClick: () => setDialogOpen(true) },
+        }}
+        actions={
+          <button
+            type="button"
+            onClick={() => setDialogOpen(true)}
+            className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground"
+          >
+            {t('insurance.new')}
+          </button>
+        }
+      >
+        <div className="space-y-4">
+          <FilterBar
+            fields={[
+              {
+                type: 'search',
+                id: 'insurance-search',
+                label: t('insurance.search_label'),
+                value: search,
+                onChange: setSearch,
+                placeholder: t('insurance.search_placeholder'),
+              },
+              {
+                type: 'select',
+                id: 'insurance-type',
+                label: t('insurance.field.type'),
+                value: type,
+                onChange: setType,
+                options: [
+                  { value: '', label: t('insurance.all_types') },
+                  ...TYPE_OPTIONS.map((v) => ({ value: v, label: t(`insurance.type.${v}`) })),
+                ],
+              },
+              {
+                type: 'select',
+                id: 'insurance-status',
+                label: t('insurance.field.status'),
+                value: status,
+                onChange: setStatus,
+                options: [
+                  { value: '', label: t('insurance.all_statuses') },
+                  ...STATUS_OPTIONS.map((v) => ({ value: v, label: t(`insurance.status.${v}`) })),
+                ],
+              },
+            ]}
+            onReset={resetFilters}
+            hasActiveFilters={!!(search || type || status)}
+            resetLabel={t('insurance.reset_filters')}
+            applyLabel={t('insurance.apply_filters')}
+          />
+
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+              {t('insurance.load_failed')}
+              <button
+                type="button"
+                onClick={() => qc.invalidateQueries({ queryKey: insuranceKeys.all })}
+                className="ml-2 underline hover:no-underline"
+              >
+                {t('common.retry')}
+              </button>
+            </div>
+          ) : null}
+
+          {showSkeleton ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-20 animate-pulse rounded-lg bg-muted" />
+              ))}
+            </div>
+          ) : null}
+
+          {!isLoading && !error ? (
+            <div className="space-y-2">
+              {items.map((contract) => (
+                <InsuranceCard
+                  key={contract.id}
+                  contract={contract}
+                  onEdit={(c) => {
+                    setEditing(c);
+                    setDialogOpen(true);
+                  }}
+                  onDelete={handleDelete}
+                />
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </ListPage>
+
+      <InsuranceDialog
+        open={dialogOpen}
+        onOpenChange={(open) => {
+          setDialogOpen(open);
+          if (!open) setEditing(null);
+        }}
+        existing={editing ?? undefined}
+        onSaved={() => qc.invalidateQueries({ queryKey: insuranceKeys.all })}
+      />
+    </>
+  );
+}

--- a/ui/src/features/insurance/InsurancePage.tsx
+++ b/ui/src/features/insurance/InsurancePage.tsx
@@ -97,7 +97,7 @@ export default function InsurancePage() {
             fields={[
               {
                 type: 'search',
-                id: 'insurance-search',
+                id: 'insurance-filter-search',
                 label: t('insurance.search_label'),
                 value: search,
                 onChange: setSearch,
@@ -105,7 +105,7 @@ export default function InsurancePage() {
               },
               {
                 type: 'select',
-                id: 'insurance-type',
+                id: 'insurance-filter-type',
                 label: t('insurance.field.type'),
                 value: type,
                 onChange: setType,
@@ -116,7 +116,7 @@ export default function InsurancePage() {
               },
               {
                 type: 'select',
-                id: 'insurance-status',
+                id: 'insurance-filter-status',
                 label: t('insurance.field.status'),
                 value: status,
                 onChange: setStatus,

--- a/ui/src/features/insurance/hooks.ts
+++ b/ui/src/features/insurance/hooks.ts
@@ -1,0 +1,73 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { toast } from '@/lib/toast';
+import {
+  fetchInsuranceList,
+  fetchInsurance,
+  createInsurance,
+  updateInsurance,
+  deleteInsurance,
+  type InsurancePayload,
+} from '@/lib/api/insurance';
+
+interface InsuranceFilters {
+  search?: string;
+  type?: string;
+  status?: string;
+}
+
+export const insuranceKeys = {
+  all: ['insurance'] as const,
+  list: (filters?: InsuranceFilters) => [...insuranceKeys.all, 'list', filters] as const,
+  detail: (id: string) => [...insuranceKeys.all, 'detail', id] as const,
+};
+
+export function useInsuranceList(filters: InsuranceFilters = {}) {
+  return useQuery({
+    queryKey: insuranceKeys.list(filters),
+    queryFn: () => fetchInsuranceList(filters),
+  });
+}
+
+export function useInsurance(id: string) {
+  return useQuery({
+    queryKey: insuranceKeys.detail(id),
+    queryFn: () => fetchInsurance(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateInsurance() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: InsurancePayload) => createInsurance(payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: insuranceKeys.all });
+      toast({ description: t('insurance.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useUpdateInsurance() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: InsurancePayload }) =>
+      updateInsurance(id, payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: insuranceKeys.all });
+      toast({ description: t('insurance.updated'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useDeleteInsurance() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteInsurance(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: insuranceKeys.all }),
+  });
+}

--- a/ui/src/lib/api/insurance.ts
+++ b/ui/src/lib/api/insurance.ts
@@ -1,0 +1,83 @@
+import { api } from '@/lib/axios';
+
+export type InsuranceType = 'health' | 'home' | 'car' | 'life' | 'liability' | 'other';
+export type InsuranceStatus = 'active' | 'suspended' | 'terminated';
+export type PaymentFrequency = 'monthly' | 'quarterly' | 'yearly';
+
+export interface InsuranceContract {
+  id: string;
+  household: string;
+  name: string;
+  provider: string;
+  contract_number: string;
+  type: InsuranceType;
+  insured_item: string;
+  start_date: string | null;
+  end_date: string | null;
+  renewal_date: string | null;
+  status: InsuranceStatus;
+  payment_frequency: PaymentFrequency;
+  monthly_cost: string;
+  yearly_cost: string;
+  coverage_summary: string;
+  notes: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface InsurancePayload {
+  name: string;
+  provider?: string;
+  contract_number?: string;
+  type: InsuranceType;
+  insured_item?: string;
+  start_date?: string | null;
+  end_date?: string | null;
+  renewal_date?: string | null;
+  status: InsuranceStatus;
+  payment_frequency: PaymentFrequency;
+  monthly_cost?: string;
+  yearly_cost?: string;
+  coverage_summary?: string;
+  notes?: string;
+}
+
+interface FetchInsuranceOptions {
+  search?: string;
+  type?: string;
+  status?: string;
+}
+
+function normalize(payload: unknown): InsuranceContract[] {
+  if (Array.isArray(payload)) return payload as InsuranceContract[];
+  const p = payload as { results?: InsuranceContract[] };
+  return Array.isArray(p.results) ? p.results : [];
+}
+
+export async function fetchInsuranceList(options: FetchInsuranceOptions = {}): Promise<InsuranceContract[]> {
+  const params: Record<string, string> = { ordering: 'name' };
+  if (options.search) params.search = options.search;
+  if (options.type) params.type = options.type;
+  if (options.status) params.status = options.status;
+  const { data } = await api.get('/insurance/', { params });
+  return normalize(data);
+}
+
+export async function fetchInsurance(id: string): Promise<InsuranceContract> {
+  const { data } = await api.get(`/insurance/${id}/`);
+  return data as InsuranceContract;
+}
+
+export async function createInsurance(payload: InsurancePayload): Promise<InsuranceContract> {
+  const { data } = await api.post('/insurance/', payload);
+  return data as InsuranceContract;
+}
+
+export async function updateInsurance(id: string, payload: InsurancePayload): Promise<InsuranceContract> {
+  const { data } = await api.patch(`/insurance/${id}/`, payload);
+  return data as InsuranceContract;
+}
+
+export async function deleteInsurance(id: string): Promise<void> {
+  await api.delete(`/insurance/${id}/`);
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1154,6 +1154,71 @@
       "interaction": "Interaktion"
     }
   },
+  "insurance": {
+    "title": "Versicherungen",
+    "new": "Neuer Vertrag",
+    "new_title": "Neuer Versicherungsvertrag",
+    "edit_title": "Vertrag bearbeiten",
+    "created": "Vertrag erstellt.",
+    "updated": "Vertrag aktualisiert.",
+    "deleted": "Vertrag gelöscht",
+    "empty": "Noch keine Versicherungsverträge",
+    "empty_description": "Füge deinen ersten Vertrag hinzu, um Policen, Verlängerungen und Prämien zu verfolgen.",
+    "search_label": "Suchen",
+    "search_placeholder": "Name, Anbieter, Nummer, versichertes Objekt…",
+    "all_types": "Alle Typen",
+    "all_statuses": "Alle Status",
+    "reset_filters": "Zurücksetzen",
+    "apply_filters": "Anwenden",
+    "load_failed": "Verträge konnten nicht geladen werden.",
+    "create_failed": "Vertrag konnte nicht erstellt werden.",
+    "update_failed": "Vertrag konnte nicht aktualisiert werden.",
+    "name_required": "Vertragsname ist erforderlich.",
+    "dates_inconsistent": "Das Enddatum muss am oder nach dem Startdatum liegen.",
+    "yearly_cost_value": "{{value}} €/Jahr",
+    "monthly_cost_value": "{{value}} €/Monat",
+    "renewal_on": "Verlängerung: {{date}}",
+    "field": {
+      "name": "Vertragsname",
+      "name_placeholder": "z. B. Wohngebäude — 2 route d'Olivet",
+      "provider": "Anbieter",
+      "provider_placeholder": "z. B. AXA, Allianz…",
+      "contract_number": "Vertragsnummer",
+      "contract_number_placeholder": "z. B. 1234567",
+      "type": "Typ",
+      "status": "Status",
+      "insured_item": "Versichertes Objekt",
+      "insured_item_placeholder": "z. B. Haupthaus, Dacia Sandero…",
+      "start_date": "Startdatum",
+      "end_date": "Enddatum",
+      "renewal_date": "Verlängerungsdatum",
+      "payment_frequency": "Zahlungsfrequenz",
+      "monthly_cost": "Monatliche Kosten (€)",
+      "yearly_cost": "Jährliche Kosten (€)",
+      "coverage_summary": "Deckungsübersicht",
+      "coverage_summary_placeholder": "Hauptdeckung, Grenzen, Selbstbeteiligungen…",
+      "notes": "Notizen",
+      "notes_placeholder": "Zusätzliche Angaben"
+    },
+    "type": {
+      "health": "Kranken",
+      "home": "Wohngebäude",
+      "car": "KFZ",
+      "life": "Leben",
+      "liability": "Haftpflicht",
+      "other": "Sonstige"
+    },
+    "status": {
+      "active": "Aktiv",
+      "suspended": "Ausgesetzt",
+      "terminated": "Beendet"
+    },
+    "frequency": {
+      "monthly": "Monatlich",
+      "quarterly": "Vierteljährlich",
+      "yearly": "Jährlich"
+    }
+  },
   "stock": {
     "title": "Bestand",
     "alerts": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1154,6 +1154,71 @@
       "interaction": "Interaction"
     }
   },
+  "insurance": {
+    "title": "Insurance",
+    "new": "New contract",
+    "new_title": "New insurance contract",
+    "edit_title": "Edit contract",
+    "created": "Contract created.",
+    "updated": "Contract updated.",
+    "deleted": "Contract deleted",
+    "empty": "No insurance contract yet",
+    "empty_description": "Add your first contract to track policies, renewals and premiums.",
+    "search_label": "Search",
+    "search_placeholder": "Name, provider, number, insured item…",
+    "all_types": "All types",
+    "all_statuses": "All statuses",
+    "reset_filters": "Reset",
+    "apply_filters": "Apply",
+    "load_failed": "Failed to load contracts.",
+    "create_failed": "Failed to create the contract.",
+    "update_failed": "Failed to update the contract.",
+    "name_required": "Contract name is required.",
+    "dates_inconsistent": "End date must be on or after start date.",
+    "yearly_cost_value": "{{value}} €/year",
+    "monthly_cost_value": "{{value}} €/month",
+    "renewal_on": "Renewal: {{date}}",
+    "field": {
+      "name": "Contract name",
+      "name_placeholder": "e.g. Home — 2 route d'Olivet",
+      "provider": "Provider",
+      "provider_placeholder": "e.g. MAIF, AXA…",
+      "contract_number": "Contract number",
+      "contract_number_placeholder": "e.g. 1234567",
+      "type": "Type",
+      "status": "Status",
+      "insured_item": "Insured item",
+      "insured_item_placeholder": "e.g. Main house, Dacia Sandero…",
+      "start_date": "Start date",
+      "end_date": "End date",
+      "renewal_date": "Renewal date",
+      "payment_frequency": "Payment frequency",
+      "monthly_cost": "Monthly cost (€)",
+      "yearly_cost": "Yearly cost (€)",
+      "coverage_summary": "Coverage summary",
+      "coverage_summary_placeholder": "Main coverage, limits, deductibles…",
+      "notes": "Notes",
+      "notes_placeholder": "Additional details"
+    },
+    "type": {
+      "health": "Health",
+      "home": "Home",
+      "car": "Car",
+      "life": "Life",
+      "liability": "Liability",
+      "other": "Other"
+    },
+    "status": {
+      "active": "Active",
+      "suspended": "Suspended",
+      "terminated": "Terminated"
+    },
+    "frequency": {
+      "monthly": "Monthly",
+      "quarterly": "Quarterly",
+      "yearly": "Yearly"
+    }
+  },
   "stock": {
     "title": "Stock",
     "alerts": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1154,6 +1154,71 @@
       "interaction": "Interacción"
     }
   },
+  "insurance": {
+    "title": "Seguros",
+    "new": "Nuevo contrato",
+    "new_title": "Nuevo contrato de seguro",
+    "edit_title": "Editar contrato",
+    "created": "Contrato creado.",
+    "updated": "Contrato actualizado.",
+    "deleted": "Contrato eliminado",
+    "empty": "Aún no hay contratos de seguro",
+    "empty_description": "Añade tu primer contrato para hacer seguimiento de pólizas, renovaciones y primas.",
+    "search_label": "Buscar",
+    "search_placeholder": "Nombre, proveedor, número, objeto asegurado…",
+    "all_types": "Todos los tipos",
+    "all_statuses": "Todos los estados",
+    "reset_filters": "Restablecer",
+    "apply_filters": "Aplicar",
+    "load_failed": "No se pudieron cargar los contratos.",
+    "create_failed": "No se pudo crear el contrato.",
+    "update_failed": "No se pudo actualizar el contrato.",
+    "name_required": "El nombre del contrato es obligatorio.",
+    "dates_inconsistent": "La fecha de fin debe ser igual o posterior a la fecha de inicio.",
+    "yearly_cost_value": "{{value}} €/año",
+    "monthly_cost_value": "{{value}} €/mes",
+    "renewal_on": "Renovación: {{date}}",
+    "field": {
+      "name": "Nombre del contrato",
+      "name_placeholder": "ej. Hogar — 2 route d'Olivet",
+      "provider": "Proveedor",
+      "provider_placeholder": "ej. AXA, MAPFRE…",
+      "contract_number": "Número de contrato",
+      "contract_number_placeholder": "ej. 1234567",
+      "type": "Tipo",
+      "status": "Estado",
+      "insured_item": "Objeto asegurado",
+      "insured_item_placeholder": "ej. Casa principal, Dacia Sandero…",
+      "start_date": "Fecha de inicio",
+      "end_date": "Fecha de fin",
+      "renewal_date": "Fecha de renovación",
+      "payment_frequency": "Frecuencia de pago",
+      "monthly_cost": "Coste mensual (€)",
+      "yearly_cost": "Coste anual (€)",
+      "coverage_summary": "Resumen de cobertura",
+      "coverage_summary_placeholder": "Cobertura principal, límites, franquicias…",
+      "notes": "Notas",
+      "notes_placeholder": "Detalles adicionales"
+    },
+    "type": {
+      "health": "Salud",
+      "home": "Hogar",
+      "car": "Auto",
+      "life": "Vida",
+      "liability": "Responsabilidad civil",
+      "other": "Otro"
+    },
+    "status": {
+      "active": "Activo",
+      "suspended": "Suspendido",
+      "terminated": "Terminado"
+    },
+    "frequency": {
+      "monthly": "Mensual",
+      "quarterly": "Trimestral",
+      "yearly": "Anual"
+    }
+  },
   "stock": {
     "title": "Inventario",
     "alerts": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1154,6 +1154,71 @@
       "interaction": "Interaction"
     }
   },
+  "insurance": {
+    "title": "Assurances",
+    "new": "Nouveau contrat",
+    "new_title": "Nouveau contrat d'assurance",
+    "edit_title": "Modifier le contrat",
+    "created": "Contrat créé.",
+    "updated": "Contrat mis à jour.",
+    "deleted": "Contrat supprimé",
+    "empty": "Aucun contrat d'assurance",
+    "empty_description": "Ajoutez votre premier contrat pour suivre vos polices, échéances et primes.",
+    "search_label": "Rechercher",
+    "search_placeholder": "Nom, assureur, numéro, objet assuré…",
+    "all_types": "Tous les types",
+    "all_statuses": "Tous les statuts",
+    "reset_filters": "Réinitialiser",
+    "apply_filters": "Appliquer",
+    "load_failed": "Impossible de charger les contrats.",
+    "create_failed": "Impossible de créer le contrat.",
+    "update_failed": "Impossible de mettre à jour le contrat.",
+    "name_required": "Le nom du contrat est requis.",
+    "dates_inconsistent": "La date de fin doit être postérieure à la date de début.",
+    "yearly_cost_value": "{{value}} €/an",
+    "monthly_cost_value": "{{value}} €/mois",
+    "renewal_on": "Renouvellement : {{date}}",
+    "field": {
+      "name": "Nom du contrat",
+      "name_placeholder": "ex. : Habitation 2 route d'Olivet",
+      "provider": "Assureur",
+      "provider_placeholder": "ex. : MAIF, Macif…",
+      "contract_number": "N° de contrat",
+      "contract_number_placeholder": "ex. : 1234567",
+      "type": "Type",
+      "status": "Statut",
+      "insured_item": "Objet assuré",
+      "insured_item_placeholder": "ex. : Maison principale, Dacia Sandero…",
+      "start_date": "Date de début",
+      "end_date": "Date de fin",
+      "renewal_date": "Date de renouvellement",
+      "payment_frequency": "Périodicité",
+      "monthly_cost": "Coût mensuel (€)",
+      "yearly_cost": "Coût annuel (€)",
+      "coverage_summary": "Résumé des garanties",
+      "coverage_summary_placeholder": "Principales garanties, plafonds, franchises…",
+      "notes": "Notes",
+      "notes_placeholder": "Détails complémentaires"
+    },
+    "type": {
+      "health": "Santé",
+      "home": "Habitation",
+      "car": "Auto",
+      "life": "Vie",
+      "liability": "Responsabilité civile",
+      "other": "Autre"
+    },
+    "status": {
+      "active": "Actif",
+      "suspended": "Suspendu",
+      "terminated": "Résilié"
+    },
+    "frequency": {
+      "monthly": "Mensuel",
+      "quarterly": "Trimestriel",
+      "yearly": "Annuel"
+    }
+  },
   "stock": {
     "title": "Stock",
     "alerts": {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -21,6 +21,7 @@ const DocumentsPage = lazyWithReload(() => import('./features/documents/Document
 const DocumentDetailPage = lazyWithReload(() => import('./features/documents/DocumentDetailPage'));
 const DirectoryPage = lazyWithReload(() => import('./features/directory/DirectoryFeaturePage'));
 const ElectricityPage = lazyWithReload(() => import('./features/electricity/ElectricityPage'));
+const InsurancePage = lazyWithReload(() => import('./features/insurance/InsurancePage'));
 const PhotosPage = lazyWithReload(() => import('./features/photos/PhotosPage'));
 const SettingsPage = lazyWithReload(() => import('./features/settings/SettingsPage'));
 const DashboardPage = lazyWithReload(() => import('./features/dashboard/DashboardPage'));
@@ -65,6 +66,7 @@ export const router = createBrowserRouter([
       { path: 'documents/:id', element: <DocumentDetailPage /> },
       { path: 'directory', element: <DirectoryPage /> },
       { path: 'electricity', element: <ElectricityPage /> },
+      { path: 'insurance', element: <InsurancePage /> },
       { path: 'photos', element: <PhotosPage /> },
       { path: 'alerts', element: <AlertsPage /> },
       { path: 'notifications', element: <NotificationsPage /> },


### PR DESCRIPTION
## Summary
- Nouvelle feature `ui/src/features/insurance/` — `Page` + `Card` + `Dialog` + `hooks`
- Client API `ui/src/lib/api/insurance.ts` (list/get/create/update/delete + filtres `search`, `type`, `status`)
- Route `/app/insurance` + entrée sidebar (icône Umbrella, groupe « Maison »)
- Pattern feature standard du projet : `FilterBar`, `EmptyState`, `deleteWithUndo`, skeleton via `useDelayedLoading`
- 6 types (santé / habitation / auto / vie / RC / autre), 3 statuts (actif / suspendu / résilié), 3 fréquences (mensuelle / trimestrielle / annuelle)
- Champs couverts : nom, assureur, n° contrat, type, objet assuré, dates début/fin/renouvellement, statut, périodicité, coût mensuel/annuel, garanties, notes
- Validation : nom requis, end_date >= start_date
- i18n FR/EN/DE/ES (namespace `insurance.*` complet)

Closes #65

## Test plan
- [x] Backend déjà testé (modèle + serializer + viewset existants)
- [x] Lint passe
- [x] JSON locales valides (4 fichiers)
- [x] Route accessible (`/app/insurance` → InsurancePage en lazy load)
- [ ] Test visuel : créer, éditer, supprimer un contrat (à valider après login)

## Hors scope
- Page de détail dédiée (la card + dialog suffisent en V1, suivant le pattern stock/equipment où le détail vient si besoin)
- Alertes de renouvellement automatiques (pourrait être un follow-up à brancher sur les Notifications, cf. pattern #74 stock)
- Lien avec Documents (rattacher polices/avis d'échéance) — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)