### PR TITLE
feat(agent): registry de tools + search_household (lot 7, PR 2/4)

### DIFF
--- a/apps/agent/apps.py
+++ b/apps/agent/apps.py
@@ -4,3 +4,10 @@ from django.apps import AppConfig
 class AgentConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "agent"
+
+    def ready(self):
+        # Register the agent's built-in tools. Kept here (not at import time) so
+        # the registry is populated once the app registry is ready.
+        from .tools import build_search_household_tool, register
+
+        register(build_search_household_tool())

--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -60,6 +60,44 @@ Rules — follow them all:
 HISTORY_CHAR_BUDGET = 4000
 
 
+def render_context_block(
+    hits: list[Hit],
+    *,
+    content_top_n: int = CONTENT_TOP_N,
+    char_budget_per_hit: int = CHAR_BUDGET_PER_HIT,
+    total_char_budget: int = TOTAL_CHAR_BUDGET,
+) -> str:
+    """Render retrieval hits into the labelled, citable context block.
+
+    Shared by ``build_user_prompt`` (legacy one-shot prompt) and the
+    ``search_household`` tool, which feeds this block back to the model as a
+    ``tool_result``. The first ``content_top_n`` hits get their full content
+    (within budget); the rest fall back to their short headline snippet.
+    """
+    if not hits:
+        return "(no household items matched this question)"
+
+    rendered = []
+    remaining = total_char_budget
+    for index, hit in enumerate(hits):
+        tag = f"{hit.entity_type}:{hit.id}"
+        content = (hit.content or "").strip()
+        if index < content_top_n and remaining > 0 and content:
+            body = _truncate(content, min(char_budget_per_hit, remaining))
+            remaining -= len(body)
+            field = "content"
+        else:
+            body = (hit.snippet or "").strip() or "(no snippet)"
+            field = "excerpt"
+        rendered.append(
+            f"- id={tag}\n"
+            f"  label={hit.label}\n"
+            f"  url={hit.url_path}\n"
+            f"  {field}: {body}"
+        )
+    return "\n".join(rendered)
+
+
 def build_user_prompt(
     question: str,
     hits: list[Hit],
@@ -78,28 +116,12 @@ def build_user_prompt(
     ``history`` is an optional list of prior turns (``{"role", "content"}``,
     oldest first) replayed so the model can resolve follow-up references.
     """
-    if not hits:
-        context_block = "(no household items matched this question)"
-    else:
-        rendered = []
-        remaining = total_char_budget
-        for index, hit in enumerate(hits):
-            tag = f"{hit.entity_type}:{hit.id}"
-            content = (hit.content or "").strip()
-            if index < content_top_n and remaining > 0 and content:
-                body = _truncate(content, min(char_budget_per_hit, remaining))
-                remaining -= len(body)
-                field = "content"
-            else:
-                body = (hit.snippet or "").strip() or "(no snippet)"
-                field = "excerpt"
-            rendered.append(
-                f"- id={tag}\n"
-                f"  label={hit.label}\n"
-                f"  url={hit.url_path}\n"
-                f"  {field}: {body}"
-            )
-        context_block = "\n".join(rendered)
+    context_block = render_context_block(
+        hits,
+        content_top_n=content_top_n,
+        char_budget_per_hit=char_budget_per_hit,
+        total_char_budget=total_char_budget,
+    )
 
     history_block = _render_history(history)
 

--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -1,0 +1,182 @@
+"""Tests for the agent tool registry + the search_household tool.
+
+Retrieval runs against the real Postgres full-text layer, but the LLM is always
+faked — query expansion degrades to the raw query when the fake returns no
+extra terms, so there is zero network in CI.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent import tools
+from agent.llm import LLMResponse
+from agent.tools import (
+    REGISTRY,
+    AgentTool,
+    ToolResult,
+    build_search_household_tool,
+    dispatch,
+    register,
+    reset_registry,
+    schemas,
+)
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="tools-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    h = Household.objects.create(name="Tools House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    return h
+
+
+@pytest.fixture
+def make_document(household, owner):
+    from documents.models import Document
+
+    def _make(**overrides):
+        payload = dict(
+            household=household,
+            created_by=owner,
+            file_path="documents/x.pdf",
+            name="generic",
+            mime_type="application/pdf",
+            type="document",
+            ocr_text="",
+            notes="",
+        )
+        payload.update(overrides)
+        return Document.objects.create(**payload)
+
+    return _make
+
+
+class _FakeLLM:
+    """Fake LLM client: query expansion falls back to the raw query."""
+
+    provider = "fake"
+
+    def complete(self, **kwargs) -> LLMResponse:
+        return LLMResponse(text="", input_tokens=1, output_tokens=1, duration_ms=0, model="fake")
+
+    def run(self, **kwargs):  # pragma: no cover - not used by these tests
+        raise NotImplementedError
+
+
+@pytest.fixture
+def fresh_registry():
+    """Snapshot/restore the global registry so a test can't pollute others."""
+    snapshot = dict(REGISTRY)
+    reset_registry()
+    yield
+    reset_registry()
+    REGISTRY.update(snapshot)
+
+
+def _dummy_tool(name: str = "dummy") -> AgentTool:
+    return AgentTool(
+        name=name,
+        description="dummy",
+        input_schema={"type": "object", "properties": {}},
+        handler=lambda **kw: ToolResult(rendered="ok"),
+    )
+
+
+class TestRegistry:
+    def test_register_adds_tool(self, fresh_registry):
+        tool = _dummy_tool()
+        register(tool)
+        assert REGISTRY["dummy"] is tool
+
+    def test_double_register_raises(self, fresh_registry):
+        register(_dummy_tool())
+        with pytest.raises(ValueError, match="already registered"):
+            register(_dummy_tool())
+
+    def test_schemas_exposes_name_description_input_schema(self, fresh_registry):
+        register(_dummy_tool("alpha"))
+        (schema,) = schemas()
+        assert schema["name"] == "alpha"
+        assert schema["description"] == "dummy"
+        assert schema["input_schema"] == {"type": "object", "properties": {}}
+
+
+class TestBootRegistry:
+    def test_search_household_registered_at_boot(self):
+        assert tools.SEARCH_HOUSEHOLD in REGISTRY
+
+    def test_search_household_schema_requires_query(self):
+        schema = REGISTRY[tools.SEARCH_HOUSEHOLD].to_schema()
+        assert schema["input_schema"]["required"] == ["query"]
+
+
+class TestDispatch:
+    def test_unknown_tool_returns_recoverable_result(self, household):
+        result = dispatch("nope", {}, household=household)
+        assert isinstance(result, ToolResult)
+        assert "unknown tool" in result.rendered.lower()
+        assert result.hits == []
+
+    def test_dispatch_routes_to_handler(self, fresh_registry, household):
+        register(_dummy_tool("alpha"))
+        result = dispatch("alpha", {}, household=household)
+        assert result.rendered == "ok"
+
+
+class TestSearchHousehold:
+    def test_empty_query_searches_nothing(self, household):
+        result = dispatch(
+            tools.SEARCH_HOUSEHOLD, {"query": "   "}, household=household, client=_FakeLLM()
+        )
+        assert result.hits == []
+        assert "empty query" in result.rendered.lower()
+
+    def test_returns_hits_and_citable_block(self, household, owner, make_document):
+        doc = make_document(name="Facture Engie mars", ocr_text="total 142,67 EUR Engie")
+        result = dispatch(
+            tools.SEARCH_HOUSEHOLD,
+            {"query": "Engie"},
+            household=household,
+            user=owner,
+            client=_FakeLLM(),
+        )
+        assert any(h.id == doc.id for h in result.hits)
+        assert f"id=document:{doc.id}" in result.rendered
+        assert "Facture Engie mars" in result.rendered
+
+    def test_no_match_returns_empty_marker(self, household, owner, make_document):
+        make_document(name="Facture Engie", ocr_text="électricité")
+        result = dispatch(
+            tools.SEARCH_HOUSEHOLD,
+            {"query": "zzznomatchzzz"},
+            household=household,
+            user=owner,
+            client=_FakeLLM(),
+        )
+        assert result.hits == []
+        assert "no household items matched" in result.rendered.lower()
+
+    def test_scoped_to_household(self, household, owner, make_document, db):
+        from households.models import Household, HouseholdMember
+
+        other = Household.objects.create(name="Other Tools House")
+        HouseholdMember.objects.create(
+            user=owner, household=other, role=HouseholdMember.Role.OWNER
+        )
+        make_document(name="Facture Engie", ocr_text="Engie")  # in `household`
+        result = dispatch(
+            tools.SEARCH_HOUSEHOLD,
+            {"query": "Engie"},
+            household=other,
+            user=owner,
+            client=_FakeLLM(),
+        )
+        assert result.hits == []

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -1,0 +1,170 @@
+"""
+Agent tool registry — the base of function calling.
+
+Same pattern as ``searchables.py``: each tool declares itself, the orchestrator
+(``service.ask``) never hardcodes the tool list. The first — and for now only —
+tool is ``search_household``, which wraps query expansion + retrieval so the
+model pulls household facts **on demand** instead of the pipeline searching on
+every turn.
+
+Adding a future tool (``create_interaction``, ``create_task``, …) = one
+``register(...)`` call, no change to ``service.py``.
+
+Contract:
+- ``AgentTool`` carries the Anthropic tool schema (name / description /
+  input_schema) plus a ``handler``.
+- A handler receives ``household``, ``user``, the raw ``tool_input`` dict, and an
+  optional ``client`` (so the loop can share its LLM client). It returns a
+  ``ToolResult`` with the text to feed back to the model (``rendered``) and, for
+  retrieval tools, the ``hits`` used to keep citations honest.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import query_expansion, retrieval
+from .llm import LLMClient, get_llm_client
+from .prompts import render_context_block
+from .retrieval import Hit
+
+logger = logging.getLogger(__name__)
+
+# How many hits a single search returns. Mirrors the historical pipeline limit.
+SEARCH_RETRIEVAL_LIMIT = 12
+
+
+@dataclass
+class ToolResult:
+    """Outcome of a tool call.
+
+    ``rendered`` is the text injected back into the conversation as a
+    ``tool_result`` block. ``hits`` is the retrieval hits (empty for non-search
+    tools) that the orchestrator accumulates into the citation pool.
+    """
+
+    rendered: str
+    hits: list[Hit] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class AgentTool:
+    name: str
+    description: str
+    input_schema: dict
+    handler: Callable[..., ToolResult]
+
+    def to_schema(self) -> dict:
+        """Return the Anthropic tools API schema for this tool."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.input_schema,
+        }
+
+
+REGISTRY: dict[str, AgentTool] = {}
+
+
+def register(tool: AgentTool) -> None:
+    """Register a tool. Double registration is a programming error."""
+    if tool.name in REGISTRY:
+        raise ValueError(f"Agent tool already registered: {tool.name!r}")
+    REGISTRY[tool.name] = tool
+
+
+def reset_registry() -> None:
+    """Clear the registry — test helper only."""
+    REGISTRY.clear()
+
+
+def schemas() -> list[dict]:
+    """Return the tool schemas to pass to the LLM (stable order)."""
+    return [tool.to_schema() for tool in REGISTRY.values()]
+
+
+def dispatch(
+    name: str,
+    tool_input: dict[str, Any] | None,
+    *,
+    household,
+    user=None,
+    client: LLMClient | None = None,
+) -> ToolResult:
+    """Run the registered handler for ``name``.
+
+    An unknown tool name never raises into the loop — it returns a ``ToolResult``
+    the model can read and recover from.
+    """
+    tool = REGISTRY.get(name)
+    if tool is None:
+        logger.warning("agent.tools: unknown tool requested: %s", name)
+        return ToolResult(rendered=f"(unknown tool: {name})")
+    return tool.handler(
+        household=household,
+        user=user,
+        tool_input=tool_input or {},
+        client=client,
+    )
+
+
+# --- search_household -------------------------------------------------------
+
+SEARCH_HOUSEHOLD = "search_household"
+
+_SEARCH_HOUSEHOLD_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {
+            "type": "string",
+            "description": (
+                "Keywords or a short phrase to look up in the household data "
+                "(documents, interactions, equipment, tasks, projects, zones, "
+                "stock, insurance, contacts). Use the subject of the question, "
+                "not a full sentence."
+            ),
+        }
+    },
+    "required": ["query"],
+}
+
+_SEARCH_HOUSEHOLD_DESCRIPTION = (
+    "Search the family's household data and return matching items with their "
+    "citable ids. Call this before stating any fact about the household "
+    "(amounts, dates, brands, equipment, contracts, contacts). Returns nothing "
+    "when the household has no matching data."
+)
+
+
+def _search_household_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client: LLMClient | None = None,
+) -> ToolResult:
+    """Expand the query, run scoped retrieval, render a citable context block."""
+    query = (tool_input.get("query") or "").strip()
+    if not query:
+        return ToolResult(rendered="(empty query — nothing searched)")
+
+    llm = client or get_llm_client()
+    terms = query_expansion.expand(
+        query,
+        client=llm,
+        household_id=household.id,
+        user_id=getattr(user, "id", None),
+    )
+    hits = retrieval.search_multi(household.id, terms, limit=SEARCH_RETRIEVAL_LIMIT)
+    return ToolResult(rendered=render_context_block(hits), hits=hits)
+
+
+def build_search_household_tool() -> AgentTool:
+    return AgentTool(
+        name=SEARCH_HOUSEHOLD,
+        description=_SEARCH_HOUSEHOLD_DESCRIPTION,
+        input_schema=_SEARCH_HOUSEHOLD_SCHEMA,
+        handler=_search_household_handler,
+    )


### PR DESCRIPTION
## Contexte

Deuxième PR du **lot 7 — function calling**. Plan : `docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md`. S'appuie sur PR 1 (#154, contrat `llm.run()`).

## Cette PR (2/4) — le socle registry + le 1er tool

- **`apps/agent/tools.py`** (nouveau) : registry générique (`AgentTool`, `ToolResult`, `register`/`schemas`/`dispatch`/`reset_registry`), même pattern que `searchables.py`. Ajouter un futur tool (`create_interaction`…) = un `register(...)`.
- **`search_household`** : 1er tool, enveloppe query expansion + retrieval scoped household. Rend le bloc de contexte citable (`id=entity_type:id`) pour que les citations restent honnêtes.
- **`prompts.py`** : extraction de `render_context_block` (réutilisé par le tool ET `build_user_prompt`, comportement inchangé).
- **`apps.py`** : `register(search_household)` au boot.

**Rien n'est encore branché dans `service.ask`** — aucun changement de comportement utilisateur (PR 3).

## Tests

- Registry : add, double-register raises, `schemas()`, présence au boot.
- Dispatch : tool inconnu → `ToolResult` récupérable (pas d'exception dans la boucle).
- `search_household` : query vide, hits + bloc citable, no-match, **scope household**.
- LLM faké (query expansion dégrade sur la query brute) → zéro réseau. Suite complète : 865 passed.

## Suite

- PR 3 : boucle tool-use dans `service.py` + nouveau system prompt 3-niveaux (change le comportement)
- PR 4 : doc + recette