### PR TITLE
feat(ui): retour contextuel — le lien retour ramène à la page d'origine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,32 @@ const actions: CardAction[] = [
 <CardActions actions={actions} />
 ```
 
+### Retour contextuel (`BackLink` + `pushBack`)
+
+Toute page de détail utilise `BackLink` : le lien retour ramène à la **page
+d'origine** (ex: détail projet) si elle est connue, sinon à la liste par défaut.
+L'origine circule via une pile d'URLs dans `location.state.back` — elle survit
+aux reloads mais pas à un accès direct par URL (→ fallback).
+
+```tsx
+// Page de détail — lien retour + navigation après suppression
+import BackLink from '@/components/BackLink';
+import { useNavigateBack } from '@/lib/backNavigation';
+
+<BackLink fallback="/app/tasks" fallbackLabel={t('tasks.title')} />
+const navigateBack = useNavigateBack('/app/tasks');   // deleteMutation onSuccess
+
+// Page d'origine — tout Link/navigate() vers une page de détail empile l'URL courante
+import { pushBack } from '@/lib/backNavigation';
+const location = useLocation();
+<Link to={`/app/tasks/${id}`} state={pushBack(location)}>
+navigate(`/app/tasks/${id}`, { state: pushBack(location) });
+```
+
+Ne jamais utiliser `navigate(-1)` pour un lien retour de page de détail (casse
+sur accès direct / nouvel onglet) ni coder la liste en dur si la page peut être
+ouverte depuis un autre contexte.
+
 ### Couleurs — pas de hardcode
 
 Toujours utiliser les tokens CSS du design-system, jamais des classes Tailwind à couleur fixe :

--- a/e2e/back-navigation.spec.ts
+++ b/e2e/back-navigation.spec.ts
@@ -1,0 +1,77 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+// ---------------------------------------------------------------------------
+// Retour contextuel : depuis une page de détail, le lien « Retour » ramène
+// à la page d'origine (ex: le projet) et non à la liste par défaut.
+// ---------------------------------------------------------------------------
+
+// Ouvre le projet seedé et retourne son URL de détail.
+async function goToProject(page: Page): Promise<string> {
+  await page.goto('/app/projects');
+  await page.getByRole('link', { name: 'Rénovation salle de bain' }).click();
+  await expect(page).toHaveURL(/\/app\/projects\/[0-9a-f-]+$/);
+  return page.url();
+}
+
+// Crée une note liée au projet via le formulaire dédié (flux déterministe).
+async function createProjectNote(page: Page, projectUrl: string, subject: string) {
+  const projectId = projectUrl.split('/').pop();
+  await page.goto(`/app/interactions/new?type=note&project_id=${projectId}`);
+  await page.getByPlaceholder('Résumé court').fill(subject);
+  await page.getByRole('button', { name: 'Ajouter un événement' }).click();
+  await expect(page).not.toHaveURL(/\/app\/interactions\/new/);
+}
+
+test('retour vers le projet depuis le détail d\'une note ouverte via l\'onglet Notes', async ({ page }) => {
+  const subject = `Note retour E2E ${Date.now()}`;
+  const projectUrl = await goToProject(page);
+  await createProjectNote(page, projectUrl, subject);
+
+  // Onglet Notes du projet → détail de la note.
+  await page.goto(projectUrl);
+  await page.getByRole('button', { name: 'Notes' }).click();
+  await page.getByRole('link', { name: new RegExp(subject) }).click();
+  await expect(page).toHaveURL(/\/app\/interactions\/[0-9a-f-]+$/);
+
+  // Le lien retour ramène au projet, pas à la liste des interactions.
+  await page.getByRole('link', { name: 'Retour', exact: true }).click();
+  await expect(page).toHaveURL(projectUrl);
+});
+
+test('retour vers le projet depuis le détail d\'une note de l\'aperçu', async ({ page }) => {
+  const subject = `Note aperçu retour E2E ${Date.now()}`;
+  const projectUrl = await goToProject(page);
+  await createProjectNote(page, projectUrl, subject);
+
+  // La note apparaît dans l'aperçu du projet → détail → retour.
+  await page.goto(projectUrl);
+  await page.getByRole('button', { name: 'Aperçu' }).click();
+  await page.getByRole('link', { name: new RegExp(subject) }).click();
+  await expect(page).toHaveURL(/\/app\/interactions\/[0-9a-f-]+$/);
+
+  await page.getByRole('link', { name: 'Retour', exact: true }).click();
+  await expect(page).toHaveURL(projectUrl);
+});
+
+test('fallback : le détail d\'une note ouvert en direct retombe sur la liste', async ({ page }) => {
+  const subject = `Note fallback E2E ${Date.now()}`;
+
+  await page.goto('/app/interactions/new');
+  await page.getByPlaceholder('Résumé court').fill(subject);
+  await page.getByRole('button', { name: 'Ajouter un événement' }).click();
+  await expect(page).toHaveURL(/\/app\/interactions$/);
+
+  await page.getByRole('link', { name: subject }).click();
+  await expect(page).toHaveURL(/\/app\/interactions\/[0-9a-f-]+$/);
+  const detailUrl = page.url();
+
+  // Accès direct à l'URL (nouvelle entrée d'historique, sans state) : plus
+  // d'origine en mémoire → fallback liste. Un simple reload préserverait
+  // history.state, d'où le passage par le dashboard.
+  await page.goto('/app/dashboard');
+  await page.goto(detailUrl);
+  // (scopé au main pour ne pas matcher le lien « Activité » de la sidebar)
+  await page.getByRole('main').getByRole('link', { name: 'Activité', exact: true }).click();
+  await expect(page).toHaveURL(/\/app\/interactions$/);
+});

--- a/ui/src/components/BackLink.tsx
+++ b/ui/src/components/BackLink.tsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { ArrowLeft } from 'lucide-react';
+import { useBackTarget } from '@/lib/backNavigation';
+
+interface BackLinkProps {
+  /** Route de repli quand la page est ouverte directement (URL, nouvel onglet). */
+  fallback: string;
+  /** Libellé quand on retombe sur le fallback (ex: titre de la liste). */
+  fallbackLabel: string;
+}
+
+export default function BackLink({ fallback, fallbackLabel }: BackLinkProps) {
+  const { t } = useTranslation();
+  const { to, state, hasOrigin } = useBackTarget(fallback);
+
+  return (
+    <Link
+      to={to}
+      state={state}
+      className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      {hasOrigin ? t('common.back') : fallbackLabel}
+    </Link>
+  );
+}

--- a/ui/src/features/agent/AgentCitation.tsx
+++ b/ui/src/features/agent/AgentCitation.tsx
@@ -1,9 +1,10 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import {
   FileText, Notebook, Wrench, ListTodo, FolderKanban, MapPin,
   Box, ShieldCheck, User, Building2, ExternalLink,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { pushBack } from '@/lib/backNavigation';
 import type { AgentCitation as Citation } from './api';
 
 const ENTITY_ICONS: Record<string, LucideIcon> = {
@@ -27,9 +28,11 @@ interface Props {
 
 export default function AgentCitation({ citation, index }: Props) {
   const Icon = ENTITY_ICONS[citation.entity_type] ?? ExternalLink;
+  const location = useLocation();
   return (
     <Link
       to={citation.url_path}
+      state={pushBack(location)}
       data-testid="agent-citation"
       data-entity-type={citation.entity_type}
       title={citation.snippet || citation.label}

--- a/ui/src/features/alerts/AlertsPage.tsx
+++ b/ui/src/features/alerts/AlertsPage.tsx
@@ -1,7 +1,8 @@
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { AlertTriangle, Bell, Clock, ShieldCheck, Wrench } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
+import { pushBack } from '@/lib/backNavigation';
 import EmptyState from '@/components/EmptyState';
 import { Card } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
@@ -30,8 +31,9 @@ interface AlertCardProps {
 }
 
 function AlertCard({ to, title, meta, severityLabel, severity }: AlertCardProps) {
+  const location = useLocation();
   return (
-    <Link to={to} className="group block">
+    <Link to={to} state={pushBack(location)} className="group block">
       <Card className="p-3 transition-colors hover:bg-muted/40">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">

--- a/ui/src/features/alerts/AlertsSection.tsx
+++ b/ui/src/features/alerts/AlertsSection.tsx
@@ -1,10 +1,11 @@
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { ArrowRight, Bell } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import { buttonVariants } from '@/design-system/button';
 import { cn } from '@/lib/utils';
+import { pushBack } from '@/lib/backNavigation';
 import type { AlertSeverity } from '@/lib/api/alerts';
 import { useAlertsSummary } from './hooks';
 
@@ -26,6 +27,7 @@ function severityClass(severity: AlertSeverity): string {
 
 export default function AlertsSection() {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data } = useAlertsSummary();
 
   if (!data || data.total === 0) return null;
@@ -78,6 +80,7 @@ export default function AlertsSection() {
           <Link
             key={item.id}
             to={item.url}
+            state={pushBack(location)}
             className="group block rounded-xl border border-border/70 bg-background/80 p-3 transition-colors hover:border-border hover:bg-background"
           >
             <div className="flex items-start justify-between gap-3">

--- a/ui/src/features/dashboard/DashboardPage.tsx
+++ b/ui/src/features/dashboard/DashboardPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import {
   ArrowRight,
@@ -25,6 +25,7 @@ import { Button, buttonVariants } from '@/design-system/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/design-system/dialog';
 import { cn } from '@/lib/utils';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { pushBack } from '@/lib/backNavigation';
 import AlertsSection from '@/features/alerts/AlertsSection';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -154,6 +155,7 @@ interface SectionPanelProps {
 
 function SectionPanel({ id, title, description, href, hrefLabel, icon, emptyMessage, items, isLoading }: SectionPanelProps) {
   const Icon = ICONS[icon] ?? Sparkles;
+  const location = useLocation();
   const showSkeleton = useDelayedLoading(isLoading);
 
   return (
@@ -185,9 +187,9 @@ function SectionPanel({ id, title, description, href, hrefLabel, icon, emptyMess
           items.map((item) => (
             <div key={item.id} className={cn('rounded-2xl border border-border/70 bg-background/80 p-4 transition-colors hover:border-border hover:bg-background', item.url ? 'cursor-pointer' : '')}>
               {item.url ? (
-                <a href={item.url} className="block">
+                <Link to={item.url} state={pushBack(location)} className="block">
                   <SectionItemContent item={item} />
-                </a>
+                </Link>
               ) : (
                 <SectionItemContent item={item} />
               )}

--- a/ui/src/features/documents/DocumentCard.tsx
+++ b/ui/src/features/documents/DocumentCard.tsx
@@ -1,9 +1,10 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { FileText, FileX, Pencil, Trash2, ExternalLink, ScanText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
 import { CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
+import { pushBack } from '@/lib/backNavigation';
 import { formatFileSize, type DocumentItem } from '@/lib/api/documents';
 
 interface DocumentCardProps {
@@ -15,6 +16,7 @@ interface DocumentCardProps {
 
 export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: DocumentCardProps) {
   const { t } = useTranslation();
+  const location = useLocation();
 
   const fileName = doc.name || doc.file_path.split('/').pop() || '';
   const fileSize =
@@ -43,6 +45,7 @@ export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: Doc
         <div className="flex flex-wrap items-center gap-2">
           <Link
             to={`/app/documents/${doc.id}`}
+            state={pushBack(location)}
             className="group text-foreground hover:text-primary"
           >
             <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">{fileName}</CardTitle>

--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Download, ExternalLink, Plus, RefreshCcw } from 'lucide-react';
+import { Download, ExternalLink, Plus, RefreshCcw } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { useNavigateBack } from '@/lib/backNavigation';
 import { formatFileSize } from '@/lib/api/documents';
 import {
   useDocument,
@@ -28,7 +30,7 @@ function formatDate(value?: string | null): string {
 export default function DocumentDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigateBack = useNavigateBack('/app/documents');
   const qc = useQueryClient();
 
   const [editOpen, setEditOpen] = React.useState(false);
@@ -48,7 +50,7 @@ export default function DocumentDetailPage() {
   function handleDelete() {
     if (!id) return;
     deleteMutation.mutate(id, {
-      onSuccess: () => navigate('/app/documents'),
+      onSuccess: () => navigateBack(),
     });
   }
 
@@ -95,13 +97,7 @@ export default function DocumentDetailPage() {
     <>
       <div className="space-y-4">
         {/* Back */}
-        <Link
-          to="/app/documents"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {t('documents.title')}
-        </Link>
+        <BackLink fallback="/app/documents" fallbackLabel={t('documents.title')} />
 
         {/* Header */}
         <div className="flex items-start gap-3">

--- a/ui/src/features/equipment/EquipmentCard.tsx
+++ b/ui/src/features/equipment/EquipmentCard.tsx
@@ -1,10 +1,11 @@
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Pencil, Plus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
+import { pushBack } from '@/lib/backNavigation';
 import type { EquipmentListItem } from '@/lib/api/equipment';
 
 interface EquipmentCardProps {
@@ -30,6 +31,7 @@ function formatDate(value?: string | null): string {
 
 export default function EquipmentCard({ item, onEdit, onDelete, onPurchase }: EquipmentCardProps) {
   const { t } = useTranslation();
+  const location = useLocation();
 
   const actions: CardAction[] = [
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(item) },
@@ -42,6 +44,7 @@ export default function EquipmentCard({ item, onEdit, onDelete, onPurchase }: Eq
         <div>
           <Link
             to={`/app/equipment/${item.id}`}
+            state={pushBack(location)}
             className="group text-foreground hover:text-primary"
           >
             <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">{item.name}</CardTitle>

--- a/ui/src/features/equipment/EquipmentDetailPage.tsx
+++ b/ui/src/features/equipment/EquipmentDetailPage.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Wrench } from 'lucide-react';
+import { Wrench } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { useNavigateBack } from '@/lib/backNavigation';
 import {
   useEquipment,
   useEquipmentHistory,
@@ -67,7 +69,7 @@ function InfoField({ label, children }: { label: string; children: React.ReactNo
 export default function EquipmentDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigateBack = useNavigateBack('/app/equipment');
   const qc = useQueryClient();
 
   const [editOpen, setEditOpen] = React.useState(false);
@@ -87,7 +89,7 @@ export default function EquipmentDetailPage() {
   function handleDelete() {
     if (!id) return;
     deleteMutation.mutate(id, {
-      onSuccess: () => navigate('/app/equipment'),
+      onSuccess: () => navigateBack(),
     });
   }
 
@@ -128,13 +130,7 @@ export default function EquipmentDetailPage() {
     <>
       <div className="space-y-6">
         {/* Back */}
-        <Link
-          to="/app/equipment"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {t('equipment.title')}
-        </Link>
+        <BackLink fallback="/app/equipment" fallbackLabel={t('equipment.title')} />
 
         {/* Header */}
         <div className="flex items-start gap-3">

--- a/ui/src/features/interactions/InteractionCard.tsx
+++ b/ui/src/features/interactions/InteractionCard.tsx
@@ -1,9 +1,10 @@
 import { Pencil, Trash2, ListTodo } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardTitle } from '@/design-system/card';
+import { pushBack } from '@/lib/backNavigation';
 import type { InteractionListItem } from '@/lib/api/interactions';
 
 interface InteractionCardProps {
@@ -23,6 +24,7 @@ function formatDate(value: string): string {
 export default function InteractionCard({ item, onDelete }: InteractionCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const typeLabelKey = `equipment.interaction_type.${item.type}`;
   const statusLabelKey = item.status ? `equipment.interaction_status.${item.status}` : null;
@@ -34,6 +36,7 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
           <div className="flex flex-wrap items-center gap-2">
             <Link
               to={`/app/interactions/${item.id}`}
+              state={pushBack(location)}
               className="group text-foreground hover:text-primary"
             >
               <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">
@@ -82,12 +85,13 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
           {item.project && item.project_title ? (
             <div className="mt-1 text-xs text-muted-foreground">
               <span>{t('interactions.project_label')}: </span>
-              <a
-                href={`/app/projects/${item.project}`}
+              <Link
+                to={`/app/projects/${item.project}`}
+                state={pushBack(location)}
                 className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               >
                 {item.project_title}
-              </a>
+              </Link>
             </div>
           ) : null}
 

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowLeft, FileText, Pencil, Trash2 } from 'lucide-react';
+import { FileText, Pencil, Trash2 } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useInteraction, useDeleteInteraction } from './hooks';
 
@@ -35,6 +37,8 @@ export default function InteractionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
+  const navigateBack = useNavigateBack('/app/interactions');
 
   const [deleteOpen, setDeleteOpen] = React.useState(false);
 
@@ -46,7 +50,7 @@ export default function InteractionDetailPage() {
   function handleDelete() {
     if (!id) return;
     deleteMutation.mutate(id, {
-      onSuccess: () => navigate('/app/interactions'),
+      onSuccess: () => navigateBack(),
     });
   }
 
@@ -83,13 +87,7 @@ export default function InteractionDetailPage() {
     <>
       <div className="space-y-6">
         {/* Back */}
-        <Link
-          to="/app/interactions"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {t('interactions.title')}
-        </Link>
+        <BackLink fallback="/app/interactions" fallbackLabel={t('interactions.title')} />
 
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
@@ -148,6 +146,7 @@ export default function InteractionDetailPage() {
             <InfoField label={t('interactions.project_label')}>
               <Link
                 to={`/app/projects/${interaction.project}`}
+                state={pushBack(location)}
                 className="text-primary hover:underline"
               >
                 {interaction.project_title}
@@ -221,6 +220,7 @@ export default function InteractionDetailPage() {
                     <Link
                       key={eq.id}
                       to={`/app/equipment/${eq.id}`}
+                      state={pushBack(location)}
                       className="rounded-full border border-border px-2 py-0.5 text-xs text-foreground hover:text-primary hover:underline"
                     >
                       {eq.name}

--- a/ui/src/features/projects/ProjectDashboard.tsx
+++ b/ui/src/features/projects/ProjectDashboard.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { Textarea } from '@/design-system/textarea';
+import { pushBack } from '@/lib/backNavigation';
 import { useProjectTasks } from '@/features/tasks/hooks';
 import { useProjectInteractions, projectKeys } from './hooks';
 import { useCreateInteraction, interactionKeys } from '@/features/interactions/hooks';
@@ -148,6 +149,7 @@ function IndicatorsSection({ project }: { project: ProjectListItem }) {
 
 function TasksSection({ projectId, onAdd }: { projectId: string; onAdd: () => void }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: tasks = [], isLoading } = useProjectTasks(projectId);
   const open = React.useMemo(
     () => tasks.filter(isOpenTask).slice(0, PREVIEW_LIMIT),
@@ -186,6 +188,7 @@ function TasksSection({ projectId, onAdd }: { projectId: string; onAdd: () => vo
             <li key={task.id}>
               <Link
                 to={`/app/tasks/${task.id}`}
+                state={pushBack(location)}
                 className="flex items-center justify-between gap-2 rounded-md border border-border bg-background px-3 py-2 text-sm transition-colors hover:border-primary/40 hover:bg-muted"
               >
                 <span className="min-w-0 flex-1 truncate">{task.subject}</span>
@@ -211,6 +214,7 @@ function isOpenTask(task: Task): boolean {
 
 function NotesSection({ project }: { project: ProjectListItem }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: notes = [], isLoading } = useProjectInteractions(project.id, 'note');
   const previewNotes = notes.slice(0, PREVIEW_LIMIT);
 
@@ -236,6 +240,7 @@ function NotesSection({ project }: { project: ProjectListItem }) {
             <li key={n.id}>
               <Link
                 to={`/app/interactions/${n.id}`}
+                state={pushBack(location)}
                 className="block rounded-md border border-border bg-background px-3 py-2 text-sm transition-colors hover:border-primary/40 hover:bg-muted"
               >
                 <p className="font-medium">{n.subject}</p>

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Star, Plus } from 'lucide-react';
+import { Star, Plus } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import { TabShell } from '@/components/TabShell';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import type { ProjectStatus } from '@/lib/api/projects';
 import TasksPanel from '@/features/tasks/TasksPanel';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
@@ -61,6 +63,7 @@ function TabInteractions({
   addLabel?: string;
 }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: items = [], isLoading, error } = useProjectInteractions(projectId, type);
 
   if (isLoading) {
@@ -101,6 +104,7 @@ function TabInteractions({
             <li key={item.id}>
               <Link
                 to={`/app/interactions/${item.id}`}
+                state={pushBack(location)}
                 className="block rounded-md border p-3 text-sm transition-colors hover:border-primary/40 hover:bg-muted"
               >
                 <div className="flex items-start justify-between gap-2">
@@ -138,7 +142,7 @@ function TabInteractions({
 export default function ProjectDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const navigateBack = useNavigateBack('/app/projects');
   const qc = useQueryClient();
 
   const [editOpen, setEditOpen] = React.useState(false);
@@ -166,7 +170,7 @@ export default function ProjectDetailPage() {
   function handleDelete() {
     if (!id) return;
     deleteProjectMutation.mutate(id, {
-      onSuccess: () => navigate('/app/projects'),
+      onSuccess: () => navigateBack(),
     });
   }
 
@@ -197,13 +201,7 @@ export default function ProjectDetailPage() {
     <>
       <div className="space-y-4">
         {/* Back */}
-        <Link
-          to="/app/projects"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {t('projects.title')}
-        </Link>
+        <BackLink fallback="/app/projects" fallbackLabel={t('projects.title')} />
 
         {/* Header */}
         <div className="flex items-start gap-3">

--- a/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/ui/src/features/tasks/TaskDetailPage.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { ArrowLeft, Download, ExternalLink, FileText, Lock, Paperclip, Pencil, Trash2 } from 'lucide-react';
+import { Download, ExternalLink, FileText, Lock, Paperclip, Pencil, Trash2 } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useAuth } from '@/lib/auth/useAuth';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { isTaskOverdue, formatRelativeDate, type Task, type TaskStatus } from '@/lib/api/tasks';
@@ -53,7 +55,8 @@ function InfoField({ label, children }: { label: string; children: React.ReactNo
 export default function TaskDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const navigate = useNavigate();
+  const location = useLocation();
+  const navigateBack = useNavigateBack('/app/tasks');
   const { user } = useAuth();
   const qc = useQueryClient();
 
@@ -88,7 +91,7 @@ export default function TaskDetailPage() {
   function handleDelete() {
     if (!id) return;
     deleteMutation.mutate(id, {
-      onSuccess: () => navigate('/app/tasks'),
+      onSuccess: () => navigateBack(),
     });
   }
 
@@ -138,13 +141,7 @@ export default function TaskDetailPage() {
     <>
       <div className="space-y-6">
         {/* Back */}
-        <Link
-          to="/app/tasks"
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeft className="h-4 w-4" />
-          {t('tasks.title')}
-        </Link>
+        <BackLink fallback="/app/tasks" fallbackLabel={t('tasks.title')} />
 
         {/* Header */}
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
@@ -239,6 +236,7 @@ export default function TaskDetailPage() {
             <InfoField label={t('tasks.fieldProject')}>
               <Link
                 to={`/app/projects/${task.project}`}
+                state={pushBack(location)}
                 className="text-primary hover:underline"
               >
                 {task.project_title}
@@ -278,6 +276,7 @@ export default function TaskDetailPage() {
                   <div className="flex items-start justify-between gap-2">
                     <Link
                       to={`/app/documents/${doc.document_id}`}
+                      state={pushBack(location)}
                       className="min-w-0 flex-1 truncate font-medium text-foreground hover:text-primary hover:underline"
                     >
                       {doc.name || '—'}
@@ -324,6 +323,7 @@ export default function TaskDetailPage() {
                     </div>
                     <Link
                       to={`/app/interactions/${item.interaction_id}`}
+                      state={pushBack(location)}
                       className="ml-1 inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
                       aria-label={t('common.view')}
                     >

--- a/ui/src/features/tasks/TasksPanel.tsx
+++ b/ui/src/features/tasks/TasksPanel.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { CheckSquare, FolderOpen, Lock, Plus, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { isTaskOverdue, type Task, type TaskStatus } from '@/lib/api/tasks';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
@@ -9,6 +9,7 @@ import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useSessionState } from '@/lib/useSessionState';
 import { Button } from '@/design-system/button';
 import { FilterPill } from '@/design-system/filter-pill';
+import { pushBack } from '@/lib/backNavigation';
 import { DropdownSelect } from '@/design-system/dropdown-select';
 import {
   useTasks,
@@ -46,6 +47,7 @@ export default function TasksPanel({
   const { t } = useTranslation();
   const qc = useQueryClient();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const isEmbedded = Boolean(projectId);
   const prefix = stateKeyPrefix ?? 'tasks';
@@ -192,7 +194,7 @@ export default function TasksPanel({
     onEdit: setEditingTask,
     onDelete: handleTaskDeleted,
     onManageAttachments: setAttachmentsTask,
-    onViewDetail: (task: Task) => navigate(`/app/tasks/${task.id}`),
+    onViewDetail: (task: Task) => navigate(`/app/tasks/${task.id}`, { state: pushBack(location) }),
   };
 
   return (

--- a/ui/src/features/zones/ZoneDetailPage.tsx
+++ b/ui/src/features/zones/ZoneDetailPage.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Layers, NotebookText, FileText, ImageIcon } from 'lucide-react';
+import { pushBack } from '@/lib/backNavigation';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import { TabShell } from '@/components/TabShell';
@@ -147,6 +148,7 @@ function TabInfo({
 
 function TabEquipment({ zoneId }: { zoneId: string }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: equipmentData = [], isLoading } = useEquipmentByZone(zoneId);
 
   if (isLoading) {
@@ -167,6 +169,7 @@ function TabEquipment({ zoneId }: { zoneId: string }) {
         <li key={eq.id}>
           <Link
             to={`/app/equipment/${eq.id}`}
+            state={pushBack(location)}
             className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
           >
             <span className="truncate">{eq.name}</span>
@@ -285,6 +288,7 @@ function TabActivity({ zoneId, navigate }: { zoneId: string; navigate: (to: stri
 
 function TabProjects({ zoneId }: { zoneId: string }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: projectsData = [], isLoading } = useZoneProjects(zoneId);
 
   if (isLoading) {
@@ -305,6 +309,7 @@ function TabProjects({ zoneId }: { zoneId: string }) {
         <li key={project.id}>
           <Link
             to={`/app/projects/${project.id}`}
+            state={pushBack(location)}
             className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
           >
             <span className="truncate">{project.title}</span>
@@ -322,6 +327,7 @@ function TabProjects({ zoneId }: { zoneId: string }) {
 
 function TabPhotos({ zoneId }: { zoneId: string }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: photos = [], isLoading } = useZonePhotos(zoneId);
 
   if (isLoading) {
@@ -349,6 +355,7 @@ function TabPhotos({ zoneId }: { zoneId: string }) {
         <Link
           key={photo.id}
           to={`/app/documents/${photo.id}`}
+          state={pushBack(location)}
           className="group relative aspect-square overflow-hidden rounded-lg border border-border bg-muted"
         >
           {photo.file_url ? (
@@ -375,6 +382,7 @@ function TabPhotos({ zoneId }: { zoneId: string }) {
 
 function TabDocuments({ zoneId }: { zoneId: string }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const { data: documents = [], isLoading } = useZoneDocuments(zoneId);
 
   if (isLoading) {
@@ -400,6 +408,7 @@ function TabDocuments({ zoneId }: { zoneId: string }) {
         <li key={doc.id}>
           <Link
             to={`/app/documents/${doc.id}`}
+            state={pushBack(location)}
             className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
           >
             <div className="flex min-w-0 items-center gap-2">

--- a/ui/src/lib/backNavigation.ts
+++ b/ui/src/lib/backNavigation.ts
@@ -1,0 +1,53 @@
+import { useLocation, useNavigate, type Location } from 'react-router-dom';
+
+// Pile d'URLs d'origine portée par location.state — permet le retour vers la
+// page d'où l'on vient (ex: détail projet) plutôt que vers la liste par défaut,
+// y compris en chaîne (projet → tâche → note liée).
+export interface BackState {
+  back?: string[];
+}
+
+const MAX_STACK = 5;
+
+function readStack(location: Location): string[] {
+  const state = (location.state ?? null) as BackState | null;
+  return Array.isArray(state?.back) ? state.back : [];
+}
+
+/**
+ * À passer en `state` d'un `<Link>` (ou de `navigate()`) qui mène vers une page
+ * de détail : empile l'URL courante pour que le bouton retour y revienne.
+ *
+ *   const location = useLocation();
+ *   <Link to={`/app/tasks/${id}`} state={pushBack(location)}>
+ */
+export function pushBack(location: Location): BackState {
+  const stack = readStack(location);
+  return { back: [...stack, location.pathname + location.search].slice(-MAX_STACK) };
+}
+
+/**
+ * Cible de retour de la page courante : l'origine empilée si présente, sinon
+ * le fallback. `state` dépile pour que la page cible retrouve sa propre origine.
+ */
+export function useBackTarget(fallback: string): {
+  to: string;
+  state: BackState;
+  hasOrigin: boolean;
+} {
+  const location = useLocation();
+  const stack = readStack(location);
+  if (stack.length === 0) return { to: fallback, state: {}, hasOrigin: false };
+  return {
+    to: stack[stack.length - 1],
+    state: { back: stack.slice(0, -1) },
+    hasOrigin: true,
+  };
+}
+
+/** Navigation programmatique vers la cible de retour (ex: après suppression). */
+export function useNavigateBack(fallback: string): () => void {
+  const navigate = useNavigate();
+  const { to, state } = useBackTarget(fallback);
+  return () => navigate(to, { state });
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "back": "Zurück",
     "yes": "ja",
     "no": "nein",
     "save": "Speichern",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "back": "Back",
     "yes": "yes",
     "no": "no",
     "save": "Save",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "back": "Volver",
     "yes": "sí",
     "no": "no",
     "save": "Guardar",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "back": "Retour",
     "yes": "oui",
     "no": "non",
     "save": "Enregistrer",


### PR DESCRIPTION
## Problème

Depuis les onglets Notes / Tâches / Historique d'un projet, cliquer un item ouvre sa page de détail — mais le bouton retour renvoyait vers la liste par défaut (`/app/interactions`, `/app/tasks`…) au lieu du projet. Même problème partout où une page de détail est atteignable depuis plusieurs contextes (zone, dashboard, alertes, citations de l'agent…).

## Solution

**Pile d'origines dans `location.state`** (`ui/src/lib/backNavigation.ts`) :
- `pushBack(location)` — passé en `state` de tout `Link`/`navigate()` vers une page de détail, empile l'URL courante (plafonnée à 5 niveaux).
- `useBackTarget(fallback)` / `useNavigateBack(fallback)` — côté détail, dépilent : retour vers l'origine si connue, sinon fallback vers la liste. Le dépilage préserve le reste de la pile, donc les chaînes projet → tâche → note liée reviennent étape par étape.
- Survit au reload (history.state), retombe proprement sur le fallback en accès direct par URL ou nouvel onglet.

**`BackLink`** (`ui/src/components/BackLink.tsx`) — lien retour partagé : libellé « Retour » quand une origine est connue, sinon le titre de la liste (comportement inchangé).

## Branchements

- **Pages de détail** (lien retour + navigation après suppression) : tâche, interaction/note, document, équipement, projet.
- **Origines** : tabs Notes/Dépenses/Historique + aperçu du détail projet, `TasksPanel` (liste globale et tab projet), cards interaction/document/équipement, tabs du détail zone, dashboard, alertes (page + section), citations de l'agent, liens croisés entre détails (tâche → document lié, note → projet/équipement…).
- Au passage : le lien projet d'`InteractionCard` était un `<a href>` (rechargement complet) → `Link`.
- i18n : clé `common.back` (en/fr/de/es).
- Pattern documenté dans `CLAUDE.md`.

## Tests

- Nouveau `e2e/back-navigation.spec.ts` : retour au projet depuis l'onglet Notes et depuis l'aperçu, fallback liste en accès direct par URL — 5 tests verts.
- Suites E2E existantes des pages touchées (`tasks`, `project-tasks`, `interaction-detail`, `shell`) : 31 tests verts.
- Les échecs de la suite complète (electricity/stock/photos) sont préexistants sur `main` (vérifié via stash : 11 échecs sur HEAD sans ces changements).
- `npm run build` OK, `npm run lint` 0 erreur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)