### PR TITLE
feat(agent): tool get_related — charge le voisinage d'une entité

### DIFF
--- a/apps/agent/apps.py
+++ b/apps/agent/apps.py
@@ -10,9 +10,11 @@ class AgentConfig(AppConfig):
         # the registry is populated once the app registry is ready.
         from .tools import (
             build_get_entity_tool,
+            build_get_related_tool,
             build_search_household_tool,
             register,
         )
 
         register(build_search_household_tool())
         register(build_get_entity_tool())
+        register(build_get_related_tool())

--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -36,9 +36,17 @@ TRUNCATION_MARKER = " […]"
 SYSTEM_PROMPT = """You are the personal household assistant of a single family.
 You help by answering questions and chatting naturally.
 
-You have one tool, `search_household`, which searches this family's own data
-(documents, interactions, equipment, tasks, projects, zones, stock, insurance,
-contacts) and returns matching items with citable ids.
+You have three tools over this family's own data (documents, interactions,
+equipment, tasks, projects, zones, stock, insurance, contacts):
+
+- `search_household(query)` — search across all household items; returns matching
+  items with their citable ids. Your entry point for any household fact.
+- `get_entity(entity_type, id)` — read the FULL content of ONE item you already
+  found (e.g. a whole invoice's line items) when a search excerpt is not enough.
+- `get_related(entity_type, id)` — load everything LINKED to one item (e.g. a
+  project's documents, expenses, tasks and zones). Use it when the user wants the
+  full picture of a project or piece of equipment — typically right after they
+  confirm which item they mean.
 
 Choose how to respond based on the kind of message:
 
@@ -48,10 +56,11 @@ Choose how to respond based on the kind of message:
 2. HOUSEHOLD FACTS — anything about this family's own data (amounts, dates,
    brands, equipment, contracts, contacts, documents, what happened when). You
    MUST call `search_household` first, and answer using ONLY what it returns.
-   Never state a household fact you did not get from the tool. If the tool
-   returns nothing useful, say plainly that you do not know based on the
-   household data, in the user's language. Never invent values, dates, brands,
-   or amounts.
+   Use `get_entity` when you need an item's full content, and `get_related` when
+   the user asks for everything tied to a project or item. Never state a
+   household fact you did not get from a tool. If the tools return nothing
+   useful, say plainly that you do not know based on the household data, in the
+   user's language. Never invent values, dates, brands, or amounts.
 
 3. GENERAL KNOWLEDGE — definitions, how things work, generic advice not specific
    to this family. You may answer from your own knowledge, but make clear it is

--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -160,6 +160,28 @@ def _full_content(obj, fields: tuple[str, ...]) -> str:
     return "\n".join(parts)
 
 
+def hit_from_instance(
+    spec: SearchableSpec, instance, *, rank: float = 1.0, snippet_chars: int = 200
+) -> Hit:
+    """Build a citable Hit from a model instance using its spec — no search.
+
+    Shared by the ``get_entity`` and ``get_related`` tools, which fetch entities
+    by id or by relation rather than by full-text query. ``content`` is the
+    concatenation of the spec's ``search_fields``; ``snippet`` is its head.
+    """
+    content = _full_content(instance, spec.search_fields)
+    snippet = content[:snippet_chars].strip()
+    return Hit(
+        entity_type=spec.entity_type,
+        id=instance.pk,
+        label=resolve_label(spec, instance),
+        snippet=snippet,
+        rank=rank,
+        url_path=_spec_url(spec, instance),
+        content=content,
+    )
+
+
 def _pick_snippet(obj, fields: tuple[str, ...]) -> str:
     """Pick the longest non-empty headline among annotated candidates."""
     candidates = [getattr(obj, f"_snippet_{field}", "") or "" for field in fields]

--- a/apps/agent/searchables.py
+++ b/apps/agent/searchables.py
@@ -6,6 +6,7 @@ The agent does not know the list — adding a module = 5 lines, zero touche to a
 """
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Callable
 
@@ -23,13 +24,20 @@ class SearchableSpec:
     """The Django model class to query."""
 
     search_fields: tuple[str, ...]
-    """Tuple of field names participating in the SearchVector."""
+    """Tuple of field names participating in the SearchVector. By convention the
+    first field is the title/name — retrieval gives it weight A."""
 
     label_attr: str | Callable[[Model], str]
     """Attribute name or callable producing the human-readable label."""
 
     url_template: str
     """URL template used to build Hit.url_path. Must contain `{id}`."""
+
+    related: Callable[[Model], Iterable[Model]] | None = None
+    """Optional: given an instance, return the model instances linked to it
+    (a project's documents, expenses, tasks, zones…). Powers the `get_related`
+    agent tool. Each returned instance is turned into a citable Hit via its own
+    registered spec, so only entities that are themselves searchable surface."""
 
 
 REGISTRY: list[SearchableSpec] = []
@@ -54,6 +62,18 @@ def find_spec(entity_type: str) -> SearchableSpec | None:
     """Return the registered spec for ``entity_type``, or None if unknown."""
     for spec in REGISTRY:
         if spec.entity_type == entity_type:
+            return spec
+    return None
+
+
+def find_spec_for_instance(instance: Model) -> SearchableSpec | None:
+    """Return the spec whose model matches ``instance``, or None if unregistered.
+
+    Used by ``get_related`` to turn each related instance (of mixed types) back
+    into a citable Hit through its own spec. An instance whose model is not
+    registered as searchable is simply skipped."""
+    for spec in REGISTRY:
+        if isinstance(instance, spec.model):
             return spec
     return None
 

--- a/apps/agent/tests/test_registry.py
+++ b/apps/agent/tests/test_registry.py
@@ -7,6 +7,7 @@ from agent.searchables import (
     REGISTRY,
     SearchableSpec,
     find_spec,
+    find_spec_for_instance,
     register,
     reset_registry,
 )
@@ -76,6 +77,22 @@ class TestFindSpec:
 
     def test_returns_none_for_unknown(self, empty_registry):
         assert find_spec("nope") is None
+
+
+class TestFindSpecForInstance:
+    def test_matches_instance_by_model(self, empty_registry, db):
+        from documents.models import Document
+
+        spec = _spec("document", model=Document)
+        register(spec)
+        doc = Document(name="x")
+        assert find_spec_for_instance(doc) is spec
+
+    def test_returns_none_for_unregistered_model(self, empty_registry, db):
+        from zones.models import Zone
+
+        register(_spec("document"))  # only Document registered
+        assert find_spec_for_instance(Zone(name="z")) is None
 
 
 class TestBootRegistry:

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -66,6 +66,22 @@ def _run_get_entity(entity_type: str, entity_id: str, *, call_id: str = "toolu_g
     )
 
 
+def _run_get_related(entity_type: str, entity_id: str, *, call_id: str = "toolu_r") -> LLMRunResponse:
+    """A tool-use turn requesting ``get_related(entity_type, id)``."""
+    args = {"entity_type": entity_type, "id": entity_id}
+    call = ToolCall(id=call_id, name="get_related", input=args)
+    return LLMRunResponse(
+        assistant_blocks=[{"type": "tool_use", "id": call_id, "name": "get_related", "input": args}],
+        tool_calls=[call],
+        text="",
+        stop_reason="tool_use",
+        input_tokens=4,
+        output_tokens=2,
+        duration_ms=2,
+        model="stub-model",
+    )
+
+
 @dataclass
 class _ToolUseClient:
     """LLMClient drop-in for the loop.
@@ -314,6 +330,41 @@ class TestHouseholdFacts:
             if isinstance(block, dict) and block.get("type") == "tool_result"
         )
         assert deep in full_text
+
+    def test_chains_search_then_get_related_for_project(
+        self, with_api_key, household, owner, make_document
+    ):
+        """The 'load everything about this project' scenario: the model searches,
+        finds the project, then get_related pulls its linked document into the
+        citation pool so it can be cited in the final answer."""
+        from projects.models import Project, ProjectDocument
+
+        project = Project.objects.create(
+            household=household, created_by=owner, title="Pompe à chaleur"
+        )
+        doc = make_document(name="devis PAC", ocr_text="montant 12000")
+        ProjectDocument.objects.create(project=project, document=doc)
+
+        stub = _ToolUseClient(
+            script=[
+                _run_tool("pompe à chaleur"),
+                _run_get_related("project", str(project.pk)),
+                _run_text(
+                    f'Le projet inclut le devis <cite id="document:{doc.pk}"/>.'
+                ),
+            ]
+        )
+
+        result = service.ask(
+            "montre-moi tout ce qui concerne le projet pompe à chaleur",
+            household,
+            user=owner,
+            client=stub,
+        )
+
+        assert result.metadata["tool_calls"] == 2
+        cited_ids = {c.id for c in result.citations}
+        assert doc.pk in cited_ids
 
     def test_multiple_searches_accumulate_into_citation_pool(
         self, with_api_key, household, owner, make_document

--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -116,6 +116,13 @@ class TestBootRegistry:
     def test_get_entity_registered_at_boot(self):
         assert tools.GET_ENTITY in REGISTRY
 
+    def test_get_related_registered_at_boot(self):
+        assert tools.GET_RELATED in REGISTRY
+
+    def test_get_related_schema_requires_type_and_id(self):
+        schema = REGISTRY[tools.GET_RELATED].to_schema()
+        assert set(schema["input_schema"]["required"]) == {"entity_type", "id"}
+
     def test_search_household_schema_requires_query(self):
         schema = REGISTRY[tools.SEARCH_HOUSEHOLD].to_schema()
         assert schema["input_schema"]["required"] == ["query"]
@@ -266,3 +273,125 @@ class TestGetEntity:
         )
         assert result.hits == []
         assert "no document found" in result.rendered
+
+
+@pytest.fixture
+def make_project(household, owner):
+    from projects.models import Project
+
+    def _make(**overrides):
+        payload = dict(household=household, created_by=owner, title="generic project")
+        payload.update(overrides)
+        return Project.objects.create(**payload)
+
+    return _make
+
+
+class TestGetRelated:
+    def _link_document(self, project, doc):
+        from projects.models import ProjectDocument
+
+        return ProjectDocument.objects.create(project=project, document=doc)
+
+    def test_loads_linked_items_across_types(
+        self, household, owner, make_project, make_document
+    ):
+        from django.utils import timezone
+        from interactions.models import Interaction
+        from projects.models import ProjectZone
+        from tasks.models import Task
+        from zones.models import Zone
+
+        project = make_project(title="Rénovation PAC")
+        doc = make_document(name="devis PAC", ocr_text="montant 12000")
+        self._link_document(project, doc)
+        interaction = Interaction.objects.create(
+            household=household, created_by=owner, subject="Dépense PAC",
+            occurred_at=timezone.now(), project=project,
+        )
+        task = Task.objects.create(
+            household=household, created_by=owner, subject="Commander la PAC", project=project
+        )
+        zone = Zone.objects.create(household=household, created_by=owner, name="Chaufferie")
+        ProjectZone.objects.create(project=project, zone=zone)
+
+        result = dispatch(
+            tools.GET_RELATED,
+            {"entity_type": "project", "id": str(project.pk)},
+            household=household,
+            user=owner,
+        )
+
+        found = {(h.entity_type, h.id) for h in result.hits}
+        assert ("document", doc.id) in found
+        assert ("interaction", interaction.id) in found
+        assert ("task", task.id) in found
+        assert ("zone", zone.id) in found
+        assert f"id=document:{doc.id}" in result.rendered  # citable
+
+    def test_missing_args_are_recoverable(self, household):
+        result = dispatch(tools.GET_RELATED, {"entity_type": "project"}, household=household)
+        assert result.hits == []
+        assert "entity_type and id" in result.rendered
+
+    def test_unknown_entity_type_is_recoverable(self, household):
+        result = dispatch(
+            tools.GET_RELATED, {"entity_type": "dragon", "id": "x"}, household=household
+        )
+        assert result.hits == []
+        assert "unknown entity_type" in result.rendered
+
+    def test_entity_without_relations_declared_is_recoverable(
+        self, household, owner, make_document
+    ):
+        # documents don't declare a `related` traversal.
+        doc = make_document(name="lonely doc")
+        result = dispatch(
+            tools.GET_RELATED,
+            {"entity_type": "document", "id": str(doc.pk)},
+            household=household,
+            user=owner,
+        )
+        assert result.hits == []
+        assert "no related items" in result.rendered
+
+    def test_project_with_no_links_returns_empty_marker(self, household, owner, make_project):
+        project = make_project(title="Solo")
+        result = dispatch(
+            tools.GET_RELATED,
+            {"entity_type": "project", "id": str(project.pk)},
+            household=household,
+            user=owner,
+        )
+        assert result.hits == []
+        assert "no items linked" in result.rendered
+
+    def test_missing_project_is_recoverable(self, household):
+        import uuid
+
+        result = dispatch(
+            tools.GET_RELATED,
+            {"entity_type": "project", "id": str(uuid.uuid4())},
+            household=household,
+        )
+        assert result.hits == []
+        assert "no project found" in result.rendered
+
+    def test_scoped_to_household(self, household, owner, make_project, make_document, db):
+        from households.models import Household, HouseholdMember
+
+        other = Household.objects.create(name="Other GetRelated House")
+        HouseholdMember.objects.create(
+            user=owner, household=other, role=HouseholdMember.Role.OWNER
+        )
+        project = make_project(title="Scoped")  # in `household`
+        doc = make_document(name="secret devis")
+        self._link_document(project, doc)
+        result = dispatch(
+            tools.GET_RELATED,
+            {"entity_type": "project", "id": str(project.pk)},
+            household=other,  # asking from the other household
+            user=owner,
+        )
+        assert result.hits == []
+        assert "no project found" in result.rendered

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -2,12 +2,14 @@
 Agent tool registry — the base of function calling.
 
 Same pattern as ``searchables.py``: each tool declares itself, the orchestrator
-(``service.ask``) never hardcodes the tool list. Two read tools are registered:
+(``service.ask``) never hardcodes the tool list. Three read tools are registered:
 
 - ``search_household`` — wraps query expansion + retrieval so the model pulls
   household facts **on demand** instead of the pipeline searching every turn.
 - ``get_entity`` — reads the FULL content of one item by ``(entity_type, id)``,
   bypassing the search snippet budget (e.g. a whole invoice OCR).
+- ``get_related`` — loads everything LINKED to one item by ``(entity_type, id)``
+  (e.g. a project's documents, expenses, tasks, zones), each as a citable Hit.
 
 Adding a future tool (``create_interaction``, ``create_task``, …) = one
 ``register(...)`` call, no change to ``service.py``.
@@ -211,16 +213,30 @@ _GET_ENTITY_DESCRIPTION = (
 )
 
 
-def _concat_fields(obj, fields: tuple[str, ...]) -> str:
-    """Concatenate an instance's searchable fields into one plain-text block."""
-    parts: list[str] = []
-    for field_name in fields:
-        value = getattr(obj, field_name, None)
-        if value:
-            text = str(value).strip()
-            if text:
-                parts.append(text)
-    return "\n".join(parts)
+def _resolve_entity(entity_type: str, raw_id: str, household):
+    """Shared (entity_type, id) → instance resolution for get_entity/get_related.
+
+    Returns ``(obj, None)`` on success or ``(None, ToolResult)`` with a
+    recoverable message the model can read (unknown type, malformed id, no row).
+    """
+    if not entity_type or not raw_id:
+        return None, ToolResult(rendered="(needs both entity_type and id)")
+
+    spec = searchables.find_spec(entity_type)
+    if spec is None:
+        return None, ToolResult(rendered=f"(unknown entity_type: {entity_type})")
+
+    try:
+        obj = spec.model.objects.filter(household_id=household.id, pk=raw_id).first()
+    except (ValueError, TypeError, ValidationError):
+        # Malformed id (e.g. not a valid UUID) — recoverable, tell the model.
+        return None, ToolResult(rendered=f"(invalid id for {entity_type}: {raw_id})")
+
+    if obj is None:
+        return None, ToolResult(
+            rendered=f"(no {entity_type} found with id {raw_id} in this household)"
+        )
+    return (spec, obj), None
 
 
 def _get_entity_handler(
@@ -233,33 +249,13 @@ def _get_entity_handler(
     """Fetch one entity by (entity_type, id), scoped household, and read it whole."""
     entity_type = (tool_input.get("entity_type") or "").strip()
     raw_id = (tool_input.get("id") or "").strip()
-    if not entity_type or not raw_id:
-        return ToolResult(rendered="(get_entity needs both entity_type and id)")
 
-    spec = searchables.find_spec(entity_type)
-    if spec is None:
-        return ToolResult(rendered=f"(unknown entity_type: {entity_type})")
+    resolved, error = _resolve_entity(entity_type, raw_id, household)
+    if error is not None:
+        return error
+    spec, obj = resolved
 
-    try:
-        obj = spec.model.objects.filter(household_id=household.id, pk=raw_id).first()
-    except (ValueError, TypeError, ValidationError):
-        # Malformed id (e.g. not a valid UUID) — recoverable, tell the model.
-        return ToolResult(rendered=f"(invalid id for {entity_type}: {raw_id})")
-
-    if obj is None:
-        return ToolResult(rendered=f"(no {entity_type} found with id {raw_id} in this household)")
-
-    content = _concat_fields(obj, spec.search_fields)
-    snippet = content[:FULL_CONTENT_SNIPPET_CHARS].strip()
-    hit = Hit(
-        entity_type=spec.entity_type,
-        id=obj.pk,
-        label=searchables.resolve_label(spec, obj),
-        snippet=snippet,
-        rank=1.0,
-        url_path=spec.url_template.format(id=obj.pk),
-        content=content,
-    )
+    hit = retrieval.hit_from_instance(spec, obj, snippet_chars=FULL_CONTENT_SNIPPET_CHARS)
     # content_top_n=1 + a big budget → the whole content, in the citable format.
     rendered = render_context_block(
         [hit],
@@ -276,4 +272,93 @@ def build_get_entity_tool() -> AgentTool:
         description=_GET_ENTITY_DESCRIPTION,
         input_schema=_GET_ENTITY_SCHEMA,
         handler=_get_entity_handler,
+    )
+
+
+# --- get_related ------------------------------------------------------------
+
+GET_RELATED = "get_related"
+
+# A project can have many linked items; cap how many we pull into one result and
+# how much text they share, so a single get_related call stays bounded.
+RELATED_MAX_ITEMS = 40
+RELATED_CONTENT_TOP_N = 2
+RELATED_CHAR_BUDGET_PER_HIT = 2000
+RELATED_TOTAL_CHAR_BUDGET = 8000
+
+_GET_RELATED_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "entity_type": {
+            "type": "string",
+            "description": (
+                "The type of the item whose neighborhood to load, exactly as it "
+                "appears in an id=<type>:<id> tag (e.g. 'project')."
+            ),
+        },
+        "id": {
+            "type": "string",
+            "description": "The item id, exactly as it appears after the colon in id=<type>:<id>.",
+        },
+    },
+    "required": ["entity_type", "id"],
+}
+
+_GET_RELATED_DESCRIPTION = (
+    "Load everything LINKED to one household item you already identified: e.g. a "
+    "project's documents, expenses/interactions, tasks and zones. Use it when the "
+    "user wants the full picture of a project or piece of equipment (typically "
+    "after they confirm which one). Returns each related item with its own citable "
+    "id, so you can then get_entity into any specific one. Provide entity_type and "
+    "id exactly as shown in the id=<type>:<id> tag."
+)
+
+
+def _get_related_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client: LLMClient | None = None,
+) -> ToolResult:
+    """Resolve the source entity, walk its declared relations, render them citable."""
+    entity_type = (tool_input.get("entity_type") or "").strip()
+    raw_id = (tool_input.get("id") or "").strip()
+
+    resolved, error = _resolve_entity(entity_type, raw_id, household)
+    if error is not None:
+        return error
+    spec, obj = resolved
+
+    if spec.related is None:
+        return ToolResult(rendered=f"({entity_type} has no related items to load)")
+
+    hits: list[Hit] = []
+    for rel in list(spec.related(obj))[:RELATED_MAX_ITEMS]:
+        rel_spec = searchables.find_spec_for_instance(rel)
+        if rel_spec is None:
+            continue
+        # Defensive scope guard: never surface an item from another household.
+        if getattr(rel, "household_id", household.id) != household.id:
+            continue
+        hits.append(retrieval.hit_from_instance(rel_spec, rel))
+
+    if not hits:
+        return ToolResult(rendered=f"(no items linked to {entity_type} {raw_id})")
+
+    rendered = render_context_block(
+        hits,
+        content_top_n=RELATED_CONTENT_TOP_N,
+        char_budget_per_hit=RELATED_CHAR_BUDGET_PER_HIT,
+        total_char_budget=RELATED_TOTAL_CHAR_BUDGET,
+    )
+    return ToolResult(rendered=rendered, hits=hits)
+
+
+def build_get_related_tool() -> AgentTool:
+    return AgentTool(
+        name=GET_RELATED,
+        description=_GET_RELATED_DESCRIPTION,
+        input_schema=_GET_RELATED_SCHEMA,
+        handler=_get_related_handler,
     )

--- a/apps/projects/apps.py
+++ b/apps/projects/apps.py
@@ -1,6 +1,23 @@
 from django.apps import AppConfig
 
 
+def _project_related(project):
+    """Every household item linked to a project, for the `get_related` agent tool.
+
+    Walks the reverse relations to gather the project's documents, expenses /
+    interactions, tasks and zones. Each returned instance is turned into a
+    citable Hit through its own registered spec (unregistered types are skipped).
+    """
+    items = []
+    items.extend(
+        pd.document for pd in project.project_documents.select_related("document")
+    )
+    items.extend(project.interactions.all())
+    items.extend(project.tasks.all())
+    items.extend(pz.zone for pz in project.project_zones.select_related("zone"))
+    return items
+
+
 class ProjectsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "projects"
@@ -15,4 +32,5 @@ class ProjectsConfig(AppConfig):
             search_fields=('title', 'description'),
             label_attr='title',
             url_template='/app/projects/{id}',
+            related=_project_related,
         ))

--- a/docs/fiches/RAG.md
+++ b/docs/fiches/RAG.md
@@ -62,7 +62,12 @@ C'est cette troisième option, le RAG, qu'on implémente. C'est le pattern domin
 > modèle répond directement au dialogue (« bonjour ») et à la culture générale
 > sans recherche, et n'appelle le retrieval que pour un fait du foyer. Un 2ᵉ tool
 > `get_entity(entity_type, id)` lit le **contenu complet** d'une entité (ex : tout
-> l'OCR d'une facture) quand le snippet tronqué de la recherche ne suffit pas.
+> l'OCR d'une facture) quand le snippet tronqué de la recherche ne suffit pas. Un
+> 3ᵉ tool `get_related(entity_type, id)` charge **tout ce qui est lié** à une
+> entité (les documents, dépenses, tâches et zones d'un projet), chacun renvoyé
+> comme un Hit citable — pour le scénario « montre-moi tout sur ce projet ». Les
+> relations sont déclarées par chaque app via le champ optionnel
+> `SearchableSpec.related` (même esprit registry, aucun hardcode dans l'agent).
 > Détails : [PARCOURS_07_LOT7_FUNCTION_CALLING.md](../parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md).
 
 ### 4.1 Indexation (étape 1) — OCR avant tout

--- a/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
+++ b/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
@@ -380,3 +380,51 @@ via « Re-extraire » sur la fiche document, pas via l'agent.
   args manquants, type inconnu, id invalide, entité absente, scope household),
   `test_registry.py::TestFindSpec`, `test_service.py` (chaîne search → get_entity
   → réponse citée)
+
+## 15. Extension — 3ᵉ tool `get_related` (voisinage d'une entité)
+
+### Le besoin observé
+
+Scénario utilisateur : « retrouve le projet pompe à chaleur → oui c'est celui-là →
+charge tout ce qui s'y rapporte ». `search_household` trouve le projet (après le
+fix ranking, PR #160), mais l'agent n'avait aucun moyen de charger **ce qui est
+lié** au projet. `get_entity("project", id)` ne lit que `title + description` — pas
+ses documents, dépenses, tâches, zones.
+
+### La solution : un tool de traversée de relations
+
+`get_related(entity_type, id)` — générique via le registry. Chaque `SearchableSpec`
+déclare optionnellement un callable `related(instance) -> Iterable[Model]` qui
+renvoie les instances liées (types mélangés). Le handler :
+
+1. résout `(entity_type, id)` → instance (helper partagé `_resolve_entity`),
+2. appelle `spec.related(obj)`, cappe à `RELATED_MAX_ITEMS` (40),
+3. pour chaque instance liée, retrouve son spec via `find_spec_for_instance` et
+   construit un Hit citable (`retrieval.hit_from_instance`, partagé avec get_entity),
+4. rend le tout via `render_context_block` (budget dédié) → chaque item lié porte
+   son propre `id=<type>:<id>`, donc l'agent peut ensuite `get_entity` dans l'un.
+
+Sur le tour de confirmation, la boucle fait `search → get_related → réponse`, l'id
+du projet transitant par la citation du tour précédent (historique déjà persistant).
+
+### Choix : `related` déclaratif plutôt que hardcodé
+
+Même esprit que le reste du registry : `apps/projects/apps.py` fournit
+`_project_related` (documents via `project_documents`, dépenses via `interactions`,
+`tasks`, zones via `project_zones`). Ajouter la traversée pour equipment/zone plus
+tard = une fonction + un kwarg, zéro touche à `apps/agent/`. Seules les entités
+elles-mêmes searchables (donc citables) remontent — les autres sont ignorées.
+
+### Fichiers
+
+- `apps/agent/tools.py` : `get_related` (schéma + handler + `_resolve_entity`
+  partagé + `build_get_related_tool`), get_entity refactoré sur le helper partagé
+- `apps/agent/searchables.py` : champ `SearchableSpec.related` + `find_spec_for_instance`
+- `apps/agent/retrieval.py` : helper partagé `hit_from_instance`
+- `apps/agent/prompts.py` : system prompt décrit les **3** tools (était resté « one tool »)
+- `apps/agent/apps.py` : `register(build_get_related_tool())`
+- `apps/projects/apps.py` : `_project_related` déclaré via `related=`
+- tests : `test_tools.py::TestGetRelated` (chargement multi-types, args manquants,
+  type inconnu, entité sans relations, projet sans lien, projet absent, scope
+  household), `test_registry.py::TestFindSpecForInstance`, `test_service.py`
+  (chaîne search → get_related → réponse citée)


### PR DESCRIPTION
## Objectif

Débloque le scénario **« trouve le projet → oui c'est celui-là → charge tout ce qui s'y rapporte »**. Après le fix ranking (#160), `search_household` trouve le projet ; il manquait un moyen de charger **ce qui lui est lié**.

## Nouveau tool `get_related(entity_type, id)`

Charge tout ce qui est **LIÉ** à une entité (documents, dépenses/interactions, tâches, zones d'un projet), chacun renvoyé comme **Hit citable** → l'agent peut ensuite `get_entity` dans un item précis.

Générique, dans l'esprit du registry :
- `SearchableSpec.related(instance) → Iterable[Model]` déclaré par chaque app (ici `apps/projects/apps.py::_project_related`). Ajouter equipment/zone plus tard = une fonction + un kwarg, zéro touche à `apps/agent/`.
- `find_spec_for_instance` retrouve le spec de chaque item lié pour le rendre citable ; les types non-searchables sont ignorés.
- Helper partagé `retrieval.hit_from_instance` (get_entity refactoré dessus) + `_resolve_entity` factorise la résolution `(entity_type, id)`.
- Cappé à `RELATED_MAX_ITEMS=40` + budget de rendu dédié.

## Fix prompt au passage

Le `SYSTEM_PROMPT` disait encore **« You have one tool, search_household »** — jamais mis à jour depuis `get_entity` (#158). Il décrit maintenant les **3 tools**, ce qui explique pourquoi l'agent n'enchaînait pas vers `get_entity`.

## Validé sur la donnée prod

Le projet `🥵 Pompe à chaleur` a **18 items liés** (3 docs, 12 interactions, 2 tâches, 1 zone) — `get_related` les remontera tous, citables.

## Tests

- `TestGetRelated` : chargement multi-types, args manquants, type inconnu, entité sans relation déclarée, projet sans lien, projet absent, scope household.
- `TestFindSpecForInstance`, chaîne service `search → get_related → réponse citée`.
- Suite complète : **887 passed, 2 skipped**.