### PR TITLE
feat(agent): EntityAssistant sur les pages détail zone, équipement, tâche, document

### DIFF
--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -17,6 +17,7 @@ import {
   documentKeys,
 } from './hooks';
 import DocumentEditDialog from './DocumentEditDialog';
+import EntityAssistant from '@/features/agent/EntityAssistant';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useToast } from '@/lib/toast';
 
@@ -255,6 +256,14 @@ export default function DocumentDetailPage() {
               ))}
             </ul>
           )}
+        </div>
+
+        {/* Assistant */}
+        <div className="space-y-2">
+          <h2 className="text-base font-semibold text-foreground">
+            {t('agent.entity.section_title')}
+          </h2>
+          <EntityAssistant entityType="document" objectId={doc.id} />
         </div>
       </div>
 

--- a/ui/src/features/equipment/EquipmentDetailPage.tsx
+++ b/ui/src/features/equipment/EquipmentDetailPage.tsx
@@ -16,6 +16,7 @@ import {
   equipmentKeys,
 } from './hooks';
 import EquipmentDialog from './EquipmentDialog';
+import EntityAssistant from '@/features/agent/EntityAssistant';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Helpers ────────────────────────────────────────────────
@@ -337,6 +338,14 @@ export default function EquipmentDetailPage() {
               ))}
             </ul>
           )}
+        </section>
+
+        {/* Assistant */}
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-foreground">
+            {t('agent.entity.section_title')}
+          </h2>
+          <EntityAssistant entityType="equipment" objectId={equipment.id} />
         </section>
       </div>
 

--- a/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/ui/src/features/tasks/TaskDetailPage.tsx
@@ -23,6 +23,7 @@ import TaskStatusBadge from './TaskStatusBadge';
 import TaskAssigneeBadge from './TaskAssigneeBadge';
 import NewTaskDialog from './NewTaskDialog';
 import TaskAttachmentsDialog from './TaskAttachmentsDialog';
+import EntityAssistant from '@/features/agent/EntityAssistant';
 
 function formatDate(value?: string | null): string {
   if (!value) return '—';
@@ -351,6 +352,14 @@ export default function TaskDetailPage() {
             </Button>
           </div>
         )}
+
+        {/* Assistant */}
+        <section className="space-y-2">
+          <h2 className="text-base font-semibold text-foreground">
+            {t('agent.entity.section_title')}
+          </h2>
+          <EntityAssistant entityType="task" objectId={task.id} />
+        </section>
       </div>
 
       <NewTaskDialog

--- a/ui/src/features/zones/ZoneDetailPage.tsx
+++ b/ui/src/features/zones/ZoneDetailPage.tsx
@@ -18,12 +18,13 @@ import {
   useZonePhotos,
 } from './hooks';
 import ZoneDialog from './ZoneDialog';
+import EntityAssistant from '@/features/agent/EntityAssistant';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Tab types ──────────────────────────────────────────────
 
-type Tab = 'info' | 'equipment' | 'tasks' | 'activity' | 'projects' | 'photos' | 'documents';
-const TABS: Tab[] = ['info', 'equipment', 'tasks', 'activity', 'projects', 'photos', 'documents'];
+type Tab = 'info' | 'equipment' | 'tasks' | 'activity' | 'projects' | 'photos' | 'documents' | 'assistant';
+const TABS: Tab[] = ['info', 'equipment', 'tasks', 'activity', 'projects', 'photos', 'documents', 'assistant'];
 
 // ── Tab: Info ──────────────────────────────────────────────
 
@@ -545,6 +546,10 @@ export default function ZoneDetailPage() {
                 {tab === 'photos' ? <TabPhotos zoneId={id} /> : null}
 
                 {tab === 'documents' ? <TabDocuments zoneId={id} /> : null}
+
+                {tab === 'assistant' ? (
+                  <EntityAssistant entityType="zone" objectId={id} />
+                ) : null}
               </CardContent>
             </Card>
           )}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -429,7 +429,8 @@
       "activity": "Aktivität",
       "projects": "Projekte",
       "photos": "Fotos",
-      "documents": "Dokumente"
+      "documents": "Dokumente",
+      "assistant": "Assistent"
     },
     "photos": {
       "title": "Zonenfotos",
@@ -1641,6 +1642,7 @@
       "title": "Erstellt: {{label}}"
     },
     "entity": {
+      "section_title": "Assistent",
       "empty_title": "Stell jede Frage zu diesem Element",
       "empty_hint": "Der Assistent kennt dieses Element und alles, was damit verknüpft ist, bereits — seine Details, Dokumente, Ausgaben und Aufgaben — und nennt seine Quellen."
     },

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -429,7 +429,8 @@
       "activity": "Activity",
       "projects": "Projects",
       "photos": "Photos",
-      "documents": "Documents"
+      "documents": "Documents",
+      "assistant": "Assistant"
     },
     "photos": {
       "title": "Zone photos",
@@ -1641,6 +1642,7 @@
       "title": "Created: {{label}}"
     },
     "entity": {
+      "section_title": "Assistant",
       "empty_title": "Ask anything about this item",
       "empty_hint": "The assistant already knows this item and everything linked to it — its details, documents, expenses and tasks — and cites its sources."
     },

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -429,7 +429,8 @@
       "activity": "Actividad",
       "projects": "Proyectos",
       "photos": "Fotos",
-      "documents": "Documentos"
+      "documents": "Documentos",
+      "assistant": "Asistente"
     },
     "photos": {
       "title": "Fotos de la zona",
@@ -1641,6 +1642,7 @@
       "title": "Creado: {{label}}"
     },
     "entity": {
+      "section_title": "Asistente",
       "empty_title": "Pregunta lo que quieras sobre este elemento",
       "empty_hint": "El asistente ya conoce este elemento y todo lo vinculado a él — sus detalles, documentos, gastos y tareas — y cita sus fuentes."
     },

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -429,7 +429,8 @@
       "activity": "Activité",
       "projects": "Projets",
       "photos": "Photos",
-      "documents": "Documents"
+      "documents": "Documents",
+      "assistant": "Assistant"
     },
     "photos": {
       "title": "Photos de la zone",
@@ -1641,6 +1642,7 @@
       "title": "Créé : {{label}}"
     },
     "entity": {
+      "section_title": "Assistant",
       "empty_title": "Pose n'importe quelle question sur cet élément",
       "empty_hint": "L'assistant connaît déjà cet élément et tout ce qui lui est lié — ses détails, documents, dépenses et tâches — et cite ses sources."
     },


### PR DESCRIPTION
## Contexte

Dernier volet du palier 2 de l'audit agent, débloqué par la refacto des pages de détail (#180) : l'assistant ancré (`EntityAssistant`) n'était posé que sur le détail projet alors que le composant est générique (1 ligne par entité).

**Stackée sur #180** (`feat/ui-contextual-back`) — retargettera sur `main` après son merge.

## Changements

- **ZoneDetailPage** : nouvel onglet « Assistant » (même pattern TabShell que le projet).
- **EquipmentDetailPage / TaskDetailPage / DocumentDetailPage** : section « Assistant » en bas de page (pages à sections empilées).
- i18n : `zones.tabs.assistant` + `agent.entity.section_title` (en/fr/de/es).

Les 4 entités sont déjà enregistrées dans `agent.searchables` (prérequis du composant). Combiné avec #179 (`related` zone/équipement), l'ancrage pré-injecte tout le voisinage de l'entité — l'assistant d'une zone connaît d'emblée ses équipements, tâches, interventions et photos.

## Vérifications

- `npm run build` : OK, `npm run lint` : 0 erreur.
- Le get-or-create `for_context` couvre ces types nativement (aucun changement backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)