### PR TITLE
feat(trackers): frontend /app/trackers + onglet projet (lots 3+4)

### DIFF
--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 import {
   LayoutDashboard, ListTodo, FolderKanban, Wrench, Box,
   Zap, MapPin, Users, FileText, Image, Notebook, User,
-  ShieldCheck, X, AlertCircle, Sparkles, Receipt, Umbrella, Activity,
+  ShieldCheck, X, AlertCircle, Sparkles, Receipt, Umbrella, Activity, TrendingUp,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/lib/auth/useAuth';
@@ -35,6 +35,7 @@ const NAV_GROUPS = [
       { to: '/app/tasks',        labelKey: 'tasks.title',        Icon: ListTodo     },
       { to: '/app/projects',     labelKey: 'projects.title',     Icon: FolderKanban },
       { to: '/app/interactions', labelKey: 'interactions.title', Icon: Notebook     },
+      { to: '/app/trackers',     labelKey: 'trackers.title',     Icon: TrendingUp   },
       { to: '/app/expenses',     labelKey: 'expenses.title',     Icon: Receipt      },
     ],
   },

--- a/ui/src/components/Sparkline.tsx
+++ b/ui/src/components/Sparkline.tsx
@@ -1,0 +1,70 @@
+interface SparklinePoint {
+  /** ISO timestamp — x is proportional to time (irregular readings stay honest). */
+  t: string;
+  v: number;
+}
+
+interface SparklineProps {
+  points: SparklinePoint[];
+  width?: number;
+  height?: number;
+  strokeWidth?: number;
+  showLastDot?: boolean;
+  className?: string;
+}
+
+/**
+ * Tiny dependency-free SVG sparkline. Stroke follows `currentColor`, so the
+ * parent's text color drives the line color.
+ */
+export default function Sparkline({
+  points,
+  width = 120,
+  height = 36,
+  strokeWidth = 1.5,
+  showLastDot = true,
+  className,
+}: SparklineProps) {
+  if (points.length === 0) return null;
+
+  const pad = strokeWidth + 2;
+  const times = points.map((p) => new Date(p.t).getTime());
+  const values = points.map((p) => p.v);
+  const tMin = Math.min(...times);
+  const tMax = Math.max(...times);
+  const vMin = Math.min(...values);
+  const vMax = Math.max(...values);
+  const tSpan = tMax - tMin || 1;
+  const vSpan = vMax - vMin || 1;
+
+  const coords = points.map((p, i) => {
+    const x = pad + ((times[i] - tMin) / tSpan) * (width - 2 * pad);
+    const y = height - pad - ((p.v - vMin) / vSpan) * (height - 2 * pad);
+    return [x, y] as const;
+  });
+  const last = coords[coords.length - 1];
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      aria-hidden
+    >
+      {coords.length > 1 ? (
+        <polyline
+          points={coords.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' ')}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ) : null}
+      {showLastDot ? (
+        <circle cx={last[0]} cy={last[1]} r={strokeWidth + 1} fill="currentColor" />
+      ) : null}
+    </svg>
+  );
+}

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -12,6 +12,7 @@ import BackLink from '@/components/BackLink';
 import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import type { ProjectStatus } from '@/lib/api/projects';
 import TasksPanel from '@/features/tasks/TasksPanel';
+import TrackersPanel from '@/features/trackers/TrackersPanel';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 import { taskKeys, useHouseholdMembersWithMe } from '@/features/tasks/hooks';
 import {
@@ -30,8 +31,8 @@ import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Helpers ────────────────────────────────────────────────
 
-type Tab = 'overview' | 'tasks' | 'notes' | 'expenses' | 'documents' | 'timeline' | 'assistant';
-const TABS: Tab[] = ['overview', 'tasks', 'notes', 'expenses', 'documents', 'timeline', 'assistant'];
+type Tab = 'overview' | 'tasks' | 'trackers' | 'notes' | 'expenses' | 'documents' | 'timeline' | 'assistant';
+const TABS: Tab[] = ['overview', 'tasks', 'trackers', 'notes', 'expenses', 'documents', 'timeline', 'assistant'];
 
 function statusVariant(status: ProjectStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
   if (status === 'active') return 'default';
@@ -308,6 +309,13 @@ export default function ProjectDetailPage() {
                   <TasksPanel
                     projectId={project.id}
                     stateKeyPrefix={`project.${project.id}`}
+                  />
+                ) : null}
+
+                {tab === 'trackers' ? (
+                  <TrackersPanel
+                    projectId={project.id}
+                    stateKeyPrefix={`project.${project.id}.trackers`}
                   />
                 ) : null}
 

--- a/ui/src/features/trackers/EntryDialog.tsx
+++ b/ui/src/features/trackers/EntryDialog.tsx
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { formatTrackerValue, type Tracker, type TrackerEntry } from '@/lib/api/trackers';
+import { useCreateEntry, useUpdateEntry } from './hooks';
+
+function toLocalInputValue(iso: string): string {
+  const date = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+interface EntryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tracker: Tracker;
+  existing?: TrackerEntry;
+}
+
+export default function EntryDialog({ open, onOpenChange, tracker, existing }: EntryDialogProps) {
+  const { t } = useTranslation();
+  const isEditing = Boolean(existing);
+
+  const [value, setValue] = React.useState('');
+  const [occurredAt, setOccurredAt] = React.useState('');
+  const [note, setNote] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createEntry = useCreateEntry();
+  const updateEntry = useUpdateEntry();
+  const isPending = createEntry.isPending || updateEntry.isPending;
+
+  React.useEffect(() => {
+    if (!open) return;
+    if (existing) {
+      setValue(formatTrackerValue(existing.value));
+      setOccurredAt(toLocalInputValue(existing.occurred_at));
+      setNote(existing.note);
+    } else {
+      setValue('');
+      setOccurredAt(toLocalInputValue(new Date().toISOString()));
+      setNote('');
+    }
+    setError(null);
+  }, [open, existing]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const normalized = value.trim().replace(',', '.');
+    if (!normalized || Number.isNaN(Number(normalized)) || !occurredAt) {
+      setError(t('trackers.valueRequired'));
+      return;
+    }
+
+    const payload = {
+      value: normalized,
+      occurred_at: new Date(occurredAt).toISOString(),
+      note: note.trim(),
+    };
+
+    try {
+      if (isEditing && existing) {
+        await updateEntry.mutateAsync({ id: existing.id, payload });
+      } else {
+        await createEntry.mutateAsync({ tracker: tracker.id, ...payload });
+      }
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const data = (err as { response?: { data?: Record<string, string[]> } })?.response?.data;
+      const first = data ? Object.values(data).flat()[0] : null;
+      setError(typeof first === 'string' ? first : t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <SheetDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEditing ? t('trackers.entryEditTitle') : t('trackers.entryNewTitle')}
+      size="s"
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <div className="grid grid-cols-2 gap-3">
+          <FormField
+            label={
+              tracker.unit
+                ? `${t('trackers.fieldValue')} (${tracker.unit})`
+                : t('trackers.fieldValue')
+            }
+            htmlFor="entry-value"
+          >
+            <Input
+              id="entry-value"
+              type="text"
+              inputMode="decimal"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              required
+              autoFocus
+            />
+          </FormField>
+          <FormField label={t('trackers.fieldDate')} htmlFor="entry-occurred-at">
+            <Input
+              id="entry-occurred-at"
+              type="datetime-local"
+              value={occurredAt}
+              onChange={(e) => setOccurredAt(e.target.value)}
+              required
+            />
+          </FormField>
+        </div>
+
+        <FormField label={t('trackers.fieldNote')} htmlFor="entry-note">
+          <Input
+            id="entry-note"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            maxLength={500}
+          />
+        </FormField>
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isEditing ? t('common.save') : t('common.add')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/trackers/TrackerCard.tsx
+++ b/ui/src/features/trackers/TrackerCard.tsx
@@ -1,0 +1,191 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
+import { Check, FolderKanban, Link2, Pencil, Plus, Trash2 } from 'lucide-react';
+
+import CardActions, { type CardAction } from '@/components/CardActions';
+import Sparkline from '@/components/Sparkline';
+import { Card, CardTitle } from '@/design-system/card';
+import { Input } from '@/design-system/input';
+import { formatTrackerValue, type Tracker } from '@/lib/api/trackers';
+import { pushBack } from '@/lib/backNavigation';
+
+interface TrackerCardProps {
+  tracker: Tracker;
+  onEdit: (tracker: Tracker) => void;
+  onDelete: (trackerId: string) => void;
+  onQuickAdd: (tracker: Tracker, value: string) => Promise<void>;
+}
+
+function formatRelativeFrom(iso: string | null, locale?: string): string | null {
+  if (!iso) return null;
+  const diffMs = new Date(iso).getTime() - Date.now();
+  const days = Math.round(diffMs / 86_400_000);
+  const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+  if (Math.abs(days) >= 30) return rtf.format(Math.round(days / 30), 'month');
+  if (Math.abs(days) >= 1) return rtf.format(days, 'day');
+  const hours = Math.round(diffMs / 3_600_000);
+  if (Math.abs(hours) >= 1) return rtf.format(hours, 'hour');
+  return rtf.format(Math.round(diffMs / 60_000), 'minute');
+}
+
+export default function TrackerCard({ tracker, onEdit, onDelete, onQuickAdd }: TrackerCardProps) {
+  const { t, i18n } = useTranslation();
+  const location = useLocation();
+  const [quickAddOpen, setQuickAddOpen] = React.useState(false);
+  const [quickValue, setQuickValue] = React.useState('');
+  const [saving, setSaving] = React.useState(false);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const relative = formatRelativeFrom(tracker.last_entry_at, i18n.language);
+  const sparkPoints = tracker.sparkline.map((p) => ({
+    t: p.occurred_at,
+    v: Number(p.value),
+  }));
+
+  const actions: CardAction[] = [
+    { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(tracker) },
+    {
+      label: t('common.delete'),
+      icon: Trash2,
+      onClick: () => onDelete(tracker.id),
+      variant: 'danger',
+    },
+  ];
+
+  const openQuickAdd = () => {
+    setQuickValue(tracker.last_value ? formatTrackerValue(tracker.last_value) : '');
+    setQuickAddOpen(true);
+    requestAnimationFrame(() => inputRef.current?.select());
+  };
+
+  const submitQuickAdd = async () => {
+    const value = quickValue.trim().replace(',', '.');
+    if (!value || Number.isNaN(Number(value))) return;
+    setSaving(true);
+    try {
+      await onQuickAdd(tracker, value);
+      setQuickAddOpen(false);
+      setQuickValue('');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0 flex-1">
+          <Link
+            to={`/app/trackers/${tracker.id}`}
+            state={pushBack(location)}
+            className="group text-foreground hover:text-primary"
+          >
+            <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">
+              {`${tracker.emoji ? `${tracker.emoji} ` : ''}${tracker.name}`}
+            </CardTitle>
+          </Link>
+
+          <div className="mt-1 flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+            {tracker.last_value != null ? (
+              <>
+                <span className="text-lg font-semibold text-foreground">
+                  {formatTrackerValue(tracker.last_value)}
+                  {tracker.unit ? (
+                    <span className="ml-1 text-xs font-normal text-muted-foreground">
+                      {tracker.unit}
+                    </span>
+                  ) : null}
+                </span>
+                {relative ? (
+                  <span className="text-xs text-muted-foreground">{relative}</span>
+                ) : null}
+              </>
+            ) : (
+              <span className="text-xs text-muted-foreground">{t('trackers.noEntries')}</span>
+            )}
+          </div>
+
+          <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+            {tracker.project && tracker.project_title ? (
+              <Link
+                to={`/app/projects/${tracker.project}`}
+                state={pushBack(location)}
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+              >
+                <FolderKanban className="h-3 w-3" />
+                {tracker.project_title}
+              </Link>
+            ) : null}
+            {tracker.target_url && tracker.target_label ? (
+              <Link
+                to={tracker.target_url}
+                state={pushBack(location)}
+                className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+              >
+                <Link2 className="h-3 w-3" />
+                {tracker.target_label}
+              </Link>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-shrink-0 flex-col items-end gap-1">
+          <CardActions actions={actions} />
+          {sparkPoints.length > 0 ? (
+            <span className="text-primary/70">
+              <Sparkline points={sparkPoints} width={96} height={28} />
+            </span>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="mt-2">
+        {quickAddOpen ? (
+          <form
+            className="flex items-center gap-1.5"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void submitQuickAdd();
+            }}
+          >
+            <Input
+              ref={inputRef}
+              type="text"
+              inputMode="decimal"
+              value={quickValue}
+              onChange={(e) => setQuickValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Escape') setQuickAddOpen(false);
+              }}
+              placeholder={t('trackers.quickAddPlaceholder')}
+              className="h-8 flex-1 text-sm"
+              disabled={saving}
+              autoFocus
+            />
+            {tracker.unit ? (
+              <span className="text-xs text-muted-foreground">{tracker.unit}</span>
+            ) : null}
+            <button
+              type="submit"
+              disabled={saving}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground disabled:opacity-50"
+              aria-label={t('trackers.addValue')}
+            >
+              <Check className="h-4 w-4" />
+            </button>
+          </form>
+        ) : (
+          <button
+            type="button"
+            onClick={openQuickAdd}
+            className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:border-primary hover:text-primary"
+          >
+            <Plus className="h-3 w-3" />
+            {t('trackers.addValue')}
+          </button>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/features/trackers/TrackerDetailPage.tsx
+++ b/ui/src/features/trackers/TrackerDetailPage.tsx
@@ -1,0 +1,246 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { FolderKanban, Link2, Pencil, Plus, Trash2 } from 'lucide-react';
+
+import BackLink from '@/components/BackLink';
+import CardActions, { type CardAction } from '@/components/CardActions';
+import PageHeader from '@/components/PageHeader';
+import Sparkline from '@/components/Sparkline';
+import { Button } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import {
+  formatTrackerValue,
+  type Tracker,
+  type TrackerEntry,
+} from '@/lib/api/trackers';
+import { pushBack } from '@/lib/backNavigation';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import EntryDialog from './EntryDialog';
+import TrackerDialog from './TrackerDialog';
+import { useDeleteEntry, useTracker, useTrackerEntries } from './hooks';
+
+function formatEntryDate(iso: string, locale?: string): string {
+  return new Intl.DateTimeFormat(locale, { dateStyle: 'medium', timeStyle: 'short' }).format(
+    new Date(iso),
+  );
+}
+
+function EntryRow({
+  entry,
+  previous,
+  tracker,
+  onEdit,
+  onDelete,
+}: {
+  entry: TrackerEntry;
+  previous: TrackerEntry | null;
+  tracker: Tracker;
+  onEdit: (entry: TrackerEntry) => void;
+  onDelete: (entryId: string) => void;
+}) {
+  const { t, i18n } = useTranslation();
+
+  const delta = previous != null ? Number(entry.value) - Number(previous.value) : null;
+  const deltaText =
+    delta != null && !Number.isNaN(delta)
+      ? `${delta >= 0 ? '+' : ''}${Number(delta.toFixed(3))}`
+      : null;
+
+  const actions: CardAction[] = [
+    { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(entry) },
+    {
+      label: t('common.delete'),
+      icon: Trash2,
+      onClick: () => onDelete(entry.id),
+      variant: 'danger',
+    },
+  ];
+
+  return (
+    <div className="flex items-start justify-between gap-2 border-b border-border py-2 last:border-b-0">
+      <div className="min-w-0 flex-1">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span className="text-sm font-semibold text-foreground">
+            {formatTrackerValue(entry.value)}
+            {tracker.unit ? (
+              <span className="ml-1 text-xs font-normal text-muted-foreground">
+                {tracker.unit}
+              </span>
+            ) : null}
+          </span>
+          {deltaText ? (
+            <span className="text-xs text-muted-foreground">({deltaText})</span>
+          ) : null}
+          <span className="text-xs text-muted-foreground">
+            {formatEntryDate(entry.occurred_at, i18n.language)}
+          </span>
+        </div>
+        {entry.note ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">{entry.note}</p>
+        ) : null}
+      </div>
+      <CardActions actions={actions} />
+    </div>
+  );
+}
+
+export default function TrackerDetailPage() {
+  const { id = '' } = useParams();
+  const { t } = useTranslation();
+  const location = useLocation();
+
+  const { data: tracker, isLoading, isError } = useTracker(id);
+  const { data: entries } = useTrackerEntries(id);
+  const showSkeleton = useDelayedLoading(isLoading);
+  const deleteEntry = useDeleteEntry();
+
+  const [editOpen, setEditOpen] = React.useState(false);
+  const [entryDialogOpen, setEntryDialogOpen] = React.useState(false);
+  const [editingEntry, setEditingEntry] = React.useState<TrackerEntry | undefined>(undefined);
+  const [hiddenEntryIds, setHiddenEntryIds] = React.useState<Set<string>>(new Set());
+
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('trackers.entryDeleted'),
+    onDelete: (entryId) => deleteEntry.mutateAsync(entryId).then(() => undefined),
+  });
+
+  const handleDeleteEntry = (entryId: string) => {
+    deleteWithUndo(entryId, {
+      onRemove: () => setHiddenEntryIds((prev) => new Set(prev).add(entryId)),
+      onRestore: () =>
+        setHiddenEntryIds((prev) => {
+          const next = new Set(prev);
+          next.delete(entryId);
+          return next;
+        }),
+    });
+  };
+
+  const openNewEntry = () => {
+    setEditingEntry(undefined);
+    setEntryDialogOpen(true);
+  };
+
+  const openEditEntry = (entry: TrackerEntry) => {
+    setEditingEntry(entry);
+    setEntryDialogOpen(true);
+  };
+
+  // Entries arrive newest-first; hide optimistically-deleted ones.
+  const visibleEntries = (entries ?? []).filter((e) => !hiddenEntryIds.has(e.id));
+  const sparkPoints = visibleEntries
+    .slice()
+    .reverse()
+    .map((e) => ({ t: e.occurred_at, v: Number(e.value) }));
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-3">
+        <div className="h-8 w-48 animate-pulse rounded-lg bg-muted" />
+        <div className="h-32 animate-pulse rounded-2xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
+      </div>
+    );
+  }
+
+  if (isError || (!isLoading && !tracker)) {
+    return (
+      <div className="space-y-3">
+        <BackLink fallback="/app/trackers" fallbackLabel={t('trackers.title')} />
+        <p className="text-sm text-destructive">{t('trackers.loadFailed')}</p>
+      </div>
+    );
+  }
+  if (!tracker) return null;
+
+  return (
+    <div>
+      <BackLink fallback="/app/trackers" fallbackLabel={t('trackers.title')} />
+
+      <PageHeader
+        title={`${tracker.emoji ? `${tracker.emoji} ` : ''}${tracker.name}${tracker.unit ? ` (${tracker.unit})` : ''}`}
+        description={tracker.description || undefined}
+      >
+        <Button size="sm" variant="outline" onClick={() => setEditOpen(true)}>
+          <Pencil className="mr-1 h-3.5 w-3.5" />
+          {t('common.edit')}
+        </Button>
+        <Button size="sm" onClick={openNewEntry}>
+          <Plus className="mr-1 h-3.5 w-3.5" />
+          {t('trackers.addValue')}
+        </Button>
+      </PageHeader>
+
+      {tracker.project || tracker.target_url ? (
+        <div className="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {tracker.project && tracker.project_title ? (
+            <Link
+              to={`/app/projects/${tracker.project}`}
+              state={pushBack(location)}
+              className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+            >
+              <FolderKanban className="h-3.5 w-3.5" />
+              {tracker.project_title}
+            </Link>
+          ) : null}
+          {tracker.target_url && tracker.target_label ? (
+            <Link
+              to={tracker.target_url}
+              state={pushBack(location)}
+              className="inline-flex items-center gap-1 hover:text-foreground hover:underline"
+            >
+              <Link2 className="h-3.5 w-3.5" />
+              {tracker.target_label}
+            </Link>
+          ) : null}
+        </div>
+      ) : null}
+
+      {sparkPoints.length > 1 ? (
+        <Card className="mb-4 p-4">
+          <span className="block text-primary">
+            <Sparkline
+              points={sparkPoints}
+              width={600}
+              height={120}
+              strokeWidth={2}
+              className="h-auto w-full"
+            />
+          </span>
+        </Card>
+      ) : null}
+
+      <Card className="p-4">
+        <h2 className="mb-2 text-sm font-medium text-foreground">
+          {t('trackers.entriesTitle')}
+        </h2>
+        {visibleEntries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('trackers.noEntries')}</p>
+        ) : (
+          <div>
+            {visibleEntries.map((entry, index) => (
+              <EntryRow
+                key={entry.id}
+                entry={entry}
+                previous={visibleEntries[index + 1] ?? null}
+                tracker={tracker}
+                onEdit={openEditEntry}
+                onDelete={handleDeleteEntry}
+              />
+            ))}
+          </div>
+        )}
+      </Card>
+
+      <TrackerDialog open={editOpen} onOpenChange={setEditOpen} existing={tracker} />
+      <EntryDialog
+        open={entryDialogOpen}
+        onOpenChange={setEntryDialogOpen}
+        tracker={tracker}
+        existing={editingEntry}
+      />
+    </div>
+  );
+}

--- a/ui/src/features/trackers/TrackerDialog.tsx
+++ b/ui/src/features/trackers/TrackerDialog.tsx
@@ -1,0 +1,248 @@
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/design-system/button';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Textarea } from '@/design-system/textarea';
+import { fetchEquipmentList } from '@/lib/api/equipment';
+import { fetchProjects } from '@/lib/api/projects';
+import { fetchStockItems } from '@/lib/api/stock';
+import { fetchZones } from '@/lib/api/zones';
+import type { Tracker } from '@/lib/api/trackers';
+import { useCreateTracker, useUpdateTracker } from './hooks';
+
+/** Linkable entity types offered in the picker (all agent-searchable). */
+type TargetType = 'equipment' | 'zone' | 'stock_item';
+const TARGET_TYPES: TargetType[] = ['equipment', 'zone', 'stock_item'];
+
+interface TrackerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  existing?: Tracker;
+  /** Locks the tracker to this project (embed in the project detail tab). */
+  defaultProjectId?: string;
+}
+
+export default function TrackerDialog({
+  open,
+  onOpenChange,
+  existing,
+  defaultProjectId,
+}: TrackerDialogProps) {
+  const { t } = useTranslation();
+  const isEditing = Boolean(existing);
+
+  const [name, setName] = React.useState('');
+  const [emoji, setEmoji] = React.useState('');
+  const [unit, setUnit] = React.useState('');
+  const [description, setDescription] = React.useState('');
+  const [projectId, setProjectId] = React.useState('');
+  const [targetType, setTargetType] = React.useState<'' | TargetType>('');
+  const [targetId, setTargetId] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const createTracker = useCreateTracker();
+  const updateTracker = useUpdateTracker();
+  const isPending = createTracker.isPending || updateTracker.isPending;
+
+  const { data: projects } = useQuery({
+    queryKey: ['projects'],
+    queryFn: () => fetchProjects(),
+    enabled: open && !defaultProjectId,
+  });
+  const { data: equipment } = useQuery({
+    queryKey: ['equipment'],
+    queryFn: () => fetchEquipmentList(),
+    enabled: open && targetType === 'equipment',
+  });
+  const { data: zones } = useQuery({
+    queryKey: ['zones'],
+    queryFn: fetchZones,
+    enabled: open && targetType === 'zone',
+  });
+  const { data: stockItems } = useQuery({
+    queryKey: ['stock-items'],
+    queryFn: () => fetchStockItems(),
+    enabled: open && targetType === 'stock_item',
+  });
+
+  React.useEffect(() => {
+    if (!open) return;
+    if (existing) {
+      setName(existing.name);
+      setEmoji(existing.emoji);
+      setUnit(existing.unit);
+      setDescription(existing.description);
+      setProjectId(existing.project ?? '');
+      setTargetType((existing.target_type as TargetType | null) ?? '');
+      setTargetId(existing.target_id ?? '');
+    } else {
+      setName('');
+      setEmoji('');
+      setUnit('');
+      setDescription('');
+      setProjectId(defaultProjectId ?? '');
+      setTargetType('');
+      setTargetId('');
+    }
+    setError(null);
+  }, [open, existing, defaultProjectId]);
+
+  const targetOptions = React.useMemo(() => {
+    if (targetType === 'equipment') {
+      return (equipment ?? []).map((e) => ({ value: e.id, label: e.name }));
+    }
+    if (targetType === 'zone') {
+      return (zones ?? []).map((z) => ({ value: z.id, label: z.name }));
+    }
+    if (targetType === 'stock_item') {
+      return (stockItems ?? []).map((s) => ({ value: s.id, label: s.name }));
+    }
+    return [];
+  }, [targetType, equipment, zones, stockItems]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) {
+      setError(t('trackers.nameRequired'));
+      return;
+    }
+    if (targetType && !targetId) {
+      setError(t('trackers.targetEntityRequired'));
+      return;
+    }
+
+    const payload = {
+      name: name.trim(),
+      emoji: emoji.trim(),
+      unit: unit.trim(),
+      description: description.trim(),
+      project: projectId || null,
+      target_type: targetType || null,
+      target_id: targetType ? targetId : null,
+    };
+
+    try {
+      if (isEditing && existing) {
+        await updateTracker.mutateAsync({ id: existing.id, payload });
+      } else {
+        await createTracker.mutateAsync(payload);
+      }
+      onOpenChange(false);
+    } catch (err: unknown) {
+      const data = (err as { response?: { data?: Record<string, string[]> } })?.response?.data;
+      const first = data ? Object.values(data).flat()[0] : null;
+      setError(typeof first === 'string' ? first : t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <SheetDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={isEditing ? t('trackers.editTitle') : t('trackers.new')}
+    >
+      <form onSubmit={(e) => void handleSubmit(e)} className="space-y-4">
+        <div className="grid grid-cols-[1fr_5rem] gap-3">
+          <FormField label={t('trackers.fieldName')} htmlFor="tracker-name">
+            <Input
+              id="tracker-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t('trackers.namePlaceholder')}
+              required
+            />
+          </FormField>
+          <FormField label={t('trackers.fieldEmoji')} htmlFor="tracker-emoji">
+            <Input
+              id="tracker-emoji"
+              value={emoji}
+              onChange={(e) => setEmoji(e.target.value)}
+              placeholder="💧"
+              maxLength={8}
+            />
+          </FormField>
+        </div>
+
+        <FormField label={t('trackers.fieldUnit')} htmlFor="tracker-unit">
+          <Input
+            id="tracker-unit"
+            value={unit}
+            onChange={(e) => setUnit(e.target.value)}
+            placeholder={t('trackers.unitPlaceholder')}
+            maxLength={50}
+          />
+        </FormField>
+
+        <FormField label={t('trackers.fieldDescription')} htmlFor="tracker-description">
+          <Textarea
+            id="tracker-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+          />
+        </FormField>
+
+        {!defaultProjectId ? (
+          <FormField label={t('trackers.fieldProject')} htmlFor="tracker-project">
+            <Select
+              id="tracker-project"
+              value={projectId}
+              onChange={(e) => setProjectId(e.target.value)}
+              options={[
+                { value: '', label: t('trackers.noProject') },
+                ...(projects ?? []).map((p) => ({ value: p.id, label: p.title })),
+              ]}
+            />
+          </FormField>
+        ) : null}
+
+        <div className="grid grid-cols-2 gap-3">
+          <FormField label={t('trackers.fieldLinkedTo')} htmlFor="tracker-target-type">
+            <Select
+              id="tracker-target-type"
+              value={targetType}
+              onChange={(e) => {
+                setTargetType(e.target.value as '' | TargetType);
+                setTargetId('');
+              }}
+              options={[
+                { value: '', label: t('trackers.linkedNone') },
+                ...TARGET_TYPES.map((type) => ({
+                  value: type,
+                  label: t(`trackers.linkedType.${type}`),
+                })),
+              ]}
+            />
+          </FormField>
+          {targetType ? (
+            <FormField label={t('trackers.fieldTargetEntity')} htmlFor="tracker-target-id">
+              <Select
+                id="tracker-target-id"
+                value={targetId}
+                onChange={(e) => setTargetId(e.target.value)}
+                options={[{ value: '', label: '—' }, ...targetOptions]}
+              />
+            </FormField>
+          ) : null}
+        </div>
+
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={isPending}>
+            {isEditing ? t('common.save') : t('common.create')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/trackers/TrackersPage.tsx
+++ b/ui/src/features/trackers/TrackersPage.tsx
@@ -1,0 +1,15 @@
+import { useTranslation } from 'react-i18next';
+
+import PageHeader from '@/components/PageHeader';
+import TrackersPanel from './TrackersPanel';
+
+export default function TrackersPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div>
+      <PageHeader title={t('trackers.title')} description={t('trackers.subtitle')} />
+      <TrackersPanel />
+    </div>
+  );
+}

--- a/ui/src/features/trackers/TrackersPanel.tsx
+++ b/ui/src/features/trackers/TrackersPanel.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { TrendingUp } from 'lucide-react';
+
+import EmptyState from '@/components/EmptyState';
+import { Button } from '@/design-system/button';
+import { FilterPill } from '@/design-system/filter-pill';
+import type { Tracker } from '@/lib/api/trackers';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import { useSessionState } from '@/lib/useSessionState';
+import TrackerCard from './TrackerCard';
+import TrackerDialog from './TrackerDialog';
+import { useArchiveTracker, useCreateEntry, useTrackers } from './hooks';
+
+type FilterKey = 'all' | 'general' | 'projects' | 'linked';
+const FILTERS: FilterKey[] = ['all', 'general', 'projects', 'linked'];
+
+interface TrackersPanelProps {
+  /** Embed mode: only this project's trackers, creation pre-linked to it. */
+  projectId?: string;
+  /** Isolates session-persisted UI state per context (e.g. per project). */
+  stateKeyPrefix?: string;
+}
+
+export default function TrackersPanel({ projectId, stateKeyPrefix = 'trackers' }: TrackersPanelProps) {
+  const { t } = useTranslation();
+  const [activeFilter, setActiveFilter] = useSessionState<FilterKey>(
+    `${stateKeyPrefix}.filter`,
+    'all',
+  );
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [editing, setEditing] = React.useState<Tracker | undefined>(undefined);
+  const [hiddenIds, setHiddenIds] = React.useState<Set<string>>(new Set());
+
+  const { data: trackers, isLoading, isError } = useTrackers(projectId);
+  const createEntry = useCreateEntry();
+  const archiveTracker = useArchiveTracker();
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  const { deleteWithUndo } = useDeleteWithUndo({
+    label: t('trackers.deleted'),
+    onDelete: (id) => archiveTracker.mutateAsync(id).then(() => undefined),
+  });
+
+  const handleDelete = (id: string) => {
+    deleteWithUndo(id, {
+      onRemove: () => setHiddenIds((prev) => new Set(prev).add(id)),
+      onRestore: () =>
+        setHiddenIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        }),
+    });
+  };
+
+  const handleQuickAdd = async (tracker: Tracker, value: string) => {
+    await createEntry.mutateAsync({ tracker: tracker.id, value });
+  };
+
+  const openCreate = () => {
+    setEditing(undefined);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (tracker: Tracker) => {
+    setEditing(tracker);
+    setDialogOpen(true);
+  };
+
+  const visible = React.useMemo(() => {
+    let items = (trackers ?? []).filter((tr) => !hiddenIds.has(tr.id));
+    if (!projectId) {
+      if (activeFilter === 'general') {
+        items = items.filter((tr) => !tr.project && !tr.target_type);
+      } else if (activeFilter === 'projects') {
+        items = items.filter((tr) => Boolean(tr.project));
+      } else if (activeFilter === 'linked') {
+        items = items.filter((tr) => Boolean(tr.target_type));
+      }
+    }
+    return items;
+  }, [trackers, hiddenIds, activeFilter, projectId]);
+
+  if (showSkeleton) {
+    return (
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-28 animate-pulse rounded-2xl bg-muted" />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <p className="text-sm text-destructive">{t('trackers.loadFailed')}</p>;
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center justify-between gap-2 pb-4">
+        {!projectId ? (
+          <div className="flex flex-wrap gap-1.5">
+            {FILTERS.map((key) => (
+              <FilterPill
+                key={key}
+                active={activeFilter === key}
+                onClick={() => setActiveFilter(key)}
+              >
+                {t(`trackers.filter.${key}`)}
+              </FilterPill>
+            ))}
+          </div>
+        ) : (
+          <div />
+        )}
+        <Button size="sm" onClick={openCreate}>
+          {t('trackers.new')}
+        </Button>
+      </div>
+
+      {visible.length === 0 ? (
+        <EmptyState
+          icon={TrendingUp}
+          title={t('trackers.empty')}
+          description={t('trackers.emptyDescription')}
+          action={{ label: t('trackers.new'), onClick: openCreate }}
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {visible.map((tracker) => (
+            <TrackerCard
+              key={tracker.id}
+              tracker={tracker}
+              onEdit={openEdit}
+              onDelete={handleDelete}
+              onQuickAdd={handleQuickAdd}
+            />
+          ))}
+        </div>
+      )}
+
+      <TrackerDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        existing={editing}
+        defaultProjectId={projectId}
+      />
+    </div>
+  );
+}

--- a/ui/src/features/trackers/hooks.ts
+++ b/ui/src/features/trackers/hooks.ts
@@ -1,0 +1,115 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import {
+  archiveTracker,
+  createTracker,
+  createTrackerEntry,
+  deleteTrackerEntry,
+  fetchTracker,
+  fetchTrackerEntries,
+  fetchTrackers,
+  updateTracker,
+  updateTrackerEntry,
+  type TrackerEntryPayload,
+  type TrackerPayload,
+} from '@/lib/api/trackers';
+import { toast } from '@/lib/toast';
+
+export const trackerKeys = {
+  all: ['trackers'] as const,
+  list: () => [...trackerKeys.all, 'list'] as const,
+  project: (projectId: string) => [...trackerKeys.all, 'project', projectId] as const,
+  detail: (id: string) => [...trackerKeys.all, 'detail', id] as const,
+  entries: (trackerId: string) => [...trackerKeys.all, trackerId, 'entries'] as const,
+};
+
+export function useTrackers(projectId?: string) {
+  return useQuery({
+    queryKey: projectId ? trackerKeys.project(projectId) : trackerKeys.list(),
+    queryFn: () => fetchTrackers({ projectId }),
+  });
+}
+
+export function useTracker(id: string) {
+  return useQuery({
+    queryKey: trackerKeys.detail(id),
+    queryFn: () => fetchTracker(id),
+    enabled: Boolean(id),
+  });
+}
+
+export function useTrackerEntries(trackerId: string) {
+  return useQuery({
+    queryKey: trackerKeys.entries(trackerId),
+    queryFn: () => fetchTrackerEntries(trackerId),
+    enabled: Boolean(trackerId),
+  });
+}
+
+export function useCreateTracker() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: TrackerPayload) => createTracker(payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: trackerKeys.all });
+      toast({ description: t('trackers.created'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useUpdateTracker() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: Partial<TrackerPayload> }) =>
+      updateTracker(id, payload),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: trackerKeys.all }),
+  });
+}
+
+export function useArchiveTracker() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => archiveTracker(id),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: trackerKeys.all }),
+  });
+}
+
+export function useCreateEntry() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: TrackerEntryPayload) => createTrackerEntry(payload),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: trackerKeys.all });
+      toast({ description: t('trackers.entryAdded'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useUpdateEntry() {
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({
+      id,
+      payload,
+    }: {
+      id: string;
+      payload: Partial<Omit<TrackerEntryPayload, 'tracker'>>;
+    }) => updateTrackerEntry(id, payload),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: trackerKeys.all }),
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useDeleteEntry() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteTrackerEntry(id),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: trackerKeys.all }),
+  });
+}

--- a/ui/src/lib/api/trackers.ts
+++ b/ui/src/lib/api/trackers.ts
@@ -1,0 +1,122 @@
+import { api } from '@/lib/axios';
+
+export interface TrackerSparklinePoint {
+  value: string;
+  occurred_at: string;
+}
+
+export interface Tracker {
+  id: string;
+  name: string;
+  description: string;
+  unit: string;
+  emoji: string;
+  is_active: boolean;
+  project: string | null;
+  project_title: string | null;
+  target_type: string | null;
+  target_id: string | null;
+  target_label: string | null;
+  target_url: string | null;
+  last_value: string | null;
+  last_entry_at: string | null;
+  sparkline: TrackerSparklinePoint[];
+  created_at: string;
+  created_by: number | null;
+}
+
+export interface TrackerEntry {
+  id: string;
+  tracker: string;
+  value: string;
+  occurred_at: string;
+  note: string;
+  created_at: string;
+  created_by: number | null;
+}
+
+export interface TrackerPayload {
+  name: string;
+  unit?: string;
+  description?: string;
+  emoji?: string;
+  project?: string | null;
+  target_type?: string | null;
+  target_id?: string | null;
+}
+
+export interface TrackerEntryPayload {
+  tracker: string;
+  value: string;
+  occurred_at?: string;
+  note?: string;
+}
+
+/** Render an API decimal without trailing zeros (148.200 → "148.2"). */
+export function formatTrackerValue(value: string | null): string {
+  if (value == null) return '';
+  if (!value.includes('.')) return value;
+  return value.replace(/0+$/, '').replace(/\.$/, '');
+}
+
+function unwrap<T>(data: { results?: T[] } | T[]): T[] {
+  return Array.isArray(data) ? data : (data.results ?? []);
+}
+
+export async function fetchTrackers(
+  options: { projectId?: string } = {},
+): Promise<Tracker[]> {
+  const params: Record<string, string> = { limit: '200' };
+  if (options.projectId) params.project = options.projectId;
+  const res = await api.get('/trackers/trackers/', { params });
+  return unwrap<Tracker>(res.data);
+}
+
+export async function fetchTracker(id: string): Promise<Tracker> {
+  const res = await api.get(`/trackers/trackers/${id}/`);
+  return res.data;
+}
+
+export async function createTracker(payload: TrackerPayload): Promise<Tracker> {
+  const res = await api.post('/trackers/trackers/', payload);
+  return res.data;
+}
+
+export async function updateTracker(
+  id: string,
+  payload: Partial<TrackerPayload>,
+): Promise<Tracker> {
+  const res = await api.patch(`/trackers/trackers/${id}/`, payload);
+  return res.data;
+}
+
+/** DELETE archives the tracker (is_active=false) — history is kept server-side. */
+export async function archiveTracker(id: string): Promise<void> {
+  await api.delete(`/trackers/trackers/${id}/`);
+}
+
+export async function fetchTrackerEntries(trackerId: string): Promise<TrackerEntry[]> {
+  const res = await api.get('/trackers/entries/', {
+    params: { tracker: trackerId, limit: '100' },
+  });
+  return unwrap<TrackerEntry>(res.data);
+}
+
+export async function createTrackerEntry(
+  payload: TrackerEntryPayload,
+): Promise<TrackerEntry> {
+  const res = await api.post('/trackers/entries/', payload);
+  return res.data;
+}
+
+export async function updateTrackerEntry(
+  id: string,
+  payload: Partial<Omit<TrackerEntryPayload, 'tracker'>>,
+): Promise<TrackerEntry> {
+  const res = await api.patch(`/trackers/entries/${id}/`, payload);
+  return res.data;
+}
+
+export async function deleteTrackerEntry(id: string): Promise<void> {
+  await api.delete(`/trackers/entries/${id}/`);
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -21,7 +21,9 @@
     "linked": "Bereits verknüpft",
     "actions": "Aktionen",
     "error_loading": "Laden fehlgeschlagen.",
-    "loading": "Wird geladen…"
+    "loading": "Wird geladen…",
+    "add": "Hinzufügen",
+    "create": "Erstellen"
   },
   "errors": {
     "notFoundTitle": "Seite nicht gefunden",
@@ -625,6 +627,53 @@
     "pickInteraction": "Ereignis auswählen",
     "attachmentUnlinked": "Verknüpfung entfernt",
     "attachmentLinked": "Anhang hinzugefügt"
+  },
+  "trackers": {
+    "title": "Tracker",
+    "subtitle": "Werte im Zeitverlauf verfolgen — Zähler, Füllstände, Gewicht, Stunden.",
+    "new": "Neuer Tracker",
+    "editTitle": "Tracker bearbeiten",
+    "created": "Tracker erstellt.",
+    "deleted": "Tracker gelöscht",
+    "loadFailed": "Tracker konnten nicht geladen werden.",
+    "empty": "Noch keine Tracker.",
+    "emptyDescription": "Erstelle einen Tracker, um einen Wert im Zeitverlauf zu verfolgen — Zähler, Gewicht, Füllstand…",
+    "addValue": "Wert hinzufügen",
+    "quickAddPlaceholder": "Wert",
+    "entryAdded": "Wert hinzugefügt.",
+    "entryDeleted": "Eintrag gelöscht",
+    "entryNewTitle": "Wert hinzufügen",
+    "entryEditTitle": "Eintrag bearbeiten",
+    "entriesTitle": "Einträge",
+    "noEntries": "Noch keine Einträge.",
+    "nameRequired": "Name ist erforderlich.",
+    "valueRequired": "Ein numerischer Wert und ein Datum sind erforderlich.",
+    "targetEntityRequired": "Wähle die verknüpfte Entität.",
+    "namePlaceholder": "Wasserzähler",
+    "unitPlaceholder": "m³, kg, h, %…",
+    "fieldName": "Name",
+    "fieldEmoji": "Emoji",
+    "fieldUnit": "Einheit",
+    "fieldDescription": "Beschreibung",
+    "fieldProject": "Projekt",
+    "noProject": "Kein Projekt",
+    "fieldLinkedTo": "Verknüpft mit",
+    "linkedNone": "Nichts",
+    "fieldTargetEntity": "Entität",
+    "linkedType": {
+      "equipment": "Gerät",
+      "zone": "Raum / Bereich",
+      "stock_item": "Vorratsartikel"
+    },
+    "fieldValue": "Wert",
+    "fieldDate": "Datum",
+    "fieldNote": "Notiz",
+    "filter": {
+      "all": "Alle",
+      "general": "Allgemein",
+      "projects": "Projekte",
+      "linked": "Verknüpft"
+    }
   },
   "settings": {
     "app_title": "Einstellungen-Mini-App",
@@ -1563,7 +1612,8 @@
       "expenses": "Ausgaben",
       "documents": "Dokumente",
       "timeline": "Verlauf",
-      "assistant": "Assistent"
+      "assistant": "Assistent",
+      "trackers": "Tracker"
     },
     "metrics": {
       "planned_budget": "Geplantes Budget",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -21,7 +21,9 @@
     "linked": "Already linked",
     "actions": "Actions",
     "error_loading": "Failed to load.",
-    "loading": "Loading…"
+    "loading": "Loading…",
+    "add": "Add",
+    "create": "Create"
   },
   "errors": {
     "notFoundTitle": "Page not found",
@@ -625,6 +627,53 @@
     "pickInteraction": "Select an interaction",
     "attachmentUnlinked": "Link removed",
     "attachmentLinked": "Attachment added"
+  },
+  "trackers": {
+    "title": "Trackers",
+    "subtitle": "Track values over time — meters, levels, weights, hours.",
+    "new": "New tracker",
+    "editTitle": "Edit tracker",
+    "created": "Tracker created.",
+    "deleted": "Tracker deleted",
+    "loadFailed": "Failed to load trackers.",
+    "empty": "No trackers yet.",
+    "emptyDescription": "Create a tracker to follow a value over time — meter, weight, tank level…",
+    "addValue": "Add a value",
+    "quickAddPlaceholder": "Value",
+    "entryAdded": "Value added.",
+    "entryDeleted": "Entry deleted",
+    "entryNewTitle": "Add a value",
+    "entryEditTitle": "Edit entry",
+    "entriesTitle": "Entries",
+    "noEntries": "No entries yet.",
+    "nameRequired": "Name is required.",
+    "valueRequired": "A numeric value and a date are required.",
+    "targetEntityRequired": "Choose the linked entity.",
+    "namePlaceholder": "Water meter",
+    "unitPlaceholder": "m³, kg, h, %…",
+    "fieldName": "Name",
+    "fieldEmoji": "Emoji",
+    "fieldUnit": "Unit",
+    "fieldDescription": "Description",
+    "fieldProject": "Project",
+    "noProject": "No project",
+    "fieldLinkedTo": "Linked to",
+    "linkedNone": "Nothing",
+    "fieldTargetEntity": "Entity",
+    "linkedType": {
+      "equipment": "Equipment",
+      "zone": "Zone",
+      "stock_item": "Stock item"
+    },
+    "fieldValue": "Value",
+    "fieldDate": "Date",
+    "fieldNote": "Note",
+    "filter": {
+      "all": "All",
+      "general": "General",
+      "projects": "Projects",
+      "linked": "Linked"
+    }
   },
   "settings": {
     "app_title": "Settings mini-app",
@@ -1563,7 +1612,8 @@
       "expenses": "Expenses",
       "documents": "Documents",
       "timeline": "Timeline",
-      "assistant": "Assistant"
+      "assistant": "Assistant",
+      "trackers": "Trackers"
     },
     "metrics": {
       "planned_budget": "Planned budget",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -21,7 +21,9 @@
     "linked": "Ya vinculado",
     "actions": "Acciones",
     "error_loading": "Error al cargar.",
-    "loading": "Cargando…"
+    "loading": "Cargando…",
+    "add": "Añadir",
+    "create": "Crear"
   },
   "errors": {
     "notFoundTitle": "Página no encontrada",
@@ -625,6 +627,53 @@
     "pickInteraction": "Seleccionar interacción",
     "attachmentUnlinked": "Vínculo eliminado",
     "attachmentLinked": "Adjunto añadido"
+  },
+  "trackers": {
+    "title": "Trackers",
+    "subtitle": "Sigue valores a lo largo del tiempo — contadores, niveles, peso, horas.",
+    "new": "Nuevo tracker",
+    "editTitle": "Editar tracker",
+    "created": "Tracker creado.",
+    "deleted": "Tracker eliminado",
+    "loadFailed": "No se pudieron cargar los trackers.",
+    "empty": "Aún no hay trackers.",
+    "emptyDescription": "Crea un tracker para seguir un valor en el tiempo — contador, peso, nivel del depósito…",
+    "addValue": "Añadir un valor",
+    "quickAddPlaceholder": "Valor",
+    "entryAdded": "Valor añadido.",
+    "entryDeleted": "Entrada eliminada",
+    "entryNewTitle": "Añadir un valor",
+    "entryEditTitle": "Editar entrada",
+    "entriesTitle": "Entradas",
+    "noEntries": "Aún no hay entradas.",
+    "nameRequired": "El nombre es obligatorio.",
+    "valueRequired": "Se requieren un valor numérico y una fecha.",
+    "targetEntityRequired": "Elige la entidad vinculada.",
+    "namePlaceholder": "Contador de agua",
+    "unitPlaceholder": "m³, kg, h, %…",
+    "fieldName": "Nombre",
+    "fieldEmoji": "Emoji",
+    "fieldUnit": "Unidad",
+    "fieldDescription": "Descripción",
+    "fieldProject": "Proyecto",
+    "noProject": "Sin proyecto",
+    "fieldLinkedTo": "Vinculado a",
+    "linkedNone": "Nada",
+    "fieldTargetEntity": "Entidad",
+    "linkedType": {
+      "equipment": "Equipo",
+      "zone": "Zona",
+      "stock_item": "Artículo de stock"
+    },
+    "fieldValue": "Valor",
+    "fieldDate": "Fecha",
+    "fieldNote": "Nota",
+    "filter": {
+      "all": "Todos",
+      "general": "Generales",
+      "projects": "Proyectos",
+      "linked": "Vinculados"
+    }
   },
   "settings": {
     "app_title": "Mini-app Configuración",
@@ -1563,7 +1612,8 @@
       "expenses": "Gastos",
       "documents": "Documentos",
       "timeline": "Historial",
-      "assistant": "Asistente"
+      "assistant": "Asistente",
+      "trackers": "Trackers"
     },
     "metrics": {
       "planned_budget": "Presupuesto planificado",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -21,7 +21,9 @@
     "linked": "Déjà lié",
     "actions": "Actions",
     "error_loading": "Erreur lors du chargement.",
-    "loading": "Chargement…"
+    "loading": "Chargement…",
+    "add": "Ajouter",
+    "create": "Créer"
   },
   "errors": {
     "notFoundTitle": "Page introuvable",
@@ -625,6 +627,53 @@
     "pickInteraction": "Sélectionner une interaction",
     "attachmentUnlinked": "Lien supprimé",
     "attachmentLinked": "Pièce jointe ajoutée"
+  },
+  "trackers": {
+    "title": "Trackers",
+    "subtitle": "Suivre des valeurs dans le temps — compteurs, niveaux, poids, heures.",
+    "new": "Nouveau tracker",
+    "editTitle": "Modifier le tracker",
+    "created": "Tracker créé.",
+    "deleted": "Tracker supprimé",
+    "loadFailed": "Impossible de charger les trackers.",
+    "empty": "Aucun tracker pour l'instant.",
+    "emptyDescription": "Créez un tracker pour suivre une valeur dans le temps — compteur, poids, niveau de cuve…",
+    "addValue": "Ajouter une valeur",
+    "quickAddPlaceholder": "Valeur",
+    "entryAdded": "Valeur ajoutée.",
+    "entryDeleted": "Entrée supprimée",
+    "entryNewTitle": "Ajouter une valeur",
+    "entryEditTitle": "Modifier l'entrée",
+    "entriesTitle": "Entrées",
+    "noEntries": "Aucune entrée pour l'instant.",
+    "nameRequired": "Le nom est requis.",
+    "valueRequired": "Une valeur numérique et une date sont requises.",
+    "targetEntityRequired": "Choisissez l'entité liée.",
+    "namePlaceholder": "Compteur d'eau",
+    "unitPlaceholder": "m³, kg, h, %…",
+    "fieldName": "Nom",
+    "fieldEmoji": "Emoji",
+    "fieldUnit": "Unité",
+    "fieldDescription": "Description",
+    "fieldProject": "Projet",
+    "noProject": "Aucun projet",
+    "fieldLinkedTo": "Lié à",
+    "linkedNone": "Rien",
+    "fieldTargetEntity": "Entité",
+    "linkedType": {
+      "equipment": "Équipement",
+      "zone": "Pièce / zone",
+      "stock_item": "Article de stock"
+    },
+    "fieldValue": "Valeur",
+    "fieldDate": "Date",
+    "fieldNote": "Note",
+    "filter": {
+      "all": "Tous",
+      "general": "Généraux",
+      "projects": "Projets",
+      "linked": "Liés"
+    }
   },
   "settings": {
     "app_title": "Mini-app Paramètres",
@@ -1563,7 +1612,8 @@
       "expenses": "Dépenses",
       "documents": "Documents",
       "timeline": "Historique",
-      "assistant": "Assistant"
+      "assistant": "Assistant",
+      "trackers": "Trackers"
     },
     "metrics": {
       "planned_budget": "Budget prévisionnel",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -23,6 +23,8 @@ const DocumentsPage = lazyWithReload(() => import('./features/documents/Document
 const DocumentDetailPage = lazyWithReload(() => import('./features/documents/DocumentDetailPage'));
 const DirectoryPage = lazyWithReload(() => import('./features/directory/DirectoryFeaturePage'));
 const ElectricityPage = lazyWithReload(() => import('./features/electricity/ElectricityPage'));
+const TrackersPage = lazyWithReload(() => import('./features/trackers/TrackersPage'));
+const TrackerDetailPage = lazyWithReload(() => import('./features/trackers/TrackerDetailPage'));
 const InsurancePage = lazyWithReload(() => import('./features/insurance/InsurancePage'));
 const PhotosPage = lazyWithReload(() => import('./features/photos/PhotosPage'));
 const SettingsPage = lazyWithReload(() => import('./features/settings/SettingsPage'));
@@ -71,6 +73,8 @@ export const router = createBrowserRouter([
       { path: 'documents/:id', element: <DocumentDetailPage /> },
       { path: 'directory', element: <DirectoryPage /> },
       { path: 'electricity', element: <ElectricityPage /> },
+      { path: 'trackers', element: <TrackersPage /> },
+      { path: 'trackers/:id', element: <TrackerDetailPage /> },
       { path: 'insurance', element: <InsurancePage /> },
       { path: 'photos', element: <PhotosPage /> },
       { path: 'alerts', element: <AlertsPage /> },


### PR DESCRIPTION
Closes #194, closes #195 — lots 3 et 4 du parcours 11. **Empilée sur #209** (base `feat/trackers-socle`) — à merger après elle.

## Contenu

- **`ui/src/components/Sparkline.tsx`** — SVG maison réutilisable, zéro dépendance : `points {t, v}[]`, x proportionnel à `occurred_at` (relevés irréguliers honnêtes), dot sur la dernière valeur, `stroke="currentColor"`.
- **`ui/src/lib/api/trackers.ts`** — types + fetchers (trackers CRUD dont archive, entries CRUD), helper `formatTrackerValue`.
- **`ui/src/features/trackers/`** :
  - `hooks.ts` — `trackerKeys` factory, hooks query/mutation avec toast + invalidation.
  - `TrackersPanel.tsx` — panel embarquable (contrat de `TasksPanel` : `projectId`, `stateKeyPrefix`), pills all/généraux/projets/liés (`useSessionState`), skeleton `useDelayedLoading`, `EmptyState`, suppression (= archivage) avec undo.
  - `TrackerCard.tsx` — emoji + nom (`CardTitle`), dernière valeur + unité + date relative, sparkline, badges projet/cible cliquables (`pushBack`), **saisie rapide inline** (bouton `+` → input pré-rempli avec la dernière valeur, Enter = enregistré à maintenant, Échap = annule).
  - `TrackerDetailPage.tsx` — `BackLink`, sparkline large, liste chronologique avec **delta vs entrée précédente**, édition/suppression d'entrée avec undo.
  - `TrackerDialog.tsx` — create/edit : nom, emoji, unité, description, projet, **picker cible générique** (équipement / pièce / article de stock — tout entity_type searchable côté backend).
  - `EntryDialog.tsx` — valeur, datetime-local (antidatage), note.
- **Onglet projet** : `'trackers'` dans `TABS` de `ProjectDetailPage` + `TrackersPanel projectId=…` (création pré-liée au projet, filtres de session isolés par projet).
- Routes lazy `/app/trackers` + `/app/trackers/:id`, entrée Sidebar (groupe Suivi, icône `TrendingUp`), i18n 4 locales `trackers.*` + `projects.tabs.trackers` + `common.add`/`common.create`.

Note : l'`EntityAssistant` de la page détail arrive avec le lot 5 (il requiert le `SearchableSpec('tracker')` — l'ajouter avant aurait affiché un onglet cassé entre deux merges).

## Vérifications

- `npm run lint` : 0 erreur (warnings préexistants uniquement)
- `tsc --noEmit` : propre
- `npm run build` : OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)