### PR TITLE
feat(agent): API conversations — CRUD + endpoint messages (lot 2)

### DIFF
--- a/apps/agent/models.py
+++ b/apps/agent/models.py
@@ -17,6 +17,7 @@ import uuid
 
 from django.db import models
 
+from core.managers import HouseholdScopedManager
 from core.models import HouseholdScopedModel, TimestampedModel
 
 
@@ -28,6 +29,8 @@ class AgentConversation(HouseholdScopedModel):
     # Mirrors the newest message's timestamp so conversations sort by recency
     # without a subquery. Kept in sync when a message is appended.
     last_message_at = models.DateTimeField(null=True, blank=True)
+
+    objects = HouseholdScopedManager()
 
     class Meta:
         ordering = ["-last_message_at", "-created_at"]

--- a/apps/agent/serializers.py
+++ b/apps/agent/serializers.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from rest_framework import serializers
 
+from .models import AgentConversation, AgentMessage
+
 
 class AskRequestSerializer(serializers.Serializer):
     question = serializers.CharField(min_length=1, max_length=2000, trim_whitespace=True)
@@ -20,3 +22,50 @@ class AskResponseSerializer(serializers.Serializer):
     answer = serializers.CharField()
     citations = CitationSerializer(many=True)
     metadata = serializers.DictField()
+
+
+# --- Conversations -----------------------------------------------------------
+
+
+class AgentMessageSerializer(serializers.ModelSerializer):
+    """A persisted turn — everything the UI needs to re-render it identically."""
+
+    class Meta:
+        model = AgentMessage
+        fields = ["id", "role", "content", "citations", "metadata", "created_at"]
+        read_only_fields = fields
+
+
+class ConversationListSerializer(serializers.ModelSerializer):
+    """Lightweight row for the conversation list (no messages)."""
+
+    message_count = serializers.IntegerField(read_only=True)
+
+    class Meta:
+        model = AgentConversation
+        fields = ["id", "title", "last_message_at", "created_at", "message_count"]
+        read_only_fields = ["id", "last_message_at", "created_at", "message_count"]
+
+
+class ConversationDetailSerializer(serializers.ModelSerializer):
+    """Full conversation with its ordered messages. `title` writable on create."""
+
+    messages = AgentMessageSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = AgentConversation
+        fields = ["id", "title", "last_message_at", "created_at", "messages"]
+        read_only_fields = ["id", "last_message_at", "created_at", "messages"]
+
+
+class ConversationUpdateSerializer(serializers.ModelSerializer):
+    """Rename only — the title is the sole user-editable field."""
+
+    class Meta:
+        model = AgentConversation
+        fields = ["id", "title"]
+        read_only_fields = ["id"]
+
+
+class PostMessageSerializer(serializers.Serializer):
+    question = serializers.CharField(min_length=1, max_length=2000, trim_whitespace=True)

--- a/apps/agent/tests/test_conversations_api.py
+++ b/apps/agent/tests/test_conversations_api.py
@@ -1,0 +1,268 @@
+"""Tests for the /api/agent/conversations/ endpoints."""
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from agent import service
+from agent.llm import LLMError, LLMTimeoutError
+from agent.models import AgentConversation, AgentMessage
+from households.models import Household, HouseholdMember
+
+
+BASE = "/api/agent/conversations/"
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _with_active_household(user, household):
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="conv-api-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    h = Household.objects.create(name="Conv API House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    _with_active_household(owner, h)
+    return h
+
+
+@pytest.fixture
+def owner_client(owner):
+    return _client_for(owner)
+
+
+@pytest.fixture
+def conversation(household, owner):
+    return AgentConversation.objects.create(household=household, created_by=owner)
+
+
+def _answer(text="ok", citations=None, metadata=None):
+    return service.AnswerResult(
+        answer=text,
+        citations=citations or [],
+        metadata=metadata or {"model": "m", "tokens_in": 1, "tokens_out": 2},
+    )
+
+
+def _patch_ask(monkeypatch, return_value=None, side_effect=None):
+    fake = mock.Mock(return_value=return_value, side_effect=side_effect)
+    monkeypatch.setattr("agent.views.service.ask", fake)
+    return fake
+
+
+def _rows(resp):
+    """Return the list rows whether or not the endpoint paginates."""
+    body = resp.json()
+    if isinstance(body, dict) and "results" in body:
+        return body["results"]
+    return body
+
+
+class TestAuth:
+    def test_anonymous_is_rejected(self):
+        resp = APIClient().get(BASE)
+        assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+
+class TestCreateAndList:
+    def test_create_conversation(self, owner_client, household):
+        resp = owner_client.post(BASE, {"title": "Chaudière"}, format="json")
+        assert resp.status_code == status.HTTP_201_CREATED
+        conv = AgentConversation.objects.get(id=resp.json()["id"])
+        assert conv.created_by_id is not None
+        assert conv.household_id == household.id
+        assert conv.title == "Chaudière"
+
+    def test_list_only_my_conversations(self, owner_client, household, owner):
+        AgentConversation.objects.create(household=household, created_by=owner, title="mine")
+        other = UserFactory(email="other-conv@example.com")
+        HouseholdMember.objects.create(
+            user=other, household=household, role=HouseholdMember.Role.MEMBER
+        )
+        AgentConversation.objects.create(household=household, created_by=other, title="theirs")
+
+        resp = owner_client.get(BASE)
+        assert resp.status_code == status.HTTP_200_OK
+        titles = {c["title"] for c in _rows(resp)}
+        assert "mine" in titles
+        assert "theirs" not in titles
+
+    def test_list_includes_message_count(self, owner_client, conversation):
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.USER, content="q"
+        )
+        resp = owner_client.get(BASE)
+        row = next(r for r in _rows(resp) if r["id"] == str(conversation.id))
+        assert row["message_count"] == 1
+
+
+class TestRetrieve:
+    def test_retrieve_includes_messages(self, owner_client, conversation):
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.USER, content="Q1"
+        )
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.AGENT, content="A1"
+        )
+        resp = owner_client.get(f"{BASE}{conversation.id}/")
+        assert resp.status_code == status.HTTP_200_OK
+        body = resp.json()
+        assert [m["content"] for m in body["messages"]] == ["Q1", "A1"]
+
+    def test_cannot_retrieve_another_users_conversation(self, owner_client, household):
+        other = UserFactory(email="stranger@example.com")
+        HouseholdMember.objects.create(
+            user=other, household=household, role=HouseholdMember.Role.MEMBER
+        )
+        theirs = AgentConversation.objects.create(household=household, created_by=other)
+        resp = owner_client.get(f"{BASE}{theirs.id}/")
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestPostMessage:
+    def test_happy_path_persists_both_turns_and_returns_agent_message(
+        self, owner_client, conversation, monkeypatch
+    ):
+        result = _answer(
+            text='4200 EUR <cite id="document:abc"/>',
+            citations=[
+                service.Citation(
+                    entity_type="document", id="abc", label="facture-pac",
+                    snippet="pompe", url_path="/app/documents/abc",
+                )
+            ],
+        )
+        _patch_ask(monkeypatch, return_value=result)
+
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/",
+            {"question": "combien coûte la PAC ?"},
+            format="json",
+        )
+
+        assert resp.status_code == status.HTTP_201_CREATED
+        body = resp.json()
+        assert body["role"] == "agent"
+        assert body["content"] == '4200 EUR <cite id="document:abc"/>'
+        assert body["citations"][0]["label"] == "facture-pac"
+
+        roles = list(conversation.messages.values_list("role", "content"))
+        assert roles == [("user", "combien coûte la PAC ?"), ("agent", result.answer)]
+
+    def test_sets_recency_and_auto_title_on_first_message(
+        self, owner_client, conversation, monkeypatch
+    ):
+        _patch_ask(monkeypatch, return_value=_answer())
+        owner_client.post(
+            f"{BASE}{conversation.id}/messages/",
+            {"question": "Quand a-t-on changé la chaudière ?"},
+            format="json",
+        )
+        conversation.refresh_from_db()
+        assert conversation.title == "Quand a-t-on changé la chaudière ?"
+        assert conversation.last_message_at is not None
+
+    def test_existing_title_is_not_overwritten(self, owner_client, household, owner, monkeypatch):
+        conv = AgentConversation.objects.create(
+            household=household, created_by=owner, title="Mon titre"
+        )
+        _patch_ask(monkeypatch, return_value=_answer())
+        owner_client.post(
+            f"{BASE}{conv.id}/messages/", {"question": "autre chose"}, format="json"
+        )
+        conv.refresh_from_db()
+        assert conv.title == "Mon titre"
+
+    def test_prior_turns_are_threaded_as_history(
+        self, owner_client, conversation, monkeypatch
+    ):
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.USER,
+            content="tu as la facture de la PAC ?",
+        )
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.AGENT, content="Oui, facture-pac.",
+        )
+        ask_mock = _patch_ask(monkeypatch, return_value=_answer())
+
+        owner_client.post(
+            f"{BASE}{conversation.id}/messages/", {"question": "et son prix ?"}, format="json"
+        )
+
+        history = ask_mock.call_args.kwargs["history"]
+        assert history == [
+            {"role": "user", "content": "tu as la facture de la PAC ?"},
+            {"role": "agent", "content": "Oui, facture-pac."},
+        ]
+
+    def test_blank_question_rejected(self, owner_client, conversation, monkeypatch):
+        _patch_ask(monkeypatch, return_value=_answer())
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/", {"question": "  "}, format="json"
+        )
+        assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_timeout_returns_504_and_persists_nothing(
+        self, owner_client, conversation, monkeypatch
+    ):
+        _patch_ask(monkeypatch, side_effect=LLMTimeoutError("slow"))
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/", {"question": "x"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_504_GATEWAY_TIMEOUT
+        assert conversation.messages.count() == 0
+
+    def test_llm_error_returns_503_and_persists_nothing(
+        self, owner_client, conversation, monkeypatch
+    ):
+        _patch_ask(monkeypatch, side_effect=LLMError("boom"))
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/", {"question": "x"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert conversation.messages.count() == 0
+
+    def test_cannot_post_to_another_users_conversation(self, owner_client, household):
+        other = UserFactory(email="intruder-target@example.com")
+        HouseholdMember.objects.create(
+            user=other, household=household, role=HouseholdMember.Role.MEMBER
+        )
+        theirs = AgentConversation.objects.create(household=household, created_by=other)
+        resp = owner_client.post(
+            f"{BASE}{theirs.id}/messages/", {"question": "x"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestRenameAndDelete:
+    def test_rename(self, owner_client, conversation):
+        resp = owner_client.patch(
+            f"{BASE}{conversation.id}/", {"title": "Nouveau titre"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        conversation.refresh_from_db()
+        assert conversation.title == "Nouveau titre"
+
+    def test_delete_cascades_messages(self, owner_client, conversation):
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.USER, content="q"
+        )
+        resp = owner_client.delete(f"{BASE}{conversation.id}/")
+        assert resp.status_code == status.HTTP_204_NO_CONTENT
+        assert not AgentConversation.objects.filter(id=conversation.id).exists()
+        assert AgentMessage.objects.count() == 0

--- a/apps/agent/urls.py
+++ b/apps/agent/urls.py
@@ -1,8 +1,13 @@
 """Agent URLs."""
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 
-from .views import AskView
+from .views import AskView, ConversationViewSet
+
+router = DefaultRouter()
+router.register(r"conversations", ConversationViewSet, basename="agent-conversation")
 
 urlpatterns = [
     path("ask/", AskView.as_view(), name="agent-ask"),
+    *router.urls,
 ]

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -2,9 +2,13 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict
 
-from rest_framework import status
+from django.db import transaction
+from django.db.models import Count
+from django.utils import timezone
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,9 +17,38 @@ from core.permissions import IsHouseholdMember, resolve_request_household
 
 from . import service
 from .llm import LLMError, LLMTimeoutError
-from .serializers import AskRequestSerializer, AskResponseSerializer
+from .models import AgentConversation, AgentMessage
+from .serializers import (
+    AskRequestSerializer,
+    AskResponseSerializer,
+    AgentMessageSerializer,
+    ConversationDetailSerializer,
+    ConversationListSerializer,
+    ConversationUpdateSerializer,
+    PostMessageSerializer,
+)
 
 logger = logging.getLogger(__name__)
+
+CONVERSATION_HISTORY_LIMIT = 20
+AUTO_TITLE_MAX_LEN = 60
+
+
+def _citations_to_json(citations) -> list[dict]:
+    return [
+        {
+            "entity_type": c.entity_type,
+            "id": str(c.id),
+            "label": c.label,
+            "snippet": c.snippet,
+            "url_path": c.url_path,
+        }
+        for c in citations
+    ]
+
+
+def _derive_title(question: str) -> str:
+    return " ".join((question or "").split())[:AUTO_TITLE_MAX_LEN]
 
 
 class AskView(APIView):
@@ -66,3 +99,100 @@ class AskView(APIView):
         response_serializer = AskResponseSerializer(data=payload)
         response_serializer.is_valid(raise_exception=True)
         return Response(response_serializer.validated_data, status=status.HTTP_200_OK)
+
+
+class ConversationViewSet(viewsets.ModelViewSet):
+    """CRUD on the user's agent conversations + a `messages` action to ask.
+
+    Conversations are private per user within a household. `POST
+    conversations/{id}/messages/` runs the agent with the conversation as
+    history, persists both the user turn and the agent answer, and returns the
+    agent message.
+    """
+
+    permission_classes = [IsAuthenticated, IsHouseholdMember]
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return ConversationListSerializer
+        if self.action in {"update", "partial_update"}:
+            return ConversationUpdateSerializer
+        return ConversationDetailSerializer
+
+    def get_queryset(self):
+        qs = (
+            AgentConversation.objects.for_user_households(self.request.user)
+            .filter(created_by=self.request.user)
+            .annotate(message_count=Count("messages"))
+        )
+        household = getattr(self.request, "household", None)
+        if household is not None:
+            qs = qs.filter(household=household)
+        if self.action in {"retrieve", "messages"}:
+            qs = qs.prefetch_related("messages")
+        return qs
+
+    def _resolve_household(self):
+        household = getattr(self.request, "household", None) or resolve_request_household(
+            self.request
+        )
+        if household is None:
+            raise ValidationError("No active household for this user.")
+        return household
+
+    def perform_create(self, serializer):
+        serializer.save(household=self._resolve_household(), created_by=self.request.user)
+
+    @action(detail=True, methods=["post"], url_path="messages")
+    def messages(self, request, pk=None):
+        conversation = self.get_object()
+
+        request_serializer = PostMessageSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        question = request_serializer.validated_data["question"]
+
+        # History = prior turns (oldest first), bounded. Built before we persist
+        # the new question so the current turn isn't fed back to itself.
+        prior = list(conversation.messages.all())[-CONVERSATION_HISTORY_LIMIT:]
+        history = [{"role": m.role, "content": m.content} for m in prior]
+
+        try:
+            result = service.ask(
+                question, conversation.household, user=request.user, history=history
+            )
+        except LLMTimeoutError:
+            return Response(
+                {"detail": "Agent timed out, please retry."},
+                status=status.HTTP_504_GATEWAY_TIMEOUT,
+            )
+        except LLMError as exc:
+            logger.warning("agent.messages: LLM error: %s", exc)
+            return Response(
+                {"detail": "Agent is unavailable, please retry later."},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+
+        # Persist both turns only once we have an answer — a failed call leaves
+        # the conversation untouched.
+        with transaction.atomic():
+            AgentMessage.objects.create(
+                conversation=conversation,
+                role=AgentMessage.Role.USER,
+                content=question,
+                created_by=request.user,
+            )
+            agent_msg = AgentMessage.objects.create(
+                conversation=conversation,
+                role=AgentMessage.Role.AGENT,
+                content=result.answer,
+                citations=_citations_to_json(result.citations),
+                metadata=result.metadata,
+            )
+            conversation.last_message_at = timezone.now()
+            if not conversation.title:
+                conversation.title = _derive_title(question)
+            conversation.save(update_fields=["last_message_at", "title", "updated_at"])
+
+        return Response(
+            AgentMessageSerializer(agent_msg).data, status=status.HTTP_201_CREATED
+        )


### PR DESCRIPTION
> **Lot 2/5** de la mémoire conversationnelle. Expose la ressource conversations au-dessus des modèles du lot 1 (#149). Backend uniquement — le frontend (lot 3) consommera ces endpoints.

## Endpoints (`/api/agent/conversations/`)

| Méthode | Route | Rôle |
|---|---|---|
| `GET` | `conversations/` | liste des conversations du user (récence, `message_count` annoté) |
| `POST` | `conversations/` | créer une conversation (titre optionnel) |
| `GET` | `conversations/{id}/` | conversation + messages ordonnés |
| `POST` | `conversations/{id}/messages/` | poser une question → réponse agent |
| `PATCH` | `conversations/{id}/` | renommer (titre) |
| `DELETE` | `conversations/{id}/` | supprimer (cascade messages) |

L'endpoint `ask/` stateless **reste inchangé** (rétrocompat, E2E existants intacts).

## Endpoint `messages` — le cœur

1. construit l'historique depuis les tours précédents (borné à 20) ;
2. appelle `service.ask(question, household, history=…)` ;
3. **persiste user + agent en transaction** — si le LLM échoue (504/503), **rien n'est écrit**, la conversation reste intacte ;
4. met à jour `last_message_at` et pose le **titre auto** au premier message (non écrasé ensuite).

## Sécurité / scope

- `IsAuthenticated + IsHouseholdMember`
- scope **household + `created_by`** (conversations privées par user) → la conversation d'un autre user renvoie **404**
- `AgentConversation` branche `HouseholdScopedManager` (`for_user_households`)

## Tests

16 tests API : auth, création/scope, list (isolation entre users) + `message_count`, retrieve avec messages, **threading de l'historique** vers `service.ask`, titre auto non écrasé, **504/503 sans aucune persistance**, rename, delete cascade.

Suite agent complète verte (hors 3 `test_llm.py` pré-existants). Migration inchangée (le manager n'affecte pas le schéma).

> ⚠️ Nouveaux endpoints → le lot 3 (frontend) lancera `gen:api` pour régénérer les types TS (serveur requis sur :8001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)