### PR TITLE
feat(agent): durcissement palier 1 — throttling, date courante, prompt caching

### DIFF
--- a/apps/agent/llm.py
+++ b/apps/agent/llm.py
@@ -209,7 +209,16 @@ class AnthropicClient:
             create_kwargs: dict[str, Any] = {
                 "model": self.model,
                 "max_tokens": max_tokens,
-                "system": system,
+                # One cache breakpoint at the end of the system block caches the
+                # whole prefix before the messages (tool schemas + system prompt)
+                # across loop iterations and conversation turns (5-min TTL).
+                "system": [
+                    {
+                        "type": "text",
+                        "text": system,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ],
                 "messages": messages,
             }
             if tools:
@@ -244,7 +253,7 @@ class AnthropicClient:
             input_tokens=input_tokens,
             output_tokens=output_tokens,
             success=True,
-            metadata=metadata,
+            metadata=_with_cache_usage(metadata, usage),
         )
 
         return LLMRunResponse(
@@ -288,6 +297,22 @@ class AnthropicClient:
         if error_type == "timeout":
             raise LLMTimeoutError(str(exc)) from exc
         raise LLMError(str(exc)) from exc
+
+
+def _with_cache_usage(metadata: dict[str, Any] | None, usage) -> dict[str, Any] | None:
+    """Fold the provider's prompt-cache counters into the AIUsageLog metadata.
+
+    Lets us verify from the logs that prefix caching actually hits (reads grow,
+    creations stay rare). No-op when the provider reports nothing.
+    """
+    extra = {
+        key: getattr(usage, key, None)
+        for key in ("cache_read_input_tokens", "cache_creation_input_tokens")
+        if usage is not None and getattr(usage, key, None) is not None
+    }
+    if not extra:
+        return metadata
+    return {**(metadata or {}), **extra}
 
 
 def _block_get(block, key, default=None):

--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -23,6 +23,8 @@ remaining hits fall back to their short headline snippet.
 """
 from __future__ import annotations
 
+from django.utils import timezone
+
 from .retrieval import Hit
 
 # Context-enrichment budgets. Roughly: 6000 chars ≈ 1500 tokens of extra input
@@ -106,11 +108,22 @@ the full text of a document only summarised there).
 """
 
 
+# Grounds relative-date reasoning ("tomorrow", "this week", the `due_date` of
+# `create_entity`). Stable within a day, so it does not break prompt caching.
+CURRENT_DATE_ADDENDUM = """
+
+Today's date is {weekday} {date}. Use it to resolve relative dates ("tomorrow",
+"next week", "this year") into concrete YYYY-MM-DD values.
+"""
+
+
 def build_system_prompt(*, anchored: bool = False) -> str:
     """Return the system prompt, optionally extended for an anchored conversation."""
-    if anchored:
-        return SYSTEM_PROMPT + ANCHORED_ADDENDUM
-    return SYSTEM_PROMPT
+    prompt = SYSTEM_PROMPT + ANCHORED_ADDENDUM if anchored else SYSTEM_PROMPT
+    today = timezone.localdate()
+    return prompt + CURRENT_DATE_ADDENDUM.format(
+        weekday=today.strftime("%A"), date=today.isoformat()
+    )
 
 
 def render_context_block(

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -40,7 +40,9 @@ DEFAULT_MAX_TOKENS = 1024
 DEFAULT_MAX_TOOL_ITERATIONS = 3
 IDK_MARKER = "no_household_match"
 
-_CITE_RE = re.compile(r'<cite\s+id="(?P<tag>[^"]+)"\s*/?>', re.IGNORECASE)
+# The prompt asks for double quotes, but models occasionally emit single quotes —
+# accept both rather than silently dropping the citation.
+_CITE_RE = re.compile(r'''<cite\s+id=["'](?P<tag>[^"']+)["']\s*/?>''', re.IGNORECASE)
 
 
 @dataclass
@@ -203,6 +205,10 @@ def ask(
             "tool_calls": tool_calls,
             "iterations": iterations,
             "stop_reason": stop_reason,
+            # The model ran out of max_tokens mid-answer — the text is cut short.
+            # Surfaced so the frontend can tell the user instead of serving a
+            # sentence that just stops.
+            "truncated": stop_reason == "max_tokens",
             "answer_kind": answer_kind,
             "anchored": anchored,
             "created_entities": created_entities,

--- a/apps/agent/tests/test_conversations_api.py
+++ b/apps/agent/tests/test_conversations_api.py
@@ -331,6 +331,42 @@ class TestForContext:
         resp = owner_client.get(f"{BASE}for_context/", {"entity_type": "project"})
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_nonexistent_object_returns_404_and_creates_nothing(
+        self, owner_client, household
+    ):
+        resp = owner_client.get(
+            f"{BASE}for_context/",
+            {
+                "entity_type": "project",
+                "object_id": "00000000-0000-0000-0000-000000000000",
+            },
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+        assert not AgentConversation.objects.filter(
+            context_entity_type="project"
+        ).exists()
+
+    def test_object_from_another_household_returns_404(
+        self, owner_client, household, owner
+    ):
+        from projects.models import Project
+
+        other_household = Household.objects.create(name="Elsewhere")
+        foreign = Project.objects.create(
+            household=other_household, created_by=owner, title="Pas chez moi"
+        )
+        resp = owner_client.get(
+            f"{BASE}for_context/",
+            {"entity_type": "project", "object_id": str(foreign.pk)},
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_malformed_object_id_returns_404(self, owner_client, household):
+        resp = owner_client.get(
+            f"{BASE}for_context/", {"entity_type": "project", "object_id": "not-a-uuid"}
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
 
 class TestAnchoredMessage:
     def test_context_entity_is_passed_to_ask(
@@ -408,3 +444,42 @@ class TestRenameAndDelete:
         assert resp.status_code == status.HTTP_204_NO_CONTENT
         assert not AgentConversation.objects.filter(id=conversation.id).exists()
         assert AgentMessage.objects.count() == 0
+
+
+class TestThrottling:
+    """Only the LLM-backed `messages` action is rate-limited — CRUD is free."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_throttle_state(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        yield
+        cache.clear()
+
+    @pytest.fixture
+    def _tight_burst(self, monkeypatch):
+        from agent.throttles import AgentBurstRateThrottle
+
+        # DRF resolves the rate at throttle instantiation via the class `rate`
+        # attribute — patching it beats overriding REST_FRAMEWORK (whose
+        # THROTTLE_RATES snapshot is frozen at import time).
+        monkeypatch.setattr(AgentBurstRateThrottle, "rate", "2/min", raising=False)
+
+    def test_messages_throttled_after_burst_limit(
+        self, owner_client, conversation, monkeypatch, _tight_burst
+    ):
+        _patch_ask(monkeypatch, return_value=_answer())
+        url = f"{BASE}{conversation.id}/messages/"
+        for _ in range(2):
+            resp = owner_client.post(url, {"question": "q"}, format="json")
+            assert resp.status_code == status.HTTP_201_CREATED
+        resp = owner_client.post(url, {"question": "q"}, format="json")
+        assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    def test_conversation_crud_is_not_throttled(
+        self, owner_client, conversation, _tight_burst
+    ):
+        for _ in range(5):
+            resp = owner_client.get(BASE)
+            assert resp.status_code == status.HTTP_200_OK

--- a/apps/agent/tests/test_llm.py
+++ b/apps/agent/tests/test_llm.py
@@ -203,9 +203,51 @@ class TestAnthropicClientRun:
             household_id=household.id,
         )
 
-        assert fake.messages.last_kwargs["system"] == "SYSTEM"
+        # The system prompt is sent as a block carrying the prompt-cache
+        # breakpoint (caches the tools + system prefix across calls).
+        assert fake.messages.last_kwargs["system"] == [
+            {"type": "text", "text": "SYSTEM", "cache_control": {"type": "ephemeral"}}
+        ]
         assert fake.messages.last_kwargs["messages"] == messages
         assert fake.messages.last_kwargs["tools"] == tools
+
+    def test_run_logs_cache_usage_when_reported(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        message = _fake_run_message([_text_block("ok")])
+        message.usage.cache_read_input_tokens = 1800
+        message.usage.cache_creation_input_tokens = 0
+        fake = _FakeClient(response=message)
+        monkeypatch.setattr(client, "_client", lambda: fake)
+
+        client.run(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            feature="agent_ask",
+            household_id=household.id,
+        )
+
+        log = AIUsageLog.objects.get()
+        assert log.metadata["cache_read_input_tokens"] == 1800
+        assert log.metadata["cache_creation_input_tokens"] == 0
+
+    def test_run_tolerates_missing_cache_counters(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        fake = _FakeClient(response=_fake_run_message([_text_block("ok")]))
+        monkeypatch.setattr(client, "_client", lambda: fake)
+
+        client.run(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            feature="agent_ask",
+            household_id=household.id,
+            metadata={"iteration": 1},
+        )
+
+        log = AIUsageLog.objects.get()
+        assert "cache_read_input_tokens" not in (log.metadata or {})
+        assert log.metadata["iteration"] == 1
 
     def test_run_omits_tools_kwarg_when_no_tools(self, with_api_key, monkeypatch, household):
         client = AnthropicClient()

--- a/apps/agent/tests/test_prompts.py
+++ b/apps/agent/tests/test_prompts.py
@@ -1,9 +1,12 @@
 """Tests for the agent prompts module."""
 from __future__ import annotations
 
+from django.utils import timezone
+
 from agent.prompts import (
     TRUNCATION_MARKER,
     SYSTEM_PROMPT,
+    build_system_prompt,
     render_context_block,
 )
 from agent.retrieval import Hit
@@ -43,6 +46,20 @@ class TestSystemPrompt:
         assert "DIALOGUE" in upper
         assert "HOUSEHOLD FACTS" in upper
         assert "GENERAL KNOWLEDGE" in upper
+
+
+class TestCurrentDate:
+    def test_system_prompt_carries_todays_date(self):
+        today = timezone.localdate()
+        prompt = build_system_prompt()
+        assert today.isoformat() in prompt
+        assert today.strftime("%A") in prompt
+
+    def test_anchored_prompt_also_carries_the_date(self):
+        today = timezone.localdate()
+        prompt = build_system_prompt(anchored=True)
+        assert "CURRENT ITEM CONTEXT" in prompt
+        assert today.isoformat() in prompt
 
 
 class TestRenderContextBlock:

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -312,6 +312,19 @@ class TestHouseholdFacts:
         result = service.ask("engie ?", household, user=owner, client=stub)
         assert len(result.citations) == 1
 
+    def test_single_quoted_citations_are_resolved(
+        self, with_api_key, household, owner, make_document
+    ):
+        doc = make_document(name="Engie facture mars")
+        stub = _ToolUseClient(
+            script=[
+                _run_tool("Engie"),
+                _run_text(f"Tu as payé 142,67€ <cite id='document:{doc.pk}'/>."),
+            ]
+        )
+        result = service.ask("engie ?", household, user=owner, client=stub)
+        assert [c.id for c in result.citations] == [doc.pk]
+
     def test_chains_search_then_get_entity_for_full_content(
         self, with_api_key, household, owner, make_document
     ):
@@ -488,6 +501,20 @@ class TestMetadataAndWiring:
         assert result.metadata["model"] == "stub-model"
         assert result.metadata["iterations"] == 2
         assert result.metadata["stop_reason"] == "end_turn"
+
+    def test_truncated_flag_set_when_answer_hits_max_tokens(
+        self, with_api_key, household, owner
+    ):
+        cut = _run_text("Réponse coupée en plein")
+        cut.stop_reason = "max_tokens"
+        stub = _ToolUseClient(script=[cut])
+        result = service.ask("bonjour", household, user=owner, client=stub)
+        assert result.metadata["truncated"] is True
+
+    def test_truncated_flag_false_on_normal_answer(self, with_api_key, household, owner):
+        stub = _ToolUseClient(script=[_run_text("ok")])
+        result = service.ask("bonjour", household, user=owner, client=stub)
+        assert result.metadata["truncated"] is False
 
     def test_system_prompt_and_identity_are_passed(self, with_api_key, household, owner):
         stub = _ToolUseClient(script=[_run_text("ok")])

--- a/apps/agent/tests/test_views.py
+++ b/apps/agent/tests/test_views.py
@@ -120,3 +120,33 @@ class TestHouseholdResolution:
         _patch_ask(monkeypatch)
         resp = client.post(URL, {"question": "engie?"}, format="json")
         assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+class TestThrottling:
+    """Every question costs LLM calls — the endpoint is rate-limited per user."""
+
+    @pytest.fixture(autouse=True)
+    def _isolated_throttle_state(self):
+        from django.core.cache import cache
+
+        cache.clear()
+        yield
+        cache.clear()
+
+    def test_burst_limit_returns_429(self, owner_client, household, monkeypatch):
+        from agent.throttles import AgentBurstRateThrottle
+
+        # DRF resolves the rate at throttle instantiation via the class `rate`
+        # attribute — patching it beats overriding REST_FRAMEWORK (whose
+        # THROTTLE_RATES snapshot is frozen at import time).
+        monkeypatch.setattr(AgentBurstRateThrottle, "rate", "2/min", raising=False)
+        _patch_ask(
+            monkeypatch,
+            return_value=service.AnswerResult(answer="ok", citations=[], metadata={}),
+        )
+
+        for _ in range(2):
+            resp = owner_client.post(URL, {"question": "engie?"}, format="json")
+            assert resp.status_code == status.HTTP_200_OK
+        resp = owner_client.post(URL, {"question": "engie?"}, format="json")
+        assert resp.status_code == status.HTTP_429_TOO_MANY_REQUESTS

--- a/apps/agent/throttles.py
+++ b/apps/agent/throttles.py
@@ -1,0 +1,27 @@
+"""
+Agent endpoint throttles.
+
+Every agent question triggers up to AGENT_MAX_TOOL_ITERATIONS LLM calls plus a
+query-expansion call — unthrottled, an authenticated user could generate
+unbounded provider cost. Two independent axes, both per user:
+
+- AgentBurstRateThrottle    : short-window cap (absorbs runaway loops/scripts)
+- AgentSustainedRateThrottle: hourly cap (bounds the cost of a long session)
+
+Rates are configurable via settings:
+    DEFAULT_THROTTLE_RATES = {
+        "agent_burst":     "10/min",
+        "agent_sustained": "100/hour",
+    }
+"""
+from rest_framework.throttling import UserRateThrottle
+
+
+class AgentBurstRateThrottle(UserRateThrottle):
+    """10 agent questions per minute per user."""
+    scope = "agent_burst"
+
+
+class AgentSustainedRateThrottle(UserRateThrottle):
+    """100 agent questions per hour per user."""
+    scope = "agent_sustained"

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -8,16 +8,17 @@ from django.db.models import Count
 from django.utils import timezone
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
-from rest_framework.exceptions import ValidationError
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from core.permissions import IsHouseholdMember, resolve_request_household
 
-from . import searchables, service
+from . import searchables, service, tools
 from .llm import LLMError, LLMTimeoutError
 from .models import AgentConversation, AgentMessage
+from .throttles import AgentBurstRateThrottle, AgentSustainedRateThrottle
 from .serializers import (
     AskRequestSerializer,
     AskResponseSerializer,
@@ -55,6 +56,7 @@ class AskView(APIView):
     """``POST /api/agent/ask/`` — answer a household question."""
 
     permission_classes = [IsAuthenticated, IsHouseholdMember]
+    throttle_classes = [AgentBurstRateThrottle, AgentSustainedRateThrottle]
 
     def post(self, request):
         request_serializer = AskRequestSerializer(data=request.data)
@@ -111,6 +113,13 @@ class ConversationViewSet(viewsets.ModelViewSet):
     """
 
     permission_classes = [IsAuthenticated, IsHouseholdMember]
+
+    def get_throttles(self):
+        # Only the LLM-backed action costs money — plain conversation CRUD
+        # stays unthrottled.
+        if self.action == "messages":
+            return [AgentBurstRateThrottle(), AgentSustainedRateThrottle()]
+        return super().get_throttles()
 
     def get_serializer_class(self):
         if self.action == "list":
@@ -225,6 +234,11 @@ class ConversationViewSet(viewsets.ModelViewSet):
             raise ValidationError(f"Unknown entity_type: {entity_type}")
 
         household = self._resolve_household()
+        # The anchor must be a real entity of this household — otherwise any id
+        # would silently create an orphan-anchored conversation row.
+        resolved, _error = tools.resolve_entity(entity_type, object_id, household)
+        if resolved is None:
+            raise NotFound(f"No {entity_type} with id {object_id} in this household.")
         conversation, _created = AgentConversation.objects.get_or_create(
             household=household,
             created_by=request.user,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -158,6 +158,8 @@ REST_FRAMEWORK = {
         "login_email": "5/min",
         "change_password": "5/hour",
         "password_reset": "3/hour",
+        "agent_burst": "10/min",
+        "agent_sustained": "100/hour",
     },
 }
 


### PR DESCRIPTION
## Contexte

Palier 1 de l'audit du système d'agent : fiabiliser l'existant avant d'étendre les capacités. Partie backend.

## Changements

- **Rate limiting** (`apps/agent/throttles.py`) : chaque question coûte jusqu'à 5 appels LLM ; les endpoints `ask` et `conversations/{id}/messages/` sont désormais throttlés par user (burst `10/min` + sustained `100/hour`, configurables via `DEFAULT_THROTTLE_RATES`). Le CRUD des conversations reste libre.
- **Date courante dans le system prompt** (`prompts.py`) : jour de la semaine + date ISO, pour résoudre « demain », « cette semaine » et le `due_date` de `create_entity` sans deviner.
- **Prompt caching Anthropic** (`llm.py`) : le bloc system porte un breakpoint `cache_control` — le préfixe tools + system est mis en cache à travers les itérations de la boucle et les tours de conversation (TTL 5 min). Les compteurs `cache_read/creation_input_tokens` sont remontés dans `AIUsageLog.metadata` pour vérifier les hits.
- **`metadata.truncated`** (`service.py`) : signalé quand `stop_reason=max_tokens`, pour que le front puisse indiquer une réponse coupée au lieu de la servir telle quelle.
- **Citations à guillemets simples** : la regex accepte `<cite id='…'/>` en plus des doubles — les citations n'étaient silencieusement perdues.
- **Validation de l'ancre `for_context`** (`views.py`) : 404 si l'`object_id` n'existe pas dans le foyer (avant : n'importe quel id créait une row de conversation ancrée orpheline).

## Tests

- 15 nouveaux tests (throttling, date, cache_control + compteurs, truncated, citations single-quote, for_context 404/cross-household/id malformé)
- Suite complète : **944 passed, 2 skipped**

🤖 Generated with [Claude Code](https://claude.com/claude-code)