### PR TITLE
feat(agent): expansion de requête par Haiku avant le retrieval

### DIFF
--- a/apps/agent/query_expansion.py
+++ b/apps/agent/query_expansion.py
@@ -1,0 +1,141 @@
+"""
+Query expansion: turn a natural-language question into search terms.
+
+The retrieval layer is a naive lexical full-text search (`config='simple'`, no
+stemming, no stopwords). Fed a raw question like "trouve-moi la facture de la
+pompe à chaleur", it treats *every* token as mandatory (websearch AND) — filler
+included ("trouve", "moi", "la", "de") — so it almost always returns nothing.
+
+This module inserts a cheap LLM pass **before** retrieval that rewrites the
+question into a short list of search keywords + synonyms/abbreviations
+("pompe à chaleur", "PAC", "Daikin", "facture"). Retrieval then runs on those
+terms instead of the raw sentence.
+
+Design rules:
+- **Best-effort**: any failure (LLM error, timeout, empty/garbage output)
+  degrades gracefully to the original question — expansion never makes retrieval
+  worse than it is today.
+- The cleaned original question is **always** kept as a fallback term.
+- Logged under its own feature name (`agent_query_expansion`) so the extra call
+  stays visible in ``AIUsageLog`` separately from the answer call.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from uuid import UUID
+
+from .llm import LLMClient
+
+logger = logging.getLogger(__name__)
+
+FEATURE_NAME = "agent_query_expansion"
+
+# Keep the expansion cheap: a handful of terms is plenty for lexical retrieval,
+# and the response is a short comma-separated list.
+MAX_TERMS = 8
+MIN_TERM_LEN = 2
+EXPANSION_MAX_TOKENS = 128
+
+EXPANSION_SYSTEM_PROMPT = """You turn a household member's natural-language \
+question into search keywords for a lexical (keyword) full-text search engine.
+
+Return ONLY a comma-separated list of search terms. No sentences, no \
+explanation, no labels, no quotes.
+
+Rules:
+- Drop filler and stopwords (trouve-moi, peux-tu, est-ce que, la, de, my, the, \
+please, …). Keep only meaningful nouns, proper names, brands, places, dates, \
+amounts.
+- Add obvious synonyms and common abbreviations that could appear in the stored \
+data. Examples: "pompe à chaleur" → also "PAC"; "assurance habitation" → also \
+"MRH"; "voiture" → also "auto". Keep additions short.
+- Keep proper nouns and brand names as-is (Engie, Daikin, …).
+- Answer in the same language as the question, but you may add well-known \
+abbreviations from any language.
+- Output 3 to 8 terms. Prefer single words or short two-word phrases.
+"""
+
+
+def expand(
+    question: str,
+    *,
+    client: LLMClient,
+    household_id: UUID | str,
+    user_id: int | None = None,
+) -> list[str]:
+    """Return search terms for ``question``.
+
+    The result always contains the cleaned original question as a fallback,
+    followed by the LLM-extracted keywords/synonyms (deduped, order preserved).
+    Any failure degrades to ``[original]`` — the caller can always run retrieval.
+    """
+    original = (question or "").strip()
+    terms: list[str] = [original] if original else []
+
+    if not original:
+        return terms
+
+    try:
+        response = client.complete(
+            system=EXPANSION_SYSTEM_PROMPT,
+            user=original,
+            feature=FEATURE_NAME,
+            household_id=household_id,
+            user_id=user_id,
+            max_tokens=EXPANSION_MAX_TOKENS,
+            metadata={"stage": "query_expansion"},
+        )
+    except Exception as exc:  # noqa: BLE001 — expansion is best-effort by design
+        logger.warning("query_expansion: LLM call failed, using raw question: %s", exc)
+        return _dedupe(terms)
+
+    return _dedupe(terms + _parse_terms(response.text))
+
+
+def _parse_terms(raw: str) -> list[str]:
+    """Parse the model output into a clean list of terms.
+
+    Accepts a comma-separated list (the requested format), a newline list, or a
+    JSON array — models drift, so we stay lenient.
+    """
+    text = (raw or "").strip()
+    if not text:
+        return []
+
+    # A model may wrap the list in a JSON array despite the instructions.
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        data = None
+    if isinstance(data, list):
+        return _clean([str(item) for item in data])
+
+    return _clean(re.split(r"[,\n;]+", text))
+
+
+def _clean(parts: list[str]) -> list[str]:
+    """Strip bullets/quotes/whitespace, drop tiny tokens, cap at ``MAX_TERMS``."""
+    out: list[str] = []
+    for part in parts:
+        term = part.strip().strip("-•*\"'`").strip()
+        if len(term) < MIN_TERM_LEN:
+            continue
+        out.append(term)
+        if len(out) >= MAX_TERMS:
+            break
+    return out
+
+
+def _dedupe(terms: list[str]) -> list[str]:
+    """Case-insensitive dedupe, preserving first-seen order."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for term in terms:
+        key = term.casefold()
+        if not term or key in seen:
+            continue
+        seen.add(key)
+        out.append(term)
+    return out

--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -140,3 +140,28 @@ def search(household_id: UUID, query: str, limit: int = 20) -> list[Hit]:
 
     all_hits.sort(key=lambda h: h.rank, reverse=True)
     return all_hits[:limit]
+
+
+def search_multi(household_id: UUID, queries: list[str], limit: int = 20) -> list[Hit]:
+    """Run `search` for each query string and merge the results.
+
+    Used by query expansion: a natural-language question is rewritten into
+    several keyword variants, each searched independently, then unioned here.
+    Hits are deduped by `(entity_type, id)` keeping the highest rank, then
+    ranked desc and capped at `limit`.
+
+    Ranks produced by different tsqueries are not strictly comparable, so this
+    is a heuristic merge — good enough for the modest household volume.
+    """
+    best: dict[tuple[str, Any], Hit] = {}
+    for query in queries:
+        if not query or not query.strip():
+            continue
+        for hit in search(household_id, query, limit=limit):
+            key = (hit.entity_type, hit.id)
+            existing = best.get(key)
+            if existing is None or hit.rank > existing.rank:
+                best[key] = hit
+
+    merged = sorted(best.values(), key=lambda h: h.rank, reverse=True)
+    return merged[:limit]

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -4,12 +4,15 @@ Agent orchestrator: question -> retrieval -> LLM -> answer + citations.
 `ask(question, household)` is the only thing the API view talks to. It owns the
 end-to-end flow:
 
-1. retrieval.search(household_id, question) — bounded by the household scope
-2. build the prompt (system + user with citation-ready context)
-3. LLM call via the configured `LLMClient`
-4. parse <cite id="entity_type:id"/> markers, intersect with retrieved hits to
+1. query_expansion.expand(question) — rewrite the natural-language question into
+   search keywords + synonyms (best-effort LLM pass; skipped when the LLM is
+   disabled)
+2. retrieval.search_multi(household_id, terms) — bounded by the household scope
+3. build the prompt (system + user with citation-ready context)
+4. LLM call via the configured `LLMClient`
+5. parse <cite id="entity_type:id"/> markers, intersect with retrieved hits to
    keep citations honest (the LLM can't cite something we didn't retrieve)
-5. return AnswerResult with the human-readable answer + machine-friendly
+6. return AnswerResult with the human-readable answer + machine-friendly
    citations + metadata (tokens, duration)
 
 When retrieval returns nothing OR when the configured `ANTHROPIC_API_KEY` is
@@ -26,7 +29,7 @@ from uuid import UUID
 
 from django.conf import settings
 
-from . import retrieval
+from . import query_expansion, retrieval
 from .llm import LLMClient, LLMError, LLMTimeoutError, get_llm_client
 from .prompts import SYSTEM_PROMPT, build_user_prompt
 
@@ -69,15 +72,30 @@ def ask(
     if not cleaned:
         return AnswerResult(answer=_dont_know_message(), citations=[])
 
-    hits = retrieval.search(household.id, cleaned, limit=retrieval_limit)
+    enabled = _llm_enabled()
+    llm = (client or get_llm_client()) if enabled else None
+
+    # Expand the natural-language question into keyword variants before search.
+    # Only worth an LLM call when the LLM is enabled (otherwise we return IDK
+    # below anyway); falls back to the raw question when disabled.
+    if enabled:
+        terms = query_expansion.expand(
+            cleaned,
+            client=llm,
+            household_id=household.id,
+            user_id=getattr(user, "id", None),
+        )
+    else:
+        terms = [cleaned]
+
+    hits = retrieval.search_multi(household.id, terms, limit=retrieval_limit)
     if not hits:
         return _idk_result()
 
-    if not _llm_enabled():
+    if not enabled:
         logger.warning("agent.ask: LLM disabled (no ANTHROPIC_API_KEY) — returning IDK")
         return _idk_result()
 
-    llm = client or get_llm_client()
     user_prompt = build_user_prompt(cleaned, hits)
 
     try:

--- a/apps/agent/tests/test_query_expansion.py
+++ b/apps/agent/tests/test_query_expansion.py
@@ -1,0 +1,131 @@
+"""Tests for agent.query_expansion.
+
+No network: the LLM client is a deterministic stub for every test.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from agent import query_expansion
+from agent.llm import LLMError, LLMResponse, LLMTimeoutError
+
+
+@dataclass
+class _StubLLMClient:
+    """LLMClient drop-in. Returns canned text (or raises), records the last call."""
+
+    text: str = ""
+    raises: Exception | None = None
+    last_call: dict[str, Any] | None = None
+    provider: str = "stub"
+
+    def complete(self, **kwargs):
+        self.last_call = kwargs
+        if self.raises:
+            raise self.raises
+        return LLMResponse(
+            text=self.text,
+            input_tokens=1,
+            output_tokens=1,
+            duration_ms=1,
+            model="stub-model",
+        )
+
+
+HH = "00000000-0000-0000-0000-000000000001"
+
+
+class TestExpandHappyPath:
+    def test_returns_original_plus_keywords(self):
+        stub = _StubLLMClient(text="pompe à chaleur, PAC, Daikin, facture")
+        terms = query_expansion.expand(
+            "trouve-moi la facture de la pompe à chaleur",
+            client=stub,
+            household_id=HH,
+        )
+        assert terms[0] == "trouve-moi la facture de la pompe à chaleur"
+        assert "PAC" in terms
+        assert "Daikin" in terms
+        assert "pompe à chaleur" in terms
+
+    def test_original_is_always_first_even_when_repeated_by_model(self):
+        stub = _StubLLMClient(text="engie, facture")
+        terms = query_expansion.expand("engie", client=stub, household_id=HH)
+        assert terms[0] == "engie"
+        # case-insensitive dedupe keeps the first occurrence only
+        assert sum(1 for t in terms if t.casefold() == "engie") == 1
+
+    def test_uses_distinct_feature_name_for_usage_log(self):
+        stub = _StubLLMClient(text="a, b")
+        query_expansion.expand("question", client=stub, household_id=HH, user_id=7)
+        assert stub.last_call is not None
+        assert stub.last_call["feature"] == query_expansion.FEATURE_NAME
+        assert stub.last_call["feature"] != "agent_ask"
+        assert stub.last_call["household_id"] == HH
+        assert stub.last_call["user_id"] == 7
+
+    def test_only_the_question_is_sent_to_the_model(self):
+        stub = _StubLLMClient(text="a, b")
+        query_expansion.expand("où est la clé ?", client=stub, household_id=HH)
+        assert stub.last_call["user"] == "où est la clé ?"
+
+
+class TestExpandParsing:
+    def test_parses_json_array(self):
+        stub = _StubLLMClient(text='["pompe à chaleur", "PAC"]')
+        terms = query_expansion.expand("q", client=stub, household_id=HH)
+        assert "pompe à chaleur" in terms
+        assert "PAC" in terms
+
+    def test_parses_newlines_and_bullets(self):
+        stub = _StubLLMClient(text="- pompe à chaleur\n- PAC\n- Daikin")
+        terms = query_expansion.expand("q", client=stub, household_id=HH)
+        assert "pompe à chaleur" in terms
+        assert "PAC" in terms
+        assert "Daikin" in terms
+
+    def test_drops_tiny_tokens(self):
+        stub = _StubLLMClient(text="a, PAC, x, chaudière")
+        terms = query_expansion.expand("q", client=stub, household_id=HH)
+        assert "a" not in terms
+        assert "x" not in terms
+        assert "PAC" in terms
+
+    def test_caps_number_of_terms(self):
+        many = ", ".join(f"term{i}" for i in range(50))
+        stub = _StubLLMClient(text=many)
+        terms = query_expansion.expand("question", client=stub, household_id=HH)
+        # original + at most MAX_TERMS parsed keywords
+        assert len(terms) <= query_expansion.MAX_TERMS + 1
+
+    def test_strips_surrounding_quotes(self):
+        stub = _StubLLMClient(text='"Engie", \'facture\'')
+        terms = query_expansion.expand("q", client=stub, household_id=HH)
+        assert "Engie" in terms
+        assert "facture" in terms
+
+
+class TestExpandDegradesGracefully:
+    def test_llm_error_falls_back_to_original(self):
+        stub = _StubLLMClient(raises=LLMError("boom"))
+        terms = query_expansion.expand("ma question", client=stub, household_id=HH)
+        assert terms == ["ma question"]
+
+    def test_timeout_falls_back_to_original(self):
+        stub = _StubLLMClient(raises=LLMTimeoutError("slow"))
+        terms = query_expansion.expand("ma question", client=stub, household_id=HH)
+        assert terms == ["ma question"]
+
+    def test_empty_model_output_falls_back_to_original(self):
+        stub = _StubLLMClient(text="   ")
+        terms = query_expansion.expand("ma question", client=stub, household_id=HH)
+        assert terms == ["ma question"]
+
+    def test_blank_question_returns_empty_without_calling_llm(self):
+        stub = _StubLLMClient(text="whatever")
+        terms = query_expansion.expand("   ", client=stub, household_id=HH)
+        assert terms == []
+        assert stub.last_call is None

--- a/apps/agent/tests/test_retrieval.py
+++ b/apps/agent/tests/test_retrieval.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import pytest
 
-from agent.retrieval import Hit, search
+from agent.retrieval import Hit, search, search_multi
 
 
 @pytest.fixture
@@ -352,3 +352,74 @@ class TestHitContract:
         hits = search(household.id, "chaudière", limit=20)
         types = {h.entity_type for h in hits}
         assert {"document", "equipment", "task", "interaction"}.issubset(types)
+
+
+class TestSearchMulti:
+    def test_empty_queries_returns_empty(self, household):
+        assert search_multi(household.id, []) == []
+        assert search_multi(household.id, ["", "   "]) == []
+
+    def test_unions_hits_from_different_queries(
+        self, household, make_document, make_equipment
+    ):
+        make_document(name="Facture Engie mars")
+        make_equipment(name="Chaudière Bosch")
+        hits = search_multi(household.id, ["engie", "chaudière"])
+        labels = {h.label for h in hits}
+        assert "Facture Engie mars" in labels
+        assert "Chaudière Bosch" in labels
+
+    def test_dedupes_same_entity_matched_by_several_queries(self, household, make_document):
+        # A doc matched by two synonym queries must appear once.
+        make_document(name="Pompe à chaleur Daikin", ocr_text="PAC air-eau Daikin")
+        hits = search_multi(household.id, ["pompe", "PAC", "Daikin"])
+        docs = [h for h in hits if h.entity_type == "document"]
+        assert len(docs) == 1
+
+    def test_expansion_finds_what_raw_natural_language_misses(
+        self, household, make_document
+    ):
+        # The raw sentence carries filler ("trouve", "moi", "la", "de") that the
+        # `simple` config keeps as mandatory tokens → 0 hits. The expanded
+        # keywords match.
+        make_document(name="Pompe à chaleur Daikin", ocr_text="PAC air-eau")
+        raw = "trouve-moi la facture de la pompe à chaleur"
+        assert search(household.id, raw) == []
+        expanded = search_multi(household.id, [raw, "pompe à chaleur", "PAC", "Daikin"])
+        assert any(h.entity_type == "document" for h in expanded)
+
+    def test_skips_blank_queries_without_error(self, household, make_document):
+        make_document(name="Facture Engie")
+        hits = search_multi(household.id, ["", "engie", "   "])
+        assert any(h.label == "Facture Engie" for h in hits)
+
+    def test_limit_respected_across_union(self, household, make_document):
+        for i in range(6):
+            make_document(name=f"Engie doc {i}")
+        hits = search_multi(household.id, ["engie", "doc"], limit=3)
+        assert len(hits) == 3
+
+    def test_results_ranked_descending(self, household, make_document):
+        make_document(name="Engie facture", ocr_text="total 142")
+        make_document(name="autre", ocr_text="engie en passant")
+        hits = search_multi(household.id, ["engie"])
+        ranks = [h.rank for h in hits]
+        assert ranks == sorted(ranks, reverse=True)
+
+    def test_household_scope_preserved(
+        self, household, other_household, owner, make_document
+    ):
+        from documents.models import Document
+
+        make_document(name="Engie facture mine")
+        Document.objects.create(
+            household=other_household,
+            created_by=owner,
+            file_path="documents/y.pdf",
+            name="Engie facture theirs",
+            mime_type="application/pdf",
+            type="document",
+        )
+        labels = {h.label for h in search_multi(household.id, ["engie", "facture"])}
+        assert "Engie facture mine" in labels
+        assert "Engie facture theirs" not in labels

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -4,14 +4,14 @@ The LLM client is replaced by a deterministic stub for every test — no network
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 from uuid import UUID
 
 import pytest
 
 from accounts.tests.factories import UserFactory
-from agent import service
+from agent import query_expansion, service
 from agent.llm import LLMError, LLMResponse, LLMTimeoutError
 from ai_usage.models import AIUsageLog
 from documents.models import Document
@@ -36,6 +36,29 @@ class _StubLLMClient:
             input_tokens=11,
             output_tokens=22,
             duration_ms=42,
+            model="stub-model",
+        )
+
+
+@dataclass
+class _ScriptedLLMClient:
+    """LLMClient drop-in that returns different text per `feature`.
+
+    Lets a test drive the two-call flow (query expansion, then answer) with a
+    distinct canned response for each stage.
+    """
+
+    by_feature: dict[str, str] = field(default_factory=dict)
+    calls: list[dict[str, Any]] = field(default_factory=list)
+    provider: str = "stub"
+
+    def complete(self, **kwargs):
+        self.calls.append(kwargs)
+        return LLMResponse(
+            text=self.by_feature.get(kwargs["feature"], ""),
+            input_tokens=1,
+            output_tokens=1,
+            duration_ms=1,
             model="stub-model",
         )
 
@@ -187,6 +210,105 @@ class TestErrorPaths:
         stub = _StubLLMClient(raises=LLMError("boom"))
         with pytest.raises(LLMError):
             service.ask("engie", household, user=owner, client=stub)
+
+
+# ---------------------------------------------------------------------------
+# Query expansion
+# ---------------------------------------------------------------------------
+
+
+class TestQueryExpansion:
+    def test_natural_language_question_finds_doc_via_expanded_keywords(
+        self, with_api_key, household, owner, make_document
+    ):
+        # Raw sentence with filler → retrieval on it alone finds nothing.
+        doc = make_document(name="Pompe à chaleur Daikin", ocr_text="PAC air-eau")
+        scripted = _ScriptedLLMClient(
+            by_feature={
+                query_expansion.FEATURE_NAME: "pompe à chaleur, PAC, Daikin",
+                service.FEATURE_NAME: f'C\'est un Daikin <cite id="document:{doc.pk}"/>.',
+            }
+        )
+
+        result = service.ask(
+            "trouve-moi la facture de la pompe à chaleur",
+            household,
+            user=owner,
+            client=scripted,
+        )
+
+        assert len(result.citations) == 1
+        assert result.citations[0].id == doc.pk
+
+    def test_makes_two_calls_expansion_then_answer(
+        self, with_api_key, household, owner, make_document
+    ):
+        doc = make_document(name="Facture Engie mars")
+        scripted = _ScriptedLLMClient(
+            by_feature={
+                query_expansion.FEATURE_NAME: "engie, facture",
+                service.FEATURE_NAME: f'ok <cite id="document:{doc.pk}"/>',
+            }
+        )
+        service.ask("combien pour engie ?", household, user=owner, client=scripted)
+
+        features = [c["feature"] for c in scripted.calls]
+        assert features == [query_expansion.FEATURE_NAME, service.FEATURE_NAME]
+
+    def test_expansion_never_receives_household_data(
+        self, with_api_key, household, owner, make_document
+    ):
+        make_document(name="Facture Engie mars", ocr_text="secret montant 999")
+        scripted = _ScriptedLLMClient(
+            by_feature={
+                query_expansion.FEATURE_NAME: "engie",
+                service.FEATURE_NAME: "ok",
+            }
+        )
+        service.ask("engie", household, user=owner, client=scripted)
+
+        expansion_call = scripted.calls[0]
+        assert expansion_call["feature"] == query_expansion.FEATURE_NAME
+        # The expansion prompt is built from the question only, never the data.
+        assert "999" not in expansion_call["user"]
+        assert expansion_call["user"] == "engie"
+
+    def test_no_api_key_skips_expansion_entirely(
+        self, settings, household, owner, make_document
+    ):
+        settings.ANTHROPIC_API_KEY = ""
+        make_document(name="Engie facture mars")
+        scripted = _ScriptedLLMClient(by_feature={})
+        result = service.ask("engie", household, user=owner, client=scripted)
+
+        # No LLM call at all — not even for expansion.
+        assert scripted.calls == []
+        assert result.metadata.get("reason") == service.IDK_MARKER
+
+    def test_expansion_failure_degrades_to_raw_question(
+        self, with_api_key, household, owner, make_document
+    ):
+        # Expansion raises, but the raw keyword still matches → we still answer.
+        doc = make_document(name="Engie facture mars")
+
+        @dataclass
+        class _FlakyExpansionClient:
+            provider: str = "stub"
+
+            def complete(self, **kwargs):
+                if kwargs["feature"] == query_expansion.FEATURE_NAME:
+                    raise LLMTimeoutError("expansion slow")
+                return LLMResponse(
+                    text=f'ok <cite id="document:{doc.pk}"/>',
+                    input_tokens=1,
+                    output_tokens=1,
+                    duration_ms=1,
+                    model="stub",
+                )
+
+        result = service.ask("engie", household, user=owner, client=_FlakyExpansionClient())
+        assert len(result.citations) == 1
+        assert result.citations[0].id == doc.pk
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problème

Une question en langage naturel — *« trouve-moi la facture de la pompe à chaleur »* — retournait systématiquement « je ne sais pas ». Le retrieval lexical (`config='simple'`, sans stopwords, `websearch` = AND) traite **chaque token comme obligatoire**, filler inclus (« trouve », « moi », « la », « de »). Aucun document ne contient « trouve moi » → 0 hit → l'agent n'appelle même pas Haiku.

## Solution

Un passage Haiku **avant** le retrieval qui réécrit la question en mots-clés + synonymes/abréviations (`pompe à chaleur, PAC, Daikin, facture`), puis retrieval sur chaque terme.

```
question naturelle
  → query_expansion.expand()   ← NOUVEAU
  → retrieval.search_multi()   ← NOUVEAU (union dédupée)
  → Haiku → réponse + citations (inchangé)
```

## Détails

- **`apps/agent/query_expansion.py`** (nouveau) — `expand()` : appel Haiku, parsing robuste (CSV/JSON/retours ligne), cap `MAX_TERMS=8`, dédup.
- **`apps/agent/retrieval.py`** — `search_multi(household, queries)` : union par terme, dédup `(entity_type, id)`, meilleur rang conservé.
- **`apps/agent/service.py`** — `ask()` insère l'expansion, gatée sur `_llm_enabled()`.

### Choix de conception
- **Best-effort** : toute erreur d'expansion (timeout/erreur/vide) retombe sur la question brute — jamais pire qu'avant. L'erreur de l'appel *réponse* se propage comme avant.
- La question originale reste toujours un terme de secours.
- L'expansion ne voit **que la question**, jamais les données du foyer (scope household intact).
- Loguée sous le feature `agent_query_expansion` dans `AIUsageLog` (2 appels visibles séparément).
- Sans clé API → expansion skippée, aucun appel gaspillé.

### Implication
- **2 appels Haiku par question** (~$0.002 vs $0.001, +qq centaines de ms). Trade-off assumé.
- Pas de changement d'API (aucun serializer/model touché).

## Tests

63 tests verts sur les fichiers touchés, dont la démonstration du bug :

```python
raw = "trouve-moi la facture de la pompe à chaleur"
assert search(household.id, raw) == []           # le symptôme
expanded = search_multi(household.id, [raw, "pompe à chaleur", "PAC", "Daikin"])
assert any(h.entity_type == "document" for h in expanded)  # débloqué
```

Couverture : parsing, dégradation gracieuse, dédup, scope household, flux 2-appels, skip sans clé API.

> ℹ️ 3 tests pré-existants de `test_llm.py` échouent sur `main` (pollution de la base de test réutilisée, `AIUsageLog.objects.get()` → `MultipleObjectsReturned`) — sans rapport avec cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)