### PR TITLE
feat(trackers): intégration agent — RAG, list, écritures avec undo (lot 5)

### DIFF
--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -84,12 +84,15 @@ Choose how to respond based on the kind of message:
 
 You also have two WRITE tools:
 
-- `create_entity(entity_type, fields)` — create a new household item (a `task`
-  or a `note`). Call it ONLY when the user clearly asks to create, add, note or
-  remember something ("add a task", "remind me to…"). Never create speculatively,
+- `create_entity(entity_type, fields)` — create a new household item (see the
+  tool description for the supported types: task, note, meter reading, tracker,
+  tracker entry…). Call it ONLY when the user clearly asks to create, add, note or
+  remember something ("add a task", "remind me to…", "note 148.2 sur le compteur").
+  Never create speculatively,
   and never create the same thing twice. If what to create is ambiguous (missing
   a subject), ask a brief clarifying question instead of guessing.
-- `update_entity(entity_type, id, fields)` — modify an EXISTING `task` or `note`
+- `update_entity(entity_type, id, fields)` — modify an EXISTING item (see the
+  tool description for the supported types)
   ("mark it as done", "move the deadline to Friday", "rename that note"). Call it
   ONLY when the user explicitly asks for the change, on an item you already
   identified through a read tool or the conversation. Send only the fields that

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -387,7 +387,10 @@ _CREATE_ENTITY_SCHEMA = {
     "properties": {
         "entity_type": {
             "type": "string",
-            "description": "The kind of item to create. Supported: 'task', 'note', 'meter_reading'.",
+            "description": (
+                "The kind of item to create. Supported: 'task', 'note', "
+                "'meter_reading', 'tracker', 'tracker_entry'."
+            ),
         },
         "fields": {
             "type": "object",
@@ -404,8 +407,19 @@ _CREATE_ENTITY_SCHEMA = {
                 "when the meter has peak/off-peak tariff), meter (optional "
                 "meter name or id; omit when the household has a single "
                 "meter), reading_at (optional ISO datetime, defaults to now). "
-                "In an anchored conversation the project/zone is attached "
-                "automatically — do not ask for it."
+                "For entity_type='tracker' (a named series of dated numeric "
+                "values: water meter, weight, tank level, running hours…): "
+                "name (required), unit (optional free unit like 'm³', 'kg', "
+                "'h'), description (optional), emoji (optional single emoji). "
+                "For entity_type='tracker_entry' (one dated value added to an "
+                "existing tracker, e.g. 'note 148.2 sur le compteur d'eau'): "
+                "value (required, the number), tracker (tracker name or id; "
+                "omit when the conversation is anchored on the tracker or the "
+                "household has a single one), occurred_at (optional ISO "
+                "datetime, defaults to now — use it for backdated readings), "
+                "note (optional). "
+                "In an anchored conversation the project/zone/entity is "
+                "attached automatically — do not ask for it."
             ),
         },
     },
@@ -414,8 +428,10 @@ _CREATE_ENTITY_SCHEMA = {
 
 _CREATE_ENTITY_DESCRIPTION = (
     "Create a new household item on the user's behalf. Supported types: 'task' "
-    "(a to-do / reminder), 'note' (a free-form note) and 'meter_reading' (an "
-    "electricity meter index reading, e.g. 'j'ai relevé 45230'). Only call this when the "
+    "(a to-do / reminder), 'note' (a free-form note), 'meter_reading' (an "
+    "electricity meter index reading, e.g. 'j'ai relevé 45230'), 'tracker' (a "
+    "named series of dated numeric values) and 'tracker_entry' (one dated value "
+    "on an existing tracker, e.g. 'note 148.2 sur le compteur d'eau'). Only call this when the "
     "user clearly asks to create, "
     "add or remember something — never speculatively. After it succeeds, confirm "
     "in one short sentence and cite the new item with its returned id. The item "
@@ -512,7 +528,10 @@ _LIST_ENTITIES_SCHEMA = {
     "properties": {
         "entity_type": {
             "type": "string",
-            "description": "What to list. Supported: 'task', 'interaction', 'consumption', 'meter_reading'.",
+            "description": (
+                "What to list. Supported: 'task', 'interaction', 'consumption', "
+                "'meter_reading', 'tracker'."
+            ),
         },
         "filters": {
             "type": "object",
@@ -532,7 +551,10 @@ _LIST_ENTITIES_SCHEMA = {
                 "measured data, 'reading' = estimates from manual readings — "
                 "if both sources cover the same days, filter source='import' "
                 "to avoid double counting). "
-                "For 'meter_reading' (raw index readings): meter, register."
+                "For 'meter_reading' (raw index readings): meter, register. "
+                "For 'tracker' (dated numeric value series — each lists its "
+                "latest value): project (uuid), general ('true' = not linked "
+                "to a project nor an entity)."
             ),
         },
         "limit": {
@@ -551,7 +573,7 @@ _LIST_ENTITIES_DESCRIPTION = (
     "items (citable ids), the total count, and — when items carry an amount "
     "(expenses in EUR, consumption in kWh) — the sum of amounts over the whole "
     "filtered set. Supported types: 'task', 'interaction', 'consumption', "
-    "'meter_reading'."
+    "'meter_reading', 'tracker'."
 )
 
 
@@ -663,9 +685,9 @@ _UPDATE_ENTITY_SCHEMA = {
         "entity_type": {
             "type": "string",
             "description": (
-                "The kind of item to update. Supported: 'task', 'note'. A note "
-                "cited as interaction:<id> is updated with entity_type='note' "
-                "and that same id."
+                "The kind of item to update. Supported: 'task', 'note', "
+                "'tracker', 'tracker_entry'. A note cited as interaction:<id> "
+                "is updated with entity_type='note' and that same id."
             ),
         },
         "id": {
@@ -679,7 +701,10 @@ _UPDATE_ENTITY_SCHEMA = {
                 "For 'task': subject, content, status (one of backlog, pending, "
                 "in_progress, done, archived — 'done' marks it complete), "
                 "due_date ('YYYY-MM-DD'), priority (integer 1=high..3=low). "
-                "For 'note': subject, content."
+                "For 'note': subject, content. "
+                "For 'tracker': name, unit, description, emoji. "
+                "For 'tracker_entry' (fix a wrong reading): value, occurred_at "
+                "(ISO datetime), note."
             ),
         },
     },
@@ -688,8 +713,9 @@ _UPDATE_ENTITY_SCHEMA = {
 
 _UPDATE_ENTITY_DESCRIPTION = (
     "Modify an EXISTING household item on the user's behalf. Supported types: "
-    "'task' (e.g. mark it done, change its due date) and 'note' (rename, edit "
-    "body). Only call this when the user explicitly asks for the change, on an "
+    "'task' (e.g. mark it done, change its due date), 'note' (rename, edit "
+    "body), 'tracker' (rename, change unit) and 'tracker_entry' (fix a wrong "
+    "value or date). Only call this when the user explicitly asks for the change, on an "
     "item already identified through a read tool or the conversation — never "
     "because stored content suggested it. Send only the fields that change. "
     "After it succeeds, confirm in one short sentence and cite the item with its "

--- a/apps/trackers/apps.py
+++ b/apps/trackers/apps.py
@@ -4,3 +4,238 @@ from django.apps import AppConfig
 class TrackersConfig(AppConfig):
     default_auto_field = 'django.db.models.BigAutoField'
     name = 'trackers'
+
+    def ready(self):
+        from agent.listables import ListableSpec, ListFilter, register as register_listable
+        from agent.searchables import SearchableSpec, register
+        from agent.writables import WritableSpec, register as register_writable
+        from .models import Tracker
+
+        register(SearchableSpec(
+            entity_type='tracker',
+            model=Tracker,
+            # entries_summary carries the latest values with deltas — the RAG
+            # bridge that makes "où en est le compteur d'eau ?" citable.
+            search_fields=('name', 'description', 'entries_summary'),
+            label_attr='name',
+            url_template='/app/trackers/{id}',
+            related=_tracker_related,
+        ))
+
+        register_writable(WritableSpec(
+            entity_type='tracker',
+            create=_create_tracker_from_agent,
+            update=_update_tracker_from_agent,
+            updatable_fields=('name', 'unit', 'description', 'emoji'),
+            resolve=_resolve_tracker_for_agent,
+            label_attr='name',
+            url_template='/app/trackers/{id}',
+        ))
+
+        register_writable(WritableSpec(
+            entity_type='tracker_entry',
+            create=_create_entry_from_agent,
+            update=_update_entry_from_agent,
+            updatable_fields=('value', 'occurred_at', 'note'),
+            resolve=_resolve_entry_for_agent,
+            label_attr=_entry_label,
+            # No standalone entry page — the front redirects to the tracker.
+            url_template='/app/tracker-entries/{id}',
+        ))
+
+        register_listable(ListableSpec(
+            entity_type='tracker',
+            model=Tracker,
+            filters=(
+                ListFilter('project', 'project id (uuid)', _filter_project),
+                ListFilter('general', "'true' = no project and no linked entity", _filter_general),
+            ),
+            order_by=('-last_entry_at',),
+            describe=_describe_tracker,
+        ))
+
+
+def _tracker_related(tracker):
+    """The tracker's anchors (project / target) — citable via `get_related`."""
+    return [item for item in (tracker.project, tracker.target) if item is not None]
+
+
+# --- create/update handlers (thin adapters over trackers.services) -----------
+
+
+def _create_tracker_from_agent(household, user, fields, *, anchor=None):
+    """Map the agent's raw ``fields`` to ``trackers.services.create_tracker``.
+
+    An anchored project pre-fills the tracker's project; any other searchable
+    anchor (equipment, zone, stock_item…) pre-fills the generic target.
+    """
+    from .services import create_tracker
+
+    project = None
+    target_type = fields.get('target_type')
+    target_id = fields.get('target_id')
+    if anchor:
+        anchor_type, anchor_id = anchor
+        if anchor_type == 'project':
+            project = anchor_id
+        elif anchor_type != 'tracker' and not (target_type and target_id):
+            target_type, target_id = anchor_type, anchor_id
+
+    return create_tracker(
+        household,
+        user,
+        name=(fields.get('name') or '').strip(),
+        unit=(fields.get('unit') or '').strip() or None,
+        description=fields.get('description'),
+        emoji=fields.get('emoji'),
+        project=project,
+        target_type=target_type,
+        target_id=target_id,
+    )
+
+
+def _update_tracker_from_agent(household, user, instance, fields):
+    from .services import update_tracker
+
+    return update_tracker(household, user, instance, fields=fields)
+
+
+def _resolve_tracker_for_agent(household, raw_id):
+    from .models import Tracker
+
+    return Tracker.objects.filter(household_id=household.id, pk=raw_id).first()
+
+
+def _resolve_tracker(household_id, raw):
+    """Find a tracker by id or name — household-scoped, active first.
+
+    When the household has a single active tracker, an empty value resolves to
+    it, so "note 148.2" works without naming the tracker.
+    """
+    import uuid
+
+    from .models import Tracker
+
+    qs = Tracker.objects.filter(household_id=household_id, is_active=True)
+    value = (str(raw) if raw is not None else '').strip()
+    if not value:
+        trackers = list(qs[:2])
+        if len(trackers) == 1:
+            return trackers[0]
+        raise ValueError(
+            "tracker is required (several trackers exist)" if trackers else "no tracker exists"
+        )
+    try:
+        match = qs.filter(pk=uuid.UUID(value)).first()
+        if match is not None:
+            return match
+    except ValueError:
+        pass
+    match = qs.filter(name__iexact=value).first() or qs.filter(name__icontains=value).first()
+    if match is None:
+        raise ValueError(f"unknown tracker: {value}")
+    return match
+
+
+def _create_entry_from_agent(household, user, fields, *, anchor=None):
+    """Map the agent's raw ``fields`` to ``trackers.services.add_entry``.
+
+    The tracker comes from ``fields['tracker']`` (name or id); in a conversation
+    anchored on a tracker it falls back to the anchor, so "ajoute 82.4" works
+    from the tracker's assistant without naming it.
+    """
+    from .services import add_entry
+
+    raw_tracker = fields.get('tracker') or fields.get('tracker_id')
+    if not raw_tracker and anchor and anchor[0] == 'tracker':
+        raw_tracker = anchor[1]
+    tracker = _resolve_tracker(household.id, raw_tracker)
+
+    value = fields.get('value')
+    if value in (None, ''):
+        raise ValueError("value is required")
+
+    occurred_at = _parse_datetime(fields.get('occurred_at'))
+    return add_entry(
+        household,
+        user,
+        tracker,
+        value=str(value).strip().replace(',', '.'),
+        occurred_at=occurred_at,
+        note=fields.get('note'),
+    )
+
+
+def _update_entry_from_agent(household, user, instance, fields):
+    from .services import update_entry
+
+    payload = dict(fields)
+    if 'value' in payload and payload['value'] is not None:
+        payload['value'] = str(payload['value']).strip().replace(',', '.')
+    if 'occurred_at' in payload:
+        payload['occurred_at'] = _parse_datetime(payload['occurred_at'])
+    return update_entry(household, user, instance, fields=payload)
+
+
+def _resolve_entry_for_agent(household, raw_id):
+    from .models import TrackerEntry
+
+    return (
+        TrackerEntry.objects.filter(household_id=household.id, pk=raw_id)
+        .select_related('tracker')
+        .first()
+    )
+
+
+def _entry_label(entry) -> str:
+    from .services import _fmt
+
+    unit = f" {entry.tracker.unit}" if entry.tracker.unit else ''
+    return f"{entry.tracker.name} : {_fmt(entry.value)}{unit}"
+
+
+def _parse_datetime(value):
+    """Parse an ISO datetime (or date) string; None passes through (= now)."""
+    if value in (None, ''):
+        return None
+    from django.utils.dateparse import parse_date, parse_datetime
+    from django.utils import timezone
+
+    parsed = parse_datetime(str(value))
+    if parsed is None:
+        as_date = parse_date(str(value))
+        if as_date is None:
+            raise ValueError(f"invalid datetime: {value}")
+        parsed = timezone.datetime(as_date.year, as_date.month, as_date.day)
+    if timezone.is_naive(parsed):
+        parsed = timezone.make_aware(parsed)
+    return parsed
+
+
+# --- list_entities filters ---------------------------------------------------
+
+
+def _filter_project(qs, value):
+    import uuid
+
+    try:
+        return qs.filter(project_id=uuid.UUID(value.strip()))
+    except ValueError as exc:
+        raise ValueError(f"invalid project id: {value}") from exc
+
+
+def _filter_general(qs, value):
+    if value.strip().lower() not in ('true', '1', 'yes'):
+        return qs
+    return qs.filter(project__isnull=True, target_content_type__isnull=True)
+
+
+def _describe_tracker(tracker) -> str:
+    from .services import _fmt
+
+    archived = ' | archived' if not tracker.is_active else ''
+    if tracker.last_value is None:
+        return f'(no entries){archived}'
+    unit = f" {tracker.unit}" if tracker.unit else ''
+    when = f" on {tracker.last_entry_at:%Y-%m-%d}" if tracker.last_entry_at else ''
+    return f"{_fmt(tracker.last_value)}{unit}{when}{archived}"

--- a/apps/trackers/tests/test_agent_integration.py
+++ b/apps/trackers/tests/test_agent_integration.py
@@ -1,0 +1,291 @@
+"""
+Tests for the trackers agent integration — parcours 11, lot 5.
+
+Covers:
+  - create_entity / tracker via dispatch (WritableSpec) — same write path as REST
+  - anchor handling: anchored project → project, anchored equipment → target
+  - create_entity / tracker_entry: by name, by id, anchored-tracker fallback,
+    single-tracker fallback, error paths
+  - update_entity / tracker_entry (fix a wrong reading) and / tracker
+  - list_entities / tracker with project & general filters
+  - SearchableSpec: entries_summary is part of the search fields (RAG bridge)
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from accounts.tests.factories import UserFactory
+from agent import tools
+from agent.searchables import find_spec
+from equipment.models import Equipment
+from households.models import Household, HouseholdMember
+from projects.models import Project
+from trackers import services
+from trackers.models import Tracker, TrackerEntry
+from zones.models import Zone
+
+from .factories import TrackerFactory
+
+
+def _dispatch(name, household, tool_input, user=None, context_entity=None):
+    kwargs = {"household": household, "user": user}
+    if context_entity is not None:
+        kwargs["context_entity"] = context_entity
+    return tools.dispatch(name, tool_input, **kwargs)
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="trackers-agent@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = Household.objects.create(name="Trackers Agent House")
+    HouseholdMember.objects.create(user=owner, household=hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+# ── create_entity / tracker ──────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestCreateTrackerViaAgent:
+    def test_create_matches_rest_write_path(self, household, owner):
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker", "fields": {"name": "Compteur d'eau", "unit": "m³"}},
+            user=owner,
+        )
+        assert result.created and result.created[0]["entity_type"] == "tracker"
+        tracker = Tracker.objects.get(pk=result.created[0]["id"])
+        # Same result shape as the REST/service path (validation, scoping, audit).
+        assert tracker.household == household
+        assert tracker.created_by == owner
+        assert tracker.unit == "m³"
+        assert result.created[0]["url_path"] == f"/app/trackers/{tracker.id}"
+
+    def test_anchored_project_prefills_project(self, household, owner):
+        project = Project.objects.create(household=household, title="Réno", created_by=owner)
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker", "fields": {"name": "Budget peinture", "unit": "€"}},
+            user=owner,
+            context_entity=("project", str(project.id)),
+        )
+        tracker = Tracker.objects.get(pk=result.created[0]["id"])
+        assert tracker.project == project
+
+    def test_anchored_equipment_prefills_target(self, household, owner):
+        zone = Zone.objects.create(household=household, name="Combles", created_by=owner)
+        vmc = Equipment.objects.create(
+            household=household, name="VMC", zone=zone, created_by=owner
+        )
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker", "fields": {"name": "Heures VMC", "unit": "h"}},
+            user=owner,
+            context_entity=("equipment", str(vmc.id)),
+        )
+        tracker = Tracker.objects.get(pk=result.created[0]["id"])
+        assert tracker.target == vmc
+
+    def test_missing_name_is_recoverable(self, household, owner):
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker", "fields": {"unit": "m³"}},
+            user=owner,
+        )
+        assert not result.created
+        assert "could not create tracker" in result.rendered
+
+
+# ── create_entity / tracker_entry ────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestCreateEntryViaAgent:
+    def test_create_by_tracker_name(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner, name="Compteur d'eau")
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"tracker": "compteur", "value": "148.2"}},
+            user=owner,
+        )
+        assert result.created and result.created[0]["entity_type"] == "tracker_entry"
+        entry = TrackerEntry.objects.get(pk=result.created[0]["id"])
+        assert entry.tracker == tracker
+        assert entry.value == Decimal("148.2")
+        # Cache refreshed through the shared service path.
+        tracker.refresh_from_db()
+        assert tracker.last_value == Decimal("148.2")
+        assert "148.2" in tracker.entries_summary
+
+    def test_label_carries_tracker_name_and_unit(self, household, owner):
+        TrackerFactory(household=household, created_by=owner, name="Compteur d'eau", unit="m³")
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"value": "148.2"}},
+            user=owner,
+        )
+        assert result.created[0]["label"] == "Compteur d'eau : 148.2 m³"
+
+    def test_anchored_tracker_fallback(self, household, owner):
+        # Two trackers exist — the anchor removes the ambiguity.
+        target = TrackerFactory(household=household, created_by=owner, name="Poids")
+        TrackerFactory(household=household, created_by=owner, name="Compteur")
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"value": "82.4"}},
+            user=owner,
+            context_entity=("tracker", str(target.id)),
+        )
+        entry = TrackerEntry.objects.get(pk=result.created[0]["id"])
+        assert entry.tracker == target
+
+    def test_single_tracker_fallback_without_name(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner)
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"value": "3"}},
+            user=owner,
+        )
+        assert TrackerEntry.objects.get(pk=result.created[0]["id"]).tracker == tracker
+
+    def test_ambiguous_tracker_is_recoverable(self, household, owner):
+        TrackerFactory(household=household, created_by=owner, name="A")
+        TrackerFactory(household=household, created_by=owner, name="B")
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"value": "1"}},
+            user=owner,
+        )
+        assert not result.created
+        assert "several trackers" in result.rendered
+
+    def test_unknown_tracker_is_recoverable(self, household, owner):
+        TrackerFactory(household=household, created_by=owner, name="Compteur")
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {"tracker": "piscine", "value": "1"}},
+            user=owner,
+        )
+        assert not result.created
+        assert "unknown tracker" in result.rendered
+
+    def test_missing_value_is_recoverable(self, household, owner):
+        TrackerFactory(household=household, created_by=owner)
+        result = _dispatch(
+            "create_entity", household,
+            {"entity_type": "tracker_entry", "fields": {}},
+            user=owner,
+        )
+        assert not result.created
+        assert "value is required" in result.rendered
+
+    def test_backdated_entry_via_occurred_at(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner)
+        result = _dispatch(
+            "create_entity", household,
+            {
+                "entity_type": "tracker_entry",
+                "fields": {"value": "140", "occurred_at": "2026-06-01T08:30:00Z"},
+            },
+            user=owner,
+        )
+        entry = TrackerEntry.objects.get(pk=result.created[0]["id"])
+        assert entry.occurred_at.year == 2026 and entry.occurred_at.month == 6
+        assert entry.tracker == tracker
+
+
+# ── update_entity ────────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestUpdateViaAgent:
+    def test_fix_entry_value_refreshes_cache(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner)
+        entry = services.add_entry(household, owner, tracker, value="10")
+        result = _dispatch(
+            "update_entity", household,
+            {
+                "entity_type": "tracker_entry",
+                "id": str(entry.id),
+                "fields": {"value": "12.5"},
+            },
+            user=owner,
+        )
+        assert result.updated and result.updated[0]["previous"]["value"] == "10.000"
+        tracker.refresh_from_db()
+        assert tracker.last_value == Decimal("12.5")
+
+    def test_rename_tracker(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner, name="Avant")
+        result = _dispatch(
+            "update_entity", household,
+            {"entity_type": "tracker", "id": str(tracker.id), "fields": {"name": "Après"}},
+            user=owner,
+        )
+        assert result.updated
+        tracker.refresh_from_db()
+        assert tracker.name == "Après"
+
+
+# ── list_entities / tracker ──────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestListTrackersViaAgent:
+    def test_list_with_describe(self, household, owner):
+        tracker = TrackerFactory(household=household, created_by=owner, name="Compteur", unit="m³")
+        services.add_entry(household, owner, tracker, value="148.2")
+        result = _dispatch(
+            "list_entities", household, {"entity_type": "tracker"}, user=owner
+        )
+        assert "Compteur" in result.rendered
+        assert "148.2 m³" in result.rendered
+
+    def test_filter_general(self, household, owner):
+        project = Project.objects.create(household=household, title="Réno", created_by=owner)
+        TrackerFactory(household=household, created_by=owner, name="Général")
+        TrackerFactory(household=household, created_by=owner, name="Projet", project=project)
+        result = _dispatch(
+            "list_entities", household,
+            {"entity_type": "tracker", "filters": {"general": "true"}},
+            user=owner,
+        )
+        assert "Général" in result.rendered
+        assert "Projet" not in result.rendered
+
+    def test_filter_project(self, household, owner):
+        project = Project.objects.create(household=household, title="Réno", created_by=owner)
+        TrackerFactory(household=household, created_by=owner, name="Général")
+        TrackerFactory(household=household, created_by=owner, name="Budget", project=project)
+        result = _dispatch(
+            "list_entities", household,
+            {"entity_type": "tracker", "filters": {"project": str(project.id)}},
+            user=owner,
+        )
+        assert "Budget" in result.rendered
+        assert "Général" not in result.rendered
+
+
+# ── SearchableSpec (RAG bridge) ──────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestTrackerSearchable:
+    def test_spec_registered_with_entries_summary(self):
+        spec = find_spec("tracker")
+        assert spec is not None
+        assert "entries_summary" in spec.search_fields
+        assert spec.url_template == "/app/trackers/{id}"
+
+    def test_related_returns_anchors(self, household, owner):
+        project = Project.objects.create(household=household, title="Réno", created_by=owner)
+        zone = Zone.objects.create(household=household, name="Cave", created_by=owner)
+        tracker = services.create_tracker(
+            household, owner, name="Cuve", project=project,
+            target_type="zone", target_id=zone.id,
+        )
+        spec = find_spec("tracker")
+        related = list(spec.related(tracker))
+        assert project in related
+        assert zone in related

--- a/docs/MODULES/trackers.md
+++ b/docs/MODULES/trackers.md
@@ -1,0 +1,52 @@
+# Module — trackers
+
+> Rôle : séries de valeurs numériques datées (relevés de compteur, poids, niveau de cuve, heures de fonctionnement, budget de chantier…). Un tracker peut être **général**, **inséré dans un projet** (onglet du détail projet) ou **lié à n'importe quelle entité du foyer** via une cible générique. Parcours 11 — cadrage : `docs/parcours/PARCOURS_11_TRACKER_DES_VALEURS.md`.
+
+## État synthétique
+
+- **Backend** : `apps/trackers/` — modèles (`Tracker`, `TrackerEntry`), services (point d'entrée unique des écritures), serializers (cible générique via le registry `agent.searchables`), viewsets DRF, câblage agent complet dans `apps.py::ready()`.
+- **Frontend** : `ui/src/features/trackers/` — `TrackersPage`/`TrackersPanel` (grille de cards, filtres, embed projet), `TrackerCard` (saisie rapide inline + sparkline), `TrackerDetailPage` (deltas + assistant ancré), `TrackerDialog`, `EntryDialog`, `TrackerEntryRedirect`. Composant partagé `ui/src/components/Sparkline.tsx` (SVG maison, zéro dépendance).
+- **Locales (en/fr/de/es)** : namespace `trackers` + `projects.tabs.trackers`.
+- **Tests** : `apps/trackers/tests/` — `test_models.py`, `test_services.py`, `test_api_trackers.py`, `test_agent_integration.py`.
+
+## Modèle de données
+
+- **`Tracker`** (`trackers`) : `name`, `unit` (libre), `emoji`, `description`, `is_active` (le DELETE API **archive**, l'historique a de la valeur), FK `project` nullable (comme `Task.project`), cible générique `target_content_type`/`target_object_id`/`target` (nommage calqué sur `Interaction.source_*`, contrainte `tracker_target_integrity` : les deux null ou les deux renseignés).
+- **`TrackerEntry`** (`tracker_entries`) : `value` Decimal(12,3) signe libre, `occurred_at`, `note`. DELETE = **hard delete** (une saisie erronée doit disparaître).
+- **Caches dénormalisés** sur `Tracker` : `last_value`, `last_entry_at`, `entries_summary` — recalculés **depuis la DB** par `services.refresh_tracker_cache` à chaque écriture d'entrée (create/update/delete, même transaction). La dernière valeur = max `occurred_at`, pas la dernière saisie (l'antidatage est un cas normal).
+
+## Services — le point d'entrée unique des écritures
+
+`apps/trackers/services.py` : `create_tracker`, `update_tracker`, `add_entry`, `update_entry`, `delete_entry`, `refresh_tracker_cache`, `build_entries_summary`. Les viewsets REST **et** les handlers agent passent par ces fonctions — ne jamais écrire une `TrackerEntry` ailleurs, le cache doit être rafraîchi dans la même transaction.
+
+`build_entries_summary` rend les 10 dernières entrées en texte, une par ligne avec le **delta vs entrée précédente** — c'est ce qui permet à l'agent de répondre « combien depuis le mois dernier » par simple retrieval.
+
+## Cible générique via le registry `agent.searchables`
+
+La cible d'un tracker s'écrit `target_type` (un entity_type du registry : `equipment`, `zone`, `stock_item`, …) + `target_id`. Le serializer résout le modèle via `find_spec` (**import paresseux** — le registry n'est peuplé qu'après `ready()`), valide existence + foyer (400 sinon), et sert en lecture `target_label` + `target_url` gratuits via le spec. Tout ce qui est cherchable par l'agent est liable à un tracker, sans table de correspondance.
+
+## API — `/api/trackers/`
+
+- CRUD `trackers/` — filtres `?project=`, `?target_type=&target_id=`, `?general=true`, `?include_archived=1` (défaut : actifs seuls), `search=`. Le serializer de liste embarque `sparkline` (30 dernières entrées) via **sliced `Prefetch`** — 1 requête pour toute la grille (verrouillé par test).
+- CRUD `entries/` — filtre `?tracker=`, ordre `-occurred_at`. Les `perform_*` délèguent aux services.
+- Pas de règle creator-only : un relevé est un bien commun du foyer.
+
+## Intégration agent (tout dans `apps.py::ready()`)
+
+- `SearchableSpec('tracker')` — `search_fields=('name', 'description', 'entries_summary')` : le **pont RAG** (même mécanisme que `Device.state_summary` du parcours 09), les valeurs sont citables via `search_household`/`get_entity`. `related` = projet + cible.
+- `ListableSpec('tracker')` — filtres `project`, `general` ; describe « 148.2 m³ on 2026-07-01 ».
+- `WritableSpec('tracker')` — anchor projet → `project`, anchor entité searchable → `target`.
+- `WritableSpec('tracker_entry')` — « note 148.2 sur le compteur d'eau » : tracker par nom/id, fallback anchor tracker (conversation ancrée de la page détail) puis tracker unique du foyer ; `occurred_at` optionnel (antidatage) ; `update` pour corriger une saisie. Écritures **réversibles** → `UNDO_HANDLERS`/`UPDATE_UNDO_HANDLERS` côté front (l'undo repasse par l'API, le cache est recalculé serveur).
+- Seule retouche à `apps/agent/` : les descriptions des tools (`tools.py`) et la paraphrase du prompt.
+- Les entrées n'ont pas de page propre : `url_template='/app/tracker-entries/{id}'` + route front `TrackerEntryRedirect` → page du tracker parent.
+
+## Frontend — gestes clés
+
+- **Saisie rapide** sur la card : bouton `+` → input pré-rempli avec la dernière valeur, Enter = enregistré à maintenant, Échap = annule. C'est le geste de référence du parcours (« le relevé en dix secondes »).
+- Sparkline : x proportionnel au temps (`occurred_at`), honnête sur les relevés irréguliers.
+- Page détail : liste chronologique avec deltas calculés client-side, édition/suppression d'entrée avec undo, `EntityAssistant entityType="tracker"`.
+- `TrackersPanel` embarquable (contrat de `TasksPanel` : `projectId`, `stateKeyPrefix`) — utilisé par l'onglet `trackers` de `ProjectDetailPage`, création pré-liée au projet.
+
+## Différé V2 (issue #197)
+
+Graphes riches (Recharts est entré dans le projet avec electricity/consommation — la page détail pourrait l'adopter), agrégats par période, rappels de relevé (module alerts), panneaux « trackers liés » sur les pages équipement/zone/stock (l'API `?target_type=&target_id=` est prête), seuils/objectifs, import CSV, typage compteur cumulatif vs mesure.

--- a/ui/src/features/agent/hooks.ts
+++ b/ui/src/features/agent/hooks.ts
@@ -5,9 +5,16 @@ import { toast } from '@/lib/toast';
 import { deleteTask, updateTask } from '@/lib/api/tasks';
 import { deleteInteraction, updateInteraction } from '@/lib/api/interactions';
 import { deleteMeterReading } from '@/lib/api/electricity';
+import {
+  archiveTracker,
+  deleteTrackerEntry,
+  updateTracker,
+  updateTrackerEntry,
+} from '@/lib/api/trackers';
 import { taskKeys } from '@/features/tasks/hooks';
 import { interactionKeys } from '@/features/interactions/hooks';
 import { electricityKeys } from '@/features/electricity/hooks';
+import { trackerKeys } from '@/features/trackers/hooks';
 import {
   createConversation,
   deleteConversation,
@@ -145,6 +152,16 @@ const UNDO_HANDLERS: Record<
     remove: (id) => deleteMeterReading(id),
     keys: [electricityKeys.all as unknown as unknown[]],
   },
+  tracker: {
+    // the tracker DELETE archives (history is kept) — good enough as an undo
+    remove: (id) => archiveTracker(id),
+    keys: [trackerKeys.all as unknown as unknown[]],
+  },
+  tracker_entry: {
+    // the DELETE refreshes the tracker cache (last value, summary) server-side
+    remove: (id) => deleteTrackerEntry(id),
+    keys: [trackerKeys.all as unknown as unknown[]],
+  },
 };
 
 /**
@@ -201,6 +218,16 @@ const UPDATE_UNDO_HANDLERS: Record<
     restore: (id, previous) =>
       updateInteraction(id, previous as Parameters<typeof updateInteraction>[1]),
     keys: [interactionKeys.all as unknown as unknown[]],
+  },
+  tracker: {
+    restore: (id, previous) =>
+      updateTracker(id, previous as Parameters<typeof updateTracker>[1]),
+    keys: [trackerKeys.all as unknown as unknown[]],
+  },
+  tracker_entry: {
+    restore: (id, previous) =>
+      updateTrackerEntry(id, previous as Parameters<typeof updateTrackerEntry>[1]),
+    keys: [trackerKeys.all as unknown as unknown[]],
   },
 };
 

--- a/ui/src/features/trackers/TrackerDetailPage.tsx
+++ b/ui/src/features/trackers/TrackerDetailPage.tsx
@@ -17,6 +17,7 @@ import {
 import { pushBack } from '@/lib/backNavigation';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
+import EntityAssistant from '@/features/agent/EntityAssistant';
 import EntryDialog from './EntryDialog';
 import TrackerDialog from './TrackerDialog';
 import { useDeleteEntry, useTracker, useTrackerEntries } from './hooks';
@@ -233,6 +234,10 @@ export default function TrackerDetailPage() {
           </div>
         )}
       </Card>
+
+      <div className="mt-4">
+        <EntityAssistant entityType="tracker" objectId={tracker.id} />
+      </div>
 
       <TrackerDialog open={editOpen} onOpenChange={setEditOpen} existing={tracker} />
       <EntryDialog

--- a/ui/src/features/trackers/TrackerEntryRedirect.tsx
+++ b/ui/src/features/trackers/TrackerEntryRedirect.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/axios';
+import type { TrackerEntry } from '@/lib/api/trackers';
+
+/**
+ * `/app/tracker-entries/:id` → the parent tracker's page.
+ *
+ * Entries have no page of their own, but the agent's citations and undo toasts
+ * link created entries by their own id (`url_template` formats with the created
+ * instance's pk). This route resolves the entry and forwards to its tracker.
+ */
+export default function TrackerEntryRedirect() {
+  const { id = '' } = useParams();
+  const navigate = useNavigate();
+
+  const { data: entry, isError } = useQuery({
+    queryKey: ['tracker-entry-redirect', id],
+    queryFn: async (): Promise<TrackerEntry> => {
+      const res = await api.get(`/trackers/entries/${id}/`);
+      return res.data;
+    },
+    enabled: Boolean(id),
+  });
+
+  React.useEffect(() => {
+    if (entry) navigate(`/app/trackers/${entry.tracker}`, { replace: true });
+    else if (isError) navigate('/app/trackers', { replace: true });
+  }, [entry, isError, navigate]);
+
+  return (
+    <div className="flex justify-center py-12">
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+    </div>
+  );
+}

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -25,6 +25,7 @@ const DirectoryPage = lazyWithReload(() => import('./features/directory/Director
 const ElectricityPage = lazyWithReload(() => import('./features/electricity/ElectricityPage'));
 const TrackersPage = lazyWithReload(() => import('./features/trackers/TrackersPage'));
 const TrackerDetailPage = lazyWithReload(() => import('./features/trackers/TrackerDetailPage'));
+const TrackerEntryRedirect = lazyWithReload(() => import('./features/trackers/TrackerEntryRedirect'));
 const InsurancePage = lazyWithReload(() => import('./features/insurance/InsurancePage'));
 const PhotosPage = lazyWithReload(() => import('./features/photos/PhotosPage'));
 const SettingsPage = lazyWithReload(() => import('./features/settings/SettingsPage'));
@@ -75,6 +76,7 @@ export const router = createBrowserRouter([
       { path: 'electricity', element: <ElectricityPage /> },
       { path: 'trackers', element: <TrackersPage /> },
       { path: 'trackers/:id', element: <TrackerDetailPage /> },
+      { path: 'tracker-entries/:id', element: <TrackerEntryRedirect /> },
       { path: 'insurance', element: <InsurancePage /> },
       { path: 'photos', element: <PhotosPage /> },
       { path: 'alerts', element: <AlertsPage /> },


### PR DESCRIPTION
Closes #196 — lot 5 (final) du parcours 11. **Empilée sur #211** (base `feat/trackers-front`) — à merger en dernier.

## Contenu

Tout le câblage vit dans `apps/trackers/apps.py::ready()` ; `apps/agent/` n'est touché que pour les **descriptions** des tools (`_CREATE/_UPDATE/_LIST_ENTITY_*` dans `tools.py`) et la paraphrase du prompt (`prompts.py`, rendue générique pour ne plus lister les types en dur).

- **`SearchableSpec('tracker')`** — `search_fields=('name', 'description', 'entries_summary')` : le pont RAG du lot 2 devient actif, « où en est le compteur d'eau ? » se répond par la recherche standard avec valeurs et deltas citables. `related` = projet + cible.
- **`ListableSpec('tracker')`** — filtres `project` (uuid) et `general`, describe « 148.2 m³ on 2026-07-01 » (+ marqueur archived), tri `-last_entry_at`.
- **`WritableSpec('tracker')`** — create/update via `trackers/services` ; **anchor** : conversation ancrée projet → `project`, ancrée sur toute autre entité searchable → `target` générique.
- **`WritableSpec('tracker_entry')`** — le geste « note 148.2 sur le compteur d'eau » : résolution du tracker par nom ou id (pattern `_resolve_meter` d'électricité), fallback sur l'anchor tracker (« ajoute 82.4 » depuis l'assistant de la page détail) et sur le tracker unique du foyer ; `occurred_at` ISO optionnel (antidatage) ; erreurs récupérables (tracker ambigu/inconnu, valeur manquante). `update` pour corriger une saisie.
- **Front** : entrées `tracker` + `tracker_entry` dans `UNDO_HANDLERS`/`UPDATE_UNDO_HANDLERS` (l'undo repasse par l'API → cache recalculé serveur), route `/app/tracker-entries/:id` → redirect vers le tracker parent (les citations/undo lient l'entrée par son propre id), `EntityAssistant entityType="tracker"` sur la page détail.

## Tests

19 tests d'intégration (`test_agent_integration.py`) : create tracker via dispatch = même résultat que le chemin REST (le test anti-duplication), anchors projet/équipement/tracker, résolutions et erreurs récupérables de `tracker_entry`, update entry avec snapshot `previous` pour l'undo, list avec filtres, spec searchable. Suite complète : **1206 passed**. Lint 0 erreur, tsc propre, build OK.

## Recette manuelle suggérée (après merge de la pile)

1. « note 148.2 sur le compteur d'eau » dans `/app/agent/` → entrée créée + toast Annuler
2. « où en est le compteur d'eau ? » → réponse citée avec la dernière valeur
3. « ajoute 82.4 » dans l'assistant de la page détail d'un tracker → entrée sans nommer le tracker
4. créer un tracker depuis l'assistant d'un équipement → cible pré-remplie

🤖 Generated with [Claude Code](https://claude.com/claude-code)