### PR TITLE
fix(agent): lien de citation interaction → route existante (/edit)

### DIFF
--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -479,7 +479,7 @@ class TestCreateEntity:
                 "entity_type": "note",
                 "id": str(note.id),
                 "label": "Idée déco",
-                "url_path": f"/app/interactions/{note.id}",
+                "url_path": f"/app/interactions/{note.id}/edit",
             }
         ]
 

--- a/apps/interactions/apps.py
+++ b/apps/interactions/apps.py
@@ -15,14 +15,14 @@ class InteractionsConfig(AppConfig):
             model=Interaction,
             search_fields=('subject', 'content'),
             label_attr='subject',
-            url_template='/app/interactions/{id}',
+            url_template='/app/interactions/{id}/edit',
         ))
 
         register_writable(WritableSpec(
             entity_type='note',
             create=_create_note_from_agent,
             label_attr='subject',
-            url_template='/app/interactions/{id}',
+            url_template='/app/interactions/{id}/edit',
         ))
 
 


### PR DESCRIPTION
## Problème

Le chip de redirection d'une **note créée par l'agent** (et de **toute citation d'interaction**) menait à une page 404. Exemple rapporté : cliquer sur la citation d'une note ouvrait `/app/interactions/<id>` → `NotFoundPage`.

## Cause

`apps/interactions/apps.py` déclarait `url_template='/app/interactions/{id}'` pour le `SearchableSpec` **et** le `WritableSpec` (note). Or cette route SPA n'existe pas — le routeur (`ui/src/router.tsx`) n'expose que :
- `interactions` (liste)
- `interactions/new`
- `interactions/:id/edit` ← **seule route de détail d'une interaction**

## Fix

Les deux `url_template` pointent désormais sur `/app/interactions/{id}/edit`, la vraie route de détail/édition. Test `test_tools.py::TestCreateEntity` mis à jour en conséquence.

Portée : corrige aussi toutes les citations d'interaction (dépenses, notes existantes…), pas seulement les notes créées par l'agent.

## Tests

`pytest apps/agent/tests/test_tools.py apps/interactions/tests/test_services.py` (note/interaction/create) → **26 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)