### PR TITLE
feat(tasks): filtrer la liste sur les projets actifs par défaut

### DIFF
--- a/apps/tasks/serializers.py
+++ b/apps/tasks/serializers.py
@@ -69,6 +69,7 @@ class TaskSerializer(serializers.ModelSerializer):
 
     # Read-only computed fields
     project_title = serializers.SerializerMethodField()
+    project_status = serializers.SerializerMethodField()
     zone_names = serializers.SerializerMethodField()
     assigned_to_name = serializers.SerializerMethodField()
     completed_by_name = serializers.SerializerMethodField()
@@ -108,7 +109,7 @@ class TaskSerializer(serializers.ModelSerializer):
             'subject', 'content', 'status', 'priority', 'due_date', 'is_private',
             'assigned_to', 'assigned_to_id', 'assigned_to_name',
             'completed_by', 'completed_by_name', 'completed_at',
-            'project', 'project_title',
+            'project', 'project_title', 'project_status',
             'zone_ids', 'zone_names',
             'source_interaction',
             'linked_documents', 'linked_interactions',
@@ -123,6 +124,9 @@ class TaskSerializer(serializers.ModelSerializer):
 
     def get_project_title(self, obj):
         return obj.project.title if obj.project_id and obj.project else None
+
+    def get_project_status(self, obj):
+        return obj.project.status if obj.project_id and obj.project else None
 
     def get_zone_names(self, obj):
         return [zone.name for zone in obj.zones.all()]

--- a/apps/tasks/tests/test_api_tasks.py
+++ b/apps/tasks/tests/test_api_tasks.py
@@ -8,6 +8,7 @@ from rest_framework.test import APIClient
 
 from accounts.tests.factories import UserFactory
 from households.models import Household, HouseholdMember
+from projects.models import Project
 from tasks.models import Task, TaskZone
 from zones.models import Zone
 
@@ -483,3 +484,47 @@ class TestTaskUpdatePermissions:
         url = reverse("task-detail", kwargs={"pk": str(task_with_assignee.id)})
         response = client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+class TestTaskProjectStatus:
+    def _create_project(self, household, owner, status_value):
+        return Project.objects.create(
+            household=household,
+            created_by=owner,
+            title="Kitchen renovation",
+            status=status_value,
+            priority=3,
+            planned_budget=0,
+            actual_cost_cached=0,
+            type=Project.Type.OTHER,
+        )
+
+    def test_serializer_exposes_active_project_status(self, owner_client, household, owner, zone):
+        project = self._create_project(household, owner, Project.Status.ACTIVE)
+        create = owner_client.post(
+            reverse("task-list"),
+            _task_payload([zone.id], project=str(project.id)),
+            format="json",
+        )
+        assert create.status_code == status.HTTP_201_CREATED
+        assert create.data["project_status"] == "active"
+
+    def test_serializer_exposes_inactive_project_status(self, owner_client, household, owner, zone):
+        project = self._create_project(household, owner, Project.Status.COMPLETED)
+        create = owner_client.post(
+            reverse("task-list"),
+            _task_payload([zone.id], project=str(project.id)),
+            format="json",
+        )
+        assert create.status_code == status.HTTP_201_CREATED
+        assert create.data["project_status"] == "completed"
+
+    def test_standalone_task_has_null_project_status(self, owner_client, household, zone):
+        create = owner_client.post(
+            reverse("task-list"),
+            _task_payload([zone.id]),
+            format="json",
+        )
+        assert create.status_code == status.HTTP_201_CREATED
+        assert create.data["project_status"] is None

--- a/ui/src/features/tasks/TasksPanel.tsx
+++ b/ui/src/features/tasks/TasksPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CheckSquare, Lock, Plus, User } from 'lucide-react';
+import { CheckSquare, FolderOpen, Lock, Plus, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import { isTaskOverdue, type Task, type TaskStatus } from '@/lib/api/tasks';
@@ -67,6 +67,7 @@ export default function TasksPanel({
   const [detailTask, setDetailTask] = React.useState<Task | null>(null);
   const [activeFilter, setActiveFilter] = useSessionState<FilterKey>(`${prefix}.filter`, 'all');
   const [showPrivateOnly, setShowPrivateOnly] = useSessionState(`${prefix}.filterPrivate`, false);
+  const [showInactiveProjects, setShowInactiveProjects] = useSessionState(`${prefix}.filterInactiveProjects`, false);
   const [filterAssigneeId, setFilterAssigneeId] = useSessionState(`${prefix}.filterAssignee`, '');
   const savedAssigneeFilter = React.useRef('');
 
@@ -125,13 +126,18 @@ export default function TasksPanel({
 
   const filteredTasks = React.useMemo(() => {
     let result = showPrivateOnly ? tasks.filter((t) => t.is_private) : tasks;
+    // Liste globale : par défaut on masque les tâches liées à un projet non-actif.
+    // Les tâches autonomes (sans projet) restent toujours visibles.
+    if (!isEmbedded && !showInactiveProjects) {
+      result = result.filter((t) => !t.project || t.project_status === 'active');
+    }
     if (filterAssigneeId === 'unassigned') {
       result = result.filter((t) => !t.assigned_to);
     } else if (filterAssigneeId) {
       result = result.filter((t) => t.assigned_to === filterAssigneeId);
     }
     return result;
-  }, [tasks, showPrivateOnly, filterAssigneeId]);
+  }, [tasks, showPrivateOnly, showInactiveProjects, isEmbedded, filterAssigneeId]);
 
   const overdueTasks = React.useMemo(() => sortByPriority(filteredTasks.filter(isTaskOverdue)), [filteredTasks]);
   const inProgressTasks = React.useMemo(() => sortByPriority(filteredTasks.filter((t) => t.status === 'in_progress' && !isTaskOverdue(t))), [filteredTasks]);
@@ -231,6 +237,19 @@ export default function TasksPanel({
               {label}
             </FilterPill>
           ))}
+
+          {!isEmbedded && (
+            <>
+              <span className="h-4 w-px bg-slate-200" />
+              <FilterPill
+                active={showInactiveProjects}
+                onClick={() => setShowInactiveProjects((v) => !v)}
+              >
+                <FolderOpen className="h-3 w-3" />
+                {t('tasks.filterInactiveProjects')}
+              </FilterPill>
+            </>
+          )}
 
           {multipleMembers && !showPrivateOnly && (
             <>

--- a/ui/src/lib/api/tasks.ts
+++ b/ui/src/lib/api/tasks.ts
@@ -3,6 +3,7 @@ import { api } from '@/lib/axios';
 export type TaskStatus = 'backlog' | 'pending' | 'in_progress' | 'done' | 'archived' | null;
 export type TaskColumnId = 'backlog' | 'pending' | 'in_progress' | 'done';
 export type TaskPriority = 1 | 2 | 3 | null;
+export type ProjectStatus = 'draft' | 'active' | 'on_hold' | 'completed' | 'cancelled';
 
 export interface LinkedDocumentSummary {
   id: number;             // link id (TaskDocument.id)
@@ -40,6 +41,7 @@ export interface Task {
   created_by_name: string | null;
   project: string | null;
   project_title?: string | null;
+  project_status?: ProjectStatus | null;
   zone_names: string[];
   source_interaction: string | null;
   linked_documents: LinkedDocumentSummary[];

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -508,6 +508,7 @@
     "fieldPrivate": "Private Aufgabe (nur für mich sichtbar)",
     "private": "Privat",
     "filterPrivate": "Privat",
+    "filterInactiveProjects": "Inaktive Projekte",
     "filterEmpty": "Keine Aufgaben entsprechen diesem Filter.",
     "filterMember": "Mitglied",
     "filterMemberAll": "Alle Mitglieder",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -508,6 +508,7 @@
     "fieldPrivate": "Private task (visible only to me)",
     "private": "Private",
     "filterPrivate": "Private",
+    "filterInactiveProjects": "Inactive projects",
     "filterEmpty": "No tasks match this filter.",
     "filterMember": "Member",
     "filterMemberAll": "All members",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -508,6 +508,7 @@
     "fieldPrivate": "Tarea privada (visible solo para mí)",
     "private": "Privada",
     "filterPrivate": "Privado",
+    "filterInactiveProjects": "Proyectos inactivos",
     "filterEmpty": "Ninguna tarea coincide con este filtro.",
     "filterMember": "Miembro",
     "filterMemberAll": "Todos los miembros",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -508,6 +508,7 @@
     "fieldPrivate": "Tâche privée (visible uniquement par moi)",
     "private": "Privée",
     "filterPrivate": "Privé",
+    "filterInactiveProjects": "Projets inactifs",
     "filterEmpty": "Aucune tâche ne correspond à ce filtre.",
     "filterMember": "Membre",
     "filterMemberAll": "Tous les membres",


### PR DESCRIPTION
## Contexte

Dans la liste globale des tâches, les tâches rattachées à un projet non-actif (brouillon, en pause, terminé, annulé) encombraient la vue. On veut par défaut ne voir que les tâches pertinentes, avec la possibilité de réafficher les autres via un filtre.

## Changements

- **Backend** (`apps/tasks/serializers.py`) : expose un champ read-only `project_status` sur `TaskSerializer` (`null` si la tâche n'a pas de projet).
- **Frontend** (`TasksPanel.tsx`) : la liste globale masque par défaut les tâches d'un projet non-actif. Les tâches **autonomes** (sans projet) restent toujours visibles. Nouveau `FilterPill` « Projets inactifs » (persisté en session) pour les réafficher.
  - Le filtre ne s'applique qu'à la liste globale, pas à la vue tâches embarquée dans un projet.
- **i18n** : clé `tasks.filterInactiveProjects` ajoutée (en/fr/de/es).
- **Tests** : `TestTaskProjectStatus` couvre les cas actif / inactif / null.

## Tests

- ✅ 62 tests backend tasks (dont 3 nouveaux)
- ✅ `tsc --noEmit` clean, ESLint sans nouvelle erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)