### PR TITLE
feat(agent): related pour zone et équipement

### DIFF
--- a/apps/agent/tests/test_related_zone_equipment.py
+++ b/apps/agent/tests/test_related_zone_equipment.py
@@ -1,0 +1,124 @@
+"""Tests for the zone and equipment ``related`` callables (get_related tool).
+
+Until now only ``project`` declared a ``related`` on its SearchableSpec — asking
+``get_related`` on a zone or an equipment answered "no related items". These
+tests cover the two new neighbourhoods end-to-end through the tool.
+"""
+from __future__ import annotations
+
+import pytest
+from django.utils import timezone
+
+from accounts.tests.factories import UserFactory
+from agent import tools
+from documents.models import Document
+from equipment.models import Equipment, EquipmentInteraction
+from interactions.models import Interaction, InteractionZone
+from tasks.models import Task, TaskZone
+from zones.models import Zone, ZoneDocument
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="agent-related-owner@example.com")
+
+
+@pytest.fixture
+def zone(household, owner):
+    return Zone.objects.create(household=household, name="Salon", created_by=owner)
+
+
+def _related(household, entity_type, obj):
+    return tools.dispatch(
+        "get_related",
+        {"entity_type": entity_type, "id": str(obj.pk)},
+        household=household,
+    )
+
+
+class TestZoneRelated:
+    def test_returns_child_zones(self, household, owner, zone):
+        child = Zone.objects.create(
+            household=household, name="Coin lecture", parent=zone, created_by=owner
+        )
+        result = _related(household, "zone", zone)
+        assert f"id=zone:{child.pk}" in result.rendered
+
+    def test_returns_equipment_of_the_zone(self, household, owner, zone):
+        equipment = Equipment.objects.create(
+            household=household, name="Poêle à bois", zone=zone, created_by=owner
+        )
+        result = _related(household, "zone", zone)
+        assert f"id=equipment:{equipment.pk}" in result.rendered
+
+    def test_returns_tasks_and_interactions_of_the_zone(self, household, owner, zone):
+        task = Task.objects.create(
+            household=household, created_by=owner, subject="Repeindre le mur"
+        )
+        TaskZone.objects.create(task=task, zone=zone)
+        interaction = Interaction.objects.create(
+            household=household, created_by=owner, subject="Fuite réparée",
+            type="repair", occurred_at=timezone.now(),
+        )
+        InteractionZone.objects.create(interaction=interaction, zone=zone)
+
+        result = _related(household, "zone", zone)
+        assert f"id=task:{task.pk}" in result.rendered
+        assert f"id=interaction:{interaction.pk}" in result.rendered
+
+    def test_returns_photo_documents_of_the_zone(self, household, owner, zone):
+        document = Document.objects.create(
+            household=household, created_by=owner, file_path="documents/salon.jpg",
+            name="Photo salon", mime_type="image/jpeg", type="photo",
+        )
+        ZoneDocument.objects.create(zone=zone, document=document, created_by=owner)
+        result = _related(household, "zone", zone)
+        assert f"id=document:{document.pk}" in result.rendered
+
+    def test_related_hits_feed_the_citation_pool(self, household, owner, zone):
+        equipment = Equipment.objects.create(
+            household=household, name="Climatiseur", zone=zone, created_by=owner
+        )
+        result = _related(household, "zone", zone)
+        assert equipment.pk in {h.id for h in result.hits}
+
+    def test_zone_without_neighbours_says_so(self, household, owner, zone):
+        result = _related(household, "zone", zone)
+        assert "no items linked" in result.rendered
+
+
+class TestEquipmentRelated:
+    def test_returns_zone_and_interaction_history(self, household, owner, zone):
+        equipment = Equipment.objects.create(
+            household=household, name="Chaudière", zone=zone, created_by=owner
+        )
+        interaction = Interaction.objects.create(
+            household=household, created_by=owner, subject="Entretien annuel",
+            type="maintenance", occurred_at=timezone.now(),
+        )
+        EquipmentInteraction.objects.create(equipment=equipment, interaction=interaction)
+
+        result = _related(household, "equipment", equipment)
+        assert f"id=zone:{zone.pk}" in result.rendered
+        assert f"id=interaction:{interaction.pk}" in result.rendered
+
+    def test_equipment_without_zone_still_lists_interactions(self, household, owner):
+        equipment = Equipment.objects.create(
+            household=household, name="Aspirateur", created_by=owner
+        )
+        interaction = Interaction.objects.create(
+            household=household, created_by=owner, subject="Achat",
+            type="expense", occurred_at=timezone.now(),
+        )
+        EquipmentInteraction.objects.create(equipment=equipment, interaction=interaction)
+
+        result = _related(household, "equipment", equipment)
+        assert f"id=interaction:{interaction.pk}" in result.rendered
+        assert "id=zone:" not in result.rendered
+
+    def test_equipment_without_neighbours_says_so(self, household, owner):
+        equipment = Equipment.objects.create(
+            household=household, name="Grille-pain", created_by=owner
+        )
+        result = _related(household, "equipment", equipment)
+        assert "no items linked" in result.rendered

--- a/apps/equipment/apps.py
+++ b/apps/equipment/apps.py
@@ -1,6 +1,23 @@
 from django.apps import AppConfig
 
 
+def _equipment_related(equipment):
+    """Every household item linked to an equipment, for the `get_related` agent tool.
+
+    Gathers the equipment's zone and its interaction history (purchases,
+    maintenances, repairs…). Each instance is turned into a citable Hit through
+    its own registered spec.
+    """
+    items = []
+    if equipment.zone_id:
+        items.append(equipment.zone)
+    items.extend(
+        ei.interaction
+        for ei in equipment.equipment_interactions.select_related('interaction')
+    )
+    return items
+
+
 class EquipmentConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "equipment"
@@ -15,4 +32,5 @@ class EquipmentConfig(AppConfig):
             search_fields=('name', 'manufacturer', 'model', 'notes'),
             label_attr='name',
             url_template='/app/equipment/{id}',
+            related=_equipment_related,
         ))

--- a/apps/zones/apps.py
+++ b/apps/zones/apps.py
@@ -1,6 +1,24 @@
 from django.apps import AppConfig
 
 
+def _zone_related(zone):
+    """Every household item linked to a zone, for the `get_related` agent tool.
+
+    Gathers the zone's sub-zones, equipment, tasks, interactions and photo
+    documents. Each instance is turned into a citable Hit through its own
+    registered spec (unregistered types are skipped by the tool).
+    """
+    items = []
+    items.extend(zone.children.all())
+    items.extend(zone.equipment.all())
+    items.extend(zone.tasks.all())
+    items.extend(zone.interactions.all())
+    items.extend(
+        zd.document for zd in zone.zonedocument_set.select_related('document')
+    )
+    return items
+
+
 class ZonesConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'zones'
@@ -15,4 +33,5 @@ class ZonesConfig(AppConfig):
             search_fields=('name', 'note'),
             label_attr='name',
             url_template='/app/zones/{id}',
+            related=_zone_related,
         ))


### PR DESCRIPTION
## Contexte

Palier 2 de l'audit agent, dernier volet backend : `get_related` ne servait que pour les projets (seule entité avec un `related` déclaré). Sur une zone ou un équipement, l'agent répondait « no related items », et une conversation ancrée sur ces entités n'injectait que l'objet nu sans son voisinage.

Indépendante des autres PRs (base `main`), ne touche que `zones/apps.py`, `equipment/apps.py` et les tests.

## Changements

- **zone** → sous-zones, équipements, tâches, interactions, photos (`ZoneDocument`).
- **equipment** → sa zone + tout son historique d'interactions (achats, entretiens, réparations via `EquipmentInteraction`).
- Même pattern que `projects/apps.py` : un callable passé au `SearchableSpec`, zéro modification d'`apps/agent/`. Le scope foyer est déjà garanti par la garde défensive du tool.
- Bénéfice automatique pour l'assistant ancré (`EntityAssistant`) : ancrer une conversation sur une zone ou un équipement pré-injecte désormais tout son contexte, comme pour un projet. (Le branchement UI d'`EntityAssistant` sur les pages de détail viendra après la refacto en cours de ces pages.)

## Tests

9 nouveaux tests bout-en-bout via le tool `get_related` (voisinage zone complet, historique équipement, hits citables, cas vides). Suite complète : **940 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)