### PR TITLE
fix(agent): ranking retrieval — pondération titre + normalisation longueur

### DIFF
--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -18,12 +18,19 @@ from django.contrib.postgres.search import (
     SearchRank,
     SearchVector,
 )
-from django.db.models import F
+from django.db.models import F, Value
 
 from .searchables import REGISTRY, SearchableSpec, resolve_label
 
 SNIPPET_MAX_WORDS = 30
 SNIPPET_MIN_WORDS = 8
+
+# Postgres ts_rank length-normalization flag. 1 = divide the rank by
+# `1 + log(document length)`. Without it, ts_rank rewards term *frequency*, so a
+# long OCR document repeating a term buries a short entity whose very title is
+# the query (a project titled "Pompe à chaleur" scored 0.27 vs a PDF at 0.98).
+# With it, short-but-exact matches surface. See docs/fiches/RAG.md.
+_RANK_NORMALIZATION = 1
 
 # `simple_unaccent` is created in apps/agent/migrations/0001_initial.py.
 # It is `simple` (no stemming, no stopwords) + `unaccent` so that Engie matches
@@ -66,8 +73,19 @@ def _build_query(query: str) -> SearchQuery:
 
 
 def _vector_for_fields(fields: tuple[str, ...]) -> SearchVector:
-    """Build a SearchVector that combines all configured fields with equal weight."""
-    return SearchVector(*fields, config=_SEARCH_CONFIG)
+    """Build a SearchVector giving the primary field weight A and the rest B.
+
+    By convention the first entry of ``search_fields`` is the entity's title/name
+    (matches ``label_attr`` across every spec). Weighting it A (vs B for bodies)
+    makes a title match outrank a match buried in a long body — combined with the
+    length normalization in ``_search_one``, this is what lets a project whose
+    title *is* the query beat the long PDFs that merely mention it.
+    """
+    primary, *rest = fields
+    vector = SearchVector(primary, weight="A", config=_SEARCH_CONFIG)
+    if rest:
+        vector = vector + SearchVector(*rest, weight="B", config=_SEARCH_CONFIG)
+    return vector
 
 
 def _search_one(spec: SearchableSpec, household_id: UUID, query: str, limit: int) -> list[Hit]:
@@ -99,7 +117,11 @@ def _search_one(spec: SearchableSpec, household_id: UUID, query: str, limit: int
     qs = (
         spec.model.objects.filter(household_id=household_id)
         .annotate(_search_vector=vector)
-        .annotate(_rank=SearchRank(F("_search_vector"), ts_query))
+        .annotate(
+            _rank=SearchRank(
+                F("_search_vector"), ts_query, normalization=Value(_RANK_NORMALIZATION)
+            )
+        )
         .annotate(**headlines)
         .filter(_search_vector=ts_query)
         .order_by("-_rank")[:limit]

--- a/apps/agent/tests/test_retrieval.py
+++ b/apps/agent/tests/test_retrieval.py
@@ -297,6 +297,21 @@ class TestRanking:
         assert ocr_match.name in labels_in_order
         assert labels_in_order.index(title_match.name) < labels_in_order.index(ocr_match.name)
 
+    def test_short_title_match_outranks_long_document_repeating_query(
+        self, household, make_project, make_document
+    ):
+        """The prod 'pompe à chaleur' bug: a project whose title *is* the query
+        must outrank a long PDF that merely repeats it many times. Length
+        normalization + title weighting is what makes this hold — without them
+        ts_rank's term-frequency reward buries the short entity."""
+        project = make_project(title="Pompe à chaleur", description="")
+        make_document(name="brochure PAC", ocr_text="pompe à chaleur " * 100)
+        hits = search(household.id, "pompe à chaleur")
+        by_type = [h.entity_type for h in hits]
+        assert "project" in by_type
+        assert "document" in by_type
+        assert by_type.index("project") < by_type.index("document")
+
 
 class TestCaseAndAccentInsensitive:
     def test_case_insensitive(self, household, make_document):

--- a/docs/fiches/RAG.md
+++ b/docs/fiches/RAG.md
@@ -177,6 +177,15 @@ L'extension et la config TS sont créées dans `apps/agent/migrations/0001_initi
 
 Pas de migration de données nécessaire — le champ est déjà rempli par défaut.
 
+#### Ranking : pondération de champ + normalisation par longueur
+
+`ts_rank` brut récompense la **fréquence** d'un terme : un long document dont l'OCR répète « pompe à chaleur » 20× score ~0.98, alors qu'un projet dont le **titre est exactement la requête** score ~0.27 — et se fait éjecter du top-12. C'est le défaut classique de `ts_rank` sans réglage. Deux leviers dans `apps/agent/retrieval.py` corrigent ça :
+
+1. **Pondération de champ (`setweight`)** — `_vector_for_fields` donne au premier `search_field` (le titre/nom, par convention toujours en tête et égal à `label_attr`) le poids **A**, aux autres champs le poids **B**. Un match dans le titre pèse plus qu'un match noyé dans un corps.
+2. **Normalisation par longueur** — `SearchRank(..., normalization=Value(1))` divise le rank par `1 + log(longueur)`, ce qui pénalise les longs documents. Constante `_RANK_NORMALIZATION`.
+
+Effet mesuré sur la donnée prod (« pompe à chaleur ») : le projet passe de la **position 20/21 → 3/21**, devant les PDF. Aucun changement d'interface — `search_multi()` renvoie toujours `list[Hit]`, seul le calcul interne du `rank` change.
+
 ### 4.3 Augmentation (étape 3) — construire le prompt
 
 Une fois les hits récupérés, on construit un prompt :


### PR DESCRIPTION
## Problème (observé en prod)

Question « retrouve moi le projet de pompe à chaleur » : l'agent ne trouvait **que des documents**, jamais le projet `🥵 Pompe à chaleur + Ballon eau chaude` — pourtant son titre **est** la requête.

Cause : `ts_rank` brut récompense la **fréquence**. Un long PDF répétant « pompe à chaleur » score 0.98 ; le projet (titre court, 1 occurrence) score **0.27** → position **20/21** → coupé par `limit=12` → jamais envoyé à l'agent.

## Fix (`apps/agent/retrieval.py`)

1. **Pondération de champ** — le 1er `search_field` (titre/nom, toujours en tête = `label_attr`) reçoit le poids **A**, les corps le poids **B** (`setweight`).
2. **Normalisation par longueur** — `SearchRank(normalization=Value(1))` divise le rank par `1 + log(longueur)`, pénalisant les longs documents.

**Mesuré sur la donnée prod** (via SSH, sans écriture) : le projet passe de **20/21 → 3/21**, devant les PDF. Interface inchangée — `search_multi() → list[Hit]`, seul le calcul du `rank` change (aucun consommateur touché).

## Tests

- Nouveau test `test_short_title_match_outranks_long_document_repeating_query` : reproduit le bug (projet titré = requête vs long doc répétant la requête) et vérifie que le projet passe devant.
- Suite agent complète : **165 passed**.