### PR TITLE
feat(alerts): dashboard lot 1 — stock bas + autonomie trackers dans le summary, filtre due_before (#226)

### DIFF
--- a/apps/alerts/services.py
+++ b/apps/alerts/services.py
@@ -1,4 +1,5 @@
-"""Aggregation of household alerts (overdue tasks, expiring warranties, due maintenances)."""
+"""Aggregation of household alerts (overdue tasks, expiring warranties, due
+maintenances, low/out/expired stock, low-runway consumption trackers)."""
 
 from datetime import date, timedelta
 
@@ -6,15 +7,28 @@ from django.utils import timezone
 
 from equipment.models import Equipment
 from equipment.services import compute_next_service_due
+from stock.models import StockItem
 from tasks.models import Task
+from trackers.models import Tracker
+from trackers.services import runway
 
 
 ALERT_WARRANTY_DAYS = 90
 ALERT_MAINTENANCE_DAYS = 30
+ALERT_RUNWAY_DAYS = 14
 
 OVERDUE_TASK_CRITICAL_DAYS = 3
 WARRANTY_CRITICAL_DAYS = 30
 MAINTENANCE_CRITICAL_DAYS = 7
+RUNWAY_CRITICAL_DAYS = 7
+
+STOCK_ALERT_STATUSES = [
+    StockItem.Status.LOW_STOCK,
+    StockItem.Status.OUT_OF_STOCK,
+    StockItem.Status.EXPIRED,
+]
+# Being out of an item (or keeping an expired one) needs action now; low is a heads-up.
+STOCK_CRITICAL_STATUSES = {StockItem.Status.OUT_OF_STOCK, StockItem.Status.EXPIRED}
 
 
 def _overdue_tasks(household, today: date) -> list[dict]:
@@ -96,14 +110,80 @@ def _due_maintenances(household, today: date) -> list[dict]:
     return items
 
 
+def _low_stock(household) -> list[dict]:
+    qs = StockItem.objects.filter(
+        household=household, status__in=STOCK_ALERT_STATUSES
+    ).order_by("name")
+    items = []
+    for stock_item in qs:
+        items.append(
+            {
+                "id": str(stock_item.id),
+                "title": stock_item.name,
+                "status": stock_item.status,
+                "quantity": str(stock_item.quantity),
+                "min_quantity": (
+                    str(stock_item.min_quantity)
+                    if stock_item.min_quantity is not None
+                    else None
+                ),
+                "unit": stock_item.unit,
+                "entity_url": "/app/stock",
+                "severity": (
+                    "critical" if stock_item.status in STOCK_CRITICAL_STATUSES else "warning"
+                ),
+            }
+        )
+    items.sort(key=lambda item: (item["severity"] != "critical", item["title"].lower()))
+    return items
+
+
+def _low_runway_trackers(household) -> list[dict]:
+    qs = Tracker.objects.filter(
+        household=household, kind=Tracker.Kind.CONSUMPTION, is_active=True
+    )
+    items = []
+    for tracker in qs:
+        run = runway(tracker)
+        if run is None:
+            continue
+        days, until = run
+        if days > ALERT_RUNWAY_DAYS:
+            continue
+        title = f"{tracker.emoji} {tracker.name}".strip() if tracker.emoji else tracker.name
+        items.append(
+            {
+                "id": str(tracker.id),
+                "title": title,
+                # Same rendering as TrackerSerializer: days as str(Decimal), until as ISO date.
+                "runway_days": str(days),
+                "runway_until": until.date().isoformat(),
+                "entity_url": f"/app/trackers/{tracker.id}",
+                "severity": "critical" if days <= RUNWAY_CRITICAL_DAYS else "warning",
+            }
+        )
+    items.sort(key=lambda item: float(item["runway_days"]))
+    return items
+
+
 def build_alerts_summary(household, today: date | None = None) -> dict:
     today = today or timezone.localdate()
     overdue_tasks = _overdue_tasks(household, today)
     expiring_warranties = _expiring_warranties(household, today)
     due_maintenances = _due_maintenances(household, today)
+    low_stock = _low_stock(household)
+    low_runway_trackers = _low_runway_trackers(household)
     return {
         "overdue_tasks": overdue_tasks,
         "expiring_warranties": expiring_warranties,
         "due_maintenances": due_maintenances,
-        "total": len(overdue_tasks) + len(expiring_warranties) + len(due_maintenances),
+        "low_stock": low_stock,
+        "low_runway_trackers": low_runway_trackers,
+        "total": (
+            len(overdue_tasks)
+            + len(expiring_warranties)
+            + len(due_maintenances)
+            + len(low_stock)
+            + len(low_runway_trackers)
+        ),
     }

--- a/apps/alerts/tests/test_api_alerts_lot1.py
+++ b/apps/alerts/tests/test_api_alerts_lot1.py
@@ -1,0 +1,436 @@
+"""
+Tests for the lot-1 dashboard additions in apps/alerts/:
+  - build_alerts_summary / GET /api/alerts/summary/ now returns:
+      * low_stock   — StockItems with status ∈ {low_stock, out_of_stock, expired}
+      * low_runway_trackers — consumption trackers whose runway ≤ 14 days
+  - total includes both new lists.
+  - The "no active household" response includes both keys as empty lists.
+
+Covers: happy path, severity logic, sorting, DB-state verification, household
+isolation, anonymous 401, and the "no household" early return.
+"""
+
+from datetime import timedelta
+from decimal import Decimal
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from households.models import Household, HouseholdMember
+from stock.models import StockCategory, StockItem
+from trackers import services as tracker_services
+from trackers.models import Tracker
+from zones.models import Zone
+
+
+# ── Module-level helpers ──────────────────────────────────────────────────────
+
+def _create_household(name: str) -> Household:
+    return Household.objects.create(name=name)
+
+
+def _add_membership(user, household, role=HouseholdMember.Role.OWNER):
+    return HouseholdMember.objects.create(user=user, household=household, role=role)
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _root_zone(household: Household) -> Zone:
+    return Zone.objects.get(household=household, parent__isnull=True)
+
+
+def _create_stock_category(household, user) -> StockCategory:
+    return StockCategory.objects.get_or_create(
+        household=household,
+        name="Divers",
+        defaults={"created_by": user},
+    )[0]
+
+
+def _create_stock_item(
+    household, user, *, name: str, item_status: str, quantity="0", min_quantity=None
+) -> StockItem:
+    category = _create_stock_category(household, user)
+    return StockItem.objects.create(
+        household=household,
+        category=category,
+        name=name,
+        status=item_status,
+        quantity=quantity,
+        min_quantity=min_quantity,
+        unit="unit",
+        created_by=user,
+    )
+
+
+def _create_consumption_tracker(
+    household, user, *, name: str, reserve: str, daily_consumption: str, emoji: str = ""
+) -> Tracker:
+    """Create a consumption tracker with a deterministic runway.
+
+    One entry dated today with value=daily_consumption gives rate_per_day ≈
+    daily_consumption (coverage floored at 1 day).  runway = reserve / rate.
+    """
+    tracker = tracker_services.create_tracker(
+        household, user,
+        name=name,
+        unit="kg",
+        kind="consumption",
+        reserve=reserve,
+        emoji=emoji or None,
+    )
+    tracker_services.add_entry(
+        household, user, tracker,
+        value=daily_consumption,
+        occurred_at=timezone.now(),
+    )
+    tracker.refresh_from_db()
+    return tracker
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="alerts-lot1-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = _create_household("Alerts Lot1 House")
+    _add_membership(owner, hh)
+    owner.active_household = hh
+    owner.save(update_fields=["active_household"])
+    return hh
+
+
+@pytest.fixture
+def owner_client(owner, household):
+    return _client_for(owner)
+
+
+# ── low_stock aggregation ─────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAlertsSummaryLowStock:
+    """Covers the new 'low_stock' key in build_alerts_summary / GET /api/alerts/summary/."""
+
+    def _url(self):
+        return reverse("alerts-summary")
+
+    def test_empty_household_returns_empty_low_stock(self, owner_client, household):
+        response = owner_client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["low_stock"] == []
+
+    def test_in_stock_item_excluded(self, owner_client, household, owner):
+        _create_stock_item(household, owner, name="Full", item_status=StockItem.Status.IN_STOCK, quantity="10")
+        response = owner_client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["low_stock"] == []
+
+    def test_low_stock_item_returned_as_warning(self, owner_client, household, owner):
+        _create_stock_item(household, owner, name="Almost empty", item_status=StockItem.Status.LOW_STOCK, quantity="1")
+        response = owner_client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        low_stock = response.data["low_stock"]
+        assert len(low_stock) == 1
+        item = low_stock[0]
+        assert item["title"] == "Almost empty"
+        assert item["status"] == "low_stock"
+        assert item["severity"] == "warning"
+        assert item["entity_url"] == "/app/stock"
+        assert isinstance(item["quantity"], str)
+
+    def test_out_of_stock_item_returned_as_critical(self, owner_client, household, owner):
+        _create_stock_item(household, owner, name="Empty jar", item_status=StockItem.Status.OUT_OF_STOCK, quantity="0")
+        response = owner_client.get(self._url())
+        low_stock = response.data["low_stock"]
+        assert len(low_stock) == 1
+        assert low_stock[0]["severity"] == "critical"
+
+    def test_expired_item_returned_as_critical(self, owner_client, household, owner):
+        _create_stock_item(household, owner, name="Old flour", item_status=StockItem.Status.EXPIRED, quantity="0.5")
+        response = owner_client.get(self._url())
+        low_stock = response.data["low_stock"]
+        assert len(low_stock) == 1
+        assert low_stock[0]["severity"] == "critical"
+
+    def test_quantity_and_min_quantity_serialized_as_strings(self, owner_client, household, owner):
+        _create_stock_item(
+            household, owner,
+            name="Checked",
+            item_status=StockItem.Status.LOW_STOCK,
+            quantity="2.500",
+            min_quantity="5.000",
+        )
+        response = owner_client.get(self._url())
+        item = response.data["low_stock"][0]
+        assert item["quantity"] == "2.500"
+        assert item["min_quantity"] == "5.000"
+
+    def test_min_quantity_none_accepted(self, owner_client, household, owner):
+        _create_stock_item(
+            household, owner,
+            name="No min",
+            item_status=StockItem.Status.LOW_STOCK,
+            min_quantity=None,
+        )
+        response = owner_client.get(self._url())
+        item = response.data["low_stock"][0]
+        assert item["min_quantity"] is None
+
+    def test_sorting_criticals_first_then_by_name_case_insensitive(self, owner_client, household, owner):
+        # Insert in reverse-expected order so the test fails if ordering is wrong.
+        _create_stock_item(household, owner, name="Zucchini (low)", item_status=StockItem.Status.LOW_STOCK)
+        _create_stock_item(household, owner, name="apples (out)", item_status=StockItem.Status.OUT_OF_STOCK)
+        _create_stock_item(household, owner, name="Beans (expired)", item_status=StockItem.Status.EXPIRED)
+        _create_stock_item(household, owner, name="almonds (low)", item_status=StockItem.Status.LOW_STOCK)
+
+        response = owner_client.get(self._url())
+        low_stock = response.data["low_stock"]
+        assert len(low_stock) == 4
+
+        # Criticals first (apples, Beans), then warnings (almonds, Zucchini) — case-insensitive
+        severities = [item["severity"] for item in low_stock]
+        assert severities == ["critical", "critical", "warning", "warning"]
+
+        # Among criticals: apples < Beans (case-insensitive)
+        critical_names = [item["title"] for item in low_stock if item["severity"] == "critical"]
+        assert critical_names == ["apples (out)", "Beans (expired)"]
+
+        # Among warnings: almonds < Zucchini (case-insensitive)
+        warning_names = [item["title"] for item in low_stock if item["severity"] == "warning"]
+        assert warning_names == ["almonds (low)", "Zucchini (low)"]
+
+    def test_low_stock_included_in_total(self, owner_client, household, owner):
+        _create_stock_item(household, owner, name="A", item_status=StockItem.Status.LOW_STOCK)
+        _create_stock_item(household, owner, name="B", item_status=StockItem.Status.OUT_OF_STOCK)
+        response = owner_client.get(self._url())
+        data = response.data
+        # total must be the sum of all lists including low_stock
+        assert data["total"] == (
+            len(data["overdue_tasks"])
+            + len(data["expiring_warranties"])
+            + len(data["due_maintenances"])
+            + len(data["low_stock"])
+            + len(data["low_runway_trackers"])
+        )
+        assert data["total"] >= 2
+
+    def test_low_stock_household_isolation(self, owner_client, household, owner):
+        # Stock items belonging to another household must NOT appear.
+        other_owner = UserFactory(email="alerts-lot1-other@example.com")
+        other_hh = _create_household("Other Lot1 House")
+        _add_membership(other_owner, other_hh)
+        _create_stock_item(other_hh, other_owner, name="Foreign empty", item_status=StockItem.Status.OUT_OF_STOCK)
+
+        response = owner_client.get(self._url())
+        assert response.data["low_stock"] == []
+
+    def test_item_has_id_field(self, owner_client, household, owner):
+        item = _create_stock_item(household, owner, name="With ID", item_status=StockItem.Status.LOW_STOCK)
+        response = owner_client.get(self._url())
+        assert response.data["low_stock"][0]["id"] == str(item.id)
+
+
+# ── low_runway_trackers aggregation ──────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAlertsSummaryLowRunwayTrackers:
+    """Covers the new 'low_runway_trackers' key in build_alerts_summary."""
+
+    def _url(self):
+        return reverse("alerts-summary")
+
+    def test_empty_household_returns_empty_low_runway_trackers(self, owner_client, household):
+        response = owner_client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["low_runway_trackers"] == []
+
+    def test_tracker_above_threshold_excluded(self, owner_client, household, owner):
+        # reserve=300, consumption=3/day → runway ≈ 100 days (> 14 → absent)
+        _create_consumption_tracker(household, owner, name="Long runway", reserve="300", daily_consumption="3")
+        response = owner_client.get(self._url())
+        assert response.data["low_runway_trackers"] == []
+
+    def test_warning_tracker_returned_at_10_days(self, owner_client, household, owner):
+        # reserve=30, consumption=3/day → runway ≈ 10 days (≤ 14, > 7 → warning)
+        tracker = _create_consumption_tracker(
+            household, owner, name="Warning tracker", reserve="30", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        low_runway = response.data["low_runway_trackers"]
+        assert len(low_runway) == 1
+        item = low_runway[0]
+        assert item["id"] == str(tracker.id)
+        assert item["severity"] == "warning"
+        assert item["entity_url"] == f"/app/trackers/{tracker.id}"
+        assert "runway_days" in item
+        assert "runway_until" in item
+
+    def test_critical_tracker_returned_at_2_days(self, owner_client, household, owner):
+        # reserve=6, consumption=3/day → runway ≈ 2 days (≤ 7 → critical)
+        _create_consumption_tracker(
+            household, owner, name="Critical tracker", reserve="6", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        low_runway = response.data["low_runway_trackers"]
+        assert len(low_runway) == 1
+        assert low_runway[0]["severity"] == "critical"
+
+    def test_measure_tracker_excluded(self, owner_client, household, owner):
+        # kind=measure should never appear, regardless of reserve
+        tracker_services.create_tracker(
+            household, owner,
+            name="Measure only",
+            unit="kg",
+            kind="measure",
+        )
+        response = owner_client.get(self._url())
+        assert response.data["low_runway_trackers"] == []
+
+    def test_inactive_tracker_excluded(self, owner_client, household, owner):
+        # reserve=6, consumption=3 → would be critical, but is_active=False → excluded
+        tracker = tracker_services.create_tracker(
+            household, owner,
+            name="Inactive",
+            unit="kg",
+            kind="consumption",
+            reserve="6",
+        )
+        tracker_services.add_entry(household, owner, tracker, value="3")
+        tracker.is_active = False
+        tracker.save(update_fields=["is_active"])
+
+        response = owner_client.get(self._url())
+        assert response.data["low_runway_trackers"] == []
+
+    def test_tracker_without_reserve_excluded(self, owner_client, household, owner):
+        # No reserve → runway() returns None → excluded
+        tracker = tracker_services.create_tracker(
+            household, owner,
+            name="No reserve",
+            unit="kg",
+            kind="consumption",
+        )
+        tracker_services.add_entry(household, owner, tracker, value="3")
+        response = owner_client.get(self._url())
+        assert response.data["low_runway_trackers"] == []
+
+    def test_title_includes_emoji_when_set(self, owner_client, household, owner):
+        _create_consumption_tracker(
+            household, owner,
+            name="Poules",
+            reserve="6",
+            daily_consumption="3",
+            emoji="🐔",
+        )
+        response = owner_client.get(self._url())
+        item = response.data["low_runway_trackers"][0]
+        assert item["title"] == "🐔 Poules"
+
+    def test_title_without_emoji_is_name_only(self, owner_client, household, owner):
+        _create_consumption_tracker(
+            household, owner,
+            name="Grain",
+            reserve="6",
+            daily_consumption="3",
+            emoji="",
+        )
+        response = owner_client.get(self._url())
+        item = response.data["low_runway_trackers"][0]
+        assert item["title"] == "Grain"
+
+    def test_sorting_by_runway_days_ascending(self, owner_client, household, owner):
+        # critical (~2 days) should appear before warning (~10 days)
+        _create_consumption_tracker(
+            household, owner, name="Long warning", reserve="30", daily_consumption="3"
+        )
+        _create_consumption_tracker(
+            household, owner, name="Short critical", reserve="6", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        low_runway = response.data["low_runway_trackers"]
+        assert len(low_runway) == 2
+        runway_days = [float(item["runway_days"]) for item in low_runway]
+        assert runway_days == sorted(runway_days)
+        assert low_runway[0]["title"] == "Short critical"
+        assert low_runway[1]["title"] == "Long warning"
+
+    def test_runway_days_and_runway_until_types(self, owner_client, household, owner):
+        _create_consumption_tracker(
+            household, owner, name="Type check", reserve="6", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        item = response.data["low_runway_trackers"][0]
+        # runway_days is a string representation of a Decimal
+        assert isinstance(item["runway_days"], str)
+        # runway_until is an ISO date string (YYYY-MM-DD)
+        from datetime import date
+        date.fromisoformat(item["runway_until"])  # raises ValueError if wrong format
+
+    def test_low_runway_trackers_included_in_total(self, owner_client, household, owner):
+        _create_consumption_tracker(
+            household, owner, name="In total", reserve="6", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        data = response.data
+        assert data["total"] == (
+            len(data["overdue_tasks"])
+            + len(data["expiring_warranties"])
+            + len(data["due_maintenances"])
+            + len(data["low_stock"])
+            + len(data["low_runway_trackers"])
+        )
+        assert data["total"] >= 1
+
+    def test_low_runway_trackers_household_isolation(self, owner_client, household, owner):
+        other_owner = UserFactory(email="alerts-lot1-tracker-other@example.com")
+        other_hh = _create_household("Other Tracker House")
+        _add_membership(other_owner, other_hh)
+        _create_consumption_tracker(
+            other_hh, other_owner, name="Foreign critical", reserve="6", daily_consumption="3"
+        )
+        response = owner_client.get(self._url())
+        assert response.data["low_runway_trackers"] == []
+
+
+# ── Response shape (both keys present) ───────────────────────────────────────
+
+@pytest.mark.django_db
+class TestAlertsSummaryResponseShape:
+    """Ensures both new keys are always present in the API response."""
+
+    def _url(self):
+        return reverse("alerts-summary")
+
+    def test_both_new_keys_present_on_empty_household(self, owner_client, household):
+        response = owner_client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert "low_stock" in response.data
+        assert "low_runway_trackers" in response.data
+
+    def test_no_active_household_returns_empty_new_keys(self, db):
+        """User with no active household → the early-return branch must include both keys."""
+        user = UserFactory(email="alerts-lot1-nohouse@example.com")
+        # No household attached → request.household is None
+        client = _client_for(user)
+        response = client.get(self._url())
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["low_stock"] == []
+        assert response.data["low_runway_trackers"] == []
+        assert response.data["total"] == 0
+
+    def test_anonymous_request_rejected(self, household):
+        client = APIClient()
+        response = client.get(self._url())
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)

--- a/apps/alerts/views.py
+++ b/apps/alerts/views.py
@@ -10,7 +10,8 @@ from .services import build_alerts_summary
 
 
 class AlertsSummaryView(APIView):
-    """GET /api/alerts/summary/ — overdue tasks, expiring warranties, due maintenances."""
+    """GET /api/alerts/summary/ — overdue tasks, expiring warranties, due
+    maintenances, low/out/expired stock, low-runway consumption trackers."""
 
     permission_classes = [IsAuthenticated, IsHouseholdMember]
 
@@ -18,6 +19,13 @@ class AlertsSummaryView(APIView):
         household = request.household
         if household is None:
             return Response(
-                {"overdue_tasks": [], "expiring_warranties": [], "due_maintenances": [], "total": 0}
+                {
+                    "overdue_tasks": [],
+                    "expiring_warranties": [],
+                    "due_maintenances": [],
+                    "low_stock": [],
+                    "low_runway_trackers": [],
+                    "total": 0,
+                }
             )
         return Response(build_alerts_summary(household))

--- a/apps/tasks/tests/test_api_tasks_due_before.py
+++ b/apps/tasks/tests/test_api_tasks_due_before.py
@@ -1,0 +1,194 @@
+"""
+Tests for the ?due_before=YYYY-MM-DD filter added to TaskViewSet (lot 1, #226).
+
+GET /api/tasks/tasks/?due_before=YYYY-MM-DD returns tasks whose due_date <=
+due_before (inclusive bound).
+
+Covers:
+  - inclusive bound (task on the exact date is returned)
+  - exclusive: task one day past the bound is excluded
+  - tasks without due_date are always excluded by the filter
+  - invalid date format → 400 with 'due_before' key in the error body
+  - combination with ?status= filter works correctly
+  - household isolation: filter still scopes to the active household
+"""
+
+from datetime import date, timedelta
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from households.models import Household, HouseholdMember
+from tasks.models import Task
+from zones.models import Zone
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _create_household(name: str) -> Household:
+    return Household.objects.create(name=name)
+
+
+def _add_membership(user, household, role=HouseholdMember.Role.OWNER):
+    return HouseholdMember.objects.create(user=user, household=household, role=role)
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _root_zone(household: Household) -> Zone:
+    return Zone.objects.get(household=household, parent__isnull=True)
+
+
+def _create_task(household, user, *, subject: str = "Task", due_date=None, task_status: str = "pending") -> Task:
+    return Task.objects.create(
+        household=household,
+        created_by=user,
+        subject=subject,
+        due_date=due_date,
+        status=task_status,
+    )
+
+
+def _due_before_url(due_before: str, extra: str = "") -> str:
+    base = reverse("task-list")
+    params = f"due_before={due_before}"
+    if extra:
+        params = f"{params}&{extra}"
+    return f"{base}?{params}"
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="tasks-due-before@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = _create_household("Due Before House")
+    _add_membership(owner, hh)
+    owner.active_household = hh
+    owner.save(update_fields=["active_household"])
+    return hh
+
+
+@pytest.fixture
+def owner_client(owner, household):
+    return _client_for(owner)
+
+
+# ── Core filter behaviour ──────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestTaskDueBeforeFilter:
+    """Covers the ?due_before= filter: bounds, edge cases, validation."""
+
+    def test_task_on_exact_date_is_returned(self, owner_client, household, owner):
+        """Inclusive bound: task with due_date == due_before must appear."""
+        target_date = date(2026, 7, 14)
+        _create_task(household, owner, subject="On the day", due_date=target_date)
+
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "On the day" in subjects
+
+    def test_task_before_bound_is_returned(self, owner_client, household, owner):
+        """Task with due_date earlier than due_before must appear."""
+        _create_task(household, owner, subject="Before bound", due_date=date(2026, 7, 10))
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "Before bound" in subjects
+
+    def test_task_one_day_past_bound_is_excluded(self, owner_client, household, owner):
+        """Task with due_date == due_before + 1 day must NOT appear."""
+        _create_task(household, owner, subject="After bound", due_date=date(2026, 7, 15))
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "After bound" not in subjects
+
+    def test_task_without_due_date_excluded(self, owner_client, household, owner):
+        """Tasks with no due_date are never included when the filter is active."""
+        _create_task(household, owner, subject="No due date", due_date=None)
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "No due date" not in subjects
+
+    def test_invalid_date_returns_400(self, owner_client, household):
+        """A non-ISO date string must produce a 400 with 'due_before' in the error body."""
+        response = owner_client.get(_due_before_url("not-a-date"))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "due_before" in response.data
+
+    def test_invalid_date_format_slash_returns_400(self, owner_client, household):
+        """DD/MM/YYYY format is not ISO — must produce 400."""
+        response = owner_client.get(_due_before_url("14/07/2026"))
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "due_before" in response.data
+
+    def test_combined_with_status_filter(self, owner_client, household, owner):
+        """?due_before= and ?status= applied together narrow the result set."""
+        target_date = date(2026, 7, 14)
+        _create_task(household, owner, subject="Pending within", due_date=target_date, task_status="pending")
+        _create_task(household, owner, subject="Done within", due_date=target_date, task_status="done")
+        _create_task(household, owner, subject="Pending outside", due_date=date(2026, 7, 20), task_status="pending")
+
+        response = owner_client.get(_due_before_url("2026-07-14", extra="status=pending"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "Pending within" in subjects
+        assert "Done within" not in subjects
+        assert "Pending outside" not in subjects
+
+    def test_multiple_tasks_all_on_or_before_bound_returned(self, owner_client, household, owner):
+        """All tasks within the window are returned together."""
+        _create_task(household, owner, subject="Day 10", due_date=date(2026, 7, 10))
+        _create_task(household, owner, subject="Day 14", due_date=date(2026, 7, 14))
+        _create_task(household, owner, subject="Day 20", due_date=date(2026, 7, 20))
+
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "Day 10" in subjects
+        assert "Day 14" in subjects
+        assert "Day 20" not in subjects
+
+    def test_filter_scoped_to_active_household(self, owner_client, household, owner):
+        """Tasks from another household must not appear, even if they match the date filter."""
+        target_date = date(2026, 7, 14)
+        other_owner = UserFactory(email="tasks-due-before-other@example.com")
+        other_hh = _create_household("Other Due Before House")
+        _add_membership(other_owner, other_hh)
+        # Task in the other household within the date window
+        _create_task(other_hh, other_owner, subject="Foreign task", due_date=target_date)
+        # Own task also within the window
+        _create_task(household, owner, subject="Own task", due_date=target_date)
+
+        response = owner_client.get(_due_before_url("2026-07-14"))
+        assert response.status_code == status.HTTP_200_OK
+        results = response.data.get("results", response.data)
+        subjects = [t["subject"] for t in results]
+        assert "Own task" in subjects
+        assert "Foreign task" not in subjects
+
+    def test_anonymous_request_rejected(self, household):
+        client = APIClient()
+        response = client.get(_due_before_url("2026-07-14"))
+        assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)

--- a/apps/tasks/views.py
+++ b/apps/tasks/views.py
@@ -1,6 +1,8 @@
 """
 Task REST API views.
 """
+from datetime import date
+
 from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework import viewsets, filters, status
@@ -61,6 +63,14 @@ class TaskViewSet(viewsets.ModelViewSet):
             qs = qs.filter(
                 due_date__lt=timezone.now().date()
             ).exclude(status__in=['done', 'archived'])
+
+        due_before = self.request.query_params.get('due_before', '').strip()
+        if due_before:
+            try:
+                due_limit = date.fromisoformat(due_before)
+            except ValueError:
+                raise ValidationError({'due_before': 'Must be an ISO date (YYYY-MM-DD).'})
+            qs = qs.filter(due_date__lte=due_limit)
 
         return qs
 


### PR DESCRIPTION
Closes #226

## Quoi

Lot 1 de la refonte dashboard (parcours 12, `docs/parcours/PARCOURS_12_DASHBOARD_POSTE_DE_PILOTAGE.md`) : le bloc « À traiter » du nouveau dashboard doit voir toutes les urgences du foyer, pas seulement tâches/garanties/maintenances.

- `apps/alerts/services.py` : deux nouvelles agrégations dans `build_alerts_summary`
  - `low_stock` — StockItem `low_stock` (warning) / `out_of_stock` / `expired` (critical), tri critiques d'abord puis nom. `out_of_stock` ajouté par rapport à l'issue : être à sec demande une action immédiate, même sévérité qu'expiré.
  - `low_runway_trackers` — trackers consommation actifs dont l'autonomie (`trackers.services.runway`) ≤ 14 j (critical ≤ 7 j), tri par autonomie croissante. Rendu identique au serializer trackers (`runway_days` str Decimal, `runway_until` date ISO).
  - `total` inclut les nouvelles familles ; réponse « pas de foyer actif » alignée.
- `apps/tasks/views.py` : filtre `?due_before=YYYY-MM-DD` (borne incluse, 400 si date invalide) — sert la card « Ma semaine ».
- 37 nouveaux tests (`test_api_alerts_lot1.py`, `test_api_tasks_due_before.py`). Suite complète : 1430 verts.

## Critères de l'issue

- ✅ `GET /api/alerts/summary/` expose `low_stock` et `low_runway_trackers`, `total` à jour
- ✅ stock `expired` → critical, `low_stock` → warning (+ `out_of_stock` → critical)
- ✅ tracker à 5 j → critical, 12 j → warning, 20 j → absent
- ✅ `?due_before=` borne incluse, date invalide → 400
- ✅ aucune régression sur les alertes existantes (77 tests inchangés verts)
