### PR TITLE
feat(agent): tool get_entity — lecture complète d'une entité par id

### DIFF
--- a/apps/agent/apps.py
+++ b/apps/agent/apps.py
@@ -8,6 +8,11 @@ class AgentConfig(AppConfig):
     def ready(self):
         # Register the agent's built-in tools. Kept here (not at import time) so
         # the registry is populated once the app registry is ready.
-        from .tools import build_search_household_tool, register
+        from .tools import (
+            build_get_entity_tool,
+            build_search_household_tool,
+            register,
+        )
 
         register(build_search_household_tool())
+        register(build_get_entity_tool())

--- a/apps/agent/searchables.py
+++ b/apps/agent/searchables.py
@@ -50,6 +50,14 @@ def reset_registry() -> None:
     REGISTRY.clear()
 
 
+def find_spec(entity_type: str) -> SearchableSpec | None:
+    """Return the registered spec for ``entity_type``, or None if unknown."""
+    for spec in REGISTRY:
+        if spec.entity_type == entity_type:
+            return spec
+    return None
+
+
 def resolve_label(spec: SearchableSpec, instance: Model) -> str:
     """Resolve the label for a given instance using the spec's label_attr."""
     if callable(spec.label_attr):

--- a/apps/agent/tests/test_registry.py
+++ b/apps/agent/tests/test_registry.py
@@ -6,6 +6,7 @@ import pytest
 from agent.searchables import (
     REGISTRY,
     SearchableSpec,
+    find_spec,
     register,
     reset_registry,
 )
@@ -65,6 +66,16 @@ class TestRegister:
         register(_spec("dummy_a"))
         register(_spec("dummy_b"))
         assert {s.entity_type for s in REGISTRY} == {"dummy_a", "dummy_b"}
+
+
+class TestFindSpec:
+    def test_returns_matching_spec(self, empty_registry):
+        spec = _spec("dummy")
+        register(spec)
+        assert find_spec("dummy") is spec
+
+    def test_returns_none_for_unknown(self, empty_registry):
+        assert find_spec("nope") is None
 
 
 class TestBootRegistry:

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -50,6 +50,22 @@ def _run_tool(query: str, *, call_id: str = "toolu_1", name: str = "search_house
     )
 
 
+def _run_get_entity(entity_type: str, entity_id: str, *, call_id: str = "toolu_g") -> LLMRunResponse:
+    """A tool-use turn requesting ``get_entity(entity_type, id)``."""
+    args = {"entity_type": entity_type, "id": entity_id}
+    call = ToolCall(id=call_id, name="get_entity", input=args)
+    return LLMRunResponse(
+        assistant_blocks=[{"type": "tool_use", "id": call_id, "name": "get_entity", "input": args}],
+        tool_calls=[call],
+        text="",
+        stop_reason="tool_use",
+        input_tokens=4,
+        output_tokens=2,
+        duration_ms=2,
+        model="stub-model",
+    )
+
+
 @dataclass
 class _ToolUseClient:
     """LLMClient drop-in for the loop.
@@ -263,6 +279,41 @@ class TestHouseholdFacts:
         )
         result = service.ask("engie ?", household, user=owner, client=stub)
         assert len(result.citations) == 1
+
+    def test_chains_search_then_get_entity_for_full_content(
+        self, with_api_key, household, owner, make_document
+    ):
+        deep = "MARKER_DEEP_DETAIL"
+        long_ocr = ("ligne facturée " * 300) + " " + deep
+        doc = make_document(name="Facture PAC", ocr_text=long_ocr)
+        stub = _ToolUseClient(
+            script=[
+                _run_tool("facture PAC"),
+                _run_get_entity("document", str(doc.pk)),
+                _run_text(f'Voici le détail complet <cite id="document:{doc.pk}"/>.'),
+            ]
+        )
+
+        result = service.ask(
+            "donne-moi le descriptif complet de la facture PAC",
+            household,
+            user=owner,
+            client=stub,
+        )
+
+        assert len(result.citations) == 1
+        assert result.citations[0].id == doc.pk
+        assert result.metadata["tool_calls"] == 2
+        # The 3rd run() received the full content (past the search truncation).
+        third_messages = stub.run_calls[2]["messages"]
+        full_text = "".join(
+            block.get("content", "")
+            for msg in third_messages
+            if isinstance(msg["content"], list)
+            for block in msg["content"]
+            if isinstance(block, dict) and block.get("type") == "tool_result"
+        )
+        assert deep in full_text
 
     def test_multiple_searches_accumulate_into_citation_pool(
         self, with_api_key, household, owner, make_document

--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -113,9 +113,16 @@ class TestBootRegistry:
     def test_search_household_registered_at_boot(self):
         assert tools.SEARCH_HOUSEHOLD in REGISTRY
 
+    def test_get_entity_registered_at_boot(self):
+        assert tools.GET_ENTITY in REGISTRY
+
     def test_search_household_schema_requires_query(self):
         schema = REGISTRY[tools.SEARCH_HOUSEHOLD].to_schema()
         assert schema["input_schema"]["required"] == ["query"]
+
+    def test_get_entity_schema_requires_type_and_id(self):
+        schema = REGISTRY[tools.GET_ENTITY].to_schema()
+        assert set(schema["input_schema"]["required"]) == {"entity_type", "id"}
 
 
 class TestDispatch:
@@ -180,3 +187,82 @@ class TestSearchHousehold:
             client=_FakeLLM(),
         )
         assert result.hits == []
+
+
+class TestGetEntity:
+    def test_reads_full_content_beyond_search_truncation(
+        self, household, owner, make_document
+    ):
+        # OCR long enough that search_household (2000-char budget) would truncate
+        # before this marker; get_entity must return it in full.
+        deep = "MARKER_DEEP_4000"
+        long_ocr = ("ligne facturée " * 300) + " " + deep  # well past 2000 chars
+        doc = make_document(name="Facture PAC", ocr_text=long_ocr)
+
+        search_result = dispatch(
+            tools.SEARCH_HOUSEHOLD,
+            {"query": "facture"},
+            household=household,
+            user=owner,
+            client=_FakeLLM(),
+        )
+        assert deep not in search_result.rendered  # truncated by search budget
+
+        entity_result = dispatch(
+            tools.GET_ENTITY,
+            {"entity_type": "document", "id": str(doc.pk)},
+            household=household,
+            user=owner,
+        )
+        assert deep in entity_result.rendered  # full content
+        assert f"id=document:{doc.pk}" in entity_result.rendered
+        assert any(h.id == doc.pk for h in entity_result.hits)
+
+    def test_missing_args_are_recoverable(self, household):
+        result = dispatch(tools.GET_ENTITY, {"entity_type": "document"}, household=household)
+        assert result.hits == []
+        assert "entity_type and id" in result.rendered
+
+    def test_unknown_entity_type_is_recoverable(self, household):
+        result = dispatch(
+            tools.GET_ENTITY,
+            {"entity_type": "dragon", "id": "x"},
+            household=household,
+        )
+        assert result.hits == []
+        assert "unknown entity_type" in result.rendered
+
+    def test_invalid_id_is_recoverable(self, household):
+        result = dispatch(
+            tools.GET_ENTITY,
+            {"entity_type": "document", "id": "not-a-uuid"},
+            household=household,
+        )
+        assert result.hits == []
+        assert "invalid id" in result.rendered
+
+    def test_missing_entity_is_recoverable(self, household):
+        result = dispatch(
+            tools.GET_ENTITY,
+            {"entity_type": "document", "id": "999999999"},  # valid int, no such row
+            household=household,
+        )
+        assert result.hits == []
+        assert "no document found" in result.rendered
+
+    def test_scoped_to_household(self, household, owner, make_document, db):
+        from households.models import Household, HouseholdMember
+
+        other = Household.objects.create(name="Other GetEntity House")
+        HouseholdMember.objects.create(
+            user=owner, household=other, role=HouseholdMember.Role.OWNER
+        )
+        doc = make_document(name="Facture Engie", ocr_text="secret")  # in `household`
+        result = dispatch(
+            tools.GET_ENTITY,
+            {"entity_type": "document", "id": str(doc.pk)},
+            household=other,  # asking from the other household
+            user=owner,
+        )
+        assert result.hits == []
+        assert "no document found" in result.rendered

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -2,10 +2,12 @@
 Agent tool registry — the base of function calling.
 
 Same pattern as ``searchables.py``: each tool declares itself, the orchestrator
-(``service.ask``) never hardcodes the tool list. The first — and for now only —
-tool is ``search_household``, which wraps query expansion + retrieval so the
-model pulls household facts **on demand** instead of the pipeline searching on
-every turn.
+(``service.ask``) never hardcodes the tool list. Two read tools are registered:
+
+- ``search_household`` — wraps query expansion + retrieval so the model pulls
+  household facts **on demand** instead of the pipeline searching every turn.
+- ``get_entity`` — reads the FULL content of one item by ``(entity_type, id)``,
+  bypassing the search snippet budget (e.g. a whole invoice OCR).
 
 Adding a future tool (``create_interaction``, ``create_task``, …) = one
 ``register(...)`` call, no change to ``service.py``.
@@ -25,7 +27,9 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from . import query_expansion, retrieval
+from django.core.exceptions import ValidationError
+
+from . import query_expansion, retrieval, searchables
 from .llm import LLMClient, get_llm_client
 from .prompts import render_context_block
 from .retrieval import Hit
@@ -34,6 +38,12 @@ logger = logging.getLogger(__name__)
 
 # How many hits a single search returns. Mirrors the historical pipeline limit.
 SEARCH_RETRIEVAL_LIMIT = 12
+
+# Char cap when reading ONE entity in full via get_entity. Much larger than the
+# per-hit budget of search_household (2000) — the whole point is to read the
+# complete text (e.g. a full invoice OCR) the search snippet had to truncate.
+FULL_CONTENT_BUDGET = 20000
+FULL_CONTENT_SNIPPET_CHARS = 200
 
 
 @dataclass
@@ -167,4 +177,103 @@ def build_search_household_tool() -> AgentTool:
         description=_SEARCH_HOUSEHOLD_DESCRIPTION,
         input_schema=_SEARCH_HOUSEHOLD_SCHEMA,
         handler=_search_household_handler,
+    )
+
+
+# --- get_entity -------------------------------------------------------------
+
+GET_ENTITY = "get_entity"
+
+_GET_ENTITY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "entity_type": {
+            "type": "string",
+            "description": (
+                "The type of item, exactly as it appears in an id=... tag or "
+                "citation (e.g. 'document', 'equipment', 'interaction')."
+            ),
+        },
+        "id": {
+            "type": "string",
+            "description": "The item id, exactly as it appears after the colon in id=<type>:<id>.",
+        },
+    },
+    "required": ["entity_type", "id"],
+}
+
+_GET_ENTITY_DESCRIPTION = (
+    "Read the FULL content of one household item you already identified (from a "
+    "search_household result or a citation). Use it when a search snippet is not "
+    "enough and you need the complete text — a document's full OCR, every line "
+    "item and amount on an invoice, the full notes of an equipment. Provide "
+    "entity_type and id exactly as shown in the id=<type>:<id> tag."
+)
+
+
+def _concat_fields(obj, fields: tuple[str, ...]) -> str:
+    """Concatenate an instance's searchable fields into one plain-text block."""
+    parts: list[str] = []
+    for field_name in fields:
+        value = getattr(obj, field_name, None)
+        if value:
+            text = str(value).strip()
+            if text:
+                parts.append(text)
+    return "\n".join(parts)
+
+
+def _get_entity_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client: LLMClient | None = None,
+) -> ToolResult:
+    """Fetch one entity by (entity_type, id), scoped household, and read it whole."""
+    entity_type = (tool_input.get("entity_type") or "").strip()
+    raw_id = (tool_input.get("id") or "").strip()
+    if not entity_type or not raw_id:
+        return ToolResult(rendered="(get_entity needs both entity_type and id)")
+
+    spec = searchables.find_spec(entity_type)
+    if spec is None:
+        return ToolResult(rendered=f"(unknown entity_type: {entity_type})")
+
+    try:
+        obj = spec.model.objects.filter(household_id=household.id, pk=raw_id).first()
+    except (ValueError, TypeError, ValidationError):
+        # Malformed id (e.g. not a valid UUID) — recoverable, tell the model.
+        return ToolResult(rendered=f"(invalid id for {entity_type}: {raw_id})")
+
+    if obj is None:
+        return ToolResult(rendered=f"(no {entity_type} found with id {raw_id} in this household)")
+
+    content = _concat_fields(obj, spec.search_fields)
+    snippet = content[:FULL_CONTENT_SNIPPET_CHARS].strip()
+    hit = Hit(
+        entity_type=spec.entity_type,
+        id=obj.pk,
+        label=searchables.resolve_label(spec, obj),
+        snippet=snippet,
+        rank=1.0,
+        url_path=spec.url_template.format(id=obj.pk),
+        content=content,
+    )
+    # content_top_n=1 + a big budget → the whole content, in the citable format.
+    rendered = render_context_block(
+        [hit],
+        content_top_n=1,
+        char_budget_per_hit=FULL_CONTENT_BUDGET,
+        total_char_budget=FULL_CONTENT_BUDGET,
+    )
+    return ToolResult(rendered=rendered, hits=[hit])
+
+
+def build_get_entity_tool() -> AgentTool:
+    return AgentTool(
+        name=GET_ENTITY,
+        description=_GET_ENTITY_DESCRIPTION,
+        input_schema=_GET_ENTITY_SCHEMA,
+        handler=_get_entity_handler,
     )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -205,8 +205,9 @@ LLM_REQUEST_TIMEOUT_SECONDS = 30
 
 # Agent tool-use loop: max LLM round-trips per question. Each iteration is one
 # LLM call; the tools are dropped on the last pass to force a final answer.
-# Bounds latency and cost of the function-calling loop.
-AGENT_MAX_TOOL_ITERATIONS = 3
+# Bounds latency and cost of the function-calling loop. 4 leaves room to chain
+# search_household -> get_entity -> answer in a single turn.
+AGENT_MAX_TOOL_ITERATIONS = 4
 
 # Agent conversation retention: conversations untouched for longer than this are
 # eligible for cleanup by `manage.py cleanup_agent_conversations`. 0 disables it.

--- a/docs/fiches/RAG.md
+++ b/docs/fiches/RAG.md
@@ -60,8 +60,10 @@ C'est cette troisième option, le RAG, qu'on implémente. C'est le pattern domin
 > étapes ci-dessous restent exactes, mais elles s'exécutent désormais **dans le
 > corps du tool** au lieu d'être câblées avant chaque réponse. Conséquence : le
 > modèle répond directement au dialogue (« bonjour ») et à la culture générale
-> sans recherche, et n'appelle le retrieval que pour un fait du foyer. Détails :
-> [PARCOURS_07_LOT7_FUNCTION_CALLING.md](../parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md).
+> sans recherche, et n'appelle le retrieval que pour un fait du foyer. Un 2ᵉ tool
+> `get_entity(entity_type, id)` lit le **contenu complet** d'une entité (ex : tout
+> l'OCR d'une facture) quand le snippet tronqué de la recherche ne suffit pas.
+> Détails : [PARCOURS_07_LOT7_FUNCTION_CALLING.md](../parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md).
 
 ### 4.1 Indexation (étape 1) — OCR avant tout
 

--- a/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
+++ b/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
@@ -326,3 +326,57 @@ Recette manuelle à pratiquer à l'usage (prod, foyer réel) :
 - [ ] Vérifier qu'aucun fait foyer n'est affirmé sans passage par le tool.
 - [ ] Latence acceptable malgré les allers-retours multiples (surveiller
   `AIUsageLog` : `iterations`, `duration`).
+
+## 14. Extension — 2ᵉ tool `get_entity` (lecture complète)
+
+**Statut : ✅ livré (2026-07)** — première preuve que le socle registry tient.
+
+### Le frein observé
+
+En recette : « donne-moi le descriptif complet de cette facture » → l'agent
+répondait *« la facture existe, mais pas son contenu complet »*. Cause racine
+(pas l'OCR) : `search_household` ne renvoie le **contenu complet** que pour les 3
+premiers hits, **plafonné à 2000 caractères** (`prompts.py` : `CONTENT_TOP_N=3`,
+`CHAR_BUDGET_PER_HIT=2000`). Une facture détaillée (lignes d'articles, montants)
+dépasse ce plafond → le descriptif est **systématiquement tronqué**, quelle que
+soit la reformulation.
+
+### La solution : un tool de lecture par id
+
+`get_entity(entity_type, id)` — générique via le registry `searchables` (pas
+seulement les documents) :
+
+- résout le `SearchableSpec` par `entity_type`, fetch l'instance par `pk` **scoped
+  household**, renvoie le **contenu complet** (jusqu'à `FULL_CONTENT_BUDGET =
+  20000` chars) dans le même format citable (`id=<type>:<id>`).
+- l'agent enchaîne `search_household("facture PAC")` → récupère l'id → 
+  `get_entity("document", id)` → lit tout → répond avec le détail.
+- erreurs récupérables (id invalide, entité absente, mauvais type) → un
+  `tool_result` que le modèle peut lire, jamais d'exception dans la boucle.
+
+`AGENT_MAX_TOOL_ITERATIONS` passé de 3 à **4** pour laisser la place à la chaîne
+`search → get_entity → réponse` en un seul tour.
+
+### Choix : générique plutôt que `get_document`
+
+Décision produit : `get_entity(entity_type, id)` couvre n'importe quelle entité du
+registry, pas seulement les documents. Les documents sont aujourd'hui les seuls à
+avoir un gros contenu tronqué (OCR), mais le tool générique évite d'ajouter un
+tool par type à l'avenir.
+
+### Caveat
+
+Si un document précis a un `ocr_text` réellement incomplet (mauvais scan),
+`get_entity` renverra ce texte incomplet — c'est alors un problème d'OCR à traiter
+via « Re-extraire » sur la fiche document, pas via l'agent.
+
+### Fichiers
+
+- `apps/agent/tools.py` : `get_entity` (schéma + handler + `build_get_entity_tool`)
+- `apps/agent/searchables.py` : helper `find_spec(entity_type)`
+- `apps/agent/apps.py` : `register(build_get_entity_tool())`
+- `config/settings/base.py` : `AGENT_MAX_TOOL_ITERATIONS` 3 → 4
+- tests : `test_tools.py::TestGetEntity` (contenu complet au-delà de la troncature,
+  args manquants, type inconnu, id invalide, entité absente, scope household),
+  `test_registry.py::TestFindSpec`, `test_service.py` (chaîne search → get_entity
+  → réponse citée)


### PR DESCRIPTION
## Le frein observé

En recette : « donne-moi le descriptif complet de cette facture » → l'agent répondait *« la facture existe, mais pas son contenu complet »*, quelle que soit la reformulation.

**Cause racine (pas l'OCR)** : `search_household` ne renvoie le contenu complet que pour les 3 premiers hits, **plafonné à 2000 caractères** (`prompts.py`). Une facture détaillée dépasse ce plafond → descriptif **systématiquement tronqué**.

## La solution : un 2ᵉ tool de lecture

`get_entity(entity_type, id)` — générique via le registry `searchables` (pas seulement les documents) :

- résout le spec par `entity_type`, fetch par `pk` **scoped household**, renvoie le **contenu complet** (jusqu'à 20 000 chars) dans le format citable `id=<type>:<id>` ;
- l'agent enchaîne `search_household(...)` → récupère l'id → `get_entity(...)` → lit tout → répond avec le détail ;
- erreurs récupérables (id invalide, entité absente, type inconnu) → un `tool_result` lisible, jamais d'exception dans la boucle.

`AGENT_MAX_TOOL_ITERATIONS` : 3 → **4** (place pour `search → get_entity → réponse` en un tour).

Premier vrai usage du socle registry du lot 7 — un `register(...)`, zéro touche à `service.py`.

## Tests

`TestGetEntity` (contenu complet au-delà de la troncature de search, args manquants, type inconnu, id invalide, entité absente, **scope household**), `TestFindSpec`, `test_service` (chaîne search → get_entity → réponse citée). Suite complète : **874 passed**, zéro réseau.

## Caveat

Si un document a un `ocr_text` réellement incomplet (mauvais scan), `get_entity` renverra ce texte incomplet → c'est un sujet OCR (« Re-extraire »), pas agent.

## Docs

§14 du lot 7 (`PARCOURS_07_LOT7_FUNCTION_CALLING.md`) + encart `fiches/RAG.md`.