### PR TITLE
feat(agent): thread de conversation persistant côté frontend (lot 3)

### DIFF
--- a/e2e/agent.spec.ts
+++ b/e2e/agent.spec.ts
@@ -15,16 +15,56 @@ interface MockAnswer {
   metadata?: Record<string, unknown>;
 }
 
+const CONV_ID = 'conv-e2e-1';
+
 async function mockAskAgent(page: Page, payload: MockAnswer | (() => MockAnswer)): Promise<void> {
-  await page.route('**/api/agent/ask/', async (route: Route) => {
-    const data = typeof payload === 'function' ? payload() : payload;
+  // Empty conversation list → the first question creates a conversation.
+  await page.route('**/api/agent/conversations/', async (route: Route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: CONV_ID,
+          title: '',
+          last_message_at: null,
+          created_at: new Date().toISOString(),
+          messages: [],
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) });
+  });
+
+  // Detail fetch (if triggered) — return the empty conversation.
+  await page.route(`**/api/agent/conversations/${CONV_ID}/`, async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
       body: JSON.stringify({
-        answer: data.answer,
+        id: CONV_ID,
+        title: '',
+        last_message_at: null,
+        created_at: new Date().toISOString(),
+        messages: [],
+      }),
+    });
+  });
+
+  // Posting a message returns the persisted agent turn.
+  await page.route(`**/api/agent/conversations/${CONV_ID}/messages/`, async (route: Route) => {
+    const data = typeof payload === 'function' ? payload() : payload;
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: `msg-${Date.now()}`,
+        role: 'agent',
+        content: data.answer,
         citations: data.citations,
         metadata: data.metadata ?? { duration_ms: 1234, tokens_in: 100, tokens_out: 30, model: 'claude-haiku-4-5-20251001', hits_count: 1 },
+        created_at: new Date().toISOString(),
       }),
     });
   });
@@ -153,4 +193,75 @@ test('réponse "je ne sais pas" → message sans citation', async ({ page }) => 
   const bubble = page.getByTestId('agent-bubble-agent');
   await expect(bubble).toContainText("Je n'ai pas trouvé");
   await expect(bubble.getByTestId('agent-citation')).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// Persistance — une conversation existante se recharge au montage
+// ---------------------------------------------------------------------------
+
+test('recharge les messages d\'une conversation existante au montage', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+
+  await page.route('**/api/agent/conversations/', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: CONV_ID,
+          title: 'Chaudière',
+          last_message_at: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+          message_count: 2,
+        },
+      ]),
+    });
+  });
+
+  await page.route(`**/api/agent/conversations/${CONV_ID}/`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: CONV_ID,
+        title: 'Chaudière',
+        last_message_at: new Date().toISOString(),
+        created_at: new Date().toISOString(),
+        messages: [
+          {
+            id: 'm1',
+            role: 'user',
+            content: 'Quand a-t-on changé la chaudière ?',
+            citations: [],
+            metadata: {},
+            created_at: new Date().toISOString(),
+          },
+          {
+            id: 'm2',
+            role: 'agent',
+            content: 'En mars 2026 <cite id="document:abc-123"/>.',
+            citations: [
+              {
+                entity_type: 'document',
+                id: 'abc-123',
+                label: 'Facture chaudière',
+                snippet: 'remplacement chaudière',
+                url_path: '/app/documents/abc-123',
+              },
+            ],
+            metadata: {},
+            created_at: new Date().toISOString(),
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.goto('/app/agent');
+
+  // Les deux tours persistés se ré-affichent sans nouvelle question.
+  await expect(page.getByTestId('agent-bubble-user')).toContainText('Quand a-t-on changé la chaudière ?');
+  const agentBubble = page.getByTestId('agent-bubble-agent');
+  await expect(agentBubble).toContainText('En mars 2026');
+  await expect(agentBubble.getByTestId('agent-citation').first()).toContainText('Facture chaudière');
 });

--- a/ui/src/features/agent/AgentPage.tsx
+++ b/ui/src/features/agent/AgentPage.tsx
@@ -7,8 +7,13 @@ import { Textarea } from '@/design-system/textarea';
 import ChatBubble from './ChatBubble';
 import PrivacyNotice from './PrivacyNotice';
 import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
-import { useAskAgent } from './hooks';
-import type { AgentCitation } from './api';
+import {
+  useConversation,
+  useConversations,
+  useCreateConversation,
+  usePostMessage,
+} from './hooks';
+import type { AgentCitation, AgentMessageRow } from './api';
 
 interface UserMessage {
   id: string;
@@ -31,24 +36,58 @@ interface ErrorMessage {
 
 type Message = UserMessage | AgentMessage | ErrorMessage;
 
+function toMessage(row: AgentMessageRow): Message {
+  if (row.role === 'user') {
+    return { id: row.id, variant: 'user', text: row.content };
+  }
+  return { id: row.id, variant: 'agent', text: row.content, citations: row.citations };
+}
+
 export default function AgentPage() {
   const { t } = useTranslation();
-  const askMutation = useAskAgent();
+
+  const conversationsQuery = useConversations();
+  const [currentId, setCurrentId] = React.useState<string | null>(null);
+  const conversationQuery = useConversation(currentId);
+  const createConversation = useCreateConversation();
+  const postMessage = usePostMessage();
 
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [draft, setDraft] = React.useState('');
   const [needsPrivacy, setNeedsPrivacy] = React.useState(false);
 
+  // Guards against re-seeding local messages from a background refetch: we only
+  // load a conversation's persisted turns the first time we see it.
+  const loadedRef = React.useRef<string | null>(null);
+
   const scrollAnchorRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
+
+  const isBusy = postMessage.isPending || createConversation.isPending;
 
   React.useEffect(() => {
     setNeedsPrivacy(!hasAcceptedAgentPrivacy());
   }, []);
 
+  // On mount, continue the most recent conversation (survives reload).
+  React.useEffect(() => {
+    if (currentId === null && conversationsQuery.data && conversationsQuery.data.length > 0) {
+      setCurrentId(conversationsQuery.data[0].id);
+    }
+  }, [conversationsQuery.data, currentId]);
+
+  // Seed local messages from the loaded conversation, once per conversation.
+  React.useEffect(() => {
+    const detail = conversationQuery.data;
+    if (detail && loadedRef.current !== detail.id) {
+      loadedRef.current = detail.id;
+      setMessages(detail.messages.map(toMessage));
+    }
+  }, [conversationQuery.data]);
+
   React.useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages.length, askMutation.isPending]);
+  }, [messages.length, isBusy]);
 
   const handleAcceptPrivacy = React.useCallback(() => {
     acceptAgentPrivacy();
@@ -56,49 +95,50 @@ export default function AgentPage() {
     textareaRef.current?.focus();
   }, []);
 
-  const submit = React.useCallback(() => {
+  const submit = React.useCallback(async () => {
     const trimmed = draft.trim();
-    if (!trimmed || askMutation.isPending) return;
-    const userMsg: UserMessage = {
-      id: `u-${Date.now()}`,
-      variant: 'user',
-      text: trimmed,
-    };
-    setMessages((prev) => [...prev, userMsg]);
+    if (!trimmed || isBusy) return;
     setDraft('');
-    askMutation.mutate(trimmed, {
-      onSuccess: (data) => {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `a-${Date.now()}`,
-            variant: 'agent',
-            text: data.answer,
-            citations: data.citations,
-          },
-        ]);
-      },
-      onError: () => {
-        setMessages((prev) => [
-          ...prev,
-          {
-            id: `e-${Date.now()}`,
-            variant: 'error',
-            text: t('agent.error'),
-          },
-        ]);
-      },
-    });
-  }, [draft, askMutation, t]);
+    setMessages((prev) => [
+      ...prev,
+      { id: `u-${Date.now()}`, variant: 'user', text: trimmed },
+    ]);
+
+    try {
+      let conversationId = currentId;
+      if (!conversationId) {
+        const conversation = await createConversation.mutateAsync();
+        conversationId = conversation.id;
+        // Mark as loaded so the detail fetch doesn't clobber optimistic turns.
+        loadedRef.current = conversation.id;
+        setCurrentId(conversation.id);
+      }
+      const agentMsg = await postMessage.mutateAsync({ conversationId, question: trimmed });
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: agentMsg.id,
+          variant: 'agent',
+          text: agentMsg.content,
+          citations: agentMsg.citations,
+        },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { id: `e-${Date.now()}`, variant: 'error', text: t('agent.error') },
+      ]);
+    }
+  }, [draft, isBusy, currentId, createConversation, postMessage, t]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
-      submit();
+      void submit();
     }
   };
 
-  const isEmpty = messages.length === 0 && !askMutation.isPending;
+  const isEmpty = messages.length === 0 && !isBusy;
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -131,14 +171,14 @@ export default function AgentPage() {
               return <ErrorBubble key={msg.id} text={msg.text} />;
             })
           )}
-          {askMutation.isPending ? <ChatBubble variant="loading" /> : null}
+          {isBusy ? <ChatBubble variant="loading" /> : null}
           <div ref={scrollAnchorRef} />
         </div>
 
         <form
           onSubmit={(e) => {
             e.preventDefault();
-            submit();
+            void submit();
           }}
           className="flex items-end gap-2 rounded-xl border border-border bg-card p-2"
         >
@@ -149,13 +189,13 @@ export default function AgentPage() {
             onKeyDown={handleKeyDown}
             placeholder={t('agent.input_placeholder')}
             rows={2}
-            disabled={needsPrivacy || askMutation.isPending}
+            disabled={needsPrivacy || isBusy}
             className="min-h-0 flex-1 resize-none border-0 bg-transparent shadow-none focus-visible:ring-0"
             data-testid="agent-input"
           />
           <Button
             type="submit"
-            disabled={needsPrivacy || askMutation.isPending || draft.trim().length === 0}
+            disabled={needsPrivacy || isBusy || draft.trim().length === 0}
             data-testid="agent-send"
             aria-label={t('agent.send')}
           >

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -18,13 +18,75 @@ export interface AgentAnswerMetadata {
   [key: string]: unknown;
 }
 
-export interface AgentAnswer {
-  answer: string;
+/** A persisted conversation turn, as returned by the API. */
+export interface AgentMessageRow {
+  id: string;
+  role: 'user' | 'agent';
+  content: string;
   citations: AgentCitation[];
   metadata: AgentAnswerMetadata;
+  created_at: string;
 }
 
-export async function askAgent(question: string): Promise<AgentAnswer> {
-  const { data } = await api.post<AgentAnswer>('/agent/ask/', { question });
+/** Lightweight conversation row for the list. */
+export interface AgentConversationRow {
+  id: string;
+  title: string;
+  last_message_at: string | null;
+  created_at: string;
+  message_count?: number;
+}
+
+/** Full conversation with its ordered messages. */
+export interface AgentConversationDetail extends AgentConversationRow {
+  messages: AgentMessageRow[];
+}
+
+/** Some endpoints paginate, some don't — normalise to a plain array. */
+function asArray<T>(data: unknown): T[] {
+  if (Array.isArray(data)) return data as T[];
+  if (data && typeof data === 'object' && 'results' in data) {
+    return (data as { results: T[] }).results;
+  }
+  return [];
+}
+
+export async function listConversations(): Promise<AgentConversationRow[]> {
+  const { data } = await api.get('/agent/conversations/');
+  return asArray<AgentConversationRow>(data);
+}
+
+export async function getConversation(id: string): Promise<AgentConversationDetail> {
+  const { data } = await api.get<AgentConversationDetail>(`/agent/conversations/${id}/`);
   return data;
+}
+
+export async function createConversation(): Promise<AgentConversationDetail> {
+  const { data } = await api.post<AgentConversationDetail>('/agent/conversations/', {});
+  return data;
+}
+
+export async function postConversationMessage(
+  conversationId: string,
+  question: string,
+): Promise<AgentMessageRow> {
+  const { data } = await api.post<AgentMessageRow>(
+    `/agent/conversations/${conversationId}/messages/`,
+    { question },
+  );
+  return data;
+}
+
+export async function renameConversation(
+  id: string,
+  title: string,
+): Promise<AgentConversationRow> {
+  const { data } = await api.patch<AgentConversationRow>(`/agent/conversations/${id}/`, {
+    title,
+  });
+  return data;
+}
+
+export async function deleteConversation(id: string): Promise<void> {
+  await api.delete(`/agent/conversations/${id}/`);
 }

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -1,8 +1,82 @@
-import { useMutation } from '@tanstack/react-query';
-import { askAgent, type AgentAnswer } from './api';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  createConversation,
+  deleteConversation,
+  getConversation,
+  listConversations,
+  postConversationMessage,
+  renameConversation,
+  type AgentConversationDetail,
+  type AgentConversationRow,
+  type AgentMessageRow,
+} from './api';
 
-export function useAskAgent() {
-  return useMutation<AgentAnswer, unknown, string>({
-    mutationFn: (question: string) => askAgent(question),
+export const agentKeys = {
+  all: ['agent'] as const,
+  conversations: () => [...agentKeys.all, 'conversations'] as const,
+  conversation: (id: string | null) => [...agentKeys.all, 'conversation', id] as const,
+};
+
+export function useConversations() {
+  return useQuery<AgentConversationRow[]>({
+    queryKey: agentKeys.conversations(),
+    queryFn: listConversations,
+  });
+}
+
+export function useConversation(id: string | null) {
+  return useQuery<AgentConversationDetail>({
+    queryKey: agentKeys.conversation(id),
+    queryFn: () => getConversation(id as string),
+    enabled: Boolean(id),
+  });
+}
+
+export function useCreateConversation() {
+  const qc = useQueryClient();
+  return useMutation<AgentConversationDetail, unknown, void>({
+    mutationFn: () => createConversation(),
+    onSuccess: (conversation) => {
+      // Seed the detail cache so opening it needs no extra round-trip.
+      qc.setQueryData(agentKeys.conversation(conversation.id), conversation);
+      void qc.invalidateQueries({ queryKey: agentKeys.conversations() });
+    },
+  });
+}
+
+export function usePostMessage() {
+  const qc = useQueryClient();
+  return useMutation<
+    AgentMessageRow,
+    unknown,
+    { conversationId: string; question: string }
+  >({
+    mutationFn: ({ conversationId, question }) =>
+      postConversationMessage(conversationId, question),
+    onSuccess: (_msg, { conversationId }) => {
+      // Recency + auto-title change on the server; refresh the list. The detail
+      // is kept in sync locally by the page, so we don't refetch it here.
+      void qc.invalidateQueries({ queryKey: agentKeys.conversations() });
+      void qc.invalidateQueries({
+        queryKey: agentKeys.conversation(conversationId),
+        refetchType: 'none',
+      });
+    },
+  });
+}
+
+export function useRenameConversation() {
+  const qc = useQueryClient();
+  return useMutation<AgentConversationRow, unknown, { id: string; title: string }>({
+    mutationFn: ({ id, title }) => renameConversation(id, title),
+    onSuccess: () => qc.invalidateQueries({ queryKey: agentKeys.conversations() }),
+  });
+}
+
+export function useDeleteConversation() {
+  const qc = useQueryClient();
+  return useMutation<void, unknown, string>({
+    mutationFn: (id) => deleteConversation(id),
+    onSuccess: () => qc.invalidateQueries({ queryKey: agentKeys.conversations() }),
   });
 }


### PR DESCRIPTION
> **Lot 3/5** de la mémoire conversationnelle. Le frontend consomme la ressource conversations (#150). Les échanges **survivent au reload**. Reste : sidebar + gestion (lot 4), rétention (lot 5).

## Ce qui change

La page agent posait ses questions à l'endpoint `ask/` stateless et gardait les bulles en mémoire React (perdues au reload). Elle utilise maintenant les conversations persistées :

- **`api.ts`** : types + fonctions conversations (`list/get/create/postMessage/rename/delete`), écrits main (convention du feature agent, pas `gen:api`).
- **`hooks.ts`** : `agentKeys` + hooks react-query (`useConversations`, `useConversation`, `useCreateConversation`, `usePostMessage` ; `rename`/`delete` déjà prêts pour le lot 4).
- **`AgentPage`** :
  - au montage, reprend la **conversation la plus récente** et ré-affiche ses messages ;
  - le 1er message **crée une conversation à la volée** puis y poste ;
  - seed local **une fois par conversation** (garde `loadedRef`) pour qu'un refetch de fond n'écrase pas les tours optimistes.
- `ChatBubble` / `AgentCitation` / `PrivacyNotice` **réutilisés tels quels**.

## Compatibilité

- L'endpoint `ask/` reste en place côté backend (rétrocompat) ; le front ne l'utilise simplement plus.
- Aucune nouvelle clé i18n (clés `agent.*` existantes réutilisées).

## Tests

E2E `agent.spec.ts` : mocks adaptés aux endpoints conversations (list vide → création à la volée ; post → tour agent) + **nouveau test « recharge les messages d'une conversation existante au montage »**.

**8 tests E2E verts** (lancés localement contre le vrai serveur Django E2E servant le build). `npm run lint` : 0 erreur. `npm run build` : OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)