### PR TITLE
feat(electricity): lot 3 — onglet Consommation (Recharts, relevés, import)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-i18next": "^16.5.4",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^7.13.0",
+        "recharts": "^3.9.2",
         "remark-breaks": "^4.0.0",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^2.5.5",
@@ -2068,6 +2069,32 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.12.0.tgz",
+      "integrity": "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -2429,7 +2456,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -2912,6 +2944,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -3010,6 +3105,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3977,6 +4078,127 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -4013,6 +4235,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/decode-named-character-reference": {
@@ -4188,6 +4416,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -4458,6 +4696,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -4985,6 +5229,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "11.1.11",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.11.tgz",
+      "integrity": "sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -5027,6 +5282,15 @@
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
       "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
       "license": "MIT"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-alphabetical": {
       "version": "2.0.1",
@@ -6974,8 +7238,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -7002,6 +7266,30 @@
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
+      }
+    },
+    "node_modules/react-redux": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
+      "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -7121,6 +7409,36 @@
         }
       }
     },
+    "node_modules/recharts": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.9.2.tgz",
+      "integrity": "sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^11.1.8",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.2.0",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -7133,6 +7451,22 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/remark-breaks": {
@@ -7225,6 +7559,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+      "integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -7509,6 +7849,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -7938,6 +8284,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-i18next": "^16.5.4",
     "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.0",
+    "recharts": "^3.9.2",
     "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^2.5.5",

--- a/ui/src/features/electricity/ConsumptionChart.tsx
+++ b/ui/src/features/electricity/ConsumptionChart.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { ConsumptionSummary, EnergyRegister, Granularity } from '@/lib/api/electricity';
+
+const REGISTER_COLORS: Record<EnergyRegister, string> = {
+  base: 'hsl(var(--chart-2))',
+  hp: 'hsl(var(--chart-1))',
+  hc: 'hsl(var(--chart-4))',
+};
+
+function formatTick(ts: string, granularity: Granularity, locale: string): string {
+  const date = new Date(ts);
+  switch (granularity) {
+    case 'hour':
+      return date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' });
+    case 'day':
+      return date.toLocaleDateString(locale, { day: 'numeric' });
+    case 'month':
+      return date.toLocaleDateString(locale, { month: 'short' });
+    case 'year':
+      return date.toLocaleDateString(locale, { year: 'numeric' });
+  }
+}
+
+function formatLabel(ts: string, granularity: Granularity, locale: string): string {
+  const date = new Date(ts);
+  switch (granularity) {
+    case 'hour':
+      return date.toLocaleString(locale, { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+    case 'day':
+      return date.toLocaleDateString(locale, { weekday: 'short', day: 'numeric', month: 'short' });
+    case 'month':
+      return date.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+    case 'year':
+      return date.toLocaleDateString(locale, { year: 'numeric' });
+  }
+}
+
+interface ConsumptionChartProps {
+  summary: ConsumptionSummary;
+  granularity: Granularity;
+}
+
+export default function ConsumptionChart({ summary, granularity }: ConsumptionChartProps) {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language;
+
+  const registers = React.useMemo(() => {
+    const seen = new Set<EnergyRegister>();
+    for (const bucket of summary.buckets) {
+      for (const key of Object.keys(bucket.registers)) seen.add(key as EnergyRegister);
+    }
+    return (['base', 'hp', 'hc'] as EnergyRegister[]).filter((r) => seen.has(r));
+  }, [summary.buckets]);
+
+  const data = React.useMemo(
+    () =>
+      summary.buckets.map((bucket) => ({
+        ts: bucket.ts,
+        estimated: bucket.estimated_wh,
+        ...Object.fromEntries(
+          registers.map((r) => [r, Math.round((bucket.registers[r] ?? 0) / 10) / 100]),
+        ),
+      })),
+    [summary.buckets, registers],
+  );
+
+  const registerLabel = React.useCallback(
+    (register: string) => t(`electricity.consumption.register.${register}`),
+    [t],
+  );
+
+  return (
+    <div className="h-64 w-full sm:h-80">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+          <XAxis
+            dataKey="ts"
+            tickFormatter={(ts: string) => formatTick(ts, granularity, locale)}
+            tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+            tickLine={false}
+            axisLine={{ stroke: 'hsl(var(--border))' }}
+            interval="preserveStartEnd"
+            minTickGap={16}
+          />
+          <YAxis
+            tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+            tickLine={false}
+            axisLine={false}
+            width={44}
+            unit=" kWh"
+          />
+          <Tooltip
+            cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
+            contentStyle={{
+              backgroundColor: 'hsl(var(--card))',
+              border: '1px solid hsl(var(--border))',
+              borderRadius: 8,
+              fontSize: 12,
+            }}
+            labelFormatter={(ts) => formatLabel(String(ts), granularity, locale)}
+            formatter={(value, name) => [`${String(value)} kWh`, registerLabel(String(name))]}
+          />
+          {registers.length > 1 && (
+            <Legend formatter={(value: string) => registerLabel(value)} wrapperStyle={{ fontSize: 12 }} />
+          )}
+          {registers.map((register) => (
+            <Bar
+              key={register}
+              dataKey={register}
+              stackId="energy"
+              fill={REGISTER_COLORS[register]}
+              radius={registers.indexOf(register) === registers.length - 1 ? [3, 3, 0, 0] : undefined}
+            />
+          ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/ui/src/features/electricity/ConsumptionTab.tsx
+++ b/ui/src/features/electricity/ConsumptionTab.tsx
@@ -1,0 +1,350 @@
+import * as React from 'react';
+import { ChevronLeft, ChevronRight, Gauge, Pencil, Plus, Trash2, Upload } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Button } from '@/design-system/button';
+import { Badge } from '@/design-system/badge';
+import { Card } from '@/design-system/card';
+import { FilterPill } from '@/design-system/filter-pill';
+import { Select } from '@/design-system/select';
+import CardActions, { type CardAction } from '@/components/CardActions';
+import EmptyState from '@/components/EmptyState';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import { useSessionState } from '@/lib/useSessionState';
+import type { ElectricityMeter, Granularity, MeterReading } from '@/lib/api/electricity';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  consumptionKeys,
+  useConsumptionSummary,
+  useDeleteMeter,
+  useDeleteMeterReading,
+  useMeterReadings,
+  useMeters,
+} from './hooks';
+import ConsumptionChart from './ConsumptionChart';
+import ImportDialog from './ImportDialog';
+import MeterDialog from './MeterDialog';
+import ReadingDialog from './ReadingDialog';
+
+const GRANULARITIES: Granularity[] = ['hour', 'day', 'month', 'year'];
+
+// ── Period window: an anchor date + a granularity define [date_from, date_to] ──
+
+function isoDate(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+function periodRange(anchor: Date, granularity: Granularity): { from: string; to: string } {
+  const year = anchor.getFullYear();
+  const month = anchor.getMonth();
+  switch (granularity) {
+    case 'hour': // one day, hour by hour
+      return { from: isoDate(anchor), to: isoDate(anchor) };
+    case 'day': // one month, day by day
+      return { from: isoDate(new Date(year, month, 1)), to: isoDate(new Date(year, month + 1, 0)) };
+    case 'month': // one year, month by month
+      return { from: `${year}-01-01`, to: `${year}-12-31` };
+    case 'year': // a decade, year by year
+      return { from: `${year - 9}-01-01`, to: `${year}-12-31` };
+  }
+}
+
+function shiftAnchor(anchor: Date, granularity: Granularity, direction: 1 | -1): Date {
+  const next = new Date(anchor);
+  switch (granularity) {
+    case 'hour':
+      next.setDate(next.getDate() + direction);
+      break;
+    case 'day':
+      next.setDate(1);
+      next.setMonth(next.getMonth() + direction);
+      break;
+    case 'month':
+    case 'year':
+      next.setFullYear(next.getFullYear() + direction);
+      break;
+  }
+  return next;
+}
+
+function periodLabel(anchor: Date, granularity: Granularity, locale: string): string {
+  switch (granularity) {
+    case 'hour':
+      return anchor.toLocaleDateString(locale, { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+    case 'day':
+      return anchor.toLocaleDateString(locale, { month: 'long', year: 'numeric' });
+    case 'month':
+      return String(anchor.getFullYear());
+    case 'year':
+      return `${anchor.getFullYear() - 9} – ${anchor.getFullYear()}`;
+  }
+}
+
+function formatKwh(wh: number): string {
+  return (wh / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 });
+}
+
+// ── Readings list ─────────────────────────────────────────────────────────────
+
+interface ReadingRowProps {
+  reading: MeterReading;
+  locale: string;
+  registerLabel: (r: string) => string;
+  onEdit: () => void;
+  onDelete: () => void;
+  t: (key: string) => string;
+}
+
+function ReadingRow({ reading, locale, registerLabel, onEdit, onDelete, t }: ReadingRowProps) {
+  const actions: CardAction[] = [
+    { label: t('common.edit'), icon: Pencil, onClick: onEdit },
+    { label: t('common.delete'), icon: Trash2, onClick: onDelete, variant: 'danger' },
+  ];
+  const date = new Date(reading.reading_at);
+  return (
+    <Card className="p-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 text-sm">
+          <span className="text-muted-foreground">
+            {date.toLocaleDateString(locale, { day: '2-digit', month: '2-digit', year: 'numeric' })}{' '}
+            {date.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' })}
+          </span>
+          <Badge variant="outline" className="text-xs">{registerLabel(reading.register)}</Badge>
+          <span className="font-medium">{Number(reading.index_kwh).toLocaleString(locale)} kWh</span>
+        </div>
+        <CardActions actions={actions} />
+      </div>
+    </Card>
+  );
+}
+
+// ── Main tab ──────────────────────────────────────────────────────────────────
+
+export default function ConsumptionTab() {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language;
+  const qc = useQueryClient();
+
+  const { data: meters = [], isLoading: metersLoading } = useMeters();
+  const [selectedMeterId, setSelectedMeterId] = useSessionState<string>('electricity.consumption.meter', '');
+  const [granularity, setGranularity] = useSessionState<Granularity>('electricity.consumption.granularity', 'day');
+  const [anchorIso, setAnchorIso] = useSessionState<string>('electricity.consumption.anchor', isoDate(new Date()));
+
+  const meter: ElectricityMeter | undefined =
+    meters.find((m) => m.id === selectedMeterId) ?? meters[0];
+
+  React.useEffect(() => {
+    if (meter && meter.id !== selectedMeterId) setSelectedMeterId(meter.id);
+  }, [meter, selectedMeterId, setSelectedMeterId]);
+
+  const anchor = React.useMemo(() => new Date(`${anchorIso}T00:00:00`), [anchorIso]);
+  const { from, to } = periodRange(anchor, granularity);
+
+  const { data: summary, isLoading: summaryLoading } = useConsumptionSummary({
+    meter: meter?.id ?? '',
+    granularity,
+    date_from: from,
+    date_to: to,
+  });
+  const { data: readings = [] } = useMeterReadings(meter?.id);
+
+  const [meterDialogOpen, setMeterDialogOpen] = React.useState(false);
+  const [editingMeter, setEditingMeter] = React.useState<ElectricityMeter | undefined>(undefined);
+  const [readingDialogOpen, setReadingDialogOpen] = React.useState(false);
+  const [editingReading, setEditingReading] = React.useState<MeterReading | undefined>(undefined);
+  const [importDialogOpen, setImportDialogOpen] = React.useState(false);
+
+  const deleteMeter = useDeleteMeter();
+  const deleteReading = useDeleteMeterReading();
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('electricity.reading.deleted'),
+    onDelete: (id: string) => deleteReading.mutateAsync(id),
+  });
+
+  const registerLabel = React.useCallback(
+    (register: string) => t(`electricity.consumption.register.${register}`),
+    [t],
+  );
+
+  const showSkeleton = useDelayedLoading(metersLoading);
+  if (showSkeleton) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!metersLoading && meters.length === 0) {
+    return (
+      <>
+        <EmptyState
+          icon={Gauge}
+          title={t('electricity.meter.emptyTitle')}
+          description={t('electricity.meter.emptyDescription')}
+          action={{
+            label: t('electricity.meter.new'),
+            onClick: () => { setEditingMeter(undefined); setMeterDialogOpen(true); },
+          }}
+        />
+        <MeterDialog open={meterDialogOpen} onOpenChange={setMeterDialogOpen} existing={editingMeter} />
+      </>
+    );
+  }
+
+  if (!meter) return null;
+
+  const meterActions: CardAction[] = [
+    { label: t('common.edit'), icon: Pencil, onClick: () => { setEditingMeter(meter); setMeterDialogOpen(true); } },
+    {
+      label: t('common.delete'),
+      icon: Trash2,
+      onClick: () => deleteMeter.mutate(meter.id),
+      variant: 'danger',
+    },
+  ];
+
+  const hasData = (summary?.buckets.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Meter bar */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          {meters.length > 1 ? (
+            <Select
+              value={meter.id}
+              onChange={(e) => setSelectedMeterId(e.target.value)}
+              options={meters.map((m) => ({ value: m.id, label: m.name }))}
+              className="max-w-52"
+              aria-label={t('electricity.meter.selectLabel')}
+            />
+          ) : (
+            <span className="truncate text-sm font-medium">{meter.name}</span>
+          )}
+          <Badge variant="outline" className="text-xs">
+            {meter.tariff_type === 'hp_hc'
+              ? t('electricity.meter.tariffHpHc')
+              : t('electricity.consumption.register.base')}
+          </Badge>
+          <CardActions actions={meterActions} />
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => { setEditingReading(undefined); setReadingDialogOpen(true); }}
+          >
+            <Plus className="mr-1.5 h-4 w-4" />
+            {t('electricity.reading.new')}
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => setImportDialogOpen(true)}>
+            <Upload className="mr-1.5 h-4 w-4" />
+            {t('electricity.import.button')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Granularity + period navigation */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex flex-wrap gap-1.5">
+          {GRANULARITIES.map((g) => (
+            <FilterPill key={g} active={granularity === g} onClick={() => setGranularity(g)}>
+              {t(`electricity.consumption.granularity.${g}`)}
+            </FilterPill>
+          ))}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('electricity.consumption.previousPeriod')}
+            onClick={() => setAnchorIso(isoDate(shiftAnchor(anchor, granularity, -1)))}
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <span className="min-w-32 text-center text-sm capitalize">{periodLabel(anchor, granularity, locale)}</span>
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label={t('electricity.consumption.nextPeriod')}
+            onClick={() => setAnchorIso(isoDate(shiftAnchor(anchor, granularity, 1)))}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Chart card */}
+      <Card className="p-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-2 pb-2">
+          <p className="text-lg font-semibold">
+            {formatKwh(summary?.total_wh ?? 0)} kWh
+            <span className="pl-1.5 text-sm font-normal text-muted-foreground">
+              {t('electricity.consumption.overPeriod')}
+            </span>
+          </p>
+          {summary && summary.estimated_wh > 0 ? (
+            <p className="text-xs text-muted-foreground">
+              {t('electricity.consumption.estimatedShare', { kwh: formatKwh(summary.estimated_wh) })}
+            </p>
+          ) : null}
+        </div>
+        {summaryLoading && !summary ? (
+          <div className="h-64 animate-pulse rounded-lg bg-muted sm:h-80" />
+        ) : hasData && summary ? (
+          <ConsumptionChart summary={summary} granularity={granularity} />
+        ) : (
+          <div className="flex h-64 items-center justify-center text-sm text-muted-foreground sm:h-80">
+            {granularity === 'hour'
+              ? t('electricity.consumption.noHourlyData')
+              : t('electricity.consumption.noData')}
+          </div>
+        )}
+      </Card>
+
+      {/* Recent readings */}
+      {readings.length > 0 ? (
+        <div className="space-y-2">
+          <h3 className="text-sm font-medium text-muted-foreground">
+            {t('electricity.reading.recentTitle')}
+          </h3>
+          {readings.slice(0, 8).map((reading) => (
+            <ReadingRow
+              key={reading.id}
+              reading={reading}
+              locale={locale}
+              registerLabel={registerLabel}
+              onEdit={() => { setEditingReading(reading); setReadingDialogOpen(true); }}
+              onDelete={() => {
+                deleteWithUndo(reading.id, {
+                  onRemove: () => qc.setQueryData<MeterReading[]>(
+                    consumptionKeys.readings(meter.id),
+                    (old) => old?.filter((r) => r.id !== reading.id),
+                  ),
+                  onRestore: () => qc.setQueryData<MeterReading[]>(
+                    consumptionKeys.readings(meter.id),
+                    (old) => (old ? [...old, reading] : [reading]),
+                  ),
+                });
+              }}
+              t={t}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <MeterDialog open={meterDialogOpen} onOpenChange={setMeterDialogOpen} existing={editingMeter} />
+      <ReadingDialog
+        open={readingDialogOpen}
+        onOpenChange={setReadingDialogOpen}
+        meter={meter}
+        existing={editingReading}
+      />
+      <ImportDialog open={importDialogOpen} onOpenChange={setImportDialogOpen} meter={meter} />
+    </div>
+  );
+}

--- a/ui/src/features/electricity/ElectricityPage.tsx
+++ b/ui/src/features/electricity/ElectricityPage.tsx
@@ -34,11 +34,12 @@ import DeviceDialog from './DeviceDialog';
 import CircuitDialog from './CircuitDialog';
 import UsagePointDialog from './UsagePointDialog';
 import LinkDialog from './LinkDialog';
+import ConsumptionTab from './ConsumptionTab';
 import { useQueryClient } from '@tanstack/react-query';
 
 // ── Tab types ─────────────────────────────────────────────────────────────────
 
-type Tab = 'board' | 'circuits' | 'usagePoints' | 'links';
+type Tab = 'board' | 'circuits' | 'usagePoints' | 'links' | 'consumption';
 
 // ── Device type helpers ───────────────────────────────────────────────────────
 
@@ -407,7 +408,7 @@ export default function ElectricityPage() {
   // We only redirect once (on first non-loading render) to avoid kicking the user back if they delete devices later.
   const hasRedirectedRef = React.useRef(false);
   React.useEffect(() => {
-    if (!isLoading && boards.length > 0 && devices.length === 0 && activeTab !== 'board' && !hasRedirectedRef.current) {
+    if (!isLoading && boards.length > 0 && devices.length === 0 && activeTab !== 'board' && activeTab !== 'consumption' && !hasRedirectedRef.current) {
       hasRedirectedRef.current = true;
       setActiveTab('board');
     }
@@ -472,6 +473,7 @@ export default function ElectricityPage() {
     { key: 'circuits', label: t('electricity.tabs.circuits') },
     { key: 'usagePoints', label: t('electricity.tabs.usagePoints') },
     { key: 'links', label: t('electricity.tabs.links') },
+    { key: 'consumption', label: t('electricity.tabs.consumption') },
   ];
 
   // Skeleton
@@ -785,6 +787,9 @@ export default function ElectricityPage() {
           )}
         </div>
       )}
+
+      {/* ── Consumption tab ───────────────────────────────────────── */}
+      {activeTab === 'consumption' && <ConsumptionTab />}
 
       {/* ── Dialogs ───────────────────────────────────────────────────────── */}
       <BoardDialog

--- a/ui/src/features/electricity/ImportDialog.tsx
+++ b/ui/src/features/electricity/ImportDialog.tsx
@@ -1,0 +1,216 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import { toast } from '@/lib/toast';
+import type {
+  ElectricityMeter,
+  EnergyRegister,
+  ImportOptions,
+  ImportPreview,
+} from '@/lib/api/electricity';
+import { usePreviewConsumptionImport, useUploadConsumptionImport } from './hooks';
+
+interface ImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  meter: ElectricityMeter;
+}
+
+export default function ImportDialog({ open, onOpenChange, meter }: ImportDialogProps) {
+  const { t } = useTranslation();
+
+  const [file, setFile] = React.useState<File | null>(null);
+  const [preview, setPreview] = React.useState<ImportPreview | null>(null);
+  const [useGeneric, setUseGeneric] = React.useState(false);
+  const [timestampColumn, setTimestampColumn] = React.useState('');
+  const [valueColumn, setValueColumn] = React.useState('');
+  const [unit, setUnit] = React.useState<ImportOptions['unit']>('kwh');
+  const [intervalMinutes, setIntervalMinutes] = React.useState('30');
+  const [register, setRegister] = React.useState<EnergyRegister>('base');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const previewImport = usePreviewConsumptionImport();
+  const uploadImport = useUploadConsumptionImport();
+
+  React.useEffect(() => {
+    if (!open) return;
+    setFile(null);
+    setPreview(null);
+    setUseGeneric(false);
+    setTimestampColumn('');
+    setValueColumn('');
+    setUnit('kwh');
+    setIntervalMinutes('30');
+    setRegister('base');
+    setError(null);
+  }, [open]);
+
+  async function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const selected = e.target.files?.[0] ?? null;
+    setFile(selected);
+    setPreview(null);
+    setError(null);
+    if (!selected) return;
+    try {
+      const result = await previewImport.mutateAsync(selected);
+      setPreview(result);
+      setUseGeneric(!result.detected_provider);
+      if (result.columns.length >= 2) {
+        setTimestampColumn(result.columns[0]);
+        setValueColumn(result.columns[1]);
+      }
+    } catch {
+      setError(t('electricity.import.previewFailed'));
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!file) {
+      setError(t('electricity.import.fileRequired'));
+      return;
+    }
+
+    const generic = useGeneric || !preview?.detected_provider;
+    try {
+      const result = await uploadImport.mutateAsync({
+        meter: meter.id,
+        file,
+        provider: generic ? 'generic_csv' : undefined,
+        options: generic
+          ? {
+              timestamp_column: timestampColumn,
+              value_column: valueColumn,
+              unit,
+              interval_minutes: Number(intervalMinutes),
+              register,
+            }
+          : undefined,
+      });
+      if (result.status === 'failed') {
+        setError(result.error || t('electricity.import.failed'));
+        return;
+      }
+      toast({
+        description: t('electricity.import.done', {
+          created: result.created_count,
+          skipped: result.skipped_count,
+        }),
+        variant: 'success',
+      });
+      onOpenChange(false);
+    } catch {
+      setError(t('electricity.import.failed'));
+    }
+  }
+
+  const columnOptions = (preview?.columns ?? []).map((c) => ({ value: c, label: c }));
+  const isPending = uploadImport.isPending || previewImport.isPending;
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('electricity.import.title')}>
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <FormField label={t('electricity.import.file')} htmlFor="import-file">
+          <Input id="import-file" type="file" accept=".csv,text/csv" onChange={(e) => void handleFileChange(e)} />
+        </FormField>
+
+        {preview?.detected_provider && !useGeneric ? (
+          <div className="rounded-lg border border-border bg-muted/50 p-3 text-sm">
+            <p>
+              {t('electricity.import.detected')}{' '}
+              <span className="font-medium">{t(`electricity.import.provider.${preview.detected_provider}`)}</span>
+            </p>
+            <button
+              type="button"
+              className="mt-1 text-xs text-primary underline"
+              onClick={() => setUseGeneric(true)}
+            >
+              {t('electricity.import.useGenericInstead')}
+            </button>
+          </div>
+        ) : null}
+
+        {preview && (useGeneric || !preview.detected_provider) ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">{t('electricity.import.mappingHint')}</p>
+            <div className="grid grid-cols-2 gap-3">
+              <FormField label={t('electricity.import.timestampColumn')} htmlFor="import-ts-col">
+                <Select
+                  id="import-ts-col"
+                  value={timestampColumn}
+                  onChange={(e) => setTimestampColumn(e.target.value)}
+                  options={columnOptions}
+                />
+              </FormField>
+              <FormField label={t('electricity.import.valueColumn')} htmlFor="import-value-col">
+                <Select
+                  id="import-value-col"
+                  value={valueColumn}
+                  onChange={(e) => setValueColumn(e.target.value)}
+                  options={columnOptions}
+                />
+              </FormField>
+              <FormField label={t('electricity.import.unit')} htmlFor="import-unit">
+                <Select
+                  id="import-unit"
+                  value={unit}
+                  onChange={(e) => setUnit(e.target.value as ImportOptions['unit'])}
+                  options={[
+                    { value: 'kwh', label: 'kWh' },
+                    { value: 'wh', label: 'Wh' },
+                    { value: 'w_avg', label: t('electricity.import.unitWavg') },
+                  ]}
+                />
+              </FormField>
+              <FormField label={t('electricity.import.intervalMinutes')} htmlFor="import-interval">
+                <Input
+                  id="import-interval"
+                  type="number"
+                  min="1"
+                  value={intervalMinutes}
+                  onChange={(e) => setIntervalMinutes(e.target.value)}
+                />
+              </FormField>
+            </div>
+            {meter.tariff_type === 'hp_hc' ? (
+              <FormField label={t('electricity.consumption.registerLabel')} htmlFor="import-register">
+                <Select
+                  id="import-register"
+                  value={register}
+                  onChange={(e) => setRegister(e.target.value as EnergyRegister)}
+                  options={(['base', 'hp', 'hc'] as EnergyRegister[]).map((r) => ({
+                    value: r,
+                    label: t(`electricity.consumption.register.${r}`),
+                  }))}
+                />
+              </FormField>
+            ) : null}
+          </div>
+        ) : null}
+
+        {preview?.sample_lines.length ? (
+          <div className="max-h-28 overflow-auto rounded-lg border border-border bg-muted/30 p-2">
+            <pre className="text-[11px] leading-4 text-muted-foreground">
+              {preview.sample_lines.slice(0, 6).join('\n')}
+            </pre>
+          </div>
+        ) : null}
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={!file || isPending}>
+            {t('electricity.import.submit')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/electricity/MeterDialog.tsx
+++ b/ui/src/features/electricity/MeterDialog.tsx
@@ -1,0 +1,155 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Input } from '@/design-system/input';
+import { Textarea } from '@/design-system/textarea';
+import { Select } from '@/design-system/select';
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import { fetchZones, type Zone } from '@/lib/api/zones';
+import type { ElectricityMeter, MeterTariffType } from '@/lib/api/electricity';
+import { useCreateMeter, useUpdateMeter } from './hooks';
+
+interface MeterDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existing?: ElectricityMeter;
+}
+
+export default function MeterDialog({ open, onOpenChange, existing }: MeterDialogProps) {
+  const { t } = useTranslation();
+  const isEditing = Boolean(existing);
+
+  const [name, setName] = React.useState('');
+  const [serialNumber, setSerialNumber] = React.useState('');
+  const [tariffType, setTariffType] = React.useState<MeterTariffType>('base');
+  const [zoneId, setZoneId] = React.useState('');
+  const [notes, setNotes] = React.useState('');
+  const [zones, setZones] = React.useState<Zone[]>([]);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createMeter = useCreateMeter();
+  const updateMeter = useUpdateMeter();
+  const isPending = createMeter.isPending || updateMeter.isPending;
+
+  React.useEffect(() => {
+    if (!open) return;
+    fetchZones().then(setZones).catch(() => setZones([]));
+    if (existing) {
+      setName(existing.name);
+      setSerialNumber(existing.serial_number ?? '');
+      setTariffType(existing.tariff_type);
+      setZoneId(existing.zone ?? '');
+      setNotes(existing.notes ?? '');
+    } else {
+      setName('');
+      setSerialNumber('');
+      setTariffType('base');
+      setZoneId('');
+      setNotes('');
+    }
+    setError(null);
+  }, [open, existing]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError(t('electricity.meter.nameRequired'));
+      return;
+    }
+
+    const payload = {
+      name: name.trim(),
+      serial_number: serialNumber.trim(),
+      tariff_type: tariffType,
+      zone: zoneId || null,
+      notes: notes.trim(),
+    };
+
+    try {
+      if (isEditing && existing) {
+        await updateMeter.mutateAsync({ id: existing.id, payload });
+      } else {
+        // the metering point lives where the user is — day boundaries follow it
+        const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+        await createMeter.mutateAsync({ ...payload, timezone });
+      }
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const data = (err as { response?: { data?: Record<string, string[]> } })?.response?.data;
+      const first = data ? Object.values(data).flat()[0] : null;
+      setError(first ?? t('common.saveFailed'));
+    }
+  }
+
+  const zoneOptions = [
+    { value: '', label: t('electricity.meter.noZone') },
+    ...zones.map((z) => ({ value: z.id, label: z.name })),
+  ];
+
+  return (
+    <SheetDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEditing ? t('electricity.meter.edit') : t('electricity.meter.new')}
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <FormField label={t('electricity.meter.name')} htmlFor="meter-name">
+          <Input
+            id="meter-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder={t('electricity.meter.namePlaceholder')}
+            required
+          />
+        </FormField>
+        <div className="grid grid-cols-2 gap-3">
+          <FormField label={t('electricity.meter.tariffType')} htmlFor="meter-tariff">
+            <Select
+              id="meter-tariff"
+              value={tariffType}
+              onChange={(e) => setTariffType(e.target.value as MeterTariffType)}
+              options={[
+                { value: 'base', label: t('electricity.consumption.register.base') },
+                { value: 'hp_hc', label: t('electricity.meter.tariffHpHc') },
+              ]}
+            />
+          </FormField>
+          <FormField label={t('electricity.meter.serialNumber')} htmlFor="meter-serial">
+            <Input
+              id="meter-serial"
+              value={serialNumber}
+              onChange={(e) => setSerialNumber(e.target.value)}
+            />
+          </FormField>
+        </div>
+        <FormField label={t('electricity.meter.zone')} htmlFor="meter-zone">
+          <Select
+            id="meter-zone"
+            value={zoneId}
+            onChange={(e) => setZoneId(e.target.value)}
+            options={zoneOptions}
+          />
+        </FormField>
+        <FormField label={t('electricity.meter.notes')} htmlFor="meter-notes">
+          <Textarea
+            id="meter-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+          />
+        </FormField>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? t('common.saving') : t('common.save')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/electricity/ReadingDialog.tsx
+++ b/ui/src/features/electricity/ReadingDialog.tsx
@@ -1,0 +1,136 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import type { ElectricityMeter, EnergyRegister, MeterReading } from '@/lib/api/electricity';
+import { useCreateMeterReading, useUpdateMeterReading } from './hooks';
+
+function toLocalInputValue(iso: string): string {
+  const date = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+interface ReadingDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  meter: ElectricityMeter;
+  existing?: MeterReading;
+}
+
+export default function ReadingDialog({ open, onOpenChange, meter, existing }: ReadingDialogProps) {
+  const { t } = useTranslation();
+  const isEditing = Boolean(existing);
+  const registers: EnergyRegister[] = meter.tariff_type === 'hp_hc' ? ['hp', 'hc'] : ['base'];
+
+  const [register, setRegister] = React.useState<EnergyRegister>(registers[0]);
+  const [readingAt, setReadingAt] = React.useState('');
+  const [indexKwh, setIndexKwh] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createReading = useCreateMeterReading();
+  const updateReading = useUpdateMeterReading();
+  const isPending = createReading.isPending || updateReading.isPending;
+
+  React.useEffect(() => {
+    if (!open) return;
+    if (existing) {
+      setRegister(existing.register);
+      setReadingAt(toLocalInputValue(existing.reading_at));
+      setIndexKwh(existing.index_kwh);
+    } else {
+      setRegister(meter.tariff_type === 'hp_hc' ? 'hp' : 'base');
+      setReadingAt(toLocalInputValue(new Date().toISOString()));
+      setIndexKwh('');
+    }
+    setError(null);
+  }, [open, existing, meter.tariff_type]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!indexKwh.trim() || !readingAt) {
+      setError(t('electricity.reading.indexRequired'));
+      return;
+    }
+
+    const payload = {
+      meter: meter.id,
+      register,
+      reading_at: new Date(readingAt).toISOString(),
+      index_kwh: indexKwh.trim(),
+    };
+
+    try {
+      if (isEditing && existing) {
+        await updateReading.mutateAsync({ id: existing.id, payload });
+      } else {
+        await createReading.mutateAsync(payload);
+      }
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const data = (err as { response?: { data?: Record<string, string[]> } })?.response?.data;
+      const first = data ? Object.values(data).flat()[0] : null;
+      setError(first ?? t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <SheetDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEditing ? t('electricity.reading.edit') : t('electricity.reading.new')}
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <FormField label={t('electricity.consumption.registerLabel')} htmlFor="reading-register">
+            <Select
+              id="reading-register"
+              value={register}
+              onChange={(e) => setRegister(e.target.value as EnergyRegister)}
+              disabled={registers.length === 1}
+              options={registers.map((r) => ({
+                value: r,
+                label: t(`electricity.consumption.register.${r}`),
+              }))}
+            />
+          </FormField>
+          <FormField label={t('electricity.reading.readingAt')} htmlFor="reading-at">
+            <Input
+              id="reading-at"
+              type="datetime-local"
+              value={readingAt}
+              onChange={(e) => setReadingAt(e.target.value)}
+              required
+            />
+          </FormField>
+        </div>
+        <FormField label={t('electricity.reading.indexKwh')} htmlFor="reading-index">
+          <Input
+            id="reading-index"
+            type="number"
+            step="0.001"
+            min="0"
+            inputMode="decimal"
+            value={indexKwh}
+            onChange={(e) => setIndexKwh(e.target.value)}
+            placeholder="45230.5"
+            required
+          />
+        </FormField>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isPending ? t('common.saving') : t('common.save')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/electricity/hooks.ts
+++ b/ui/src/features/electricity/hooks.ts
@@ -22,10 +22,25 @@ import {
   deleteUsagePoint,
   createLink,
   deactivateLink,
+  fetchMeters,
+  createMeter,
+  updateMeter,
+  deleteMeter,
+  fetchMeterReadings,
+  createMeterReading,
+  updateMeterReading,
+  deleteMeterReading,
+  fetchConsumptionSummary,
+  fetchConsumptionImports,
+  uploadConsumptionImport,
+  previewConsumptionImport,
   type BoardPayload,
   type DevicePayload,
   type CircuitPayload,
   type UsagePointPayload,
+  type MeterPayload,
+  type MeterReadingPayload,
+  type Granularity,
 } from '@/lib/api/electricity';
 
 // ── Query key factory ─────────────────────────────────────────────────────────
@@ -291,4 +306,139 @@ export function useDeactivateLink() {
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
+}
+
+// ── Consumption (parcours 10) ─────────────────────────────────────────────────
+
+export const consumptionKeys = {
+  meters: () => [...electricityKeys.all, 'meters'] as const,
+  readings: (meterId?: string) => [...electricityKeys.all, 'readings', meterId ?? 'all'] as const,
+  summary: (params: { meter: string; granularity: string; date_from: string; date_to: string }) =>
+    [...electricityKeys.all, 'summary', params] as const,
+  imports: () => [...electricityKeys.all, 'imports'] as const,
+};
+
+export function useMeters() {
+  return useQuery({
+    queryKey: consumptionKeys.meters(),
+    queryFn: fetchMeters,
+  });
+}
+
+export function useMeterReadings(meterId?: string) {
+  return useQuery({
+    queryKey: consumptionKeys.readings(meterId),
+    queryFn: () => fetchMeterReadings(meterId),
+    enabled: Boolean(meterId),
+  });
+}
+
+export function useConsumptionSummary(params: {
+  meter: string;
+  granularity: Granularity;
+  date_from: string;
+  date_to: string;
+}) {
+  return useQuery({
+    queryKey: consumptionKeys.summary(params),
+    queryFn: () => fetchConsumptionSummary(params),
+    enabled: Boolean(params.meter),
+    placeholderData: (prev) => prev,
+  });
+}
+
+export function useConsumptionImports() {
+  return useQuery({
+    queryKey: consumptionKeys.imports(),
+    queryFn: fetchConsumptionImports,
+  });
+}
+
+function invalidateConsumption(qc: ReturnType<typeof useQueryClient>) {
+  void qc.invalidateQueries({ queryKey: electricityKeys.all });
+}
+
+export function useCreateMeter() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: MeterPayload) => createMeter(payload),
+    onSuccess: () => {
+      invalidateConsumption(qc);
+      toast({ description: t('electricity.meter.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useUpdateMeter() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Partial<MeterPayload> }) =>
+      updateMeter(id, payload),
+    onSuccess: () => {
+      invalidateConsumption(qc);
+      toast({ description: t('electricity.meter.updated'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useDeleteMeter() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (id: string) => deleteMeter(id),
+    onSuccess: () => {
+      invalidateConsumption(qc);
+      toast({ description: t('electricity.meter.deleted'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useCreateMeterReading() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: MeterReadingPayload) => createMeterReading(payload),
+    onSuccess: () => {
+      invalidateConsumption(qc);
+      toast({ description: t('electricity.reading.created'), variant: 'success' });
+    },
+  });
+}
+
+export function useUpdateMeterReading() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Partial<MeterReadingPayload> }) =>
+      updateMeterReading(id, payload),
+    onSuccess: () => {
+      invalidateConsumption(qc);
+      toast({ description: t('electricity.reading.updated'), variant: 'success' });
+    },
+  });
+}
+
+export function useDeleteMeterReading() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteMeterReading(id),
+    onSuccess: () => invalidateConsumption(qc),
+  });
+}
+
+export function useUploadConsumptionImport() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: uploadConsumptionImport,
+    onSuccess: () => invalidateConsumption(qc),
+  });
+}
+
+export function usePreviewConsumptionImport() {
+  return useMutation({ mutationFn: previewConsumptionImport });
 }

--- a/ui/src/lib/api/electricity.ts
+++ b/ui/src/lib/api/electricity.ts
@@ -272,3 +272,178 @@ export async function deactivateLink(id: string): Promise<void> {
   await api.post(`/electricity/links/${id}/deactivate/`, {});
 }
 
+
+// ── Consumption (parcours 10) ─────────────────────────────────────────────────
+
+export type MeterTariffType = 'base' | 'hp_hc';
+export type EnergyRegister = 'base' | 'hp' | 'hc';
+export type Granularity = 'hour' | 'day' | 'month' | 'year';
+
+export interface ElectricityMeter {
+  id: string;
+  household: string;
+  name: string;
+  serial_number?: string;
+  zone?: string | null;
+  tariff_type: MeterTariffType;
+  timezone: string;
+  notes?: string;
+  is_active?: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MeterPayload {
+  name: string;
+  serial_number?: string;
+  zone?: string | null;
+  tariff_type: MeterTariffType;
+  timezone?: string;
+  notes?: string;
+  is_active?: boolean;
+}
+
+export interface MeterReading {
+  id: string;
+  household: string;
+  meter: string;
+  register: EnergyRegister;
+  reading_at: string;
+  index_kwh: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface MeterReadingPayload {
+  meter: string;
+  register: EnergyRegister;
+  reading_at: string;
+  index_kwh: string;
+}
+
+export interface ConsumptionBucket {
+  ts: string;
+  total_wh: number;
+  estimated_wh: number;
+  registers: Partial<Record<EnergyRegister, number>>;
+}
+
+export interface ConsumptionSummary {
+  meter: string;
+  granularity: Granularity;
+  date_from: string;
+  date_to: string;
+  timezone: string;
+  total_wh: number;
+  estimated_wh: number;
+  buckets: ConsumptionBucket[];
+}
+
+export interface ConsumptionImport {
+  id: string;
+  household: string;
+  meter: string;
+  provider: string;
+  filename: string;
+  status: 'completed' | 'failed';
+  created_count: number;
+  skipped_count: number;
+  error: string;
+  created_at: string;
+}
+
+export interface ImportPreview {
+  detected_provider: string | null;
+  sample_lines: string[];
+  columns: string[];
+}
+
+export interface ImportOptions {
+  timestamp_column: string;
+  value_column: string;
+  unit: 'wh' | 'kwh' | 'w_avg';
+  interval_minutes: number;
+  register?: EnergyRegister;
+  timestamp_position?: 'start' | 'end';
+}
+
+export async function fetchMeters(): Promise<ElectricityMeter[]> {
+  const { data } = await api.get('/electricity/meters/');
+  return normalizeList<ElectricityMeter>(data);
+}
+
+export async function createMeter(payload: MeterPayload): Promise<ElectricityMeter> {
+  const { data } = await api.post('/electricity/meters/', payload);
+  return data as ElectricityMeter;
+}
+
+export async function updateMeter(id: string, payload: Partial<MeterPayload>): Promise<ElectricityMeter> {
+  const { data } = await api.patch(`/electricity/meters/${id}/`, payload);
+  return data as ElectricityMeter;
+}
+
+export async function deleteMeter(id: string): Promise<void> {
+  await api.delete(`/electricity/meters/${id}/`);
+}
+
+export async function fetchMeterReadings(meterId?: string): Promise<MeterReading[]> {
+  const { data } = await api.get('/electricity/meter-readings/', {
+    params: meterId ? { meter: meterId } : undefined,
+  });
+  return normalizeList<MeterReading>(data);
+}
+
+export async function createMeterReading(payload: MeterReadingPayload): Promise<MeterReading> {
+  const { data } = await api.post('/electricity/meter-readings/', payload);
+  return data as MeterReading;
+}
+
+export async function updateMeterReading(id: string, payload: Partial<MeterReadingPayload>): Promise<MeterReading> {
+  const { data } = await api.patch(`/electricity/meter-readings/${id}/`, payload);
+  return data as MeterReading;
+}
+
+export async function deleteMeterReading(id: string): Promise<void> {
+  await api.delete(`/electricity/meter-readings/${id}/`);
+}
+
+export async function fetchConsumptionSummary(params: {
+  meter: string;
+  granularity: Granularity;
+  date_from: string;
+  date_to: string;
+}): Promise<ConsumptionSummary> {
+  const { data } = await api.get('/electricity/consumption/summary/', { params });
+  return data as ConsumptionSummary;
+}
+
+export async function fetchConsumptionImports(): Promise<ConsumptionImport[]> {
+  const { data } = await api.get('/electricity/consumption/imports/');
+  return normalizeList<ConsumptionImport>(data);
+}
+
+export async function uploadConsumptionImport(params: {
+  meter: string;
+  file: File;
+  provider?: string;
+  options?: ImportOptions;
+}): Promise<ConsumptionImport> {
+  const form = new FormData();
+  form.append('file', params.file);
+  form.append('meter', params.meter);
+  if (params.provider) form.append('provider', params.provider);
+  if (params.options) form.append('options', JSON.stringify(params.options));
+  const { data } = await api.post('/electricity/consumption/imports/', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return data as ConsumptionImport;
+}
+
+export async function previewConsumptionImport(file: File): Promise<ImportPreview> {
+  const form = new FormData();
+  form.append('file', file);
+  const { data } = await api.post('/electricity/consumption/imports/preview/', form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return data as ImportPreview;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -53,7 +53,8 @@
       "circuits": "Stromkreise",
       "usagePoints": "Nutzungspunkte",
       "links": "Verbindungen",
-      "lookup": "Suche"
+      "lookup": "Suche",
+      "consumption": "Verbrauch"
     },
     "board": {
       "new": "Neuer Verteiler",
@@ -193,6 +194,78 @@
       "notFound": "Nicht gefunden.",
       "failed": "Suche fehlgeschlagen.",
       "required": "Bezeichnung ist erforderlich."
+    },
+    "meter": {
+      "new": "Neuer Zähler",
+      "edit": "Zähler bearbeiten",
+      "name": "Name",
+      "namePlaceholder": "Hauptzähler",
+      "nameRequired": "Ein Name ist erforderlich.",
+      "serialNumber": "Seriennummer",
+      "tariffType": "Tarif",
+      "tariffHpHc": "Haupt-/Nebenzeit",
+      "zone": "Zone",
+      "noZone": "Keine Zone",
+      "notes": "Notizen",
+      "selectLabel": "Zähler auswählen",
+      "emptyTitle": "Noch kein Zähler",
+      "emptyDescription": "Legen Sie Ihren Stromzähler an, um den Verbrauch zu verfolgen — manuelle Ablesungen oder Datei-Import.",
+      "created": "Zähler erstellt.",
+      "updated": "Zähler aktualisiert.",
+      "deleted": "Zähler gelöscht."
+    },
+    "reading": {
+      "new": "Neue Ablesung",
+      "edit": "Ablesung bearbeiten",
+      "readingAt": "Datum und Uhrzeit",
+      "indexKwh": "Zählerstand (kWh)",
+      "indexRequired": "Datum und Zählerstand sind erforderlich.",
+      "recentTitle": "Letzte Ablesungen",
+      "created": "Ablesung gespeichert.",
+      "updated": "Ablesung aktualisiert.",
+      "deleted": "Ablesung gelöscht."
+    },
+    "consumption": {
+      "registerLabel": "Zählwerk",
+      "register": {
+        "base": "Basis",
+        "hp": "Hauptzeit",
+        "hc": "Nebenzeit"
+      },
+      "granularity": {
+        "hour": "Stunde",
+        "day": "Tag",
+        "month": "Monat",
+        "year": "Jahr"
+      },
+      "previousPeriod": "Vorheriger Zeitraum",
+      "nextPeriod": "Nächster Zeitraum",
+      "overPeriod": "im Zeitraum",
+      "estimatedShare": "davon {{kwh}} kWh aus Ablesungen geschätzt",
+      "noData": "Keine Verbrauchsdaten in diesem Zeitraum.",
+      "noHourlyData": "Die Stundenansicht zeigt nur importierte Daten (Lastgang). Importieren Sie eine Datei."
+    },
+    "import": {
+      "title": "Daten importieren",
+      "button": "Importieren",
+      "file": "Datei",
+      "fileRequired": "Eine Datei ist erforderlich.",
+      "detected": "Erkanntes Format:",
+      "useGenericInstead": "Stattdessen manuelle Spaltenzuordnung verwenden",
+      "mappingHint": "Format nicht erkannt — ordnen Sie die Spalten selbst zu.",
+      "timestampColumn": "Zeitstempel-Spalte",
+      "valueColumn": "Wert-Spalte",
+      "unit": "Einheit",
+      "unitWavg": "W (mittlere Leistung)",
+      "intervalMinutes": "Intervall (Minuten)",
+      "submit": "Importieren",
+      "done": "Import abgeschlossen: {{created}} Punkte hinzugefügt, {{skipped}} bereits vorhanden.",
+      "failed": "Import fehlgeschlagen.",
+      "previewFailed": "Datei konnte nicht gelesen werden.",
+      "provider": {
+        "enedis_csv": "Enedis — Lastgang (CSV)",
+        "generic_csv": "Generisches CSV"
+      }
     }
   },
   "interactions": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -53,7 +53,8 @@
       "circuits": "Circuits",
       "usagePoints": "Usage Points",
       "links": "Links",
-      "lookup": "Lookup"
+      "lookup": "Lookup",
+      "consumption": "Consumption"
     },
     "board": {
       "new": "New Board",
@@ -193,6 +194,78 @@
       "notFound": "Not found.",
       "failed": "Search failed.",
       "required": "Label is required."
+    },
+    "meter": {
+      "new": "New meter",
+      "edit": "Edit meter",
+      "name": "Name",
+      "namePlaceholder": "Main meter",
+      "nameRequired": "A name is required.",
+      "serialNumber": "Serial number",
+      "tariffType": "Tariff",
+      "tariffHpHc": "Peak / off-peak",
+      "zone": "Zone",
+      "noZone": "No zone",
+      "notes": "Notes",
+      "selectLabel": "Select a meter",
+      "emptyTitle": "No meter yet",
+      "emptyDescription": "Declare your electricity meter to start tracking consumption — manual readings or Enedis import.",
+      "created": "Meter created.",
+      "updated": "Meter updated.",
+      "deleted": "Meter deleted."
+    },
+    "reading": {
+      "new": "New reading",
+      "edit": "Edit reading",
+      "readingAt": "Date and time",
+      "indexKwh": "Meter index (kWh)",
+      "indexRequired": "Date and index are required.",
+      "recentTitle": "Recent readings",
+      "created": "Reading saved.",
+      "updated": "Reading updated.",
+      "deleted": "Reading deleted."
+    },
+    "consumption": {
+      "registerLabel": "Register",
+      "register": {
+        "base": "Base",
+        "hp": "Peak hours",
+        "hc": "Off-peak hours"
+      },
+      "granularity": {
+        "hour": "Hour",
+        "day": "Day",
+        "month": "Month",
+        "year": "Year"
+      },
+      "previousPeriod": "Previous period",
+      "nextPeriod": "Next period",
+      "overPeriod": "over the period",
+      "estimatedShare": "incl. {{kwh}} kWh estimated from readings",
+      "noData": "No consumption data on this period.",
+      "noHourlyData": "The hourly view only shows imported data (load curve). Import a file to see it."
+    },
+    "import": {
+      "title": "Import data",
+      "button": "Import",
+      "file": "File",
+      "fileRequired": "A file is required.",
+      "detected": "Detected format:",
+      "useGenericInstead": "Use manual column mapping instead",
+      "mappingHint": "Unrecognized format — map the columns yourself.",
+      "timestampColumn": "Timestamp column",
+      "valueColumn": "Value column",
+      "unit": "Unit",
+      "unitWavg": "W (average power)",
+      "intervalMinutes": "Step (minutes)",
+      "submit": "Import",
+      "done": "Import done: {{created}} points added, {{skipped}} already known.",
+      "failed": "Import failed.",
+      "previewFailed": "Could not read the file.",
+      "provider": {
+        "enedis_csv": "Enedis — load curve (CSV)",
+        "generic_csv": "Generic CSV"
+      }
     }
   },
   "interactions": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -53,7 +53,8 @@
       "circuits": "Circuitos",
       "usagePoints": "Puntos de uso",
       "links": "Vínculos",
-      "lookup": "Búsqueda"
+      "lookup": "Búsqueda",
+      "consumption": "Consumo"
     },
     "board": {
       "new": "Nuevo cuadro",
@@ -193,6 +194,78 @@
       "notFound": "No encontrado.",
       "failed": "Búsqueda fallida.",
       "required": "La etiqueta es obligatoria."
+    },
+    "meter": {
+      "new": "Nuevo contador",
+      "edit": "Editar contador",
+      "name": "Nombre",
+      "namePlaceholder": "Contador principal",
+      "nameRequired": "Se requiere un nombre.",
+      "serialNumber": "Número de serie",
+      "tariffType": "Tarifa",
+      "tariffHpHc": "Punta / valle",
+      "zone": "Zona",
+      "noZone": "Sin zona",
+      "notes": "Notas",
+      "selectLabel": "Elegir un contador",
+      "emptyTitle": "Ningún contador",
+      "emptyDescription": "Declare su contador eléctrico para seguir su consumo — lecturas manuales o importación de archivos.",
+      "created": "Contador creado.",
+      "updated": "Contador actualizado.",
+      "deleted": "Contador eliminado."
+    },
+    "reading": {
+      "new": "Nueva lectura",
+      "edit": "Editar lectura",
+      "readingAt": "Fecha y hora",
+      "indexKwh": "Índice del contador (kWh)",
+      "indexRequired": "Fecha e índice son obligatorios.",
+      "recentTitle": "Lecturas recientes",
+      "created": "Lectura guardada.",
+      "updated": "Lectura actualizada.",
+      "deleted": "Lectura eliminada."
+    },
+    "consumption": {
+      "registerLabel": "Registro",
+      "register": {
+        "base": "Base",
+        "hp": "Horas punta",
+        "hc": "Horas valle"
+      },
+      "granularity": {
+        "hour": "Hora",
+        "day": "Día",
+        "month": "Mes",
+        "year": "Año"
+      },
+      "previousPeriod": "Período anterior",
+      "nextPeriod": "Período siguiente",
+      "overPeriod": "en el período",
+      "estimatedShare": "incl. {{kwh}} kWh estimados desde lecturas",
+      "noData": "Sin datos de consumo en este período.",
+      "noHourlyData": "La vista horaria solo muestra datos importados (curva de carga). Importe un archivo para verla."
+    },
+    "import": {
+      "title": "Importar datos",
+      "button": "Importar",
+      "file": "Archivo",
+      "fileRequired": "Se requiere un archivo.",
+      "detected": "Formato detectado:",
+      "useGenericInstead": "Usar el mapeo manual de columnas",
+      "mappingHint": "Formato no reconocido — asigne las columnas usted mismo.",
+      "timestampColumn": "Columna de fecha/hora",
+      "valueColumn": "Columna de valor",
+      "unit": "Unidad",
+      "unitWavg": "W (potencia media)",
+      "intervalMinutes": "Paso (minutos)",
+      "submit": "Importar",
+      "done": "Importación completada: {{created}} puntos añadidos, {{skipped}} ya conocidos.",
+      "failed": "Error en la importación.",
+      "previewFailed": "No se pudo leer el archivo.",
+      "provider": {
+        "enedis_csv": "Enedis — curva de carga (CSV)",
+        "generic_csv": "CSV genérico"
+      }
     }
   },
   "interactions": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -53,7 +53,8 @@
       "circuits": "Circuits",
       "usagePoints": "Points d'usage",
       "links": "Liens",
-      "lookup": "Recherche"
+      "lookup": "Recherche",
+      "consumption": "Consommation"
     },
     "board": {
       "new": "Nouveau tableau",
@@ -193,6 +194,78 @@
       "notFound": "Introuvable.",
       "failed": "Recherche échouée.",
       "required": "L'étiquette est requise."
+    },
+    "meter": {
+      "new": "Nouveau compteur",
+      "edit": "Modifier le compteur",
+      "name": "Nom",
+      "namePlaceholder": "Compteur principal",
+      "nameRequired": "Un nom est requis.",
+      "serialNumber": "Numéro de série",
+      "tariffType": "Tarification",
+      "tariffHpHc": "Heures pleines / creuses",
+      "zone": "Zone",
+      "noZone": "Aucune zone",
+      "notes": "Notes",
+      "selectLabel": "Choisir un compteur",
+      "emptyTitle": "Aucun compteur",
+      "emptyDescription": "Déclarez votre compteur électrique pour suivre votre consommation — relevés manuels ou import Enedis.",
+      "created": "Compteur créé.",
+      "updated": "Compteur modifié.",
+      "deleted": "Compteur supprimé."
+    },
+    "reading": {
+      "new": "Nouveau relevé",
+      "edit": "Modifier le relevé",
+      "readingAt": "Date et heure",
+      "indexKwh": "Index du compteur (kWh)",
+      "indexRequired": "Date et index sont requis.",
+      "recentTitle": "Relevés récents",
+      "created": "Relevé enregistré.",
+      "updated": "Relevé modifié.",
+      "deleted": "Relevé supprimé."
+    },
+    "consumption": {
+      "registerLabel": "Cadran",
+      "register": {
+        "base": "Base",
+        "hp": "Heures pleines",
+        "hc": "Heures creuses"
+      },
+      "granularity": {
+        "hour": "Heure",
+        "day": "Jour",
+        "month": "Mois",
+        "year": "Année"
+      },
+      "previousPeriod": "Période précédente",
+      "nextPeriod": "Période suivante",
+      "overPeriod": "sur la période",
+      "estimatedShare": "dont {{kwh}} kWh estimés depuis les relevés",
+      "noData": "Aucune donnée de consommation sur cette période.",
+      "noHourlyData": "La vue horaire n'affiche que les données importées (courbe de charge). Importez un fichier pour la voir."
+    },
+    "import": {
+      "title": "Importer des données",
+      "button": "Importer",
+      "file": "Fichier",
+      "fileRequired": "Un fichier est requis.",
+      "detected": "Format détecté :",
+      "useGenericInstead": "Utiliser le mapping manuel des colonnes",
+      "mappingHint": "Format non reconnu — indiquez vous-même les colonnes.",
+      "timestampColumn": "Colonne date/heure",
+      "valueColumn": "Colonne valeur",
+      "unit": "Unité",
+      "unitWavg": "W (puissance moyenne)",
+      "intervalMinutes": "Pas (minutes)",
+      "submit": "Importer",
+      "done": "Import terminé : {{created}} points ajoutés, {{skipped}} déjà connus.",
+      "failed": "Échec de l'import.",
+      "previewFailed": "Impossible de lire le fichier.",
+      "provider": {
+        "enedis_csv": "Enedis — courbe de charge (CSV)",
+        "generic_csv": "CSV générique"
+      }
     }
   },
   "interactions": {


### PR DESCRIPTION
Closes #200 — Parcours 10, lot 3.

## Contenu

- **5e onglet « Consommation »** du module Électricité : sélecteur de granularité Heure/Jour/Mois/Année (`FilterPill` + `useSessionState`), navigation ◀ période ▶ (jour ↔ mois ↔ année ↔ décennie), total kWh de la période, part estimée signalée
- **Recharts entre au projet** : BarChart empilé par cadran (HP/HC/base), couleurs via les tokens `--chart-*` du design-system, tooltip/légende localisés
- **Dialogs** : compteur (tarification base/HP-HC, zone, fuseau détecté depuis le navigateur à la création), relevé (cadrans conditionnés par la tarification, erreurs de monotonie remontées du serializer), import (upload → preview → format Enedis détecté ou mapping manuel colonnes/unité/pas → compte-rendu créés/ignorés, échec métier affiché)
- **Relevés récents** : édition + suppression avec undo optimiste (`useDeleteWithUndo` + rollback du cache)
- **i18n** : ~60 clés `electricity.{meter,reading,consumption,import}.*` en 4 langues, zéro `defaultValue`
- État vide → CTA « Nouveau compteur » ; la vue heure sans import explique pourquoi elle est vide

## Limitation connue

Si le foyer n'a **aucun tableau électrique**, la page garde son état vide global « créer un tableau » — l'onglet Consommation n'est accessible qu'avec un tableau existant. À revoir si un utilisateur veut la consommation sans modéliser son tableau.

## Tests

`tsc` + `npm run build` + `npm run lint` verts (0 erreur, warnings préexistants hors périmètre). Tests E2E Playwright prévus dans la passe de finalisation du parcours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)