### PR TITLE
feat(agent): actions d'écriture — tool générique create_entity (tâche)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,3 +393,47 @@ n'est nécessaire.
 
 Doc complète : `docs/MODULES/agent.md` + section « conversation ancrée » de
 `docs/fiches/RAG.md`.
+
+---
+
+## Agent — actions d'écriture (`create_entity`)
+
+L'agent peut **créer** des items du foyer depuis le chat via un unique tool
+générique `create_entity` (pas un `create_<type>` par entité — on ne gonfle pas le
+nombre de définitions de tools). Il est adossé au registry `agent.writables`,
+miroir écriture de `agent.searchables`. Première entité créable : la **tâche**.
+
+### Rendre une nouvelle entité créable (~5 lignes)
+
+Dans le `apps.py::ready()` de l'app, en plus du `SearchableSpec` :
+
+```python
+from agent.writables import WritableSpec, register as register_writable
+
+register_writable(WritableSpec(
+    entity_type='task',
+    create=_create_task_from_agent,   # (household, user, fields, *, anchor) -> instance
+    label_attr='subject',
+    url_template='/app/tasks/{id}',
+))
+```
+
+Règles :
+- **`create` réutilise le service métier de l'app, jamais l'ORM brut.** Ex.
+  `tasks/services.py::create_task` passe par `TaskSerializer` (validation, scope
+  foyer, fallback zone racine). Créer un service dédié si absent.
+- `create` reçoit l'`anchor` de la conversation ancrée `(entity_type, object_id)`
+  → l'utiliser pour pré-remplir un lien (ancre `project` → item lié au projet).
+- Étendre aussi la **description** du tool `create_entity` (`apps/agent/tools.py`)
+  pour lister les champs de la nouvelle entité.
+
+### Sécurité : créer + Undo
+
+Une écriture est un **effet de bord réversible**, pas un brouillon à valider :
+l'item est créé immédiatement, remonté dans `metadata.created_entities`, et le
+front affiche un toast « Annuler » (`useAgentCreatedUndo`) qui le supprime. Ajouter
+l'undo d'une nouvelle entité = une entrée dans `UNDO_HANDLERS`
+(`ui/src/features/agent/hooks.ts`). Garde-fous : prompt strict (créer seulement sur
+demande explicite) + anti-doublon par tour dans `service.ask`.
+
+Doc complète : `docs/MODULES/agent.md` + `docs/parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md`.

--- a/apps/agent/apps.py
+++ b/apps/agent/apps.py
@@ -9,6 +9,7 @@ class AgentConfig(AppConfig):
         # Register the agent's built-in tools. Kept here (not at import time) so
         # the registry is populated once the app registry is ready.
         from .tools import (
+            build_create_entity_tool,
             build_get_entity_tool,
             build_get_related_tool,
             build_search_household_tool,
@@ -18,3 +19,4 @@ class AgentConfig(AppConfig):
         register(build_search_household_tool())
         register(build_get_entity_tool())
         register(build_get_related_tool())
+        register(build_create_entity_tool())

--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -66,9 +66,21 @@ Choose how to respond based on the kind of message:
    to this family. You may answer from your own knowledge, but make clear it is
    general information, not from the household data. Do NOT search.
 
-Citations: when you state a fact that comes from `search_household`, attach a
-citation marker right after the sentence: <cite id="entity_type:id"/>, using the
-exact entity_type and id from the tool results. You may cite several items.
+You also have one WRITE tool:
+
+- `create_entity(entity_type, fields)` — create a new household item (currently:
+  a `task`). Call it ONLY when the user clearly asks to create, add, note or
+  remember something ("add a task", "remind me to…"). Never create speculatively,
+  and never create the same thing twice. If what to create is ambiguous (missing
+  a subject), ask a brief clarifying question instead of guessing. After a
+  successful creation, confirm in ONE short sentence and cite the new item with
+  the id the tool returned. The item is saved immediately and the user can undo
+  it from the interface — so do not ask for confirmation before creating.
+
+Citations: when you state a fact that comes from `search_household`, or confirm
+an item you just created with `create_entity`, attach a citation marker right
+after the sentence: <cite id="entity_type:id"/>, using the exact entity_type and
+id from the tool results. You may cite several items.
 
 Earlier conversation turns may precede the question. Use them only to resolve
 references ("this document", "and its price?"); household facts still require the

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -104,6 +104,8 @@ def ask(
 
     system_prompt = build_system_prompt(anchored=anchored)
     messages = _build_messages(cleaned, history, entity_context)
+    created_entities: list[dict] = []
+    created_signatures: set = set()
     answer_text = ""
     stop_reason = ""
     model = ""
@@ -151,11 +153,31 @@ def ask(
         tool_results = []
         for call in response.tool_calls:
             tool_calls += 1
+            # Anti-duplicate guard for writes: if the model repeats the same
+            # create call in this turn, skip the DB write and tell it so.
+            if call.name == tools.CREATE_ENTITY and _is_duplicate_create(
+                call.input, created_signatures
+            ):
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": call.id,
+                        "content": "(already created this item in this turn — skipped)",
+                    }
+                )
+                continue
+
             result = tools.dispatch(
-                call.name, call.input, household=household, user=user, client=llm
+                call.name,
+                call.input,
+                household=household,
+                user=user,
+                client=llm,
+                context_entity=context_entity if entity_context else None,
             )
             for hit in result.hits:
                 hit_pool[(hit.entity_type, hit.id)] = hit
+            created_entities.extend(result.created)
             tool_results.append(
                 {
                     "type": "tool_result",
@@ -183,8 +205,20 @@ def ask(
             "stop_reason": stop_reason,
             "answer_kind": answer_kind,
             "anchored": anchored,
+            "created_entities": created_entities,
         },
     )
+
+
+def _is_duplicate_create(tool_input: dict, seen: set) -> bool:
+    """True if this create call was already made this turn; records it otherwise."""
+    entity_type = (tool_input or {}).get("entity_type") or ""
+    fields = (tool_input or {}).get("fields") or {}
+    signature = (entity_type, tools._stable_signature(fields if isinstance(fields, dict) else {}))
+    if signature in seen:
+        return True
+    seen.add(signature)
+    return False
 
 
 def _resolve_context(context_entity, household):

--- a/apps/agent/tests/test_conversations_api.py
+++ b/apps/agent/tests/test_conversations_api.py
@@ -366,6 +366,31 @@ class TestAnchoredMessage:
         assert ask_mock.call_args.kwargs["context_entity"] is None
 
 
+class TestCreatedEntitiesInResponse:
+    def test_message_response_carries_created_entities(
+        self, owner_client, conversation, monkeypatch
+    ):
+        created = [
+            {
+                "entity_type": "task",
+                "id": "t-1",
+                "label": "Purger la VMC",
+                "url_path": "/app/tasks/t-1",
+            }
+        ]
+        _patch_ask(
+            monkeypatch,
+            return_value=_answer(metadata={"model": "m", "created_entities": created}),
+        )
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/",
+            {"question": "ajoute une tâche purger la vmc"},
+            format="json",
+        )
+        assert resp.status_code == status.HTTP_201_CREATED
+        assert resp.json()["metadata"]["created_entities"] == created
+
+
 class TestRenameAndDelete:
     def test_rename(self, owner_client, conversation):
         resp = owner_client.patch(

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -82,6 +82,22 @@ def _run_get_related(entity_type: str, entity_id: str, *, call_id: str = "toolu_
     )
 
 
+def _run_create(entity_type: str, fields: dict, *, call_id: str = "toolu_c") -> LLMRunResponse:
+    """A tool-use turn requesting ``create_entity(entity_type, fields)``."""
+    args = {"entity_type": entity_type, "fields": fields}
+    call = ToolCall(id=call_id, name="create_entity", input=args)
+    return LLMRunResponse(
+        assistant_blocks=[{"type": "tool_use", "id": call_id, "name": "create_entity", "input": args}],
+        tool_calls=[call],
+        text="",
+        stop_reason="tool_use",
+        input_tokens=4,
+        output_tokens=2,
+        duration_ms=2,
+        model="stub-model",
+    )
+
+
 @dataclass
 class _ToolUseClient:
     """LLMClient drop-in for the loop.
@@ -586,6 +602,83 @@ class TestAnchoredContext:
         assert result.metadata["anchored"] is False
         assert stub.run_calls[0]["messages"] == [{"role": "user", "content": "résume"}]
         assert "CURRENT ITEM CONTEXT" not in stub.run_calls[0]["system"]
+
+
+# ---------------------------------------------------------------------------
+# Write actions — create_entity
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEntity:
+    def test_create_populates_created_entities_metadata(
+        self, with_api_key, household, owner
+    ):
+        from tasks.models import Task
+
+        stub = _ToolUseClient(
+            script=[
+                _run_create("task", {"subject": "Purger la VMC"}),
+                _run_text("C'est noté."),
+            ]
+        )
+        result = service.ask(
+            "ajoute une tâche : purger la VMC", household, user=owner, client=stub
+        )
+
+        task = Task.objects.get(subject="Purger la VMC")
+        assert result.metadata["created_entities"] == [
+            {
+                "entity_type": "task",
+                "id": str(task.id),
+                "label": "Purger la VMC",
+                "url_path": f"/app/tasks/{task.id}",
+            }
+        ]
+        assert result.metadata["tool_calls"] == 1
+
+    def test_anchored_create_links_the_project(
+        self, with_api_key, household, owner, make_project
+    ):
+        from tasks.models import Task
+
+        project = make_project(title="Rénovation salle de bain")
+        stub = _ToolUseClient(
+            script=[
+                _run_create("task", {"subject": "Choisir le carrelage"}),
+                _run_text("Ajouté au projet."),
+            ]
+        )
+        service.ask(
+            "ajoute une tâche choisir le carrelage",
+            household,
+            user=owner,
+            client=stub,
+            context_entity=("project", str(project.pk)),
+        )
+        task = Task.objects.get(subject="Choisir le carrelage")
+        assert task.project_id == project.pk
+
+    def test_duplicate_create_in_one_turn_is_skipped(
+        self, with_api_key, household, owner
+    ):
+        from tasks.models import Task
+
+        stub = _ToolUseClient(
+            script=[
+                _run_create("task", {"subject": "Doublon"}, call_id="c1"),
+                _run_create("task", {"subject": "Doublon"}, call_id="c2"),
+                _run_text("Fait."),
+            ]
+        )
+        result = service.ask("crée la tâche", household, user=owner, client=stub)
+
+        assert Task.objects.filter(subject="Doublon").count() == 1
+        assert len(result.metadata["created_entities"]) == 1
+
+    def test_no_write_leaves_created_entities_empty(self, with_api_key, household, owner):
+        stub = _ToolUseClient(script=[_run_text("Bonjour !")])
+        result = service.ask("bonjour", household, user=owner, client=stub)
+        assert result.metadata["created_entities"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -395,3 +395,102 @@ class TestGetRelated:
         )
         assert result.hits == []
         assert "no project found" in result.rendered
+
+
+class TestCreateEntity:
+    def test_creates_task_and_returns_citable_hit(self, household, owner):
+        from tasks.models import Task
+
+        result = dispatch(
+            tools.CREATE_ENTITY,
+            {"entity_type": "task", "fields": {"subject": "Purger la VMC"}},
+            household=household,
+            user=owner,
+        )
+
+        task = Task.objects.get(subject="Purger la VMC")
+        assert task.household_id == household.id
+        assert task.created_by_id == owner.id
+        # Cited like retrieved data + surfaced as a created entity for undo.
+        assert f"id=task:{task.id}" in result.rendered
+        assert any(h.id == task.id for h in result.hits)
+        assert result.created == [
+            {
+                "entity_type": "task",
+                "id": str(task.id),
+                "label": "Purger la VMC",
+                "url_path": f"/app/tasks/{task.id}",
+            }
+        ]
+
+    def test_optional_fields_are_applied(self, household, owner):
+        from tasks.models import Task
+
+        dispatch(
+            tools.CREATE_ENTITY,
+            {
+                "entity_type": "task",
+                "fields": {
+                    "subject": "Commander la PAC",
+                    "content": "chez Leroy Merlin",
+                    "priority": 1,
+                    "due_date": "2026-08-01",
+                },
+            },
+            household=household,
+            user=owner,
+        )
+        task = Task.objects.get(subject="Commander la PAC")
+        assert task.content == "chez Leroy Merlin"
+        assert task.priority == 1
+        assert str(task.due_date) == "2026-08-01"
+
+    def test_anchored_project_links_the_task(self, household, owner, make_project):
+        from tasks.models import Task
+
+        project = make_project(title="Rénovation salle de bain")
+        dispatch(
+            tools.CREATE_ENTITY,
+            {"entity_type": "task", "fields": {"subject": "Choisir le carrelage"}},
+            household=household,
+            user=owner,
+            context_entity=("project", str(project.pk)),
+        )
+        task = Task.objects.get(subject="Choisir le carrelage")
+        assert task.project_id == project.pk
+
+    def test_unknown_entity_type_is_recoverable(self, household, owner):
+        result = dispatch(
+            tools.CREATE_ENTITY,
+            {"entity_type": "dragon", "fields": {"name": "x"}},
+            household=household,
+            user=owner,
+        )
+        assert result.created == []
+        assert "cannot create 'dragon'" in result.rendered
+        assert "task" in result.rendered  # lists creatable types
+
+    def test_missing_subject_is_recoverable(self, household, owner):
+        from tasks.models import Task
+
+        result = dispatch(
+            tools.CREATE_ENTITY,
+            {"entity_type": "task", "fields": {"content": "no subject"}},
+            household=household,
+            user=owner,
+        )
+        assert result.created == []
+        assert "could not create task" in result.rendered
+        assert not Task.objects.filter(content="no subject").exists()
+
+    def test_created_task_is_scoped_to_the_given_household(self, household, owner):
+        from tasks.models import Task
+
+        dispatch(
+            tools.CREATE_ENTITY,
+            {"entity_type": "task", "fields": {"subject": "Scoped task"}},
+            household=household,
+            user=owner,
+        )
+        task = Task.objects.get(subject="Scoped task")
+        assert task.household_id == household.id

--- a/apps/agent/tests/test_writables.py
+++ b/apps/agent/tests/test_writables.py
@@ -1,0 +1,92 @@
+"""Tests for the agent write registry (agent.writables) + the task WritableSpec."""
+from __future__ import annotations
+
+import pytest
+
+from agent import writables
+from agent.writables import (
+    REGISTRY,
+    WritableSpec,
+    as_created_dict,
+    find_spec,
+    register,
+    reset_registry,
+    resolve_label,
+    resolve_url,
+    supported_entity_types,
+)
+
+
+@pytest.fixture
+def fresh_registry():
+    """Snapshot/restore the global registry so a test can't pollute others."""
+    snapshot = dict(REGISTRY)
+    reset_registry()
+    yield
+    reset_registry()
+    REGISTRY.update(snapshot)
+
+
+def _spec(entity_type="thing"):
+    return WritableSpec(
+        entity_type=entity_type,
+        create=lambda household, user, fields, *, anchor=None: None,
+        label_attr="subject",
+        url_template="/app/things/{id}",
+    )
+
+
+class TestRegistry:
+    def test_register_and_find(self, fresh_registry):
+        spec = _spec()
+        register(spec)
+        assert find_spec("thing") is spec
+        assert find_spec("nope") is None
+
+    def test_double_register_raises(self, fresh_registry):
+        register(_spec())
+        with pytest.raises(ValueError, match="already registered"):
+            register(_spec())
+
+    def test_supported_entity_types_sorted(self, fresh_registry):
+        register(_spec("zeta"))
+        register(_spec("alpha"))
+        assert supported_entity_types() == ["alpha", "zeta"]
+
+
+class TestBootRegistry:
+    def test_task_registered_at_boot(self):
+        assert "task" in REGISTRY
+
+
+class TestResolvers:
+    def test_label_url_and_created_dict(self, fresh_registry):
+        class FakeTask:
+            pk = "abc"
+            subject = "Purger la VMC"
+
+        register(_spec("task"))
+        spec = find_spec("task")
+        obj = FakeTask()
+        assert resolve_label(spec, obj) == "Purger la VMC"
+        assert resolve_url(spec, obj) == "/app/things/abc"
+        assert as_created_dict(spec, obj) == {
+            "entity_type": "task",
+            "id": "abc",
+            "label": "Purger la VMC",
+            "url_path": "/app/things/abc",
+        }
+
+    def test_label_callable(self, fresh_registry):
+        spec = WritableSpec(
+            entity_type="x",
+            create=lambda *a, **k: None,
+            label_attr=lambda obj: f"#{obj.pk}",
+            url_template="/x/{id}",
+        )
+        register(spec)
+
+        class O:
+            pk = 7
+
+        assert resolve_label(spec, O()) == "#7"

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -29,9 +29,10 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework.exceptions import ValidationError as DRFValidationError
 
-from . import query_expansion, retrieval, searchables
+from . import query_expansion, retrieval, searchables, writables
 from .llm import LLMClient, get_llm_client
 from .prompts import render_context_block
 from .retrieval import Hit
@@ -54,11 +55,14 @@ class ToolResult:
 
     ``rendered`` is the text injected back into the conversation as a
     ``tool_result`` block. ``hits`` is the retrieval hits (empty for non-search
-    tools) that the orchestrator accumulates into the citation pool.
+    tools) that the orchestrator accumulates into the citation pool. ``created``
+    holds entities produced by a write tool (``create_entity``), surfaced by the
+    orchestrator in ``metadata.created_entities`` so the client can offer an undo.
     """
 
     rendered: str
     hits: list[Hit] = field(default_factory=list)
+    created: list[dict[str, Any]] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -104,11 +108,14 @@ def dispatch(
     household,
     user=None,
     client: LLMClient | None = None,
+    context_entity: tuple[str, str] | None = None,
 ) -> ToolResult:
     """Run the registered handler for ``name``.
 
     An unknown tool name never raises into the loop — it returns a ``ToolResult``
-    the model can read and recover from.
+    the model can read and recover from. ``context_entity`` is the conversation
+    anchor (or None); write tools use it to default a link (e.g. attach a new
+    task to the anchored project).
     """
     tool = REGISTRY.get(name)
     if tool is None:
@@ -119,6 +126,7 @@ def dispatch(
         user=user,
         tool_input=tool_input or {},
         client=client,
+        context_entity=context_entity,
     )
 
 
@@ -156,6 +164,7 @@ def _search_household_handler(
     user=None,
     tool_input: dict[str, Any],
     client: LLMClient | None = None,
+    context_entity: tuple[str, str] | None = None,
 ) -> ToolResult:
     """Expand the query, run scoped retrieval, render a citable context block."""
     query = (tool_input.get("query") or "").strip()
@@ -229,7 +238,7 @@ def resolve_entity(entity_type: str, raw_id: str, household):
 
     try:
         obj = spec.model.objects.filter(household_id=household.id, pk=raw_id).first()
-    except (ValueError, TypeError, ValidationError):
+    except (ValueError, TypeError, DjangoValidationError):
         # Malformed id (e.g. not a valid UUID) — recoverable, tell the model.
         return None, ToolResult(rendered=f"(invalid id for {entity_type}: {raw_id})")
 
@@ -246,6 +255,7 @@ def _get_entity_handler(
     user=None,
     tool_input: dict[str, Any],
     client: LLMClient | None = None,
+    context_entity: tuple[str, str] | None = None,
 ) -> ToolResult:
     """Fetch one entity by (entity_type, id), scoped household, and read it whole."""
     entity_type = (tool_input.get("entity_type") or "").strip()
@@ -321,6 +331,7 @@ def _get_related_handler(
     user=None,
     tool_input: dict[str, Any],
     client: LLMClient | None = None,
+    context_entity: tuple[str, str] | None = None,
 ) -> ToolResult:
     """Resolve the source entity, walk its declared relations, render them citable."""
     entity_type = (tool_input.get("entity_type") or "").strip()
@@ -362,4 +373,108 @@ def build_get_related_tool() -> AgentTool:
         description=_GET_RELATED_DESCRIPTION,
         input_schema=_GET_RELATED_SCHEMA,
         handler=_get_related_handler,
+    )
+
+
+# --- create_entity ----------------------------------------------------------
+
+CREATE_ENTITY = "create_entity"
+
+_CREATE_ENTITY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "entity_type": {
+            "type": "string",
+            "description": "The kind of item to create. Supported: 'task'.",
+        },
+        "fields": {
+            "type": "object",
+            "description": (
+                "The item's fields. For entity_type='task': "
+                "subject (required, short imperative title), content (optional "
+                "details), due_date (optional, 'YYYY-MM-DD'), priority (optional "
+                "integer 1=high..5=low). In an anchored conversation the project/"
+                "zone is attached automatically — do not ask for it."
+            ),
+        },
+    },
+    "required": ["entity_type", "fields"],
+}
+
+_CREATE_ENTITY_DESCRIPTION = (
+    "Create a new household item on the user's behalf. Supported types: 'task' "
+    "(a to-do / reminder). Only call this when the user clearly asks to create, "
+    "add or remember something — never speculatively. After it succeeds, confirm "
+    "in one short sentence and cite the new item with its returned id. The item "
+    "is created immediately; the user can undo it from the interface."
+)
+
+
+def _create_entity_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client: LLMClient | None = None,
+    context_entity: tuple[str, str] | None = None,
+) -> ToolResult:
+    """Create one entity via its WritableSpec, return it as a citable Hit + created ref.
+
+    The anti-duplicate guard (a repeated create call in the same tool-use loop)
+    lives in ``service.ask``, which owns the per-turn state.
+    """
+    entity_type = (tool_input.get("entity_type") or "").strip()
+    fields = tool_input.get("fields") or {}
+    if not entity_type:
+        return ToolResult(rendered="(needs an entity_type to create)")
+    if not isinstance(fields, dict):
+        return ToolResult(rendered="(fields must be an object)")
+
+    spec = writables.find_spec(entity_type)
+    if spec is None:
+        supported = ", ".join(writables.supported_entity_types()) or "(none)"
+        return ToolResult(
+            rendered=f"(cannot create '{entity_type}'; creatable types: {supported})"
+        )
+
+    try:
+        instance = spec.create(household, user, fields, anchor=context_entity)
+    except (DRFValidationError, DjangoValidationError) as exc:
+        detail = getattr(exc, "detail", None) or getattr(exc, "messages", None) or str(exc)
+        return ToolResult(rendered=f"(could not create {entity_type}: {detail})")
+    except Exception:  # noqa: BLE001 — never crash the loop on a create failure
+        logger.exception("agent.tools: create_entity failed for %s", entity_type)
+        return ToolResult(rendered=f"(could not create {entity_type}: unexpected error)")
+
+    # Turn the new instance into a citable Hit through its SEARCHABLE spec (so the
+    # model can cite it exactly like retrieved data). Falls back to a plain label.
+    search_spec = searchables.find_spec_for_instance(instance)
+    if search_spec is not None:
+        hit = retrieval.hit_from_instance(search_spec, instance)
+        hits = [hit]
+        tag = f"{hit.entity_type}:{hit.id}"
+    else:
+        hits = []
+        tag = f"{entity_type}:{instance.pk}"
+
+    label = writables.resolve_label(spec, instance)
+    rendered = f"Created {entity_type} id={tag}\n  label={label}"
+    return ToolResult(
+        rendered=rendered,
+        hits=hits,
+        created=[writables.as_created_dict(spec, instance)],
+    )
+
+
+def _stable_signature(fields: dict) -> tuple:
+    """A hashable signature of the create fields, for the anti-duplicate guard."""
+    return tuple(sorted((str(k), str(v)) for k, v in fields.items()))
+
+
+def build_create_entity_tool() -> AgentTool:
+    return AgentTool(
+        name=CREATE_ENTITY,
+        description=_CREATE_ENTITY_DESCRIPTION,
+        input_schema=_CREATE_ENTITY_SCHEMA,
+        handler=_create_entity_handler,
     )

--- a/apps/agent/writables.py
+++ b/apps/agent/writables.py
@@ -1,0 +1,92 @@
+"""
+Registry of entities the agent is allowed to *create*.
+
+The write counterpart of ``searchables.py``. Same philosophy: the agent core
+never hardcodes the list of creatable entities — each app declares its own
+``WritableSpec`` from ``apps.py.ready()``, so the single ``create_entity`` tool
+covers N entities and adding one is ~5 lines with zero touche to ``apps/agent/``.
+
+A spec carries how to *create* one instance (``create``) plus how to turn the
+result into a citable, linkable reference (``label_attr`` / ``url_template``) so
+the agent can confirm and cite what it just made, and the frontend can offer an
+undo.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from django.db.models import Model
+
+
+@dataclass(frozen=True)
+class WritableSpec:
+    """Declarative description of a model the agent may create."""
+
+    entity_type: str
+    """Discriminator used in the ``create_entity`` tool (e.g. 'task')."""
+
+    create: Callable[..., Model]
+    """``create(household, user, fields, *, anchor=None) -> instance``.
+
+    ``fields`` is the raw dict the model produced; the callable is responsible
+    for mapping/validating it and for reusing the app's own service/serializer
+    (never raw ORM shortcuts that bypass validation). ``anchor`` is the current
+    conversation anchor ``(entity_type, object_id)`` or ``None`` — used to
+    default a link (e.g. attach the new task to the anchored project)."""
+
+    label_attr: str | Callable[[Model], str]
+    """Attribute name or callable producing the created item's human label."""
+
+    url_template: str
+    """URL template for the created item's link. Must contain ``{id}``."""
+
+
+REGISTRY: dict[str, WritableSpec] = {}
+
+
+def register(spec: WritableSpec) -> None:
+    """Add a spec to the registry. Raises if ``entity_type`` is already registered."""
+    if spec.entity_type in REGISTRY:
+        raise ValueError(
+            f"WritableSpec for entity_type={spec.entity_type!r} is already registered"
+        )
+    REGISTRY[spec.entity_type] = spec
+
+
+def reset_registry() -> None:
+    """Test helper — clears the registry. Do not call from production code."""
+    REGISTRY.clear()
+
+
+def find_spec(entity_type: str) -> WritableSpec | None:
+    """Return the registered writable spec for ``entity_type``, or None."""
+    return REGISTRY.get(entity_type)
+
+
+def resolve_label(spec: WritableSpec, instance: Model) -> str:
+    """Resolve the label for a created instance using the spec's ``label_attr``."""
+    if callable(spec.label_attr):
+        return str(spec.label_attr(instance))
+    return str(getattr(instance, spec.label_attr, "") or "")
+
+
+def resolve_url(spec: WritableSpec, instance: Model) -> str:
+    """Build the created item's URL path from the spec template."""
+    return spec.url_template.format(id=instance.pk)
+
+
+def supported_entity_types() -> list[str]:
+    """Stable-sorted list of creatable entity types (for prompt/description)."""
+    return sorted(REGISTRY.keys())
+
+
+def as_created_dict(spec: WritableSpec, instance: Model) -> dict[str, Any]:
+    """Serialize a freshly-created instance into the ``created`` payload shape."""
+    return {
+        "entity_type": spec.entity_type,
+        "id": str(instance.pk),
+        "label": resolve_label(spec, instance),
+        "url_path": resolve_url(spec, instance),
+    }

--- a/apps/tasks/apps.py
+++ b/apps/tasks/apps.py
@@ -7,6 +7,7 @@ class TasksConfig(AppConfig):
 
     def ready(self):
         from agent.searchables import SearchableSpec, register
+        from agent.writables import WritableSpec, register as register_writable
         from .models import Task
 
         register(SearchableSpec(
@@ -16,3 +17,41 @@ class TasksConfig(AppConfig):
             label_attr='subject',
             url_template='/app/tasks/{id}',
         ))
+
+        register_writable(WritableSpec(
+            entity_type='task',
+            create=_create_task_from_agent,
+            label_attr='subject',
+            url_template='/app/tasks/{id}',
+        ))
+
+
+def _create_task_from_agent(household, user, fields, *, anchor=None):
+    """Map the agent's raw ``fields`` to ``tasks.services.create_task``.
+
+    Resolves the conversation ``anchor`` into a sensible default link: an
+    anchored project pre-fills the task's project (and its zones are inherited by
+    the task serializer via the project); an anchored zone pre-fills the zone.
+    """
+    from .services import create_task
+
+    project = None
+    zone_ids = None
+    if anchor:
+        anchor_type, anchor_id = anchor
+        if anchor_type == 'project':
+            project = anchor_id
+        elif anchor_type == 'zone':
+            zone_ids = [anchor_id]
+
+    priority = fields.get('priority')
+    return create_task(
+        household,
+        user,
+        subject=(fields.get('subject') or '').strip(),
+        content=fields.get('content'),
+        due_date=fields.get('due_date'),
+        priority=int(priority) if priority not in (None, '') else None,
+        project=project,
+        zone_ids=zone_ids,
+    )

--- a/apps/tasks/services.py
+++ b/apps/tasks/services.py
@@ -1,0 +1,62 @@
+"""
+Task creation service — single source of truth for "create a task".
+
+Extracted so both the REST API and the agent's ``create_entity`` tool create
+tasks the same way: validation through ``TaskSerializer`` and the household root
+zone fallback (mirrors ``TaskViewSet.perform_create``). Callers pass an explicit
+``household`` + ``user`` (the agent has no ``request``).
+"""
+from __future__ import annotations
+
+from zones.models import Zone
+
+from .models import Task
+from .serializers import TaskSerializer
+
+
+def _resolve_zone_ids(household, zone_ids) -> list[str]:
+    """Return usable zone ids, falling back to the household root zone.
+
+    Tasks require at least one zone; when the caller provides none we attach the
+    task to the household's root zone (auto-created per household), exactly like
+    ``TaskViewSet.perform_create``.
+    """
+    if zone_ids:
+        return [str(z) for z in zone_ids]
+    root = Zone.objects.filter(household=household, parent__isnull=True).first()
+    return [str(root.id)] if root is not None else []
+
+
+def create_task(
+    household,
+    user,
+    *,
+    subject: str,
+    content: str | None = None,
+    due_date=None,
+    priority: int | None = None,
+    project=None,
+    zone_ids=None,
+) -> Task:
+    """Create a task for ``household`` on behalf of ``user``.
+
+    Reuses ``TaskSerializer`` so validation (private/assignee rules, zone
+    membership, priority range) stays in one place. ``project`` and ``zone_ids``
+    are optional; with no zone the household root zone is used.
+    """
+    payload: dict = {
+        "subject": subject,
+        "zone_ids": _resolve_zone_ids(household, zone_ids),
+    }
+    if content:
+        payload["content"] = content
+    if due_date is not None:
+        payload["due_date"] = due_date
+    if priority is not None:
+        payload["priority"] = priority
+    if project is not None:
+        payload["project"] = getattr(project, "pk", project)
+
+    serializer = TaskSerializer(data=payload, context={"household_id": household.id})
+    serializer.is_valid(raise_exception=True)
+    return serializer.save(household=household, created_by=user)

--- a/apps/tasks/tests/test_services.py
+++ b/apps/tasks/tests/test_services.py
@@ -1,0 +1,70 @@
+"""Tests for tasks.services.create_task (shared by API + agent write tool)."""
+from __future__ import annotations
+
+import pytest
+
+from accounts.tests.factories import UserFactory
+from households.models import Household, HouseholdMember
+from tasks.models import Task, TaskZone
+from tasks.services import create_task
+from zones.models import Zone
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="tasks-services-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = Household.objects.create(name="Services House")
+    HouseholdMember.objects.create(user=owner, household=hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+class TestCreateTask:
+    def test_falls_back_to_root_zone_when_none_given(self, household, owner):
+        # A household auto-creates its root zone via signal.
+        root = Zone.objects.get(household=household, parent__isnull=True)
+
+        task = create_task(household, owner, subject="Purger la VMC")
+
+        assert task.household_id == household.id
+        assert task.created_by_id == owner.id
+        assert list(task.zones.values_list("id", flat=True)) == [root.id]
+
+    def test_optional_fields(self, household, owner):
+        task = create_task(
+            household,
+            owner,
+            subject="Commander la PAC",
+            content="chez Wood Co.",
+            priority=2,
+            due_date="2026-09-15",
+        )
+        assert task.content == "chez Wood Co."
+        assert task.priority == 2
+        assert str(task.due_date) == "2026-09-15"
+
+    def test_explicit_zone_is_used(self, household, owner):
+        zone = Zone.objects.create(household=household, name="Chaufferie", created_by=owner)
+        task = create_task(
+            household, owner, subject="Vérifier la chaudière", zone_ids=[str(zone.id)]
+        )
+        assert TaskZone.objects.filter(task=task, zone=zone).exists()
+
+    def test_with_project(self, household, owner):
+        from projects.models import Project
+
+        project = Project.objects.create(
+            household=household, created_by=owner, title="Rénovation"
+        )
+        task = create_task(household, owner, subject="Devis", project=project)
+        assert task.project_id == project.pk
+
+    def test_missing_subject_raises(self, household, owner):
+        from rest_framework.exceptions import ValidationError
+
+        with pytest.raises(ValidationError):
+            create_task(household, owner, subject="")
+        assert not Task.objects.filter(household=household).exists()

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -22,6 +22,45 @@ dans `tools.REGISTRY` :
 Les citations `<cite id="type:id"/>` sont intersectées avec le pool de hits
 réellement retournés (citations honnêtes, cf. `_resolve_citations`).
 
+Un **4ᵉ tool, d'écriture**, complète les trois de lecture :
+
+- `create_entity(entity_type, fields)` — crée un item du foyer (aujourd'hui :
+  `task`). Un seul tool générique, adossé au registry `writables` (cf. plus bas).
+  L'item créé est renvoyé comme Hit citable + remonté dans
+  `metadata.created_entities` pour l'Undo côté client. Livré au **lot 8** (voir
+  `docs/parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md`).
+
+## Registry d'écriture `writables` — rendre une entité créable
+
+Miroir de `searchables`, pour l'écriture. Chaque app déclare depuis
+`apps.py::ready()` :
+
+```python
+from agent.writables import WritableSpec, register as register_writable
+
+register_writable(WritableSpec(
+    entity_type='task',
+    create=_create_task_from_agent,   # (household, user, fields, *, anchor) -> instance
+    label_attr='subject',
+    url_template='/app/tasks/{id}',
+))
+```
+
+Règles :
+- `create` **réutilise le service métier** de l'app (jamais l'ORM brut) — ex.
+  `tasks.services.create_task` qui passe par `TaskSerializer` (validation, scope
+  foyer, fallback zone racine).
+- `create` reçoit l'`anchor` de la conversation ancrée `(entity_type, object_id)`
+  et l'utilise pour pré-remplir un lien (ancre `project` → tâche liée au projet).
+- Rendre une entité créable = **registrer un `WritableSpec`** + étendre la
+  description du tool `create_entity`. Zéro touche à `apps/agent/tools.py` sur le
+  fond.
+
+**Garde-fous d'écriture** : prompt strict (créer seulement sur demande explicite),
+anti-doublon par tour (`service.ask`), et **Undo** côté client (toast « Annuler »
+qui supprime l'item). Une écriture est un effet de bord réversible, pas une
+proposition à valider.
+
 ## Registry searchable — ajouter une entité
 
 Chaque app déclare ses entités depuis `apps.py::ready()` via

--- a/docs/MODULES/tasks.md
+++ b/docs/MODULES/tasks.md
@@ -25,3 +25,4 @@
 - La transition `done` est correctement gérée côté backend (`apps/tasks/views.py:123-128`) : `completed_at` et `completed_by` sont auto-set / auto-cleared.
 - La page `TasksPage` est un wrapper minimal de `TasksPanel` (réutilisable côté projets).
 - Suppression : soft-delete via `status='archived'` côté backend ; le frontend utilise `useDeleteWithUndo` + DELETE HTTP, donc l'undo restaure en repassant l'item en `pending` (à vérifier dans le hook `useDeleteTask`).
+- **Création par l'agent IA (lot 8, 2026-07)** : l'agent crée une tâche via son tool `create_entity`. La logique est centralisée dans `apps/tasks/services.py::create_task` (fallback zone racine + `TaskSerializer`), réutilisée par le `WritableSpec` enregistré dans `tasks/apps.py`. En conversation ancrée sur un projet, la tâche est auto-liée au projet. Voir `docs/MODULES/agent.md`.

--- a/docs/fiches/RAG.md
+++ b/docs/fiches/RAG.md
@@ -279,7 +279,7 @@ Plutôt que viser un retrieval parfait avant de toucher au LLM, on livre la cha�
 | **Embeddings vectoriels** (`pgvector`) | Sur < 100k entités texte modeste, gain marginal. Migration possible plus tard sans réécrire l'API. |
 | **Index `tsvector` matérialisé** | Pas nécessaire à ce volume. Si latence devient un sujet → optimisation locale. |
 | **Streaming de réponse** | Complexité UI + back. Bloc en V1 suffit. |
-| **Tool-calling** (agent qui crée des tâches, etc.) | Périmètre énorme + risque d'erreurs côté écriture. V2. |
+| **Tool-calling** (agent qui crée des tâches, etc.) | ~~Périmètre énorme + risque d'erreurs côté écriture. V2.~~ **Livré** : lecture au lot 7 (3 tools), écriture au lot 8 (`create_entity`, tâche). |
 | **Mémoire conversationnelle multi-tour** | Lot 4 du backlog, basculé V2. Question one-shot couvre 95% des cas. |
 | **Détection de langue par document** | Trop tôt. Sur ton corpus, un seul document EN/DE par-ci par-là, pas de quoi justifier le pipeline. |
 | **Redaction PII avant envoi à Claude** | Faible priorité en solo user. À reconsidérer si ouverture multi-tenant. |
@@ -368,7 +368,7 @@ Voir `docs/MODULES/agent.md` pour le mode d'emploi.
 | **Stopwords** | mots ignorés à l'indexation ("le", "la", "the", "a"…) |
 | **Citation** | référence cliquable vers la source d'une affirmation produite par le LLM |
 | **Hallucination** | quand un LLM invente une info qui n'existe pas. Le RAG + citations contraignent le LLM à ne dire que ce qui est dans le contexte. |
-| **Tool-calling** | quand un LLM peut invoquer des fonctions (créer une tâche, envoyer un mail…). Pas en V1. |
+| **Tool-calling** | quand un LLM peut invoquer des fonctions. Dans house : 3 tools de lecture (lot 7) + `create_entity` en écriture (lot 8). |
 
 ## 9. Pour aller plus loin
 

--- a/docs/journal/2026-07-02_parcours-07_lot8_actions_ecriture.md
+++ b/docs/journal/2026-07-02_parcours-07_lot8_actions_ecriture.md
@@ -1,0 +1,71 @@
+# 2026-07-02 — Parcours 07 Lot 8 : actions d'écriture
+
+## Contexte
+
+L'agent conversationnel était *read-only* depuis le lot 7 (boucle tool-use, 3 tools
+de lecture : `search_household`, `get_entity`, `get_related`). Il savait tout
+consulter mais ne pouvait rien faire — alors que l'usage naturel d'un assistant
+foyer est autant « note ça » / « rappelle-moi de… » que « combien j'ai payé ? ».
+
+Ce lot concrétise « Extension 1 / #50 » : donner à l'agent la capacité de **créer**.
+
+Contrainte directrice de l'utilisateur : **ne pas multiplier les définitions de
+tools** (c'est ce qui encombre le modèle). On refuse `create_task` +
+`create_expense` + … et on pose **un seul tool générique** `create_entity`.
+
+Décisions produit : sécurité = **créer + Undo** (pas de modale de confirmation) ;
+première entité créable = **tâche seule**.
+
+## Ce qui a été livré
+
+### Registry d'écriture `writables` + service métier
+
+- `apps/agent/writables.py` — miroir écriture de `searchables`. `WritableSpec`
+  (entity_type, `create`, label_attr, url_template) + registry.
+- `apps/tasks/services.py::create_task` — source unique de la création de tâche
+  (fallback zone racine + `TaskSerializer`), réutilisable par l'API plus tard.
+- `apps/tasks/apps.py` enregistre le `WritableSpec` `task` et résout l'ancre de
+  conversation (projet → tâche liée au projet).
+
+### Tool `create_entity`
+
+- `apps/agent/tools.py` — 4ᵉ tool (générique). Résout le `WritableSpec`, appelle le
+  service, renvoie l'item comme Hit citable + un `created` pour l'undo. Erreurs de
+  validation (DRF + Django) et exceptions → messages récupérables (jamais de crash
+  de boucle).
+- `ToolResult.created` + `dispatch(context_entity=…)` pour transmettre l'ancre.
+- `apps/agent/service.py` accumule `metadata.created_entities` + garde-fou
+  anti-doublon par tour.
+- `apps/agent/prompts.py` — garde-fous : créer seulement sur demande explicite,
+  jamais en double, confirmer + citer après création.
+
+### Frontend — Undo
+
+- `useAgentCreatedUndo()` (`agent/hooks.ts`) : toast « Créé · Annuler » par item,
+  branché dans `EntityAssistant` **et** `AgentPage`. Map `entity_type → delete`
+  (`task` → `deleteTask`, soft-delete `archived`).
+- i18n `common.undo` + `agent.created.title` (en/fr/de/es).
+
+### Tests
+
+- `test_writables.py`, `test_tools.py::TestCreateEntity`, `test_services.py`
+  (tasks), `test_service.py::TestCreateEntity`, `test_conversations_api.py`
+  (`created_entities` dans la réponse).
+
+## Décisions & compromis
+
+- **1 tool générique, N entités** (via registry) plutôt qu'un tool par entité —
+  aligné sur le côté lecture. Total : 4 tools.
+- **Créer + Undo** plutôt que draft-à-valider : moins de friction, moins de front,
+  et l'item reste réversible. On n'a pas repris le pattern `needs_review` du
+  transverse pour ce cas.
+- **Jamais d'ORM brut** : la création passe par le service métier de l'app.
+
+## Reste à faire
+
+- Recette manuelle à l'usage (repérer créations mal parsées / en double).
+- Prochaines entités créables (`interaction`/dépense, `stock`…) : même tool,
+  ~5 lignes chacune.
+- Édition/suppression par l'agent (au-delà de l'Undo immédiat) : non tranché.
+
+Doc lot : [PARCOURS_07_LOT8_ACTIONS_ECRITURE.md](../parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md)

--- a/docs/parcours/PARCOURS_07_AGENT_CONVERSATIONNEL.md
+++ b/docs/parcours/PARCOURS_07_AGENT_CONVERSATIONNEL.md
@@ -388,3 +388,12 @@ items liés) est pré-injecté, donc l'IA connaît déjà l'entité sans cherche
   équipements… sans toucher `apps/agent/`).
 - Détail d'implémentation + mode d'emploi : `docs/MODULES/agent.md`,
   section « conversation ancrée » de `docs/fiches/RAG.md`.
+
+## Extension 2026-07 — l'agent crée des choses (lot 8)
+
+L'agent passe de *read-only* à *read + write* : un unique tool générique
+`create_entity` (adossé au registry `writables`) lui permet de **créer** un item
+du foyer depuis le chat (« ajoute une tâche », « rappelle-moi de… »). Première
+entité : la **tâche**. Sécurité par **création + Undo** (toast « Annuler »), et
+dans une conversation ancrée la création hérite du contexte (tâche liée au
+projet). Détail complet : [PARCOURS_07_LOT8_ACTIONS_ECRITURE.md](./PARCOURS_07_LOT8_ACTIONS_ECRITURE.md).

--- a/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
+++ b/docs/parcours/PARCOURS_07_LOT7_FUNCTION_CALLING.md
@@ -68,6 +68,11 @@ anticipé — il émerge de la recette, comme la mémoire conversationnelle l'av
 le socle** que l'Extension 1 attendait : y ajouter `create_interaction` deviendra
 l'enregistrement d'un second tool.
 
+> **Mise à jour 2026-07 — Extension 1 livrée au lot 8.** Les actions d'écriture
+> sont arrivées via un tool générique unique `create_entity` (registry `writables`,
+> tâche en 1re entité), et non un `create_<type>` par entité. Voir
+> [PARCOURS_07_LOT8_ACTIONS_ECRITURE.md](./PARCOURS_07_LOT8_ACTIONS_ECRITURE.md).
+
 ## 3. Architecture cible
 
 ### Vue d'ensemble : boucle tool-use dans `service.py`

--- a/docs/parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md
+++ b/docs/parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md
@@ -1,0 +1,170 @@
+# Parcours 07 — Lot 8 : Actions d'écriture (l'agent crée des choses)
+
+> **État : ✅ livré, 2026-07** — l'agent passe de *read-only* à *read + write*.
+> Concrétise « Extension 1 / #50 » du lot 7 : créer un item du foyer depuis le
+> chat (« ajoute une tâche », « rappelle-moi de… »). Première entité créable : la
+> **tâche**. Sécurité par **création + Undo**, pas de modale de confirmation.
+>
+> Socle : [PARCOURS_07_LOT7_FUNCTION_CALLING.md](./PARCOURS_07_LOT7_FUNCTION_CALLING.md)
+> Doc produit : [PARCOURS_07_AGENT_CONVERSATIONNEL.md](./PARCOURS_07_AGENT_CONVERSATIONNEL.md)
+> Fiche module : [docs/MODULES/agent.md](../MODULES/agent.md)
+
+## 1. Pourquoi ce lot
+
+Le lot 7 a posé la boucle tool-use avec **3 tools de lecture**
+(`search_household`, `get_entity`, `get_related`). L'agent sait tout consulter,
+mais ne peut **rien faire**. Or l'usage naturel d'un assistant foyer est autant
+« note ça » / « rappelle-moi de… » que « combien j'ai payé ? ».
+
+### La contrainte directrice
+
+> Ne pas multiplier les *définitions* de tools — c'est ça qui encombre le modèle,
+> pas le nombre d'appels.
+
+On refuse donc l'anti-pattern `create_task` + `create_expense` + `create_note` +
+`create_stock`… (6 tools qui se ressemblent). On applique au côté écriture la même
+philosophie que la lecture : **un seul tool générique** `create_entity`, adossé à
+un registry (`writables`). Total : 3 read + 1 write = **4 tools**, extensible à N
+entités sans toucher `apps/agent/`.
+
+### Le risque à maîtriser
+
+Une écriture est un **effet de bord** : le modèle peut mal parser, créer en
+double, ou créer sans qu'on le demande. Garde-fous (§5) : prompt strict (créer
+seulement sur demande explicite), anti-doublon par tour, et **Undo** côté client
+(l'item créé est réversible en un clic).
+
+## 2. Architecture cible
+
+```
+create_entity(entity_type, fields)                 ← 1 tool, N entités
+        │
+        ▼
+writables.find_spec(entity_type)  →  WritableSpec.create(household, user, fields, anchor)
+        │                                   │
+        │                                   └─ réutilise le service métier de l'app
+        │                                      (tasks.services.create_task → TaskSerializer)
+        ▼
+ToolResult(rendered, hits=[hit_citable], created=[{entity_type,id,label,url_path}])
+        │
+        ▼
+service.ask : accumule `created` → metadata.created_entities
+        │
+        ▼
+frontend : toast « Créé · Annuler » (useAgentCreatedUndo) + citation cliquable
+```
+
+Points clés :
+- **Symétrie avec la lecture** : `writables.py` est le miroir de `searchables.py`.
+- **Jamais d'ORM brut** : la création passe par le **service métier** de l'app
+  (`tasks/services.py::create_task`), qui réutilise `TaskSerializer` — validation,
+  scope foyer, fallback zone racine restent à un seul endroit.
+- **`AnswerResult` et la signature de `ask()` ne changent pas** ; on n'ajoute
+  qu'une clé `metadata.created_entities`. Le reste du backend/API est intact.
+
+## 3. Le registry d'écriture `writables` (le socle)
+
+`apps/agent/writables.py` (nouveau), même pattern que `searchables` :
+
+```python
+@dataclass(frozen=True)
+class WritableSpec:
+    entity_type: str                       # "task"
+    create: Callable                        # (household, user, fields, *, anchor) -> instance
+    label_attr: str | Callable              # libellé de l'item créé
+    url_template: str                       # "/app/tasks/{id}"
+
+REGISTRY: dict[str, WritableSpec] = {}
+def register(spec): ...
+def find_spec(entity_type): ...
+def supported_entity_types(): ...           # pour la description du tool
+def as_created_dict(spec, instance): ...    # {entity_type, id, label, url_path}
+```
+
+Chaque app enregistre depuis `apps.py::ready()`. **Rendre une entité créable =
+~5 lignes**, zéro touche à `apps/agent/`.
+
+## 4. Le tool `create_entity` + le contrat
+
+`apps/agent/tools.py` :
+- Schéma : `{ entity_type: str, fields: object }`. La description énumère (borné)
+  les entités créables et leurs champs — aujourd'hui `task` → `subject` (requis),
+  `content`, `due_date` (`YYYY-MM-DD`), `priority` (1..5).
+- Handler : résout le `WritableSpec` (type inconnu → `ToolResult` récupérable qui
+  liste les types créables), appelle `spec.create(household, user, fields,
+  anchor=context_entity)`, attrape les `ValidationError` (DRF **et** Django) et
+  toute exception → message récupérable (jamais de crash de boucle).
+- Renvoie l'item **comme Hit citable** (via son `SearchableSpec`, donc citable
+  exactement comme une donnée retrouvée) + un `created` pour l'undo.
+- `ToolResult` gagne un champ `created: list[dict]`.
+
+**Scope depuis l'ancre** : `service.ask` transmet le `context_entity` de la
+conversation ancrée au `dispatch`. Le `WritableSpec` de la tâche le résout : ancre
+`project` → tâche liée au projet ; ancre `zone` → tâche dans cette zone. Dans
+l'onglet Assistant d'un projet, « ajoute une tâche » suffit.
+
+## 5. Garde-fous
+
+1. **Prompt système** (`prompts.py`) : ne créer que sur demande **explicite** ;
+   jamais de création spéculative ni en double ; si l'item est ambigu (pas de
+   sujet), poser une question avant ; après succès, confirmer en une phrase et
+   **citer** le nouvel item ; pas de demande de confirmation (l'Undo couvre ça).
+2. **Anti-doublon par tour** (`service.ask`) : si le modèle rappelle le même
+   `create_entity` (même `entity_type` + mêmes `fields`) dans la même boucle
+   tool-use, la 2ᵉ écriture DB est **court-circuitée** et on le signale au modèle.
+3. **Undo client** : chaque item créé remonte dans `metadata.created_entities` ;
+   le front affiche un toast « Créé · Annuler » (8 s) qui supprime (archive) l'item
+   au clic. Réutilise le pattern toast + `deleteTask` (soft-delete `archived`).
+
+## 6. Fichiers touchés
+
+**Backend**
+- `apps/agent/writables.py` (nouveau) — registry d'écriture.
+- `apps/tasks/services.py` (nouveau) — `create_task(...)` (fallback zone racine,
+  `TaskSerializer`).
+- `apps/tasks/apps.py` — enregistre le `WritableSpec` `task` + mapping/anchor.
+- `apps/agent/tools.py` — tool `create_entity`, `ToolResult.created`,
+  `dispatch(context_entity=…)`, `_stable_signature`.
+- `apps/agent/apps.py` — `register(build_create_entity_tool())`.
+- `apps/agent/service.py` — passe l'ancre au dispatch, accumule
+  `metadata.created_entities`, anti-doublon.
+- `apps/agent/prompts.py` — garde-fous d'écriture.
+
+**Frontend**
+- `ui/src/features/agent/api.ts` — type `AgentCreatedEntity` + `created_entities`.
+- `ui/src/features/agent/hooks.ts` — `useAgentCreatedUndo()` (map `entity_type →
+  delete`).
+- `EntityAssistant.tsx` + `AgentPage.tsx` — appel après réponse.
+- `locales/*` — `common.undo`, `agent.created.title`.
+
+## 7. Tests
+
+- `apps/agent/tests/test_writables.py` — registry.
+- `apps/agent/tests/test_tools.py::TestCreateEntity` — crée une tâche (hit citable
+  + `created`), champs optionnels, ancre projet, type inconnu récupérable, sujet
+  manquant récupérable, scope foyer.
+- `apps/tasks/tests/test_services.py` — `create_task` (fallback racine, champs,
+  projet, sujet vide → 400).
+- `apps/agent/tests/test_service.py::TestCreateEntity` — `created_entities` peuplé,
+  ancre → projet, anti-doublon, aucun write → liste vide.
+- `apps/agent/tests/test_conversations_api.py` — la réponse POST message porte
+  `created_entities`.
+
+## 8. Hors scope de ce lot
+
+- Autres entités créables (`interaction`/dépense, `stock`…) — même tool, +5 lignes,
+  livraison suivante.
+- **Édition / suppression** par l'agent (au-delà de l'Undo immédiat).
+- Le pattern `needs_review` (proposition vs vérité) du transverse — ici on tranche
+  « créer + Undo » plutôt que « draft à valider ».
+
+## 9. Definition of done
+
+1. ✅ Un seul tool d'écriture ajouté (`create_entity`) — 4 tools au total.
+2. ✅ « ajoute une tâche : purger la VMC samedi » crée la tâche, l'agent confirme
+   avec une citation cliquable, un toast « Annuler » la retire.
+3. ✅ Dans l'onglet Assistant d'un projet, la tâche créée est **liée au projet**.
+4. ✅ Un simple « bonjour » ne crée rien (`created_entities` vide).
+5. ✅ Rendre une nouvelle entité créable = registrer un `WritableSpec`, sans
+   toucher `apps/agent/`.
+6. ⏳ Recette manuelle à l'usage (repérer les créations mal parsées / en trop).

--- a/ui/src/features/agent/AgentPage.tsx
+++ b/ui/src/features/agent/AgentPage.tsx
@@ -10,6 +10,7 @@ import ConversationList from './ConversationList';
 import PrivacyNotice from './PrivacyNotice';
 import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
 import {
+  useAgentCreatedUndo,
   useConversation,
   useConversations,
   useCreateConversation,
@@ -53,6 +54,7 @@ export default function AgentPage() {
   const conversationQuery = useConversation(currentId);
   const createConversation = useCreateConversation();
   const postMessage = usePostMessage();
+  const notifyCreated = useAgentCreatedUndo();
 
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [draft, setDraft] = React.useState('');
@@ -147,13 +149,14 @@ export default function AgentPage() {
           citations: agentMsg.citations,
         },
       ]);
+      notifyCreated(agentMsg.metadata?.created_entities);
     } catch {
       setMessages((prev) => [
         ...prev,
         { id: `e-${Date.now()}`, variant: 'error', text: t('agent.error') },
       ]);
     }
-  }, [draft, isBusy, currentId, createConversation, postMessage, t]);
+  }, [draft, isBusy, currentId, createConversation, postMessage, notifyCreated, t]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/ui/src/features/agent/EntityAssistant.tsx
+++ b/ui/src/features/agent/EntityAssistant.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/design-system/textarea';
 import ChatBubble from './ChatBubble';
 import PrivacyNotice from './PrivacyNotice';
 import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
-import { useEntityConversation, usePostMessage } from './hooks';
+import { useAgentCreatedUndo, useEntityConversation, usePostMessage } from './hooks';
 import type { AgentCitation, AgentMessageRow } from './api';
 
 interface UserMessage {
@@ -57,6 +57,7 @@ export default function EntityAssistant({ entityType, objectId }: Props) {
   const conversationQuery = useEntityConversation(entityType, objectId);
   const conversationId = conversationQuery.data?.id ?? null;
   const postMessage = usePostMessage();
+  const notifyCreated = useAgentCreatedUndo();
 
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [draft, setDraft] = React.useState('');
@@ -112,13 +113,14 @@ export default function EntityAssistant({ entityType, objectId }: Props) {
           citations: agentMsg.citations,
         },
       ]);
+      notifyCreated(agentMsg.metadata?.created_entities);
     } catch {
       setMessages((prev) => [
         ...prev,
         { id: `e-${Date.now()}`, variant: 'error', text: t('agent.error') },
       ]);
     }
-  }, [draft, isBusy, conversationId, postMessage, t]);
+  }, [draft, isBusy, conversationId, postMessage, notifyCreated, t]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -8,6 +8,14 @@ export interface AgentCitation {
   url_path: string;
 }
 
+/** An entity the agent created this turn (via create_entity), for undo. */
+export interface AgentCreatedEntity {
+  entity_type: string;
+  id: string;
+  label: string;
+  url_path: string;
+}
+
 export interface AgentAnswerMetadata {
   duration_ms?: number;
   tokens_in?: number;
@@ -15,6 +23,7 @@ export interface AgentAnswerMetadata {
   model?: string;
   hits_count?: number;
   reason?: string;
+  created_entities?: AgentCreatedEntity[];
   [key: string]: unknown;
 }
 

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -1,4 +1,9 @@
+import * as React from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import { toast } from '@/lib/toast';
+import { deleteTask } from '@/lib/api/tasks';
+import { taskKeys } from '@/features/tasks/hooks';
 import {
   createConversation,
   deleteConversation,
@@ -9,6 +14,7 @@ import {
   renameConversation,
   type AgentConversationDetail,
   type AgentConversationRow,
+  type AgentCreatedEntity,
   type AgentMessageRow,
 } from './api';
 
@@ -87,6 +93,52 @@ export function useRenameConversation() {
     mutationFn: ({ id, title }) => renameConversation(id, title),
     onSuccess: () => qc.invalidateQueries({ queryKey: agentKeys.conversations() }),
   });
+}
+
+/**
+ * How to undo a created entity, per entity_type. Each returns a promise and the
+ * query keys to invalidate so lists refresh after create AND after undo. Adding
+ * a new creatable entity here = one entry (mirrors the backend writables registry).
+ */
+const UNDO_HANDLERS: Record<
+  string,
+  { remove: (id: string) => Promise<void>; keys: readonly unknown[][] }
+> = {
+  task: { remove: (id) => deleteTask(id), keys: [taskKeys.all as unknown as unknown[]] },
+};
+
+/**
+ * Surface a "created · Undo" toast for each entity the agent just created, and
+ * refresh the relevant lists. On "Undo", the entity is deleted (archived) again.
+ * Shared by AgentPage and EntityAssistant.
+ */
+export function useAgentCreatedUndo() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+
+  return React.useCallback(
+    (created: AgentCreatedEntity[] | undefined) => {
+      if (!created?.length) return;
+      for (const entity of created) {
+        const handler = UNDO_HANDLERS[entity.entity_type];
+        if (!handler) continue;
+        handler.keys.forEach((key) => void qc.invalidateQueries({ queryKey: key }));
+        toast({
+          title: t('agent.created.title', { label: entity.label }),
+          duration: 8000,
+          action: {
+            label: t('common.undo'),
+            onClick: () => {
+              void handler.remove(entity.id).then(() => {
+                handler.keys.forEach((key) => void qc.invalidateQueries({ queryKey: key }));
+              });
+            },
+          },
+        });
+      }
+    },
+    [qc, t],
+  );
 }
 
 export function useDeleteConversation() {

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -5,6 +5,7 @@
     "save": "Speichern",
     "saving": "Wird gespeichert…",
     "cancel": "Abbrechen",
+    "undo": "Rückgängig",
     "edit": "Bearbeiten",
     "delete": "Löschen",
     "archive": "Archivieren",
@@ -1630,6 +1631,9 @@
     "error": "Etwas ist schiefgelaufen, bitte erneut versuchen.",
     "empty_title": "Stell jede Frage zu deinem Haushalt",
     "empty_hint": "Der Agent durchsucht deine Dokumente, Geräte, Aufgaben, Verträge und mehr und nennt jede Quelle.",
+    "created": {
+      "title": "Erstellt: {{label}}"
+    },
     "entity": {
       "empty_title": "Stell jede Frage zu diesem Element",
       "empty_hint": "Der Assistent kennt dieses Element und alles, was damit verknüpft ist, bereits — seine Details, Dokumente, Ausgaben und Aufgaben — und nennt seine Quellen."

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "save": "Save",
     "saving": "Saving…",
     "cancel": "Cancel",
+    "undo": "Undo",
     "edit": "Edit",
     "delete": "Delete",
     "archive": "Archive",
@@ -1630,6 +1631,9 @@
     "error": "Something went wrong, please try again.",
     "empty_title": "Ask anything about your household",
     "empty_hint": "The agent searches your documents, equipment, tasks, contracts and more, and cites every source.",
+    "created": {
+      "title": "Created: {{label}}"
+    },
     "entity": {
       "empty_title": "Ask anything about this item",
       "empty_hint": "The assistant already knows this item and everything linked to it — its details, documents, expenses and tasks — and cites its sources."

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -5,6 +5,7 @@
     "save": "Guardar",
     "saving": "Guardando…",
     "cancel": "Cancelar",
+    "undo": "Deshacer",
     "edit": "Editar",
     "delete": "Eliminar",
     "archive": "Archivar",
@@ -1630,6 +1631,9 @@
     "error": "Algo salió mal, inténtalo de nuevo.",
     "empty_title": "Pregunta lo que quieras sobre tu hogar",
     "empty_hint": "El agente busca en tus documentos, equipos, tareas, contratos y más, y cita cada fuente.",
+    "created": {
+      "title": "Creado: {{label}}"
+    },
     "entity": {
       "empty_title": "Pregunta lo que quieras sobre este elemento",
       "empty_hint": "El asistente ya conoce este elemento y todo lo vinculado a él — sus detalles, documentos, gastos y tareas — y cita sus fuentes."

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -5,6 +5,7 @@
     "save": "Enregistrer",
     "saving": "Enregistrement…",
     "cancel": "Annuler",
+    "undo": "Annuler",
     "edit": "Modifier",
     "delete": "Supprimer",
     "archive": "Archiver",
@@ -1630,6 +1631,9 @@
     "error": "Une erreur est survenue, réessaie.",
     "empty_title": "Pose toutes tes questions sur ton foyer",
     "empty_hint": "L'agent fouille tes documents, équipements, tâches, contrats… et cite chaque source utilisée.",
+    "created": {
+      "title": "Créé : {{label}}"
+    },
     "entity": {
       "empty_title": "Pose n'importe quelle question sur cet élément",
       "empty_hint": "L'assistant connaît déjà cet élément et tout ce qui lui est lié — ses détails, documents, dépenses et tâches — et cite ses sources."


### PR DESCRIPTION
## Contexte

L'agent était *read-only* depuis le lot 7 (3 tools de lecture). Ce lot concrétise « Extension 1 / #50 » : lui donner la capacité de **créer** des items du foyer depuis le chat (« ajoute une tâche », « rappelle-moi de… »).

Contrainte directrice : **ne pas multiplier les définitions de tools**. On applique au côté écriture la philosophie de la lecture — **un seul tool générique** `create_entity`, adossé à un registry `writables`. Total : 3 read + 1 write = **4 tools**, extensible à N entités sans toucher `apps/agent/`.

Décisions validées : sécurité = **créer + Undo** ; première entité = **tâche seule**.

## Backend
- `apps/agent/writables.py` — registry d'écriture (`WritableSpec`), miroir de `searchables`.
- `apps/tasks/services.py::create_task` — source unique (fallback zone racine + `TaskSerializer`), **jamais d'ORM brut** ; enregistré comme `WritableSpec` dans `tasks/apps.py`.
- `apps/agent/tools.py` — tool `create_entity` (item créé = Hit citable + `created`), `ToolResult.created`, `dispatch(context_entity=…)` ; erreurs de validation récupérables (jamais de crash de boucle).
- `apps/agent/service.py` — `metadata.created_entities` + garde-fou anti-doublon par tour.
- `apps/agent/prompts.py` — garde-fous : créer seulement sur demande explicite, confirmer + citer.
- **Scope depuis l'ancre** : en conversation ancrée projet, la tâche créée est liée au projet.

## Frontend
- `useAgentCreatedUndo()` — toast « Créé · Annuler » (→ `deleteTask`), branché dans `EntityAssistant` + `AgentPage`.
- i18n `common.undo` + `agent.created.title` (4 langues).

## Docs (suit le format des autres lots)
Fiche lot `PARCOURS_07_LOT8_ACTIONS_ECRITURE.md` (nouveau) + màj parcours 07 / lot 7, `MODULES/agent.md` (+ how-to « rendre une entité créable »), `MODULES/tasks.md`, glossaire `RAG.md`, `CLAUDE.md`, entrée de **journal**.

## Vérifs
- ✅ **278 tests** backend (agent + tasks) verts.
- ✅ `tsc --noEmit` clean, JSON 4 locales valides, **eslint 0 erreur**.
- ⚠️ Vérif manuelle réelle (réponse LLM qui crée) non exécutée — nécessite `ANTHROPIC_API_KEY` + stack lancé.

## Réutilisation
Rendre une nouvelle entité créable (dépense, stock…) = registrer un `WritableSpec` + 1 entrée `UNDO_HANDLERS` côté front. Zéro touche à `apps/agent/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)