### PR TITLE
feat(agent): streaming SSE bout en bout — texte progressif et tool en cours

### DIFF
--- a/apps/agent/llm.py
+++ b/apps/agent/llm.py
@@ -206,24 +206,9 @@ class AnthropicClient:
         started = time.monotonic()
         try:
             client = self._client()
-            create_kwargs: dict[str, Any] = {
-                "model": self.model,
-                "max_tokens": max_tokens,
-                # One cache breakpoint at the end of the system block caches the
-                # whole prefix before the messages (tool schemas + system prompt)
-                # across loop iterations and conversation turns (5-min TTL).
-                "system": [
-                    {
-                        "type": "text",
-                        "text": system,
-                        "cache_control": {"type": "ephemeral"},
-                    }
-                ],
-                "messages": messages,
-            }
-            if tools:
-                create_kwargs["tools"] = tools
-            message = client.messages.create(**create_kwargs)
+            message = client.messages.create(
+                **self._run_create_kwargs(system, messages, tools, max_tokens)
+            )
         except Exception as exc:
             self._log_and_raise_failure(
                 exc,
@@ -234,6 +219,100 @@ class AnthropicClient:
                 metadata=metadata,
             )
 
+        return self._finalize_run(
+            message,
+            started=started,
+            feature=feature,
+            household_id=household_id,
+            user_id=user_id,
+            metadata=metadata,
+        )
+
+    def run_stream(
+        self,
+        *,
+        system: str,
+        messages: list[dict],
+        tools: list[dict],
+        feature: str,
+        household_id: UUID | str,
+        user_id: int | None = None,
+        max_tokens: int = 1024,
+        metadata: dict[str, Any] | None = None,
+    ):
+        """Streaming variant of ``run()``.
+
+        A generator yielding ``("delta", text_chunk)`` events as the model
+        produces text, then a final ``("final", LLMRunResponse)`` carrying the
+        same normalized payload ``run()`` returns (tool calls, stop reason,
+        usage). One call = one round-trip = one ``AIUsageLog`` line, exactly
+        like ``run()`` — the tool-use loop stays in the caller.
+        """
+        started = time.monotonic()
+        try:
+            client = self._client()
+            with client.messages.stream(
+                **self._run_create_kwargs(system, messages, tools, max_tokens)
+            ) as stream:
+                for text in stream.text_stream:
+                    yield ("delta", text)
+                message = stream.get_final_message()
+        except Exception as exc:
+            self._log_and_raise_failure(
+                exc,
+                started=started,
+                feature=feature,
+                household_id=household_id,
+                user_id=user_id,
+                metadata=metadata,
+            )
+
+        yield (
+            "final",
+            self._finalize_run(
+                message,
+                started=started,
+                feature=feature,
+                household_id=household_id,
+                user_id=user_id,
+                metadata=metadata,
+            ),
+        )
+
+    def _run_create_kwargs(
+        self, system: str, messages: list[dict], tools: list[dict], max_tokens: int
+    ) -> dict[str, Any]:
+        """The ``messages.create``/``messages.stream`` kwargs shared by run/run_stream."""
+        create_kwargs: dict[str, Any] = {
+            "model": self.model,
+            "max_tokens": max_tokens,
+            # One cache breakpoint at the end of the system block caches the
+            # whole prefix before the messages (tool schemas + system prompt)
+            # across loop iterations and conversation turns (5-min TTL).
+            "system": [
+                {
+                    "type": "text",
+                    "text": system,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            "messages": messages,
+        }
+        if tools:
+            create_kwargs["tools"] = tools
+        return create_kwargs
+
+    def _finalize_run(
+        self,
+        message,
+        *,
+        started: float,
+        feature: str,
+        household_id: UUID | str,
+        user_id: int | None,
+        metadata: dict[str, Any] | None,
+    ) -> LLMRunResponse:
+        """Normalize the SDK message, log the call, build the LLMRunResponse."""
         duration_ms = int((time.monotonic() - started) * 1000)
         assistant_blocks = _normalize_blocks(message)
         tool_calls = _extract_tool_calls(message)

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -72,23 +72,58 @@ def ask(
 ) -> AnswerResult:
     """Answer ``question`` using the data of ``household``. Always returns a result.
 
-    ``history`` is an optional list of prior turns (``{"role", "content"}``,
-    oldest first) threaded into the conversation so follow-up questions can
-    resolve references to earlier turns. The model decides whether to search.
+    Thin non-streaming wrapper: drains ``ask_stream`` and returns its final
+    ``AnswerResult``. Kept as the single entry point for callers that don't
+    stream (legacy ``/ask/`` endpoint, tests, CLI usage).
+    """
+    result: AnswerResult | None = None
+    for event in ask_stream(
+        question,
+        household,
+        user=user,
+        client=client,
+        history=history,
+        context_entity=context_entity,
+    ):
+        if event["type"] == "result":
+            result = event["result"]
+    assert result is not None  # ask_stream always ends with a result event
+    return result
 
-    ``context_entity`` is an optional ``(entity_type, object_id)`` anchor. When
-    given (and resolvable), that entity's full context — the item plus everything
-    linked to it — is pre-injected as the first turn and seeded into the citation
-    pool, so the agent answers about it directly without searching. Generic:
-    works for any entity registered in ``agent.searchables``.
+
+def ask_stream(
+    question: str,
+    household,
+    *,
+    user=None,
+    client: LLMClient | None = None,
+    history: list[dict] | None = None,
+    context_entity: tuple[str, str] | None = None,
+):
+    """Streaming variant of ``ask`` — a generator of progress events.
+
+    Yields dict events, always ending with the result:
+
+    - ``{"type": "delta", "text": chunk}`` — a piece of model text as it is
+      produced (only when the client supports ``run_stream``; text emitted
+      before a tool call is preamble the frontend may discard on "tool");
+    - ``{"type": "tool", "name": tool_name}`` — a tool call is being executed;
+    - ``{"type": "result", "result": AnswerResult}`` — the final answer, same
+      object ``ask`` returns (citations resolved, metadata aggregated).
+
+    ``history`` is an optional list of prior turns (``{"role", "content"}``,
+    oldest first). ``context_entity`` is an optional ``(entity_type, object_id)``
+    anchor whose full context is pre-injected (see ``ask``).
     """
     cleaned = (question or "").strip()
     if not cleaned:
-        return AnswerResult(answer=_dont_know_message(), citations=[])
+        yield {"type": "result", "result": AnswerResult(answer=_dont_know_message(), citations=[])}
+        return
 
     if not _llm_enabled():
         logger.warning("agent.ask: LLM disabled (no ANTHROPIC_API_KEY) — returning IDK")
-        return _idk_result()
+        yield {"type": "result", "result": _idk_result()}
+        return
 
     llm = client or get_llm_client()
     max_iterations = _max_tool_iterations()
@@ -123,17 +158,31 @@ def ask(
         # produce a text answer rather than requesting yet another search.
         offered_tools = tool_schemas if iterations < max_iterations else []
 
+        run_kwargs = dict(
+            system=system_prompt,
+            messages=messages,
+            tools=offered_tools,
+            feature=FEATURE_NAME,
+            household_id=household.id,
+            user_id=getattr(user, "id", None),
+            max_tokens=DEFAULT_MAX_TOKENS,
+            metadata={"iteration": iterations},
+        )
         try:
-            response = llm.run(
-                system=system_prompt,
-                messages=messages,
-                tools=offered_tools,
-                feature=FEATURE_NAME,
-                household_id=household.id,
-                user_id=getattr(user, "id", None),
-                max_tokens=DEFAULT_MAX_TOKENS,
-                metadata={"iteration": iterations},
-            )
+            # Stream when the client supports it, forwarding text chunks as they
+            # arrive; otherwise (stub clients, future providers) fall back to the
+            # blocking round-trip — same LLMRunResponse either way.
+            run_stream = getattr(llm, "run_stream", None)
+            if run_stream is not None:
+                response = None
+                for kind, payload in run_stream(**run_kwargs):
+                    if kind == "delta":
+                        yield {"type": "delta", "text": payload}
+                    else:
+                        response = payload
+                assert response is not None  # run_stream always ends with final
+            else:
+                response = llm.run(**run_kwargs)
         except LLMTimeoutError as exc:
             logger.warning("agent.ask: LLM timeout for household %s: %s", household.id, exc)
             raise
@@ -170,6 +219,7 @@ def ask(
                 )
                 continue
 
+            yield {"type": "tool", "name": call.name}
             result = tools.dispatch(
                 call.name,
                 call.input,
@@ -195,7 +245,7 @@ def ask(
     citations = _resolve_citations(answer_text, hits)
     answer_kind = _classify_answer(tool_calls, hits, citations)
 
-    return AnswerResult(
+    yield {"type": "result", "result": AnswerResult(
         answer=answer_text or _dont_know_message(),
         citations=citations,
         metadata={
@@ -216,7 +266,7 @@ def ask(
             "created_entities": created_entities,
             "updated_entities": updated_entities,
         },
-    )
+    )}
 
 
 def _is_duplicate_write(name: str, tool_input: dict, seen: set) -> bool:

--- a/apps/agent/tests/test_streaming.py
+++ b/apps/agent/tests/test_streaming.py
@@ -1,0 +1,371 @@
+"""Tests for the streaming chain: AnthropicClient.run_stream → service.ask_stream → SSE endpoint.
+
+Same philosophy as the rest of the agent suite: no network, the SDK / LLM
+client / service layer is faked at the boundary under test.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Any
+from unittest import mock
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from agent import service
+from agent.llm import AnthropicClient, LLMResponse, LLMRunResponse, LLMTimeoutError, ToolCall
+from agent.models import AgentConversation, AgentMessage
+from ai_usage.models import AIUsageLog
+from households.models import Household, HouseholdMember
+
+
+# ---------------------------------------------------------------------------
+# AnthropicClient.run_stream — fake SDK with a streaming context manager
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self, chunks, final_message, raises=None):
+        self.text_stream = iter(chunks)
+        self._final = final_message
+        self._raises = raises
+
+    def __enter__(self):
+        if self._raises:
+            raise self._raises
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def get_final_message(self):
+        return self._final
+
+
+class _FakeMessages:
+    def __init__(self, stream):
+        self._stream = stream
+        self.last_kwargs = None
+
+    def stream(self, **kwargs):
+        self.last_kwargs = kwargs
+        return self._stream
+
+
+class _FakeSDK:
+    def __init__(self, stream):
+        self.messages = _FakeMessages(stream)
+
+
+def _final_message(text="Bonjour", stop_reason="end_turn"):
+    return SimpleNamespace(
+        content=[SimpleNamespace(type="text", text=text)],
+        stop_reason=stop_reason,
+        usage=SimpleNamespace(input_tokens=11, output_tokens=7),
+    )
+
+
+@pytest.fixture
+def with_api_key(settings):
+    settings.ANTHROPIC_API_KEY = "sk-test-fake"
+    return settings
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Streaming household")
+
+
+class TestRunStream:
+    def test_yields_deltas_then_final_response(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient(model="claude-haiku-4-5")
+        fake = _FakeSDK(_FakeStream(["Bon", "jour"], _final_message("Bonjour")))
+        monkeypatch.setattr(client, "_client", lambda: fake)
+
+        events = list(
+            client.run_stream(
+                system="sys",
+                messages=[{"role": "user", "content": "salut"}],
+                tools=[],
+                feature="agent_ask",
+                household_id=household.id,
+            )
+        )
+
+        assert events[:2] == [("delta", "Bon"), ("delta", "jour")]
+        kind, response = events[-1]
+        assert kind == "final"
+        assert isinstance(response, LLMRunResponse)
+        assert response.text == "Bonjour"
+        assert response.stop_reason == "end_turn"
+        assert response.input_tokens == 11
+
+        # One round-trip = one AIUsageLog line, exactly like run().
+        log = AIUsageLog.objects.get()
+        assert log.success is True
+        assert log.input_tokens == 11
+
+    def test_stream_failure_logs_and_raises(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+
+        class FakeTimeoutError(Exception):
+            pass
+
+        fake = _FakeSDK(_FakeStream([], None, raises=FakeTimeoutError("slow")))
+        monkeypatch.setattr(client, "_client", lambda: fake)
+
+        with pytest.raises(LLMTimeoutError):
+            list(
+                client.run_stream(
+                    system="sys",
+                    messages=[{"role": "user", "content": "salut"}],
+                    tools=[],
+                    feature="agent_ask",
+                    household_id=household.id,
+                )
+            )
+        log = AIUsageLog.objects.get()
+        assert log.success is False
+
+    def test_stream_kwargs_match_run_kwargs(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        fake = _FakeSDK(_FakeStream([], _final_message()))
+        monkeypatch.setattr(client, "_client", lambda: fake)
+
+        list(
+            client.run_stream(
+                system="SYSTEM",
+                messages=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "search_household"}],
+                feature="agent_ask",
+                household_id=household.id,
+            )
+        )
+        kwargs = fake.messages.last_kwargs
+        assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+        assert kwargs["tools"] == [{"name": "search_household"}]
+
+
+# ---------------------------------------------------------------------------
+# service.ask_stream — stub LLM client with run_stream
+# ---------------------------------------------------------------------------
+
+
+def _run_response(text, *, stop_reason="end_turn", tool_calls=None, blocks=None):
+    return LLMRunResponse(
+        assistant_blocks=blocks or [{"type": "text", "text": text}],
+        tool_calls=tool_calls or [],
+        text=text,
+        stop_reason=stop_reason,
+        input_tokens=5,
+        output_tokens=7,
+        duration_ms=3,
+        model="stub-model",
+    )
+
+
+@dataclass
+class _StreamingClient:
+    """LLMClient stub whose run_stream yields scripted (deltas, final) turns."""
+
+    turns: list[tuple[list[str], LLMRunResponse]] = field(default_factory=list)
+    expansion_text: str = ""
+    calls: int = 0
+    provider: str = "stub"
+
+    def run_stream(self, **kwargs):
+        deltas, final = self.turns[min(self.calls, len(self.turns) - 1)]
+        self.calls += 1
+        for chunk in deltas:
+            yield ("delta", chunk)
+        yield ("final", final)
+
+    def run(self, **kwargs):  # pragma: no cover — ask_stream prefers run_stream
+        raise AssertionError("run() should not be called when run_stream exists")
+
+    def complete(self, **kwargs):
+        return LLMResponse(
+            text=self.expansion_text, input_tokens=1, output_tokens=1,
+            duration_ms=1, model="stub-model",
+        )
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="agent-streaming-owner@example.com")
+
+
+class TestAskStream:
+    def test_streams_deltas_then_result(self, with_api_key, household, owner):
+        stub = _StreamingClient(turns=[(["Bon", "jour !"], _run_response("Bonjour !"))])
+        events = list(service.ask_stream("bonjour", household, user=owner, client=stub))
+
+        assert [e for e in events if e["type"] == "delta"] == [
+            {"type": "delta", "text": "Bon"},
+            {"type": "delta", "text": "jour !"},
+        ]
+        result = events[-1]
+        assert result["type"] == "result"
+        assert result["result"].answer == "Bonjour !"
+
+    def test_tool_calls_emit_tool_events(self, with_api_key, household, owner):
+        call = ToolCall(id="t1", name="search_household", input={"query": "chaudière"})
+        tool_turn = _run_response(
+            "",
+            stop_reason="tool_use",
+            tool_calls=[call],
+            blocks=[{"type": "tool_use", "id": "t1", "name": "search_household",
+                     "input": {"query": "chaudière"}}],
+        )
+        stub = _StreamingClient(
+            turns=[([], tool_turn), (["Rien trouvé."], _run_response("Rien trouvé."))]
+        )
+        events = list(service.ask_stream("la chaudière ?", household, user=owner, client=stub))
+
+        assert {"type": "tool", "name": "search_household"} in events
+        assert events[-1]["result"].metadata["tool_calls"] == 1
+
+    def test_ask_returns_same_result_as_drained_stream(self, with_api_key, household, owner):
+        stub = _StreamingClient(turns=[(["Salut"], _run_response("Salut"))])
+        result = service.ask("bonjour", household, user=owner, client=stub)
+        assert result.answer == "Salut"
+
+    def test_empty_question_yields_result_only(self, with_api_key, household, owner):
+        events = list(service.ask_stream("  ", household, user=owner))
+        assert len(events) == 1
+        assert events[0]["type"] == "result"
+
+
+# ---------------------------------------------------------------------------
+# SSE endpoint — POST /conversations/{id}/messages/stream/
+# ---------------------------------------------------------------------------
+
+
+BASE = "/api/agent/conversations/"
+
+
+@pytest.fixture
+def member_household(db, owner):
+    h = Household.objects.create(name="SSE House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    owner.active_household = h
+    owner.save(update_fields=["active_household"])
+    return h
+
+
+@pytest.fixture
+def owner_client(owner):
+    client = APIClient()
+    client.force_authenticate(user=owner)
+    return client
+
+
+@pytest.fixture
+def conversation(member_household, owner):
+    return AgentConversation.objects.create(household=member_household, created_by=owner)
+
+
+def _answer(text="ok"):
+    return service.AnswerResult(answer=text, citations=[], metadata={"model": "m"})
+
+
+def _sse_frames(resp) -> list[tuple[str, str]]:
+    """Parse the streamed body into (event, data) pairs."""
+    body = b"".join(resp.streaming_content).decode()
+    frames = []
+    for block in body.strip().split("\n\n"):
+        lines = dict(line.split(": ", 1) for line in block.split("\n"))
+        frames.append((lines["event"], lines["data"]))
+    return frames
+
+
+class TestStreamEndpoint:
+    def test_streams_deltas_tools_and_done(self, owner_client, conversation, monkeypatch):
+        def fake_ask_stream(*args, **kwargs):
+            yield {"type": "delta", "text": "Bon"}
+            yield {"type": "tool", "name": "search_household"}
+            yield {"type": "delta", "text": "jour"}
+            yield {"type": "result", "result": _answer("Bonjour")}
+
+        monkeypatch.setattr("agent.views.service.ask_stream", fake_ask_stream)
+
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/stream/", {"question": "salut"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_200_OK
+        assert resp["Content-Type"] == "text/event-stream"
+        assert resp["X-Accel-Buffering"] == "no"
+
+        frames = _sse_frames(resp)
+        assert frames[0] == ("delta", '{"text": "Bon"}')
+        assert frames[1] == ("tool", '{"name": "search_household"}')
+        assert frames[-1][0] == "done"
+        assert '"content": "Bonjour"' in frames[-1][1]
+
+        # Both turns persisted, like the non-streaming endpoint.
+        roles = list(conversation.messages.values_list("role", "content"))
+        assert roles == [("user", "salut"), ("agent", "Bonjour")]
+
+    def test_llm_error_emits_error_event_and_persists_nothing(
+        self, owner_client, conversation, monkeypatch
+    ):
+        def failing_stream(*args, **kwargs):
+            yield {"type": "delta", "text": "Bon"}
+            raise service.LLMError("boom")
+
+        monkeypatch.setattr("agent.views.service.ask_stream", failing_stream)
+
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/stream/", {"question": "salut"}, format="json"
+        )
+        frames = _sse_frames(resp)
+        assert frames[-1] == ("error", '{"detail": "unavailable"}')
+        assert conversation.messages.count() == 0
+
+    def test_unexpected_error_emits_generic_error(self, owner_client, conversation, monkeypatch):
+        def exploding_stream(*args, **kwargs):
+            raise RuntimeError("nope")
+            yield  # pragma: no cover — make it a generator
+
+        monkeypatch.setattr("agent.views.service.ask_stream", exploding_stream)
+
+        resp = owner_client.post(
+            f"{BASE}{conversation.id}/messages/stream/", {"question": "salut"}, format="json"
+        )
+        assert _sse_frames(resp)[-1] == ("error", '{"detail": "error"}')
+
+    def test_cannot_stream_another_users_conversation(self, owner_client, member_household):
+        other = UserFactory(email="sse-other@example.com")
+        HouseholdMember.objects.create(
+            user=other, household=member_household, role=HouseholdMember.Role.MEMBER
+        )
+        theirs = AgentConversation.objects.create(
+            household=member_household, created_by=other
+        )
+        resp = owner_client.post(
+            f"{BASE}{theirs.id}/messages/stream/", {"question": "x"}, format="json"
+        )
+        assert resp.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_stream_action_is_throttled(self, owner_client, conversation, monkeypatch):
+        from django.core.cache import cache
+        from agent.throttles import AgentBurstRateThrottle
+
+        cache.clear()
+        monkeypatch.setattr(AgentBurstRateThrottle, "rate", "1/min", raising=False)
+
+        def fake_ask_stream(*args, **kwargs):
+            yield {"type": "result", "result": _answer()}
+
+        monkeypatch.setattr("agent.views.service.ask_stream", fake_ask_stream)
+
+        url = f"{BASE}{conversation.id}/messages/stream/"
+        first = owner_client.post(url, {"question": "q"}, format="json")
+        assert first.status_code == status.HTTP_200_OK
+        list(first.streaming_content)  # drain
+        second = owner_client.post(url, {"question": "q"}, format="json")
+        assert second.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+        cache.clear()

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -1,9 +1,11 @@
 """DRF views for the agent."""
 from __future__ import annotations
 
+import json
 import logging
 
 from django.db import transaction
+from django.http import StreamingHttpResponse
 from django.db.models import Count
 from django.utils import timezone
 from rest_framework import status, viewsets
@@ -50,6 +52,46 @@ def _citations_to_json(citations) -> list[dict]:
 
 def _derive_title(question: str) -> str:
     return " ".join((question or "").split())[:AUTO_TITLE_MAX_LEN]
+
+
+def _ask_inputs(conversation) -> tuple[list[dict], tuple[str, str] | None]:
+    """History (bounded, oldest first) + anchor of a conversation, for service.ask*."""
+    prior = list(conversation.messages.all())[-CONVERSATION_HISTORY_LIMIT:]
+    history = [{"role": m.role, "content": m.content} for m in prior]
+    context_entity = (
+        (conversation.context_entity_type, conversation.context_object_id)
+        if conversation.has_context
+        else None
+    )
+    return history, context_entity
+
+
+def _persist_turns(conversation, question: str, user, result) -> AgentMessage:
+    """Persist both turns atomically — a failed call leaves the conversation untouched."""
+    with transaction.atomic():
+        AgentMessage.objects.create(
+            conversation=conversation,
+            role=AgentMessage.Role.USER,
+            content=question,
+            created_by=user,
+        )
+        agent_msg = AgentMessage.objects.create(
+            conversation=conversation,
+            role=AgentMessage.Role.AGENT,
+            content=result.answer,
+            citations=_citations_to_json(result.citations),
+            metadata=result.metadata,
+        )
+        conversation.last_message_at = timezone.now()
+        if not conversation.title:
+            conversation.title = _derive_title(question)
+        conversation.save(update_fields=["last_message_at", "title", "updated_at"])
+    return agent_msg
+
+
+def _sse(event: str, payload: dict) -> str:
+    """Format one Server-Sent Event frame."""
+    return f"event: {event}\ndata: {json.dumps(payload, default=str)}\n\n"
 
 
 class AskView(APIView):
@@ -117,7 +159,7 @@ class ConversationViewSet(viewsets.ModelViewSet):
     def get_throttles(self):
         # Only the LLM-backed action costs money — plain conversation CRUD
         # stays unthrottled.
-        if self.action == "messages":
+        if self.action in {"messages", "messages_stream"}:
             return [AgentBurstRateThrottle(), AgentSustainedRateThrottle()]
         return super().get_throttles()
 
@@ -137,7 +179,7 @@ class ConversationViewSet(viewsets.ModelViewSet):
         household = getattr(self.request, "household", None)
         if household is not None:
             qs = qs.filter(household=household)
-        if self.action in {"retrieve", "messages", "for_context"}:
+        if self.action in {"retrieve", "messages", "messages_stream", "for_context"}:
             qs = qs.prefetch_related("messages")
         return qs
 
@@ -160,17 +202,9 @@ class ConversationViewSet(viewsets.ModelViewSet):
         request_serializer.is_valid(raise_exception=True)
         question = request_serializer.validated_data["question"]
 
-        # History = prior turns (oldest first), bounded. Built before we persist
-        # the new question so the current turn isn't fed back to itself.
-        prior = list(conversation.messages.all())[-CONVERSATION_HISTORY_LIMIT:]
-        history = [{"role": m.role, "content": m.content} for m in prior]
-
-        # Anchored conversations pre-inject their entity's context each turn.
-        context_entity = (
-            (conversation.context_entity_type, conversation.context_object_id)
-            if conversation.has_context
-            else None
-        )
+        # History built before we persist the new question so the current turn
+        # isn't fed back to itself. Anchored conversations pre-inject context.
+        history, context_entity = _ask_inputs(conversation)
 
         try:
             result = service.ask(
@@ -192,30 +226,61 @@ class ConversationViewSet(viewsets.ModelViewSet):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
 
-        # Persist both turns only once we have an answer — a failed call leaves
-        # the conversation untouched.
-        with transaction.atomic():
-            AgentMessage.objects.create(
-                conversation=conversation,
-                role=AgentMessage.Role.USER,
-                content=question,
-                created_by=request.user,
-            )
-            agent_msg = AgentMessage.objects.create(
-                conversation=conversation,
-                role=AgentMessage.Role.AGENT,
-                content=result.answer,
-                citations=_citations_to_json(result.citations),
-                metadata=result.metadata,
-            )
-            conversation.last_message_at = timezone.now()
-            if not conversation.title:
-                conversation.title = _derive_title(question)
-            conversation.save(update_fields=["last_message_at", "title", "updated_at"])
-
+        agent_msg = _persist_turns(conversation, question, request.user, result)
         return Response(
             AgentMessageSerializer(agent_msg).data, status=status.HTTP_201_CREATED
         )
+
+    @action(detail=True, methods=["post"], url_path="messages/stream")
+    def messages_stream(self, request, pk=None):
+        """Streaming variant of ``messages`` — Server-Sent Events.
+
+        Emits ``delta`` (text chunk), ``tool`` (a tool call is running), then
+        exactly one terminal event: ``done`` (the persisted agent message, same
+        payload the non-streaming endpoint returns) or ``error``. Persistence is
+        identical: both turns are written only once the answer exists.
+        """
+        conversation = self.get_object()
+
+        request_serializer = PostMessageSerializer(data=request.data)
+        request_serializer.is_valid(raise_exception=True)
+        question = request_serializer.validated_data["question"]
+
+        history, context_entity = _ask_inputs(conversation)
+        user = request.user
+
+        def event_stream():
+            try:
+                result = None
+                for event in service.ask_stream(
+                    question,
+                    conversation.household,
+                    user=user,
+                    history=history,
+                    context_entity=context_entity,
+                ):
+                    if event["type"] == "delta":
+                        yield _sse("delta", {"text": event["text"]})
+                    elif event["type"] == "tool":
+                        yield _sse("tool", {"name": event["name"]})
+                    else:
+                        result = event["result"]
+                agent_msg = _persist_turns(conversation, question, user, result)
+                yield _sse("done", AgentMessageSerializer(agent_msg).data)
+            except LLMTimeoutError:
+                yield _sse("error", {"detail": "timeout"})
+            except LLMError as exc:
+                logger.warning("agent.messages_stream: LLM error: %s", exc)
+                yield _sse("error", {"detail": "unavailable"})
+            except Exception:  # noqa: BLE001 — an SSE stream can't return a 500
+                logger.exception("agent.messages_stream: unexpected error")
+                yield _sse("error", {"detail": "error"})
+
+        response = StreamingHttpResponse(event_stream(), content_type="text/event-stream")
+        response["Cache-Control"] = "no-cache"
+        # Tell nginx not to buffer the stream (X-Accel is already used for media).
+        response["X-Accel-Buffering"] = "no"
+        return response
 
     @action(detail=False, methods=["get"], url_path="for_context")
     def for_context(self, request):

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -101,9 +101,17 @@ Sous `/api/agent/` :
 - `POST ask/` — one-shot (sans persistance).
 - `conversations/` (CRUD, privé par user × foyer) ; `POST {id}/messages/` — pose
   une question dans une conversation (history = tours précédents, bornée).
+- `POST {id}/messages/stream/` — variante **SSE** du même appel, utilisée par
+  l'UI : événements `delta` (morceau de texte), `tool` (tool en cours
+  d'exécution), puis un terminal `done` (le message agent persisté, même
+  payload que l'endpoint non-streamé) ou `error`. Persistance identique (les
+  deux tours ne sont écrits qu'une fois la réponse obtenue). Chaîne interne :
+  `AnthropicClient.run_stream` (SDK `messages.stream`) → `service.ask_stream`
+  (générateur, `ask()` le draine pour les appels non-streamés) → view SSE.
 - `GET conversations/for_context/?entity_type=&object_id=` — get-or-create de la
   conversation ancrée d'une entité pour l'utilisateur courant.
-- Permissions : `IsAuthenticated, IsHouseholdMember`.
+- Permissions : `IsAuthenticated, IsHouseholdMember` ; `ask`, `messages` et
+  `messages/stream` sont throttlés (`agent_burst`/`agent_sustained`).
 
 ## Notes / décisions
 

--- a/e2e/agent.spec.ts
+++ b/e2e/agent.spec.ts
@@ -52,22 +52,35 @@ async function mockAskAgent(page: Page, payload: MockAnswer | (() => MockAnswer)
     });
   });
 
-  // Posting a message returns the persisted agent turn.
-  await page.route(`**/api/agent/conversations/${CONV_ID}/messages/`, async (route: Route) => {
-    const data = typeof payload === 'function' ? payload() : payload;
-    await route.fulfill({
-      status: 201,
-      contentType: 'application/json',
-      body: JSON.stringify({
+  // Streaming a message emits a couple of SSE frames then the persisted turn.
+  await page.route(
+    `**/api/agent/conversations/${CONV_ID}/messages/stream/`,
+    async (route: Route) => {
+      const data = typeof payload === 'function' ? payload() : payload;
+      const row = {
         id: `msg-${Date.now()}`,
         role: 'agent',
         content: data.answer,
         citations: data.citations,
         metadata: data.metadata ?? { duration_ms: 1234, tokens_in: 100, tokens_out: 30, model: 'claude-haiku-4-5-20251001', hits_count: 1 },
         created_at: new Date().toISOString(),
-      }),
-    });
-  });
+      };
+      const body =
+        `event: tool
+data: ${JSON.stringify({ name: 'search_household' })}
+
+` +
+        `event: delta
+data: ${JSON.stringify({ text: data.answer.slice(0, 10) })}
+
+` +
+        `event: done
+data: ${JSON.stringify(row)}
+
+`;
+      await route.fulfill({ status: 200, contentType: 'text/event-stream', body });
+    },
+  );
 }
 
 async function setPrivacyAccepted(page: Page, accepted: boolean): Promise<void> {

--- a/ui/src/features/agent/ChatBubble.tsx
+++ b/ui/src/features/agent/ChatBubble.tsx
@@ -27,7 +27,15 @@ interface LoadingBubbleProps {
   variant: 'loading';
 }
 
-type Props = UserBubbleProps | AgentBubbleProps | LoadingBubbleProps;
+interface StreamingBubbleProps {
+  variant: 'streaming';
+  /** The partial answer text received so far (may be empty). */
+  text: string;
+  /** Localized label of the tool currently executing, if any. */
+  toolLabel?: string | null;
+}
+
+type Props = UserBubbleProps | AgentBubbleProps | LoadingBubbleProps | StreamingBubbleProps;
 
 export default function ChatBubble(props: Props) {
   if (props.variant === 'user') {
@@ -49,6 +57,21 @@ export default function ChatBubble(props: Props) {
     return (
       <AgentBubbleShell>
         <Loader />
+      </AgentBubbleShell>
+    );
+  }
+
+  if (props.variant === 'streaming') {
+    return (
+      <AgentBubbleShell>
+        {props.text ? (
+          <AnswerWithInlineCitations text={props.text} citations={[]} />
+        ) : null}
+        {props.toolLabel ? (
+          <Loader label={props.toolLabel} />
+        ) : props.text ? null : (
+          <Loader />
+        )}
       </AgentBubbleShell>
     );
   }
@@ -91,7 +114,7 @@ function AgentBubbleShell({ children }: { children: React.ReactNode }) {
   );
 }
 
-function Loader() {
+function Loader({ label }: { label?: string }) {
   const { t } = useTranslation();
   return (
     <div className="flex items-center gap-2 text-muted-foreground" data-testid="agent-loader">
@@ -100,7 +123,7 @@ function Loader() {
         <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current [animation-delay:-0.15s]" />
         <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-current" />
       </span>
-      <span>{t('agent.loading')}</span>
+      <span>{label ?? t('agent.loading')}</span>
     </div>
   );
 }

--- a/ui/src/features/agent/ChatPanel.tsx
+++ b/ui/src/features/agent/ChatPanel.tsx
@@ -7,7 +7,7 @@ import { cn } from '@/lib/utils';
 import ChatBubble from './ChatBubble';
 import PrivacyNotice from './PrivacyNotice';
 import { hasAcceptedAgentPrivacy, acceptAgentPrivacy } from './privacyStorage';
-import { useAgentCreatedUndo, useAgentUpdatedUndo, usePostMessage } from './hooks';
+import { useAgentCreatedUndo, useAgentUpdatedUndo, useStreamMessage } from './hooks';
 import type { AgentCitation, AgentConversationDetail, AgentMessageRow } from './api';
 
 interface UserMessage {
@@ -47,6 +47,16 @@ function toMessage(row: AgentMessageRow): Message {
   };
 }
 
+// Backend tool names with a dedicated i18n status label (agent.tools.*).
+const KNOWN_TOOLS = new Set([
+  'search_household',
+  'list_entities',
+  'get_entity',
+  'get_related',
+  'create_entity',
+  'update_entity',
+]);
+
 interface ChatPanelProps {
   /** The active conversation, or null when none is selected/created yet. */
   conversationId: string | null;
@@ -85,13 +95,17 @@ export default function ChatPanel({
 }: ChatPanelProps) {
   const { t } = useTranslation();
 
-  const postMessage = usePostMessage();
+  const streamMessage = useStreamMessage();
   const notifyCreated = useAgentCreatedUndo();
   const notifyUpdated = useAgentUpdatedUndo();
 
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [draft, setDraft] = React.useState('');
   const [needsPrivacy, setNeedsPrivacy] = React.useState(false);
+  // Live progress of the in-flight turn: partial text + the tool currently
+  // running. Text received before a tool call is preamble ("je cherche…") and
+  // is discarded when the tool event arrives.
+  const [live, setLive] = React.useState<{ text: string; tool: string | null } | null>(null);
 
   // Guards against re-seeding local messages from a background refetch: we only
   // load a conversation's persisted turns the first time we see it.
@@ -104,7 +118,7 @@ export default function ChatPanel({
   const scrollAnchorRef = React.useRef<HTMLDivElement | null>(null);
   const textareaRef = React.useRef<HTMLTextAreaElement | null>(null);
 
-  const isBusy = postMessage.isPending || creating;
+  const isBusy = streamMessage.isPending || creating;
 
   React.useEffect(() => {
     setNeedsPrivacy(!hasAcceptedAgentPrivacy());
@@ -129,7 +143,7 @@ export default function ChatPanel({
 
   React.useEffect(() => {
     scrollAnchorRef.current?.scrollIntoView({ behavior: 'smooth', block: 'end' });
-  }, [messages.length, isBusy]);
+  }, [messages.length, isBusy, live]);
 
   const handleAcceptPrivacy = React.useCallback(() => {
     acceptAgentPrivacy();
@@ -154,6 +168,7 @@ export default function ChatPanel({
         ]);
       }
 
+      setLive({ text: '', tool: null });
       try {
         let id = conversationId;
         if (!id) {
@@ -162,7 +177,19 @@ export default function ChatPanel({
           loadedRef.current = id;
           lastPropIdRef.current = id;
         }
-        const agentMsg = await postMessage.mutateAsync({ conversationId: id, question: trimmed });
+        const agentMsg = await streamMessage.mutateAsync({
+          conversationId: id,
+          question: trimmed,
+          handlers: {
+            onDelta: (text) =>
+              // A delta after a tool event starts the next turn's text fresh.
+              setLive((prev) => ({
+                text: (prev && !prev.tool ? prev.text : '') + text,
+                tool: null,
+              })),
+            onTool: (name) => setLive({ text: '', tool: name }),
+          },
+        });
         setMessages((prev) => [
           ...prev,
           {
@@ -180,10 +207,16 @@ export default function ChatPanel({
           ...prev,
           { id: `e-${Date.now()}`, variant: 'error', text: t('agent.error'), question: trimmed },
         ]);
+      } finally {
+        setLive(null);
       }
     },
-    [draft, isBusy, conversationId, ensureConversation, postMessage, notifyCreated, notifyUpdated, t],
+    [draft, isBusy, conversationId, ensureConversation, streamMessage, notifyCreated, notifyUpdated, t],
   );
+
+  const toolLabel = live?.tool
+    ? t(KNOWN_TOOLS.has(live.tool) ? `agent.tools.${live.tool}` : 'agent.tools.default')
+    : null;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
@@ -231,7 +264,9 @@ export default function ChatPanel({
             );
           })
         )}
-        {isBusy ? <ChatBubble variant="loading" /> : null}
+        {isBusy ? (
+          <ChatBubble variant="streaming" text={live?.text ?? ''} toolLabel={toolLabel} />
+        ) : null}
         <div ref={scrollAnchorRef} />
       </div>
 

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -140,3 +140,95 @@ export async function renameConversation(
 export async function deleteConversation(id: string): Promise<void> {
   await api.delete(`/agent/conversations/${id}/`);
 }
+
+/** Progress events emitted while the agent works on a streamed question. */
+export interface AgentStreamHandlers {
+  /** A chunk of model text (text emitted before a tool call is preamble). */
+  onDelta?: (text: string) => void;
+  /** A tool call started executing (name = backend tool name). */
+  onTool?: (name: string) => void;
+}
+
+function getAccessToken(): string | null {
+  try {
+    return localStorage.getItem('access_token');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Streaming variant of `postConversationMessage` (SSE over fetch — EventSource
+ * cannot POST). Resolves with the persisted agent message from the terminal
+ * `done` event; rejects on `error` events, HTTP errors, or timeout. The overall
+ * timeout matches the non-streaming call, but any received event proves the
+ * backend is alive.
+ */
+export async function streamConversationMessage(
+  conversationId: string,
+  question: string,
+  handlers: AgentStreamHandlers = {},
+): Promise<AgentMessageRow> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), AGENT_MESSAGE_TIMEOUT_MS);
+
+  try {
+    const token = getAccessToken();
+    const response = await fetch(
+      `/api/agent/conversations/${conversationId}/messages/stream/`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ question }),
+        signal: controller.signal,
+      },
+    );
+    if (!response.ok || !response.body) {
+      throw new Error(`stream failed: ${response.status}`);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let done: AgentMessageRow | null = null;
+
+    const handleFrame = (frame: string) => {
+      let event = 'message';
+      let data = '';
+      for (const line of frame.split('\n')) {
+        if (line.startsWith('event: ')) event = line.slice(7);
+        else if (line.startsWith('data: ')) data = line.slice(6);
+      }
+      if (event === 'delta') {
+        handlers.onDelta?.((JSON.parse(data) as { text: string }).text);
+      } else if (event === 'tool') {
+        handlers.onTool?.((JSON.parse(data) as { name: string }).name);
+      } else if (event === 'done') {
+        done = JSON.parse(data) as AgentMessageRow;
+      } else if (event === 'error') {
+        throw new Error((JSON.parse(data) as { detail: string }).detail);
+      }
+    };
+
+    for (;;) {
+      const { value, done: eof } = await reader.read();
+      if (eof) break;
+      buffer += decoder.decode(value, { stream: true });
+      let sep = buffer.indexOf('\n\n');
+      while (sep !== -1) {
+        const frame = buffer.slice(0, sep);
+        buffer = buffer.slice(sep + 2);
+        if (frame.trim()) handleFrame(frame);
+        sep = buffer.indexOf('\n\n');
+      }
+    }
+
+    if (!done) throw new Error('stream ended without a done event');
+    return done;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -14,10 +14,12 @@ import {
   listConversations,
   postConversationMessage,
   renameConversation,
+  streamConversationMessage,
   type AgentConversationDetail,
   type AgentConversationRow,
   type AgentCreatedEntity,
   type AgentMessageRow,
+  type AgentStreamHandlers,
   type AgentUpdatedEntity,
 } from './api';
 
@@ -81,6 +83,30 @@ export function usePostMessage() {
     onSuccess: (_msg, { conversationId }) => {
       // Recency + auto-title change on the server; refresh the list. The detail
       // is kept in sync locally by the page, so we don't refetch it here.
+      void qc.invalidateQueries({ queryKey: agentKeys.conversations() });
+      void qc.invalidateQueries({
+        queryKey: agentKeys.conversation(conversationId),
+        refetchType: 'none',
+      });
+    },
+  });
+}
+
+/**
+ * Streaming counterpart of `usePostMessage`: same terminal payload and cache
+ * invalidations, plus live `handlers` (deltas, tool status) while the agent
+ * works. `isPending` covers the whole stream.
+ */
+export function useStreamMessage() {
+  const qc = useQueryClient();
+  return useMutation<
+    AgentMessageRow,
+    unknown,
+    { conversationId: string; question: string; handlers?: AgentStreamHandlers }
+  >({
+    mutationFn: ({ conversationId, question, handlers }) =>
+      streamConversationMessage(conversationId, question, handlers),
+    onSuccess: (_msg, { conversationId }) => {
       void qc.invalidateQueries({ queryKey: agentKeys.conversations() });
       void qc.invalidateQueries({
         queryKey: agentKeys.conversation(conversationId),

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1633,6 +1633,15 @@
     "input_placeholder": "Frag den Agenten…",
     "send": "Senden",
     "loading": "Durchsuche deinen Haushalt…",
+    "tools": {
+      "search_household": "Durchsuche deinen Haushalt…",
+      "list_entities": "Gehe deine Einträge durch…",
+      "get_entity": "Lese einen Eintrag…",
+      "get_related": "Lade verknüpfte Einträge…",
+      "create_entity": "Erstelle…",
+      "update_entity": "Aktualisiere…",
+      "default": "Arbeite…"
+    },
     "error": "Etwas ist schiefgelaufen, bitte erneut versuchen.",
     "retry": "Erneut versuchen",
     "truncated_notice": "Diese Antwort wurde abgeschnitten.",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1633,6 +1633,15 @@
     "input_placeholder": "Ask the agent…",
     "send": "Send",
     "loading": "Searching your household…",
+    "tools": {
+      "search_household": "Searching your household…",
+      "list_entities": "Going through your items…",
+      "get_entity": "Reading an item…",
+      "get_related": "Loading linked items…",
+      "create_entity": "Creating…",
+      "update_entity": "Updating…",
+      "default": "Working…"
+    },
     "error": "Something went wrong, please try again.",
     "retry": "Retry",
     "truncated_notice": "This answer was cut short.",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1633,6 +1633,15 @@
     "input_placeholder": "Pregunta al agente…",
     "send": "Enviar",
     "loading": "Buscando en tu hogar…",
+    "tools": {
+      "search_household": "Buscando en tu hogar…",
+      "list_entities": "Revisando tus elementos…",
+      "get_entity": "Leyendo un elemento…",
+      "get_related": "Cargando elementos vinculados…",
+      "create_entity": "Creando…",
+      "update_entity": "Actualizando…",
+      "default": "Trabajando…"
+    },
     "error": "Algo salió mal, inténtalo de nuevo.",
     "retry": "Reintentar",
     "truncated_notice": "Esta respuesta se ha cortado.",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1633,6 +1633,15 @@
     "input_placeholder": "Pose ta question à l'agent…",
     "send": "Envoyer",
     "loading": "Recherche dans ton foyer…",
+    "tools": {
+      "search_household": "Recherche dans ton foyer…",
+      "list_entities": "Parcours de tes éléments…",
+      "get_entity": "Lecture d'un élément…",
+      "get_related": "Chargement des éléments liés…",
+      "create_entity": "Création en cours…",
+      "update_entity": "Mise à jour en cours…",
+      "default": "En cours…"
+    },
     "error": "Une erreur est survenue, réessaie.",
     "retry": "Réessayer",
     "truncated_notice": "Cette réponse a été coupée.",


### PR DESCRIPTION
## Contexte

Palier 3 de l'audit agent, le cœur : l'attente était le point noir UX (jusqu'à 20-30 s de boucle tool-use avec trois points animés pour seul feedback). L'utilisateur voit désormais la réponse s'écrire en direct et sait ce que l'agent fait (« Recherche dans ton foyer… », « Mise à jour en cours… »).

**Stackée sur #190** (refacto ChatPanel) — sans elle, tout serait implémenté deux fois.

## Backend

- **`AnthropicClient.run_stream`** : variante streaming de `run()` via le SDK (`messages.stream` + `get_final_message`) — mêmes kwargs (prompt caching conservé), même normalisation, même ligne `AIUsageLog` par round-trip. Les kwargs et la finalisation sont factorisés avec `run()`.
- **`service.ask_stream`** : la boucle tool-use devient un générateur d'événements `{delta, tool, result}` ; `ask()` n'est plus qu'un wrapper qui le draine → un seul chemin de code. Les clients sans `run_stream` (stubs de tests, futurs providers) retombent sur `run()` sans delta.
- **`POST conversations/{id}/messages/stream/`** : SSE — `delta` (morceau de texte), `tool` (tool en exécution), puis un terminal `done` (le message agent persisté, même payload que l'endpoint classique) ou `error`. Persistance identique (rien n'est écrit tant que la réponse n'existe pas), mêmes throttles, `X-Accel-Buffering: no` (nginx ne gzippe pas `text/event-stream`).

## Frontend

- `streamConversationMessage` : fetch + parser SSE maison (EventSource ne fait pas de POST), JWT Bearer, timeout global 180 s.
- `ChatPanel` : bulle « streaming » — texte au fil de l'eau (markdown, marqueurs de citation masqués tant que non résolus), statut du tool en cours via `agent.tools.*` (4 locales) ; le texte préambule (« je cherche… ») est remplacé quand le tool démarre. Erreur → bulle retry existante, transcript final identique à avant.

## Tests

- 12 nouveaux : `run_stream` (fake SDK stream : deltas + final, échec loggé, kwargs identiques à `run`), `ask_stream` (deltas, événements tool, équivalence avec `ask`), endpoint SSE (framing, persistance des deux tours, error events sans persistance, 404 cross-user, throttle).
- Suite agent : **287 passed** ; E2E agent : **10/10** (mock adapté au SSE, avec frames tool + delta avant done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)