### PR TITLE
fix(media): URL-encode X-Accel-Redirect (téléchargement 404 sur noms accentués)

### DIFF
--- a/apps/core/tests/test_views_media.py
+++ b/apps/core/tests/test_views_media.py
@@ -89,3 +89,19 @@ class TestServeProtectedMedia:
         response = client.get(media_url(path))
         assert response['X-Accel-Redirect'] == f'/_protected_media/{path}'
         assert response['Content-Type'] == ''
+
+    @override_settings(DEBUG=False)
+    def test_x_accel_redirect_url_encodes_non_ascii_filename(self, client, member_user, household):
+        # A non-ASCII filename must be percent-encoded in X-Accel-Redirect. WSGI
+        # serializes headers as latin-1, so sending "é" raw would emit the wrong
+        # byte (0xE9) instead of its on-disk UTF-8 bytes (0xC3 0xA9) → Nginx 404.
+        client.force_login(member_user)
+        path = f'documents/{household.id}/2026/07/abc-carte-identité.pdf'
+        response = client.get(media_url(path))
+        assert response.status_code == 200
+        assert response['X-Accel-Redirect'] == (
+            f'/_protected_media/documents/{household.id}/2026/07/'
+            'abc-carte-identit%C3%A9.pdf'
+        )
+        # The header value is pure ASCII → safe to serialize as latin-1.
+        response['X-Accel-Redirect'].encode('latin-1')

--- a/apps/core/views_media.py
+++ b/apps/core/views_media.py
@@ -6,6 +6,8 @@ so Nginx serves the file from an internal-only location (/_protected_media/).
 
 Development: Django serves the file directly (standard static serve).
 """
+from urllib.parse import quote
+
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, Http404
@@ -48,6 +50,10 @@ def serve_protected_media(request, path):
         return static_serve(request, path, document_root=settings.MEDIA_ROOT)
 
     response = HttpResponse()
-    response['X-Accel-Redirect'] = f'/_protected_media/{path}'
+    # The path must be URL-encoded: WSGI serializes headers as latin-1, so a
+    # non-ASCII filename (e.g. "carte-identité.pdf") would be sent as the wrong
+    # bytes and Nginx would 404. quote() keeps "/" as separators and percent-
+    # encodes the rest as UTF-8, which Nginx decodes back to the on-disk name.
+    response['X-Accel-Redirect'] = '/_protected_media/' + quote(path)
     response['Content-Type'] = ''  # Let Nginx detect from the file extension
     return response


### PR DESCRIPTION
## Problème

Les documents dont le **nom de fichier contient des caractères non-ASCII** (ex: `carte-identité-camille-galodé.pdf`) renvoient **404 au téléchargement** en prod. Les fichiers en ASCII pur passent — d'où le côté sournois.

## Cause (diagnostiquée sur prod)

Flux media : `/media/…` → Django `serve_protected_media` (auth + droits) → header `X-Accel-Redirect: /_protected_media/…` → Nginx sert depuis le volume `/app/media`.

Le header était posé avec le **chemin brut**. Or WSGI sérialise les headers HTTP en **latin-1** : le `é` (U+00E9) partait donc comme l'octet unique `0xE9`, alors que le fichier sur disque stocke `é` en **UTF-8** (`0xC3 0xA9`). Nginx cherchait un fichier au mauvais nom d'octets → 404.

Vérifié sur le VPS :
- fichier sur disque : `carte-identit` + `0xC3 0xA9` (UTF-8, correct)
- header actuel (latin-1) : `carte-identit` + `0xE9` → **mismatch**
- `default_storage.exists(file_path)` = `True` (Django lit bien le fichier ; seul le passage de relais Nginx casse)

## Fix

`quote(path)` percent-encode le chemin (en gardant les `/`) → le header devient ASCII pur (`…carte-identit%C3%A9.pdf`), et Nginx le décode vers les bons octets UTF-8. Une ligne.

## Tests

`apps/core/tests/test_views_media.py` : nouveau `test_x_accel_redirect_url_encodes_non_ascii_filename` (reproduit le bug + vérifie que le header est sérialisable en latin-1). Tests existants inchangés (ASCII → `quote` no-op). `pytest apps/core apps/documents` → **36 passed**.

## Note migration serveur

Le récent changement de serveur (copie des media) n'est **pas** en cause : les fichiers sont bien présents et encodés en UTF-8 correct sur le nouveau disque (`default_storage.exists` = True). Le bug est purement le relais Nginx et existait indépendamment de la migration — il ne se manifeste que sur les noms accentués.

🤖 Generated with [Claude Code](https://claude.com/claude-code)