### PR TITLE
feat(electricity): adaptateur enedis_xlsx — l'export énergie XLSX du portail Enedis s'importe directement

### DIFF
--- a/apps/electricity/importers/__init__.py
+++ b/apps/electricity/importers/__init__.py
@@ -4,6 +4,6 @@ The write path (upsert, dedup, audit trail) lives in ``electricity.services``;
 adapters only turn a source file into normalized points. Register new adapters
 in ``registry.py`` — no model or API change needed to support a new country.
 """
-from . import enedis_csv, generic_csv  # noqa: F401  (self-registration)
+from . import enedis_csv, enedis_xlsx, generic_csv  # noqa: F401  (self-registration)
 from .base import BaseImporter, ImporterError, ImporterFormatError, NormalizedPoint  # noqa: F401
 from .registry import detect_importer, get_importer, importer_choices  # noqa: F401

--- a/apps/electricity/importers/base.py
+++ b/apps/electricity/importers/base.py
@@ -15,6 +15,14 @@ class ImporterFormatError(ImporterError):
     """The file does not match the expected provider format."""
 
 
+def decode_text(raw: bytes) -> str:
+    """Decode a text-based consumption file: UTF-8 (BOM tolerated), latin-1 fallback."""
+    try:
+        return raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        return raw.decode("latin-1")
+
+
 @dataclass(frozen=True)
 class NormalizedPoint:
     """One consumption point in pivot shape — what every adapter produces."""
@@ -26,21 +34,27 @@ class NormalizedPoint:
 
 
 class BaseImporter(ABC):
-    """One provider format. ``parse`` must validate the WHOLE file before the
-    caller writes anything — a bad line raises ``ImporterError`` with its line
-    number, never a silent partial import."""
+    """One provider format — text (CSV) or binary (XLSX). ``parse`` must
+    validate the WHOLE file before the caller writes anything — a bad line
+    raises ``ImporterError`` with its line number, never a silent partial
+    import."""
 
     key: str
     label: str
 
     @abstractmethod
-    def detect(self, sample: str) -> bool:
-        """Cheap check on the first KBs of the file: is this my format?"""
+    def detect(self, raw: bytes) -> bool:
+        """Cheap check on the raw file bytes: is this my format?"""
 
     @abstractmethod
-    def parse(self, text: str, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
+    def parse(self, raw: bytes, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
         """Turn the full file into normalized points.
 
         ``tz`` is the meter timezone, used to localize naive timestamps.
         ``options`` carries user-provided mapping for configurable formats.
         """
+
+    def sample_lines(self, raw: bytes) -> list[str]:
+        """First lines for the import-dialog preview. Text default; binary
+        formats override to render rows."""
+        return decode_text(raw).lstrip("\ufeff").splitlines()[:10]

--- a/apps/electricity/importers/enedis_csv.py
+++ b/apps/electricity/importers/enedis_csv.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from .base import BaseImporter, ImporterError, ImporterFormatError, NormalizedPoint
+from .base import BaseImporter, ImporterError, ImporterFormatError, NormalizedPoint, decode_text
 from .registry import register
 
 DEFAULT_STEP_MINUTES = 30
@@ -34,12 +34,12 @@ class EnedisCsvImporter(BaseImporter):
     key = "enedis_csv"
     label = "Enedis — courbe de charge (CSV)"
 
-    def detect(self, sample: str) -> bool:
-        head = sample.lstrip("\ufeff").lower()
+    def detect(self, raw: bytes) -> bool:
+        head = decode_text(raw[:4096]).lstrip("\ufeff").lower()
         return "horodate" in head and ";" in head
 
-    def parse(self, text: str, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
-        lines = text.lstrip("\ufeff").splitlines()
+    def parse(self, raw: bytes, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
+        lines = decode_text(raw).lstrip("\ufeff").splitlines()
 
         # locate the Horodate;Valeur header — metadata lines may precede it
         data_start = None

--- a/apps/electricity/importers/enedis_xlsx.py
+++ b/apps/electricity/importers/enedis_xlsx.py
@@ -1,0 +1,168 @@
+"""Enedis XLSX energy export ("Export des données de l'énergie" from the
+client portal, e.g. ``…_Export_energie_Consommation_<dates>.xlsx``).
+
+Shape verified against a real household export: a cover sheet, then a data
+sheet named ``Export Consommation Quotidienne`` (or another ``Export …``
+variant) holding a header row ``Date | Valeur (en kWh)`` followed by one row
+per period. Daily rows carry the day's energy in kWh (interval = 24 h,
+``ts_start`` = local midnight); if the export ever carries finer timestamps,
+the step is inferred from consecutive rows. Dates come as ``DD/MM/YYYY``
+strings or real datetime cells depending on the export.
+"""
+from __future__ import annotations
+
+import io
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from .base import BaseImporter, ImporterError, ImporterFormatError, NormalizedPoint
+from .registry import register
+
+XLSX_MAGIC = b"PK\x03\x04"
+DAY_MINUTES = 24 * 60
+
+
+def _load_workbook(raw: bytes):
+    import openpyxl
+
+    try:
+        return openpyxl.load_workbook(io.BytesIO(raw), read_only=True, data_only=True)
+    except Exception as exc:  # zip/format errors from openpyxl are varied
+        raise ImporterFormatError(f"unreadable XLSX file: {exc}")
+
+
+def _find_data_sheet(workbook):
+    for name in workbook.sheetnames:
+        if name.strip().lower().startswith("export"):
+            return workbook[name]
+    raise ImporterFormatError("no 'Export …' data sheet found — not an Enedis energy export")
+
+
+def _parse_date_cell(value, line_no: int) -> date | datetime:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return value
+    text = str(value).strip()
+    for fmt in ("%d/%m/%Y %H:%M:%S", "%d/%m/%Y %H:%M", "%d/%m/%Y"):
+        try:
+            parsed = datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+        return parsed if fmt != "%d/%m/%Y" else parsed.date()
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        raise ImporterError(f"row {line_no}: unreadable date {text!r}")
+
+
+def _parse_value_cell(value, line_no: int) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text or text.upper() == "NA":
+        return None  # measurement gap
+    try:
+        return float(text.replace(",", "."))
+    except ValueError:
+        raise ImporterError(f"row {line_no}: unreadable value {text!r}")
+
+
+class EnedisXlsxImporter(BaseImporter):
+    key = "enedis_xlsx"
+    label = "Enedis — export énergie (XLSX)"
+
+    def detect(self, raw: bytes) -> bool:
+        if not raw.startswith(XLSX_MAGIC):
+            return False
+        try:
+            sheet = _find_data_sheet(_load_workbook(raw))
+            self._data_rows(sheet)  # requires the Date/Valeur header too
+            return True
+        except ImporterError:
+            return False
+
+    def parse(self, raw: bytes, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
+        sheet = _find_data_sheet(_load_workbook(raw))
+        rows = self._data_rows(sheet)
+
+        # first pass: timestamps + kWh values, gaps skipped
+        parsed: list[tuple[datetime, float]] = []
+        for line_no, date_cell, value_cell in rows:
+            value = _parse_value_cell(value_cell, line_no)
+            if value is None:
+                continue
+            if value < 0:
+                raise ImporterError(f"row {line_no}: negative value {value!r}")
+            moment = _parse_date_cell(date_cell, line_no)
+            if not isinstance(moment, datetime):
+                moment = datetime.combine(moment, datetime.min.time())
+            if moment.tzinfo is None:
+                moment = moment.replace(tzinfo=tz)
+            parsed.append((moment, value))
+
+        if not parsed:
+            return []
+
+        step = self._infer_step_minutes([moment for moment, _ in parsed])
+        return [
+            NormalizedPoint(
+                ts_start=moment,
+                interval_minutes=step,
+                energy_wh=int(round(value * 1000)),
+                register="base",
+            )
+            for moment, value in parsed
+        ]
+
+    def sample_lines(self, raw: bytes) -> list[str]:
+        try:
+            sheet = _find_data_sheet(_load_workbook(raw))
+        except ImporterError:
+            return []
+        return [f"{d} ; {v}" for _, d, v in self._data_rows(sheet)[:10]]
+
+    @staticmethod
+    def _data_rows(sheet) -> list[tuple[int, object, object]]:
+        """Locate the ``Date | Valeur`` header, return (row_no, date, value) rows."""
+        rows = []
+        header_cols: tuple[int, int] | None = None
+        for row_no, row in enumerate(sheet.iter_rows(values_only=True), start=1):
+            cells = [str(c).strip() if c is not None else "" for c in row]
+            if header_cols is None:
+                lowered = [c.lower() for c in cells]
+                if "date" in lowered and any(c.startswith("valeur") for c in lowered):
+                    date_idx = lowered.index("date")
+                    value_idx = next(i for i, c in enumerate(lowered) if c.startswith("valeur"))
+                    header_cols = (date_idx, value_idx)
+                continue
+            date_cell, value_cell = row[header_cols[0]], row[header_cols[1]]
+            if date_cell is None and value_cell is None:
+                continue
+            if date_cell is None:
+                continue
+            rows.append((row_no, date_cell, value_cell))
+        if header_cols is None:
+            raise ImporterFormatError(
+                "no 'Date / Valeur' header found — not an Enedis energy export"
+            )
+        return rows
+
+    @staticmethod
+    def _infer_step_minutes(timestamps: list[datetime]) -> int:
+        if len(timestamps) < 2:
+            return DAY_MINUTES
+        gaps: dict[int, int] = {}
+        for a, b in zip(timestamps, timestamps[1:]):
+            minutes = int((b - a).total_seconds() // 60)
+            if minutes > 0:
+                gaps[minutes] = gaps.get(minutes, 0) + 1
+        if not gaps:
+            return DAY_MINUTES
+        # cap at one day: daily exports separated by DST days must not drift
+        return min(max(gaps, key=gaps.get), DAY_MINUTES)
+
+
+register(EnedisXlsxImporter())

--- a/apps/electricity/importers/generic_csv.py
+++ b/apps/electricity/importers/generic_csv.py
@@ -17,7 +17,7 @@ import io
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from .base import BaseImporter, ImporterError, NormalizedPoint
+from .base import BaseImporter, ImporterError, NormalizedPoint, decode_text
 from .registry import register
 
 UNITS = ("wh", "kwh", "w_avg")
@@ -35,10 +35,10 @@ class GenericCsvImporter(BaseImporter):
     key = "generic_csv"
     label = "CSV générique (mapping manuel)"
 
-    def detect(self, sample: str) -> bool:
+    def detect(self, raw: bytes) -> bool:
         return False  # never auto-detected — requires explicit user mapping
 
-    def parse(self, text: str, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
+    def parse(self, raw: bytes, *, tz: ZoneInfo, options: dict | None = None) -> list[NormalizedPoint]:
         options = options or {}
         ts_col = options.get("timestamp_column")
         value_col = options.get("value_column")
@@ -61,7 +61,7 @@ class GenericCsvImporter(BaseImporter):
         if position not in ("start", "end"):
             raise ImporterError("timestamp_position must be 'start' or 'end'")
 
-        body = text.lstrip("\ufeff")
+        body = decode_text(raw).lstrip("\ufeff")
         delimiter = options.get("delimiter") or _sniff_delimiter(body)
         reader = csv.DictReader(io.StringIO(body), delimiter=delimiter)
         if reader.fieldnames is None:

--- a/apps/electricity/importers/registry.py
+++ b/apps/electricity/importers/registry.py
@@ -20,10 +20,10 @@ def importer_choices() -> list[tuple[str, str]]:
     return [(imp.key, imp.label) for imp in REGISTRY.values()]
 
 
-def detect_importer(sample: str) -> BaseImporter | None:
-    """First importer whose ``detect`` recognizes the sample (generic_csv never
+def detect_importer(raw: bytes) -> BaseImporter | None:
+    """First importer whose ``detect`` recognizes the file (generic_csv never
     self-detects: it requires explicit user mapping)."""
     for importer in REGISTRY.values():
-        if importer.detect(sample):
+        if importer.detect(raw):
             return importer
     return None

--- a/apps/electricity/services.py
+++ b/apps/electricity/services.py
@@ -259,14 +259,6 @@ def consumption_summary(household, meter: ElectricityMeter, *, granularity: str,
 # --- imports --------------------------------------------------------------------
 
 
-def decode_uploaded_file(raw: bytes) -> str:
-    """Decode a consumption file: UTF-8 (BOM tolerated), latin-1 fallback."""
-    try:
-        return raw.decode("utf-8-sig")
-    except UnicodeDecodeError:
-        return raw.decode("latin-1")
-
-
 def import_consumption_file(household, user, *, meter, uploaded_file, provider=None, options=None):
     """Import a consumption file onto ``meter`` — idempotent by design.
 
@@ -280,14 +272,14 @@ def import_consumption_file(household, user, *, meter, uploaded_file, provider=N
     from .models import ConsumptionImport, ImportStatus
 
     filename = getattr(uploaded_file, "name", "") or ""
-    text = decode_uploaded_file(uploaded_file.read())
+    raw = uploaded_file.read()
 
     if provider:
         importer = importers.get_importer(provider)
         if importer is None:
             raise importers.ImporterError(f"unknown provider: {provider}")
     else:
-        importer = importers.detect_importer(text[:4096])
+        importer = importers.detect_importer(raw)
         if importer is None:
             return ConsumptionImport.objects.create(
                 household=household,
@@ -301,7 +293,7 @@ def import_consumption_file(household, user, *, meter, uploaded_file, provider=N
             )
 
     try:
-        points = importer.parse(text, tz=meter_tz(meter), options=options)
+        points = importer.parse(raw, tz=meter_tz(meter), options=options)
     except importers.ImporterError as exc:
         return ConsumptionImport.objects.create(
             household=household,
@@ -359,10 +351,13 @@ def import_consumption_file(household, user, *, meter, uploaded_file, provider=N
 def preview_consumption_file(raw: bytes) -> dict:
     """Cheap preview for the import dialog: detected provider + first lines."""
     from . import importers
+    from .importers.base import decode_text
 
-    text = decode_uploaded_file(raw)
-    sample_lines = text.lstrip("\ufeff").splitlines()[:10]
-    importer = importers.detect_importer(text[:4096])
+    importer = importers.detect_importer(raw)
+    if importer is not None:
+        sample_lines = importer.sample_lines(raw)
+    else:
+        sample_lines = decode_text(raw).lstrip("\ufeff").splitlines()[:10]
     first_line = sample_lines[0] if sample_lines else ""
     delimiter = next((d for d in (";", ",", "\t") if d in first_line), ";")
     return {

--- a/apps/electricity/tests/test_importer_enedis_xlsx.py
+++ b/apps/electricity/tests/test_importer_enedis_xlsx.py
@@ -1,0 +1,131 @@
+"""Enedis XLSX importer — structure mirrored from a real household export."""
+import datetime as dt
+import io
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from electricity import services
+from electricity.importers import detect_importer
+from electricity.importers.base import ImporterError
+from electricity.importers.enedis_xlsx import EnedisXlsxImporter
+from electricity.models import ConsumptionRecord, ImportStatus
+from electricity.tests.factories import ElectricityMeterFactory, HouseholdFactory, UserFactory
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+def build_xlsx(rows, *, sheet_title="Export Consommation Quotidienne", header=("Date", "Valeur (en kWh)")):
+    """Build an in-memory workbook shaped like the real portal export: a cover
+    sheet, then the data sheet with metadata lines above the header row."""
+    import openpyxl
+
+    workbook = openpyxl.Workbook()
+    workbook.active.title = "Page d'accueil"
+    workbook.active.cell(row=6, column=2, value="Les données de ce fichier sont…")
+    sheet = workbook.create_sheet(sheet_title)
+    sheet.cell(row=8, column=2, value="Point Référence Mesure (PRM) :")
+    sheet.cell(row=8, column=3, value="09000000000000")
+    sheet.cell(row=14, column=2, value=header[0])
+    sheet.cell(row=14, column=3, value=header[1])
+    for i, (day, value) in enumerate(rows, start=15):
+        sheet.cell(row=i, column=2, value=day)
+        sheet.cell(row=i, column=3, value=value)
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()
+
+
+DAILY_ROWS = [("05/06/2026", "15.064"), ("06/06/2026", "12.485"), ("07/06/2026", "12.406")]
+
+
+class TestParse:
+    def test_daily_export_parses_to_local_midnight_day_points(self):
+        importer = EnedisXlsxImporter()
+        points = importer.parse(build_xlsx(DAILY_ROWS), tz=PARIS)
+        assert len(points) == 3
+        first = points[0]
+        assert first.ts_start == dt.datetime(2026, 6, 5, 0, 0, tzinfo=PARIS)
+        assert first.interval_minutes == 1440
+        assert first.energy_wh == 15064
+        assert first.register == "base"
+        assert sum(p.energy_wh for p in points) == 15064 + 12485 + 12406
+
+    def test_detected_automatically_and_before_csv(self):
+        raw = build_xlsx(DAILY_ROWS)
+        importer = detect_importer(raw)
+        assert importer is not None and importer.key == "enedis_xlsx"
+
+    def test_gap_rows_and_na_skipped(self):
+        rows = [("05/06/2026", "1.0"), ("06/06/2026", None), ("07/06/2026", "NA"), ("08/06/2026", "2.0")]
+        points = EnedisXlsxImporter().parse(build_xlsx(rows), tz=PARIS)
+        assert [p.energy_wh for p in points] == [1000, 2000]
+
+    def test_numeric_and_datetime_cells_supported(self):
+        rows = [(dt.datetime(2026, 6, 5), 15.064), (dt.datetime(2026, 6, 6), 12.485)]
+        points = EnedisXlsxImporter().parse(build_xlsx(rows), tz=PARIS)
+        assert points[0].ts_start == dt.datetime(2026, 6, 5, 0, 0, tzinfo=PARIS)
+        assert points[0].energy_wh == 15064
+
+    def test_unreadable_value_fails_with_row_number(self):
+        rows = [("05/06/2026", "1.0"), ("06/06/2026", "abc")]
+        with pytest.raises(ImporterError, match="row 16"):
+            EnedisXlsxImporter().parse(build_xlsx(rows), tz=PARIS)
+
+    def test_missing_header_is_format_error(self):
+        raw = build_xlsx([], header=("Foo", "Bar"))
+        with pytest.raises(ImporterError, match="Date / Valeur"):
+            EnedisXlsxImporter().parse(raw, tz=PARIS)
+        assert EnedisXlsxImporter().detect(raw) is False
+
+    def test_non_xlsx_bytes_not_detected(self):
+        assert EnedisXlsxImporter().detect(b"Horodate;Valeur\n2026-06-01T00:30:00+02:00;420\n") is False
+
+    def test_sample_lines_render_rows(self):
+        lines = EnedisXlsxImporter().sample_lines(build_xlsx(DAILY_ROWS))
+        assert lines[0] == "05/06/2026 ; 15.064"
+
+
+@pytest.mark.django_db
+class TestServiceIntegration:
+    def test_import_via_service_is_idempotent(self):
+        household, user = HouseholdFactory(), UserFactory()
+        meter = ElectricityMeterFactory(household=household, timezone="Europe/Paris")
+        upload = io.BytesIO(build_xlsx(DAILY_ROWS))
+        upload.name = "export.xlsx"
+        imported = services.import_consumption_file(household, user, meter=meter, uploaded_file=upload)
+        assert imported.status == ImportStatus.COMPLETED
+        assert imported.provider == "enedis_xlsx"
+        assert imported.created_count == 3
+        assert ConsumptionRecord.objects.filter(meter=meter).count() == 3
+
+        upload2 = io.BytesIO(build_xlsx(DAILY_ROWS))
+        upload2.name = "export.xlsx"
+        again = services.import_consumption_file(household, user, meter=meter, uploaded_file=upload2)
+        assert again.created_count == 0
+        assert again.skipped_count == 3
+
+    def test_daily_points_visible_in_day_view_but_not_hour_view(self):
+        household, user = HouseholdFactory(), UserFactory()
+        meter = ElectricityMeterFactory(household=household, timezone="Europe/Paris")
+        upload = io.BytesIO(build_xlsx(DAILY_ROWS))
+        upload.name = "export.xlsx"
+        services.import_consumption_file(household, user, meter=meter, uploaded_file=upload)
+
+        day = services.consumption_summary(
+            household, meter, granularity="day",
+            date_from=dt.date(2026, 6, 5), date_to=dt.date(2026, 6, 7),
+        )
+        assert day["total_wh"] == 15064 + 12485 + 12406
+        assert day["estimated_wh"] == 0
+
+        hour = services.consumption_summary(
+            household, meter, granularity="hour",
+            date_from=dt.date(2026, 6, 5), date_to=dt.date(2026, 6, 7),
+        )
+        assert hour["total_wh"] == 0
+
+    def test_preview_detects_xlsx(self):
+        preview = services.preview_consumption_file(build_xlsx(DAILY_ROWS))
+        assert preview["detected_provider"] == "enedis_xlsx"
+        assert preview["sample_lines"][0].startswith("05/06/2026")

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,7 @@ gunicorn==21.2.0
 inflection==0.5.1
 jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
+openpyxl==3.1.5
 packaging==26.0
 pillow==12.1.1
 pillow-heif==0.18.0

--- a/ui/src/features/electricity/ImportDialog.tsx
+++ b/ui/src/features/electricity/ImportDialog.tsx
@@ -116,7 +116,7 @@ export default function ImportDialog({ open, onOpenChange, meter }: ImportDialog
     <SheetDialog open={open} onOpenChange={onOpenChange} title={t('electricity.import.title')}>
       <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
         <FormField label={t('electricity.import.file')} htmlFor="import-file">
-          <Input id="import-file" type="file" accept=".csv,text/csv" onChange={(e) => void handleFileChange(e)} />
+          <Input id="import-file" type="file" accept=".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" onChange={(e) => void handleFileChange(e)} />
         </FormField>
 
         {preview?.detected_provider && !useGeneric ? (

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -264,7 +264,8 @@
       "previewFailed": "Datei konnte nicht gelesen werden.",
       "provider": {
         "enedis_csv": "Enedis — Lastgang (CSV)",
-        "generic_csv": "Generisches CSV"
+        "generic_csv": "Generisches CSV",
+        "enedis_xlsx": "Enedis — Energie-Export (XLSX)"
       }
     }
   },

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -264,7 +264,8 @@
       "previewFailed": "Could not read the file.",
       "provider": {
         "enedis_csv": "Enedis — load curve (CSV)",
-        "generic_csv": "Generic CSV"
+        "generic_csv": "Generic CSV",
+        "enedis_xlsx": "Enedis — energy export (XLSX)"
       }
     }
   },

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -264,7 +264,8 @@
       "previewFailed": "No se pudo leer el archivo.",
       "provider": {
         "enedis_csv": "Enedis — curva de carga (CSV)",
-        "generic_csv": "CSV genérico"
+        "generic_csv": "CSV genérico",
+        "enedis_xlsx": "Enedis — exportación de energía (XLSX)"
       }
     }
   },

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -264,7 +264,8 @@
       "previewFailed": "Impossible de lire le fichier.",
       "provider": {
         "enedis_csv": "Enedis — courbe de charge (CSV)",
-        "generic_csv": "CSV générique"
+        "generic_csv": "CSV générique",
+        "enedis_xlsx": "Enedis — export énergie (XLSX)"
       }
     }
   },


### PR DESCRIPTION
Suite de #199 (parcours 10). L'export réellement téléchargeable depuis le portail Enedis du foyer est un **XLSX** (« Consommation Quotidienne », un kWh par jour), pas le CSV courbe de charge : cette PR le rend importable directement, sans conversion manuelle.

## Contenu

- **Contrat importers généralisé en bytes** : `detect(raw)`/`parse(raw)` reçoivent le fichier brut (les formats binaires deviennent possibles), `decode_text` mutualisé dans `base.py`, `sample_lines(raw)` devient un hook par adaptateur pour la preview du dialog — les adaptateurs CSV décodent eux-mêmes.
- **`enedis_xlsx`** : feuille `Export Consommation Quotidienne` (ou variante `Export …`), header `Date | Valeur (en kWh)`, dates `DD/MM/YYYY` ou cellules datetime, trous `NA` ignorés, erreurs avec numéro de ligne. Points quotidiens `ts_start` = minuit local du compteur, pas inféré depuis les lignes et plafonné à 24 h. Détection stricte (magic bytes + feuille + header).
- **Validé sur le fichier réel du foyer** : `09243560041696_Export_energie_Consommation_05062026-04072026.xlsx` → détection auto, 30 points quotidiens du 05/06 au 04/07, total 322,379 kWh, ré-import = 0 création.
- `openpyxl==3.1.5` entre dans `requirements/base.txt` ; `ImportDialog` accepte `.xlsx` ; libellé provider i18n ×4.

Comme c'est du quotidien (pas 1440 min), ces données alimentent les vues **jour/mois/année** en données réelles (elles priment sur les estimations de relevés) et restent exclues de la vue heure — qui attend la courbe de charge 30 min (activation nécessaire côté Enedis).

## Tests

616 tests verts (`apps/electricity/` + `apps/agent/`), dont 12 nouveaux (parsing, détection stricte, cellules datetime/numériques, idempotence via le service, règles de vues jour/heure, preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)