### PR TITLE
feat(agent): sidebar de conversations — liste, nouvelle, renommer, supprimer (lot 4)

### DIFF
--- a/e2e/agent.spec.ts
+++ b/e2e/agent.spec.ts
@@ -265,3 +265,79 @@ test('recharge les messages d\'une conversation existante au montage', async ({ 
   await expect(agentBubble).toContainText('En mars 2026');
   await expect(agentBubble.getByTestId('agent-citation').first()).toContainText('Facture chaudière');
 });
+
+// ---------------------------------------------------------------------------
+// Sidebar — liste, bascule, nouvelle conversation
+// ---------------------------------------------------------------------------
+
+function conversationDetail(id: string, title: string, userText: string, agentText: string) {
+  const now = new Date().toISOString();
+  return {
+    id,
+    title,
+    last_message_at: now,
+    created_at: now,
+    messages: [
+      { id: `${id}-u`, role: 'user', content: userText, citations: [], metadata: {}, created_at: now },
+      { id: `${id}-a`, role: 'agent', content: agentText, citations: [], metadata: {}, created_at: now },
+    ],
+  };
+}
+
+async function mockSidebar(page: Page): Promise<void> {
+  const now = new Date().toISOString();
+  await page.route('**/api/agent/conversations/', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        { id: 'conv-a', title: 'Chaudière', last_message_at: now, created_at: now, message_count: 2 },
+        { id: 'conv-b', title: 'Assurance', last_message_at: now, created_at: now, message_count: 2 },
+      ]),
+    });
+  });
+  await page.route('**/api/agent/conversations/conv-a/', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(conversationDetail('conv-a', 'Chaudière', 'Question chaudière', 'Réponse chaudière')),
+    });
+  });
+  await page.route('**/api/agent/conversations/conv-b/', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(conversationDetail('conv-b', 'Assurance', 'Question assurance', 'Réponse assurance')),
+    });
+  });
+}
+
+test('la sidebar liste les conversations et permet de basculer', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await mockSidebar(page);
+
+  await page.goto('/app/agent');
+
+  // Au montage, la plus récente (conv-a) est ouverte.
+  await expect(page.getByTestId('agent-conversation-list')).toContainText('Chaudière');
+  await expect(page.getByTestId('agent-conversation-list')).toContainText('Assurance');
+  await expect(page.getByTestId('agent-bubble-agent')).toContainText('Réponse chaudière');
+
+  // Bascule vers l'autre conversation.
+  await page.getByTestId('agent-conversation-item').filter({ hasText: 'Assurance' }).getByRole('button').first().click();
+  await expect(page.getByTestId('agent-bubble-agent')).toContainText('Réponse assurance');
+});
+
+test('« nouvelle conversation » vide l\'écran', async ({ page }) => {
+  await setPrivacyAccepted(page, true);
+  await mockSidebar(page);
+
+  await page.goto('/app/agent');
+  await expect(page.getByTestId('agent-bubble-agent')).toContainText('Réponse chaudière');
+
+  await page.getByTestId('agent-new-conversation').first().click();
+
+  // Retour à l'état vide (aucune bulle).
+  await expect(page.getByTestId('agent-bubble-agent')).toHaveCount(0);
+  await expect(page.getByTestId('agent-messages')).toContainText('Pose toutes tes questions');
+});

--- a/ui/src/features/agent/AgentPage.tsx
+++ b/ui/src/features/agent/AgentPage.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
-import { Send, Sparkles, AlertTriangle } from 'lucide-react';
+import { Send, Sparkles, AlertTriangle, History } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/PageHeader';
 import { Button } from '@/design-system/button';
 import { Textarea } from '@/design-system/textarea';
+import { SheetDialog } from '@/design-system/sheet-dialog';
 import ChatBubble from './ChatBubble';
+import ConversationList from './ConversationList';
 import PrivacyNotice from './PrivacyNotice';
 import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
 import {
@@ -59,6 +61,9 @@ export default function AgentPage() {
   // Guards against re-seeding local messages from a background refetch: we only
   // load a conversation's persisted turns the first time we see it.
   const loadedRef = React.useRef<string | null>(null);
+  // Auto-select the latest conversation only once, on first load — so clicking
+  // "New conversation" (currentId → null) isn't immediately overridden.
+  const initializedRef = React.useRef(false);
 
   const scrollAnchorRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
@@ -69,12 +74,31 @@ export default function AgentPage() {
     setNeedsPrivacy(!hasAcceptedAgentPrivacy());
   }, []);
 
-  // On mount, continue the most recent conversation (survives reload).
+  // On first load, continue the most recent conversation (survives reload).
   React.useEffect(() => {
-    if (currentId === null && conversationsQuery.data && conversationsQuery.data.length > 0) {
-      setCurrentId(conversationsQuery.data[0].id);
+    if (!initializedRef.current && conversationsQuery.data) {
+      initializedRef.current = true;
+      if (conversationsQuery.data.length > 0) {
+        setCurrentId(conversationsQuery.data[0].id);
+      }
     }
-  }, [conversationsQuery.data, currentId]);
+  }, [conversationsQuery.data]);
+
+  const handleSelect = React.useCallback(
+    (id: string) => {
+      if (id === currentId) return;
+      loadedRef.current = null;
+      setMessages([]);
+      setCurrentId(id);
+    },
+    [currentId],
+  );
+
+  const handleNew = React.useCallback(() => {
+    loadedRef.current = null;
+    setMessages([]);
+    setCurrentId(null);
+  }, []);
 
   // Seed local messages from the loaded conversation, once per conversation.
   React.useEffect(() => {
@@ -142,11 +166,51 @@ export default function AgentPage() {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <PageHeader title={t('agent.title')} description={t('agent.description')} />
+      <PageHeader title={t('agent.title')} description={t('agent.description')}>
+        <SheetDialog
+          title={t('agent.conversations')}
+          trigger={
+            <Button
+              variant="outline"
+              size="icon"
+              className="md:hidden"
+              aria-label={t('agent.conversations')}
+              data-testid="agent-conversations-toggle"
+            >
+              <History className="h-4 w-4" />
+            </Button>
+          }
+        >
+          {({ close }) => (
+            <ConversationList
+              currentId={currentId}
+              onSelect={(id) => {
+                handleSelect(id);
+                close();
+              }}
+              onNew={() => {
+                handleNew();
+                close();
+              }}
+              onCurrentDeleted={handleNew}
+            />
+          )}
+        </SheetDialog>
+      </PageHeader>
 
       <PrivacyNotice open={needsPrivacy} onAccept={handleAcceptPrivacy} />
 
-      <div className="flex min-h-0 flex-1 flex-col gap-4">
+      <div className="flex min-h-0 flex-1 gap-4">
+        <aside className="hidden w-64 shrink-0 border-r border-border pr-3 md:flex md:flex-col">
+          <ConversationList
+            currentId={currentId}
+            onSelect={handleSelect}
+            onNew={handleNew}
+            onCurrentDeleted={handleNew}
+          />
+        </aside>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-4">
         <div
           className="min-h-0 flex-1 space-y-3 overflow-y-auto pr-1"
           data-testid="agent-messages"
@@ -202,6 +266,7 @@ export default function AgentPage() {
             <Send className="h-4 w-4" />
           </Button>
         </form>
+        </div>
       </div>
     </div>
   );

--- a/ui/src/features/agent/ConversationList.tsx
+++ b/ui/src/features/agent/ConversationList.tsx
@@ -1,0 +1,161 @@
+import * as React from 'react';
+import { Plus, Pencil, Trash2, MessageSquare } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/design-system/button';
+import { Input } from '@/design-system/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/design-system/dialog';
+import CardActions, { type CardAction } from '@/components/CardActions';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import { cn } from '@/lib/utils';
+import { agentKeys, useConversations, useRenameConversation } from './hooks';
+import { deleteConversation, type AgentConversationRow } from './api';
+
+interface Props {
+  currentId: string | null;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  /** Called when the currently-open conversation is deleted. */
+  onCurrentDeleted: () => void;
+}
+
+export default function ConversationList({ currentId, onSelect, onNew, onCurrentDeleted }: Props) {
+  const { t } = useTranslation();
+  const qc = useQueryClient();
+  const { data: conversations } = useConversations();
+  const rename = useRenameConversation();
+
+  const [renaming, setRenaming] = React.useState<AgentConversationRow | null>(null);
+  const [renameTitle, setRenameTitle] = React.useState('');
+
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('agent.deleted'),
+    onDelete: (id) => deleteConversation(id),
+  });
+
+  const handleDelete = (conv: AgentConversationRow) => {
+    deleteWithUndo(conv.id, {
+      onRemove: () =>
+        qc.setQueryData<AgentConversationRow[]>(agentKeys.conversations(), (old) =>
+          (old ?? []).filter((c) => c.id !== conv.id),
+        ),
+      onRestore: () => void qc.invalidateQueries({ queryKey: agentKeys.conversations() }),
+    });
+    if (conv.id === currentId) onCurrentDeleted();
+  };
+
+  const openRename = (conv: AgentConversationRow) => {
+    setRenaming(conv);
+    setRenameTitle(conv.title);
+  };
+
+  const submitRename = () => {
+    if (!renaming) return;
+    const title = renameTitle.trim();
+    if (title) rename.mutate({ id: renaming.id, title });
+    setRenaming(null);
+  };
+
+  const items = conversations ?? [];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <Button
+        onClick={onNew}
+        variant="outline"
+        className="w-full justify-start gap-2"
+        data-testid="agent-new-conversation"
+      >
+        <Plus className="h-4 w-4" />
+        {t('agent.new_conversation')}
+      </Button>
+
+      <div
+        className="min-h-0 flex-1 space-y-1 overflow-y-auto"
+        data-testid="agent-conversation-list"
+      >
+        {items.length === 0 ? (
+          <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+            {t('agent.conversations_empty')}
+          </p>
+        ) : (
+          items.map((conv) => {
+            const active = conv.id === currentId;
+            const actions: CardAction[] = [
+              { label: t('common.edit'), icon: Pencil, onClick: () => openRename(conv) },
+              {
+                label: t('common.delete'),
+                icon: Trash2,
+                onClick: () => handleDelete(conv),
+                variant: 'danger',
+              },
+            ];
+            return (
+              <div
+                key={conv.id}
+                className={cn(
+                  'group flex items-center gap-1 rounded-lg px-1',
+                  active ? 'bg-primary/10' : 'hover:bg-muted',
+                )}
+                data-testid="agent-conversation-item"
+              >
+                <button
+                  type="button"
+                  onClick={() => onSelect(conv.id)}
+                  className={cn(
+                    'flex min-w-0 flex-1 items-center gap-2 px-2 py-2 text-left text-sm',
+                    active ? 'text-primary' : 'text-foreground',
+                  )}
+                >
+                  <MessageSquare className="h-3.5 w-3.5 shrink-0 opacity-60" />
+                  <span className="truncate">{conv.title || t('agent.untitled')}</span>
+                </button>
+                <CardActions actions={actions} />
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <Dialog
+        open={renaming !== null}
+        onOpenChange={(open) => {
+          if (!open) setRenaming(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t('agent.rename_title')}</DialogTitle>
+          </DialogHeader>
+          <Input
+            value={renameTitle}
+            onChange={(e) => setRenameTitle(e.target.value)}
+            placeholder={t('agent.rename_placeholder')}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                submitRename();
+              }
+            }}
+            autoFocus
+            data-testid="agent-rename-input"
+          />
+          <DialogFooter>
+            <Button variant="ghost" onClick={() => setRenaming(null)}>
+              {t('common.cancel')}
+            </Button>
+            <Button onClick={submitRename} data-testid="agent-rename-save">
+              {t('common.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1637,7 +1637,14 @@
       "point_scope": "Es werden nur Daten deines Haushalts geteilt, niemals Daten eines anderen Haushalts.",
       "point_retention": "Wir protokollieren Nutzungsstatistiken (Latenz, Erfolg), nicht aber den Inhalt deiner Unterhaltungen.",
       "accept": "Verstanden"
-    }
+    },
+    "conversations": "Unterhaltungen",
+    "new_conversation": "Neue Unterhaltung",
+    "untitled": "Ohne Titel",
+    "rename_title": "Unterhaltung umbenennen",
+    "rename_placeholder": "Titel der Unterhaltung",
+    "deleted": "Unterhaltung gelöscht",
+    "conversations_empty": "Noch keine Unterhaltungen"
   },
   "expenses": {
     "title": "Ausgaben",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1637,7 +1637,14 @@
       "point_scope": "Only data from your household is shared, never data from another household.",
       "point_retention": "We log usage statistics (latency, success) but not the content of your conversations.",
       "accept": "Got it"
-    }
+    },
+    "conversations": "Conversations",
+    "new_conversation": "New conversation",
+    "untitled": "Untitled",
+    "rename_title": "Rename conversation",
+    "rename_placeholder": "Conversation title",
+    "deleted": "Conversation deleted",
+    "conversations_empty": "No conversations yet"
   },
   "expenses": {
     "title": "Expenses",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1637,7 +1637,14 @@
       "point_scope": "Solo se comparten datos de tu hogar, nunca de otro hogar.",
       "point_retention": "Registramos estadísticas de uso (latencia, éxito) pero no el contenido de tus conversaciones.",
       "accept": "Entendido"
-    }
+    },
+    "conversations": "Conversaciones",
+    "new_conversation": "Nueva conversación",
+    "untitled": "Sin título",
+    "rename_title": "Renombrar conversación",
+    "rename_placeholder": "Título de la conversación",
+    "deleted": "Conversación eliminada",
+    "conversations_empty": "Aún no hay conversaciones"
   },
   "expenses": {
     "title": "Gastos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1637,7 +1637,14 @@
       "point_scope": "Seules les données de ton foyer sont transmises, jamais celles d'un autre foyer.",
       "point_retention": "On enregistre les statistiques d'usage (latence, succès) mais pas le contenu de tes conversations.",
       "accept": "J'ai compris"
-    }
+    },
+    "conversations": "Conversations",
+    "new_conversation": "Nouvelle conversation",
+    "untitled": "Sans titre",
+    "rename_title": "Renommer la conversation",
+    "rename_placeholder": "Titre de la conversation",
+    "deleted": "Conversation supprimée",
+    "conversations_empty": "Aucune conversation"
   },
   "expenses": {
     "title": "Dépenses",


### PR DESCRIPTION
> **Lot 4/5** de la mémoire conversationnelle. Rend la V2 complète côté produit : gestion des conversations. Reste : rétention (lot 5).

## Ce qui est ajouté

- **`ConversationList`** (nouveau) :
  - liste des conversations triées par récence, item actif surligné ;
  - bouton **« Nouvelle conversation »** ;
  - dropdown par item (`CardActions`) → **renommer** (dialog + input) et **supprimer avec undo** (`useDeleteWithUndo` + retrait optimiste du cache react-query).
- **`AgentPage`** :
  - **sidebar persistante** en desktop (`hidden md:flex`, `w-64`) ;
  - **drawer** `SheetDialog` en mobile, déclenché par une icône `History` dans le header ;
  - bascule de conversation (reset local + re-seed à l'arrivée du détail) ;
  - auto-sélection de la plus récente **une seule fois** (`initializedRef`) pour ne pas court-circuiter « Nouvelle conversation ».

## i18n

7 clés `agent.*` ajoutées en **en/fr/de/es** (insertion chirurgicale, pas de reformat) : `conversations`, `new_conversation`, `untitled`, `rename_title`, `rename_placeholder`, `deleted`, `conversations_empty`. Réutilise `common.edit/delete/cancel/save`.

## Tests

E2E `agent.spec.ts` : **liste + bascule entre conversations**, **« nouvelle conversation » vide l'écran**. **10 tests verts** (lancés localement contre le serveur Django E2E). `npm run lint` : 0 erreur. `npm run build` : OK.

## Reste (lot 5)

Management command de rétention (nettoyage des vieilles conversations) + doc du parcours 07 mise à jour (Story 4 livrée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)