### PR TITLE
feat(electricity): lot 4 — intégration agent (compteur searchable, somme kWh, relevé dictable)

### DIFF
--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -387,7 +387,7 @@ _CREATE_ENTITY_SCHEMA = {
     "properties": {
         "entity_type": {
             "type": "string",
-            "description": "The kind of item to create. Supported: 'task', 'note'.",
+            "description": "The kind of item to create. Supported: 'task', 'note', 'meter_reading'.",
         },
         "fields": {
             "type": "object",
@@ -398,6 +398,12 @@ _CREATE_ENTITY_SCHEMA = {
                 "'YYYY-MM-DD'), priority (optional integer 1=high..5=low). "
                 "For entity_type='note' (a free-form note in the household log): "
                 "subject (required, short title), content (optional body text). "
+                "For entity_type='meter_reading' (an electricity meter index "
+                "reading): index_kwh (required, the number read on the meter, "
+                "in kWh), register (optional: 'base', 'hp' or 'hc' — required "
+                "when the meter has peak/off-peak tariff), meter (optional "
+                "meter name or id; omit when the household has a single "
+                "meter), reading_at (optional ISO datetime, defaults to now). "
                 "In an anchored conversation the project/zone is attached "
                 "automatically — do not ask for it."
             ),
@@ -408,7 +414,8 @@ _CREATE_ENTITY_SCHEMA = {
 
 _CREATE_ENTITY_DESCRIPTION = (
     "Create a new household item on the user's behalf. Supported types: 'task' "
-    "(a to-do / reminder) and 'note' (a free-form note). Only call this when the "
+    "(a to-do / reminder), 'note' (a free-form note) and 'meter_reading' (an "
+    "electricity meter index reading, e.g. 'j'ai relevé 45230'). Only call this when the "
     "user clearly asks to create, "
     "add or remember something — never speculatively. After it succeeds, confirm "
     "in one short sentence and cite the new item with its returned id. The item "
@@ -445,7 +452,9 @@ def _create_entity_handler(
 
     try:
         instance = spec.create(household, user, fields, anchor=context_entity)
-    except (DRFValidationError, DjangoValidationError) as exc:
+    except (DRFValidationError, DjangoValidationError, ValueError) as exc:
+        # ValueError is the writables' recoverable-error contract (unknown
+        # meter, missing register…) — surface the hint instead of burying it.
         detail = getattr(exc, "detail", None) or getattr(exc, "messages", None) or str(exc)
         return ToolResult(rendered=f"(could not create {entity_type}: {detail})")
     except Exception:  # noqa: BLE001 — never crash the loop on a create failure
@@ -503,7 +512,7 @@ _LIST_ENTITIES_SCHEMA = {
     "properties": {
         "entity_type": {
             "type": "string",
-            "description": "What to list. Supported: 'task', 'interaction'.",
+            "description": "What to list. Supported: 'task', 'interaction', 'consumption', 'meter_reading'.",
         },
         "filters": {
             "type": "object",
@@ -516,7 +525,14 @@ _LIST_ENTITIES_SCHEMA = {
                 "For 'interaction': type (comma-separated among note, todo, "
                 "expense, maintenance, repair, installation, inspection, "
                 "warranty, issue, upgrade, replacement, disposal), "
-                "occurred_after / occurred_before (YYYY-MM-DD)."
+                "occurred_after / occurred_before (YYYY-MM-DD). "
+                "For 'consumption' (electricity consumption points; sum_amount "
+                "is in kWh): meter (name or id), date_from / date_to "
+                "(YYYY-MM-DD), register (base, hp, hc), source ('import' = "
+                "measured data, 'reading' = estimates from manual readings — "
+                "if both sources cover the same days, filter source='import' "
+                "to avoid double counting). "
+                "For 'meter_reading' (raw index readings): meter, register."
             ),
         },
         "limit": {
@@ -531,9 +547,11 @@ _LIST_ENTITIES_DESCRIPTION = (
     "List household items structurally, with filters and totals — the right tool "
     "for enumeration and aggregation questions where keyword search fails: 'all "
     "my overdue tasks', 'the expenses of March', 'how much did we spend this "
-    "year'. Returns the matching items (citable ids), the total count, and — for "
-    "interactions carrying an amount (expenses) — the sum of amounts over the "
-    "whole filtered set. Supported types: 'task', 'interaction'."
+    "year', 'how much electricity did we use in June'. Returns the matching "
+    "items (citable ids), the total count, and — when items carry an amount "
+    "(expenses in EUR, consumption in kWh) — the sum of amounts over the whole "
+    "filtered set. Supported types: 'task', 'interaction', 'consumption', "
+    "'meter_reading'."
 )
 
 

--- a/apps/electricity/apps.py
+++ b/apps/electricity/apps.py
@@ -5,3 +5,180 @@ from django.apps import AppConfig
 class ElectricityConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "electricity"
+
+    def ready(self):
+        from agent.listables import ListableSpec, ListFilter, register as register_listable
+        from agent.searchables import SearchableSpec, register
+        from agent.writables import WritableSpec, register as register_writable
+
+        from .models import ConsumptionRecord, ElectricityMeter, MeterReading
+
+        register(SearchableSpec(
+            entity_type='meter',
+            model=ElectricityMeter,
+            search_fields=('name', 'serial_number', 'notes'),
+            label_attr='name',
+            url_template='/app/electricity?meter={id}',
+        ))
+
+        register_writable(WritableSpec(
+            entity_type='meter_reading',
+            create=_create_reading_from_agent,
+            label_attr=_reading_label,
+            url_template='/app/electricity?reading={id}',
+        ))
+
+        register_listable(ListableSpec(
+            entity_type='consumption',
+            model=ConsumptionRecord,
+            filters=(
+                ListFilter('meter', 'meter name or id', _filter_meter),
+                ListFilter('date_from', 'ts_start >= YYYY-MM-DD (UTC day boundary)', _filter_date_from),
+                ListFilter('date_to', 'ts_start <= YYYY-MM-DD end of day (UTC)', _filter_date_to),
+                ListFilter('register', 'comma-separated among base, hp, hc', _filter_register),
+                ListFilter('source', "'reading' (estimates) or 'import' (measured)", _filter_source),
+            ),
+            order_by=('-ts_start',),
+            describe=_describe_consumption,
+            amount_of=_consumption_kwh,
+        ))
+
+        register_listable(ListableSpec(
+            entity_type='meter_reading',
+            model=MeterReading,
+            filters=(
+                ListFilter('meter', 'meter name or id', _filter_meter),
+                ListFilter('register', 'comma-separated among base, hp, hc', _filter_register),
+            ),
+            order_by=('-reading_at',),
+            describe=_describe_reading,
+        ))
+
+
+def _resolve_meter(household_id, raw):
+    """Find a meter by id or name — household-scoped.
+
+    When the household has a single meter, an empty value resolves to it, so
+    the agent can record "j'ai relevé 45230" without naming the meter.
+    """
+    import uuid
+
+    from .models import ElectricityMeter
+
+    qs = ElectricityMeter.objects.filter(household_id=household_id)
+    value = (str(raw) if raw is not None else '').strip()
+    if not value:
+        meters = list(qs[:2])
+        if len(meters) == 1:
+            return meters[0]
+        raise ValueError(
+            "meter is required (several meters exist)" if meters else "no meter declared"
+        )
+    try:
+        match = qs.filter(pk=uuid.UUID(value)).first()
+        if match is not None:
+            return match
+    except ValueError:
+        pass
+    match = qs.filter(name__iexact=value).first() or qs.filter(name__icontains=value).first()
+    if match is None:
+        raise ValueError(f"unknown meter: {value}")
+    return match
+
+
+def _create_reading_from_agent(household, user, fields, *, anchor=None):
+    """Map the agent's raw ``fields`` to ``electricity.services.create_meter_reading``.
+
+    Same write path as the REST viewset: serializer validation (register vs
+    tariff, index monotonicity) + regeneration of the daily estimates.
+    """
+    from django.utils import timezone
+
+    from .models import MeterTariffType
+    from .services import create_meter_reading
+
+    meter = _resolve_meter(household.id, fields.get('meter'))
+    register = (fields.get('register') or '').strip().lower()
+    if not register:
+        if meter.tariff_type != MeterTariffType.BASE:
+            raise ValueError("register is required for a peak/off-peak meter: 'hp' or 'hc'")
+        register = 'base'
+
+    return create_meter_reading(
+        household,
+        user,
+        meter=meter,
+        register=register,
+        reading_at=fields.get('reading_at') or timezone.now(),
+        index_kwh=fields.get('index_kwh'),
+    )
+
+
+def _reading_label(reading) -> str:
+    return f"{reading.meter.name} — {reading.register} {reading.index_kwh} kWh"
+
+
+# --- list_entities filters -----------------------------------------------------
+
+
+def _filter_meter(qs, value):
+    """The queryset is already household-scoped by the tool — narrow by meter."""
+    import uuid
+
+    value = value.strip()
+    try:
+        return qs.filter(meter_id=uuid.UUID(value))
+    except ValueError:
+        pass
+    exact = qs.filter(meter__name__iexact=value)
+    return exact if exact.exists() else qs.filter(meter__name__icontains=value)
+
+
+def _filter_date_from(qs, value):
+    return qs.filter(ts_start__gte=_parse_utc_day(value))
+
+
+def _filter_date_to(qs, value):
+    from datetime import timedelta
+
+    return qs.filter(ts_start__lt=_parse_utc_day(value) + timedelta(days=1))
+
+
+def _filter_register(qs, value):
+    registers = [v.strip().lower() for v in value.split(',') if v.strip()]
+    unknown = [v for v in registers if v not in ('base', 'hp', 'hc')]
+    if not registers or unknown:
+        raise ValueError(f"unknown register: {', '.join(unknown) or '(empty)'}")
+    return qs.filter(register__in=registers)
+
+
+def _filter_source(qs, value):
+    source = value.strip().lower()
+    if source not in ('reading', 'import'):
+        raise ValueError("source must be 'reading' or 'import'")
+    return qs.filter(source=source)
+
+
+def _parse_utc_day(value):
+    from datetime import date, datetime, time, timezone as dt_timezone
+
+    parsed = date.fromisoformat(value.strip())
+    return datetime.combine(parsed, time.min, tzinfo=dt_timezone.utc)
+
+
+def _describe_consumption(record) -> str:
+    kwh = record.energy_wh / 1000
+    return (
+        f"{record.ts_start:%Y-%m-%d %H:%M} | {record.interval_minutes} min | "
+        f"{kwh:g} kWh | {record.register} | {record.source}"
+    )
+
+
+def _describe_reading(reading) -> str:
+    return f"{reading.reading_at:%Y-%m-%d %H:%M} | {reading.register} | index {reading.index_kwh} kWh"
+
+
+def _consumption_kwh(record):
+    from decimal import Decimal
+
+    return Decimal(record.energy_wh) / 1000

--- a/apps/electricity/tests/test_agent_integration.py
+++ b/apps/electricity/tests/test_agent_integration.py
@@ -1,0 +1,554 @@
+"""
+Tests for the electricity agent integration — parcours 10, lot 4.
+
+Covers:
+  - create_entity / meter_reading via dispatch (WritableSpec)
+  - list_entities / consumption with date/register/source/meter filters + sum_amount
+  - list_entities / meter_reading
+  - SearchableSpec registration and retrieval of 'meter'
+  - Error paths: missing register on hp_hc meter, decreasing index, ambiguous meter,
+    meter not found by name, unknown register value
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone as dt_timezone
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from agent import tools
+from agent.searchables import REGISTRY as SEARCH_REGISTRY, find_spec
+from electricity.models import (
+    ConsumptionRecord,
+    ConsumptionSource,
+    ElectricityMeter,
+    EnergyRegister,
+    MeterReading,
+    MeterTariffType,
+)
+from electricity.tests.factories import (
+    ConsumptionRecordFactory,
+    ElectricityMeterFactory,
+    MeterReadingFactory,
+    UserFactory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create(household, tool_input, user=None):
+    """Dispatch create_entity and return the ToolResult."""
+    return tools.dispatch("create_entity", tool_input, household=household, user=user)
+
+
+def _list(household, tool_input, user=None):
+    """Dispatch list_entities and return the ToolResult."""
+    return tools.dispatch("list_entities", tool_input, household=household, user=user)
+
+
+def _utc(year, month, day, hour=0, minute=0):
+    return datetime(year, month, day, hour, minute, tzinfo=dt_timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="elec-agent-owner@example.com")
+
+
+@pytest.fixture
+def household(db):
+    from households.models import Household
+    return Household.objects.create(name="Elec Agent Household")
+
+
+@pytest.fixture
+def other_household(db):
+    from households.models import Household
+    return Household.objects.create(name="Other Elec Household")
+
+
+@pytest.fixture
+def base_meter(household, owner):
+    return ElectricityMeterFactory(
+        household=household,
+        name="Compteur principal",
+        tariff_type=MeterTariffType.BASE,
+        created_by=owner,
+    )
+
+
+@pytest.fixture
+def hphc_meter(household, owner):
+    return ElectricityMeterFactory(
+        household=household,
+        name="Compteur HP/HC",
+        tariff_type=MeterTariffType.HP_HC,
+        created_by=owner,
+    )
+
+
+# ===========================================================================
+# 1. create_entity / meter_reading — happy path
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestCreateMeterReadingHappyPath:
+    """create_entity with a single BASE meter — meter resolved implicitly."""
+
+    def test_reading_created_in_db(self, household, owner, base_meter):
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45230"}},
+            user=owner,
+        )
+        assert MeterReading.objects.filter(household=household).count() == 1
+        reading = MeterReading.objects.get(household=household)
+        assert reading.index_kwh == Decimal("45230")
+        assert reading.register == EnergyRegister.BASE
+        assert reading.meter == base_meter
+
+    def test_result_rendered_contains_id(self, household, owner, base_meter):
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45230"}},
+            user=owner,
+        )
+        reading = MeterReading.objects.get(household=household)
+        assert str(reading.pk) in result.rendered
+
+    def test_result_created_dict_has_entity_type_and_id(self, household, owner, base_meter):
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45230"}},
+            user=owner,
+        )
+        assert len(result.created) == 1
+        created = result.created[0]
+        assert created["entity_type"] == "meter_reading"
+        reading = MeterReading.objects.get(household=household)
+        assert str(created["id"]) == str(reading.pk)
+
+    def test_register_defaults_to_base(self, household, owner, base_meter):
+        _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "10000"}},
+            user=owner,
+        )
+        reading = MeterReading.objects.get(household=household)
+        assert reading.register == EnergyRegister.BASE
+
+    def test_second_reading_regenerates_consumption_records(self, household, owner, base_meter):
+        """After two readings, rebuild_reading_records generates ConsumptionRecords."""
+        # First reading
+        _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "10000", "reading_at": "2026-06-01T00:00:00Z"}},
+            user=owner,
+        )
+        assert ConsumptionRecord.objects.filter(
+            household=household, source=ConsumptionSource.READING
+        ).count() == 0  # single reading → no interval to compute
+
+        # Second reading — now there's a pair, estimates should be generated
+        _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "10100", "reading_at": "2026-07-01T00:00:00Z"}},
+            user=owner,
+        )
+        assert ConsumptionRecord.objects.filter(
+            household=household, source=ConsumptionSource.READING
+        ).count() >= 1
+
+
+# ===========================================================================
+# 2. Anti-duplication: REST service vs. agent dispatch — same write path
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestCreateReadingViaServiceIsEquivalent:
+    """create_meter_reading service and dispatch produce identical DB state."""
+
+    def test_service_and_dispatch_produce_same_db_shape(self, household, owner, base_meter):
+        from electricity.services import create_meter_reading
+
+        # Create via service directly
+        r1 = create_meter_reading(
+            household,
+            owner,
+            meter=base_meter,
+            register="base",
+            reading_at=timezone.now(),
+            index_kwh=Decimal("45000"),
+        )
+
+        # Both go through the same serializer + rebuild path
+        assert r1.register == EnergyRegister.BASE
+        assert r1.index_kwh == Decimal("45000")
+        assert r1.meter == base_meter
+        assert r1.household == household
+
+        # Reset, then create via dispatch — same outcome
+        MeterReading.objects.all().delete()
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45000"}},
+            user=owner,
+        )
+        r2 = MeterReading.objects.get(household=household)
+        assert r2.register == r1.register
+        assert r2.index_kwh == r1.index_kwh
+        assert r2.meter == r1.meter
+        assert r2.household == r1.household
+        # The dispatch also produced a created dict
+        assert len(result.created) == 1
+
+
+# ===========================================================================
+# 3. Error paths — all recoverable (no exception bubbles up)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestCreateMeterReadingErrors:
+    """All validation failures return a ToolResult, never raise."""
+
+    def test_hphc_meter_without_register_returns_error(self, household, owner, hphc_meter):
+        # BUG (known): _create_reading_from_agent raises ValueError, which is caught
+        # by the bare `except Exception` in _create_entity_handler (tools.py:458).
+        # The ValueError message ("register is required for a peak/off-peak meter…")
+        # is therefore swallowed and the model only sees "unexpected error" instead of
+        # the actionable register hint.  Fix: add ValueError to the explicit except
+        # clause in _create_entity_handler alongside DRFValidationError.
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45230"}},
+            user=owner,
+        )
+        assert MeterReading.objects.filter(household=household).count() == 0
+        # The call is recoverable (no unhandled exception) — the rendered message
+        # contains "could not create" even if the detail is unhelpfully generic.
+        assert "could not create meter_reading" in result.rendered
+
+    def test_decreasing_index_returns_error(self, household, owner, base_meter):
+        # First reading at a high index
+        MeterReadingFactory(
+            meter=base_meter,
+            household=household,
+            register=EnergyRegister.BASE,
+            index_kwh=Decimal("50000"),
+            reading_at=timezone.now(),
+            created_by=owner,
+        )
+        # Try to create a lower index — serializer should reject it
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "40000"}},
+            user=owner,
+        )
+        assert "could not create meter_reading" in result.rendered
+        # The number of readings should not have grown beyond the initial one
+        assert MeterReading.objects.filter(household=household).count() == 1
+
+    def test_two_meters_without_meter_field_returns_error(self, household, owner, base_meter):
+        # Create a second meter in the same household
+        ElectricityMeterFactory(household=household, name="Second meter", created_by=owner)
+        result = _create(
+            household,
+            {"entity_type": "meter_reading", "fields": {"index_kwh": "45230"}},
+            user=owner,
+        )
+        assert MeterReading.objects.filter(household=household).count() == 0
+        assert "meter" in result.rendered.lower()
+
+    def test_meter_by_name_case_insensitive(self, household, owner, base_meter):
+        result = _create(
+            household,
+            {
+                "entity_type": "meter_reading",
+                "fields": {"index_kwh": "45230", "meter": "compteur principal"},
+            },
+            user=owner,
+        )
+        # Should resolve via iexact lookup
+        assert MeterReading.objects.filter(household=household).count() == 1
+
+    def test_unknown_meter_name_returns_error(self, household, owner, base_meter):
+        result = _create(
+            household,
+            {
+                "entity_type": "meter_reading",
+                "fields": {"index_kwh": "45230", "meter": "compteur inconnu XYZ"},
+            },
+            user=owner,
+        )
+        assert MeterReading.objects.filter(household=household).count() == 0
+        assert "could not create meter_reading" in result.rendered
+
+
+# ===========================================================================
+# 4. list_entities / consumption — date filters and sum_amount
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestListConsumption:
+    """Listing consumption records with date, register, source, meter filters."""
+
+    def _make_record(self, household, meter, ts_start, energy_wh=1000, **kwargs):
+        return ConsumptionRecordFactory(
+            household=household,
+            meter=meter,
+            ts_start=ts_start,
+            energy_wh=energy_wh,
+            **kwargs,
+        )
+
+    def test_date_from_to_filters_june_only(self, household, owner, base_meter):
+        june_ts = _utc(2026, 6, 15)
+        july_ts = _utc(2026, 7, 10)
+        self._make_record(household, base_meter, june_ts, energy_wh=3000)
+        self._make_record(household, base_meter, july_ts, energy_wh=4000)
+
+        result = _list(
+            household,
+            {
+                "entity_type": "consumption",
+                "filters": {"date_from": "2026-06-01", "date_to": "2026-06-30"},
+            },
+        )
+        assert "total=1" in result.rendered
+        # sum should be 3 kWh (3000 Wh)
+        assert "sum_amount=3" in result.rendered
+
+    def test_sum_amount_exact_decimal(self, household, owner, base_meter):
+        """sum_amount = exact Decimal sum of kWh over the filtered set."""
+        self._make_record(household, base_meter, _utc(2026, 6, 1), energy_wh=1500)
+        self._make_record(household, base_meter, _utc(2026, 6, 2), energy_wh=2500)
+        self._make_record(household, base_meter, _utc(2026, 7, 1), energy_wh=9000)
+
+        result = _list(
+            household,
+            {
+                "entity_type": "consumption",
+                "filters": {"date_from": "2026-06-01", "date_to": "2026-06-30"},
+            },
+        )
+        # 1500 + 2500 = 4000 Wh = 4 kWh
+        assert "sum_amount=4" in result.rendered
+        assert "total=2" in result.rendered
+
+    def test_rendered_contains_sum_amount_label(self, household, owner, base_meter):
+        self._make_record(household, base_meter, _utc(2026, 6, 5), energy_wh=2000)
+        result = _list(household, {"entity_type": "consumption"})
+        assert "sum_amount=" in result.rendered
+
+    def test_filter_register(self, household, owner):
+        hphc = ElectricityMeterFactory(
+            household=household, tariff_type=MeterTariffType.HP_HC, created_by=owner
+        )
+        self._make_record(household, hphc, _utc(2026, 6, 1), register=EnergyRegister.HP, energy_wh=1000)
+        self._make_record(household, hphc, _utc(2026, 6, 2), register=EnergyRegister.HC, energy_wh=2000)
+
+        result = _list(household, {"entity_type": "consumption", "filters": {"register": "hp"}})
+        assert "total=1" in result.rendered
+
+    def test_filter_source_reading(self, household, owner, base_meter):
+        self._make_record(
+            household, base_meter, _utc(2026, 6, 1),
+            source=ConsumptionSource.READING, energy_wh=500,
+        )
+        self._make_record(
+            household, base_meter, _utc(2026, 6, 2),
+            source=ConsumptionSource.IMPORT, energy_wh=600,
+        )
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"source": "reading"}},
+        )
+        assert "total=1" in result.rendered
+
+    def test_filter_source_import(self, household, owner, base_meter):
+        self._make_record(
+            household, base_meter, _utc(2026, 6, 1),
+            source=ConsumptionSource.READING, energy_wh=500,
+        )
+        self._make_record(
+            household, base_meter, _utc(2026, 6, 2),
+            source=ConsumptionSource.IMPORT, energy_wh=600,
+        )
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"source": "import"}},
+        )
+        assert "total=1" in result.rendered
+
+    def test_filter_meter_by_name(self, household, owner, base_meter):
+        other = ElectricityMeterFactory(household=household, name="Other meter", created_by=owner)
+        self._make_record(household, base_meter, _utc(2026, 6, 1), energy_wh=1000)
+        self._make_record(household, other, _utc(2026, 6, 2), energy_wh=2000)
+
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"meter": base_meter.name}},
+        )
+        assert "total=1" in result.rendered
+
+    def test_cross_household_scoping(self, household, other_household, owner, base_meter):
+        other_meter = ElectricityMeterFactory(household=other_household, created_by=owner)
+        # Record in other household
+        self._make_record(other_household, other_meter, _utc(2026, 6, 1), energy_wh=9000)
+        # Record in our household
+        self._make_record(household, base_meter, _utc(2026, 6, 2), energy_wh=1000)
+
+        result = _list(household, {"entity_type": "consumption"})
+        assert "total=1" in result.rendered
+
+    def test_output_wrapped_in_household_data_delimiters(self, household, owner, base_meter):
+        self._make_record(household, base_meter, _utc(2026, 6, 1))
+        result = _list(household, {"entity_type": "consumption"})
+        assert result.rendered.startswith("<household_data>")
+        assert result.rendered.endswith("</household_data>")
+
+    def test_invalid_register_filter_is_recoverable(self, household, owner, base_meter):
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"register": "bogus"}},
+        )
+        assert "invalid value" in result.rendered
+
+    def test_invalid_source_filter_is_recoverable(self, household, owner, base_meter):
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"source": "unknown"}},
+        )
+        assert "invalid value" in result.rendered
+
+    def test_invalid_date_format_is_recoverable(self, household, owner, base_meter):
+        result = _list(
+            household,
+            {"entity_type": "consumption", "filters": {"date_from": "not-a-date"}},
+        )
+        assert "invalid value" in result.rendered
+
+
+# ===========================================================================
+# 5. list_entities / meter_reading
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestListMeterReading:
+    """Listing raw meter readings with describe output."""
+
+    def test_readings_listed_with_describe(self, household, owner, base_meter):
+        reading = MeterReadingFactory(
+            meter=base_meter,
+            household=household,
+            register=EnergyRegister.BASE,
+            index_kwh=Decimal("12345.678"),
+            reading_at=_utc(2026, 6, 15, 9, 30),
+            created_by=owner,
+        )
+        result = _list(household, {"entity_type": "meter_reading"})
+        assert "total=1" in result.rendered
+        # describe format: "YYYY-MM-DD HH:MM | register | index X kWh"
+        assert "base" in result.rendered
+        assert "12345" in result.rendered
+
+    def test_filter_meter_by_name(self, household, owner, base_meter):
+        other_meter = ElectricityMeterFactory(household=household, name="Meter B", created_by=owner)
+        MeterReadingFactory(
+            meter=base_meter, household=household, register=EnergyRegister.BASE,
+            index_kwh=Decimal("1000"), created_by=owner,
+        )
+        MeterReadingFactory(
+            meter=other_meter, household=household, register=EnergyRegister.BASE,
+            index_kwh=Decimal("2000"), created_by=owner,
+        )
+        result = _list(
+            household,
+            {"entity_type": "meter_reading", "filters": {"meter": base_meter.name}},
+        )
+        assert "total=1" in result.rendered
+
+    def test_filter_register(self, household, owner):
+        hphc = ElectricityMeterFactory(
+            household=household, tariff_type=MeterTariffType.HP_HC, created_by=owner
+        )
+        MeterReadingFactory(
+            meter=hphc, household=household, register=EnergyRegister.HP,
+            index_kwh=Decimal("5000"), created_by=owner,
+        )
+        MeterReadingFactory(
+            meter=hphc, household=household, register=EnergyRegister.HC,
+            index_kwh=Decimal("6000"), created_by=owner,
+        )
+        result = _list(
+            household,
+            {"entity_type": "meter_reading", "filters": {"register": "hp"}},
+        )
+        assert "total=1" in result.rendered
+
+    def test_cross_household_scoping(self, household, other_household, owner, base_meter):
+        other_meter = ElectricityMeterFactory(household=other_household, created_by=owner)
+        MeterReadingFactory(
+            meter=other_meter, household=other_household, register=EnergyRegister.BASE,
+            index_kwh=Decimal("99999"), created_by=owner,
+        )
+        result = _list(household, {"entity_type": "meter_reading"})
+        assert "total=0" in result.rendered
+
+    def test_empty_listing_message(self, household):
+        result = _list(household, {"entity_type": "meter_reading"})
+        assert "no items matched" in result.rendered
+
+
+# ===========================================================================
+# 6. SearchableSpec — 'meter' registered at boot
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestMeterSearchableSpec:
+    """Verify the SearchableSpec for 'meter' is registered at app startup."""
+
+    def test_meter_spec_registered(self):
+        spec = find_spec("meter")
+        assert spec is not None, "'meter' not found in searchable REGISTRY"
+        assert spec.entity_type == "meter"
+
+    def test_meter_spec_has_search_fields(self):
+        spec = find_spec("meter")
+        assert spec is not None
+        assert len(spec.search_fields) > 0
+
+    def test_meter_spec_has_url_template(self):
+        spec = find_spec("meter")
+        assert spec is not None
+        # url_template for meter points to the electricity section (no {id} needed for meter,
+        # but we just verify it is set and non-empty)
+        assert spec.url_template
+
+    def test_meter_instance_can_be_turned_into_hit(self, household, owner):
+        """hit_from_instance works on a real ElectricityMeter instance."""
+        from agent.retrieval import hit_from_instance
+        from agent.searchables import find_spec_for_instance
+
+        meter = ElectricityMeterFactory(household=household, name="Compteur test", created_by=owner)
+        spec = find_spec_for_instance(meter)
+        assert spec is not None, "find_spec_for_instance returned None for ElectricityMeter"
+        hit = hit_from_instance(spec, meter)
+        assert hit.entity_type == "meter"
+        assert str(meter.pk) in str(hit.id)
+        assert "Compteur test" in hit.label

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -4,8 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
 import { deleteTask, updateTask } from '@/lib/api/tasks';
 import { deleteInteraction, updateInteraction } from '@/lib/api/interactions';
+import { deleteMeterReading } from '@/lib/api/electricity';
 import { taskKeys } from '@/features/tasks/hooks';
 import { interactionKeys } from '@/features/interactions/hooks';
+import { electricityKeys } from '@/features/electricity/hooks';
 import {
   createConversation,
   deleteConversation,
@@ -137,6 +139,11 @@ const UNDO_HANDLERS: Record<
   note: {
     remove: (id) => deleteInteraction(id),
     keys: [interactionKeys.all as unknown as unknown[]],
+  },
+  meter_reading: {
+    // the DELETE regenerates the derived daily estimates server-side
+    remove: (id) => deleteMeterReading(id),
+    keys: [electricityKeys.all as unknown as unknown[]],
   },
 };
 


### PR DESCRIPTION
Closes #201 — Parcours 10, lot 4. Dernière brique de la V1 du parcours.

## Contenu

- **`apps/electricity/apps.py::ready()`** (nouveau) — tout par déclaration, zéro logique ajoutée dans `apps/agent/` :
  - `SearchableSpec('meter')` — le compteur est trouvable par la recherche standard
  - `ListableSpec('consumption')` avec `amount_of` en kWh → « combien a-t-on consommé en juin ? » répond via le `sum_amount` de `list_entities` (filtres meter/date_from/date_to/register/source)
  - `ListableSpec('meter_reading')` — relevés listables
  - `WritableSpec('meter_reading')` create-only → `services.create_meter_reading` : « j'ai relevé 45230 » crée le relevé avec les **mêmes validations et side-effects que le REST** (test anti-duplication inclus). Compteur résolu par nom/id, implicite si le foyer n'en a qu'un ; register déduit pour un tarif base, exigé en HP/HC avec message actionnable
- **`apps/agent/tools.py`** : extension des descriptions `create_entity`/`list_entities` (seule retouche prévue) + un fix de contrat : `ValueError` rejoint les erreurs récupérables de `create_entity` — l'indice « register requis » remonte au modèle au lieu d'un « unexpected error » silencieux
- **Undo** : entrée `meter_reading` dans `UNDO_HANDLERS` — le DELETE régénère les estimations côté serveur

## Limitation connue (documentée dans la description du tool)

Le `sum_amount` de `list_entities consumption` somme les records bruts : si relevés manuels **et** imports couvrent les mêmes jours, l'agent doit filtrer `source='import'` (la règle de priorité des sources ne s'applique que dans l'endpoint summary). La description du tool le dit explicitement.

## Tests

605 tests verts (`apps/electricity/` + `apps/agent/`), dont 32 nouveaux tests d'intégration (dispatch create/list, équivalence agent↔REST, erreurs récupérables, sommes kWh filtrées). Le fix d'url_template `{id}` fait passer le test de registry existant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)