### PR TITLE
refactor(interactions): supprime Interaction.project, source polymorphe seule (#131)

### DIFF
--- a/apps/agent/tests/test_context.py
+++ b/apps/agent/tests/test_context.py
@@ -62,9 +62,10 @@ class TestBuildEntityContext:
     def test_anchor_and_related_are_rendered_and_citable(
         self, household, owner, make_project, make_document
     ):
+        from django.contrib.contenttypes.models import ContentType
         from django.utils import timezone
         from interactions.models import Interaction
-        from projects.models import ProjectDocument
+        from projects.models import Project, ProjectDocument
         from tasks.models import Task
 
         project = make_project(title="Rénovation PAC", description="devis en cours")
@@ -72,7 +73,9 @@ class TestBuildEntityContext:
         ProjectDocument.objects.create(project=project, document=doc)
         interaction = Interaction.objects.create(
             household=household, created_by=owner, subject="Dépense PAC",
-            occurred_at=timezone.now(), project=project,
+            occurred_at=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(Project),
+            source_object_id=project.pk,
         )
         task = Task.objects.create(
             household=household, created_by=owner, subject="Commander la PAC", project=project

--- a/apps/agent/tests/test_tools.py
+++ b/apps/agent/tests/test_tools.py
@@ -297,8 +297,9 @@ class TestGetRelated:
         self, household, owner, make_project, make_document
     ):
         from django.utils import timezone
+        from django.contrib.contenttypes.models import ContentType
         from interactions.models import Interaction
-        from projects.models import ProjectZone
+        from projects.models import Project, ProjectZone
         from tasks.models import Task
         from zones.models import Zone
 
@@ -307,7 +308,9 @@ class TestGetRelated:
         self._link_document(project, doc)
         interaction = Interaction.objects.create(
             household=household, created_by=owner, subject="Dépense PAC",
-            occurred_at=timezone.now(), project=project,
+            occurred_at=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(Project),
+            source_object_id=project.pk,
         )
         task = Task.objects.create(
             household=household, created_by=owner, subject="Commander la PAC", project=project
@@ -495,7 +498,7 @@ class TestCreateEntity:
             context_entity=("project", str(project.pk)),
         )
         note = Interaction.objects.get(subject="Penser au budget")
-        assert note.project_id == project.pk
+        assert note.source == project
 
     def test_unknown_entity_type_is_recoverable(self, household, owner):
         result = dispatch(

--- a/apps/interactions/admin.py
+++ b/apps/interactions/admin.py
@@ -17,7 +17,6 @@ class InteractionAdmin(admin.ModelAdmin):
     list_filter = ['type', 'status', 'is_private', 'household', 'occurred_at', 'created_at']
     search_fields = ['subject', 'content', 'enriched_text', 'tags__tag__name']
     readonly_fields = ['id', 'created_at', 'updated_at', 'created_by', 'updated_by']
-    # autocomplete_fields = ['project']  # TODO: Uncomment after projects app
     inlines = [InteractionZoneInline]
     
     fieldsets = [
@@ -31,9 +30,6 @@ class InteractionAdmin(admin.ModelAdmin):
             'fields': ['metadata', 'enriched_text'],
             'classes': ['collapse']
         }),
-        # ('Relations', {  # TODO: Uncomment after projects
-        #     'fields': ['project']
-        # }),
         ('Audit', {
             'fields': ['id', 'created_at', 'updated_at', 'created_by', 'updated_by'],
             'classes': ['collapse']

--- a/apps/interactions/management/commands/import_supabase_interactions.py
+++ b/apps/interactions/management/commands/import_supabase_interactions.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from typing import Any
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
@@ -210,6 +211,7 @@ class Command(BaseCommand):
         counters = ImportCounters()
         valid_types = {choice for choice, _label in Interaction.INTERACTION_TYPES}
         valid_statuses = {choice for choice, _label in Interaction.STATUS_CHOICES}
+        project_content_type = ContentType.objects.get_for_model(Project)
 
         for row in rows:
             interaction_id = row.get("id")
@@ -252,7 +254,8 @@ class Command(BaseCommand):
                 "occurred_at": occurred_at,
                 "metadata": metadata_value,
                 "enriched_text": row.get("enriched_text") or "",
-                "project_id": project_id,
+                "source_content_type": project_content_type if project_id else None,
+                "source_object_id": project_id,
                 "created_by_id": self._map_user_id(row.get("created_by"), fallback_user_id, existing_user_ids),
                 "updated_by_id": self._map_user_id(row.get("updated_by"), fallback_user_id, existing_user_ids),
             }

--- a/apps/interactions/migrations/0016_drop_interaction_project_fk.py
+++ b/apps/interactions/migrations/0016_drop_interaction_project_fk.py
@@ -1,0 +1,58 @@
+"""
+Step 1/2 of dropping `Interaction.project` (see #131): copy the legacy FK into
+the generic polymorphic source `(source_content_type, source_object_id)` — the
+same link stock and equipment already use (see 0015).
+
+Only rows without a source are touched: a dialog-created purchase already
+carries its source. The FK + index drop lives in 0017 — same transaction would
+fail on Postgres ("pending trigger events": the row updates fire deferred FK
+triggers that must commit before the ALTER TABLE).
+"""
+from django.db import migrations
+
+
+def copy_project_to_source(apps, schema_editor):
+    Interaction = apps.get_model('interactions', 'Interaction')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+
+    # Resolve the ContentType for projects.Project once
+    project_ct = ContentType.objects.filter(app_label='projects', model='project').first()
+    if project_ct is None:
+        return
+
+    # Interactions linked via the legacy FK that have no polymorphic source yet
+    candidates = Interaction.objects.filter(
+        project__isnull=False,
+        source_content_type__isnull=True,
+    )
+    for interaction in candidates.iterator():
+        interaction.source_content_type = project_ct
+        interaction.source_object_id = interaction.project_id
+        interaction.save(update_fields=['source_content_type', 'source_object_id'])
+
+
+def restore_project_from_source(apps, schema_editor):
+    """Reverse: only used if you migrate back. Best-effort."""
+    Interaction = apps.get_model('interactions', 'Interaction')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+
+    project_ct = ContentType.objects.filter(app_label='projects', model='project').first()
+    if project_ct is None:
+        return
+
+    candidates = Interaction.objects.filter(source_content_type=project_ct)
+    for interaction in candidates.iterator():
+        interaction.project_id = interaction.source_object_id
+        interaction.save(update_fields=['project_id'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('interactions', '0015_add_polymorphic_source'),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_project_to_source, reverse_code=restore_project_from_source),
+    ]

--- a/apps/interactions/migrations/0017_remove_interaction_project_field.py
+++ b/apps/interactions/migrations/0017_remove_interaction_project_field.py
@@ -1,0 +1,23 @@
+"""
+Step 2/2 of dropping `Interaction.project` (see #131): remove the FK + index
+now that 0016 copied the data into the polymorphic source columns.
+"""
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('interactions', '0016_drop_interaction_project_fk'),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name='interaction',
+            name='idx_int_project',
+        ),
+        migrations.RemoveField(
+            model_name='interaction',
+            name='project',
+        ),
+    ]

--- a/apps/interactions/models.py
+++ b/apps/interactions/models.py
@@ -80,14 +80,6 @@ class Interaction(HouseholdScopedModel):
     )
     
     # Relations
-    project = models.ForeignKey(
-        'projects.Project',
-        on_delete=models.SET_NULL,
-        null=True,
-        blank=True,
-        related_name='interactions',
-        db_column='project_id'
-    )
     source_content_type = models.ForeignKey(
         ContentType,
         on_delete=models.SET_NULL,
@@ -118,7 +110,6 @@ class Interaction(HouseholdScopedModel):
         indexes = [
             models.Index(fields=['household', 'type'], name='idx_int_hh_type'),
             models.Index(fields=['household', '-occurred_at'], name='idx_int_hh_date'),
-            models.Index(fields=['project'], name='idx_int_project'),
             models.Index(
                 fields=['source_content_type', 'source_object_id'],
                 name='idx_int_source',

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -17,6 +17,28 @@ from .models import (
 )
 
 
+# Source models a client may link an interaction to via the generic write API.
+# Stock/equipment purchases go through their own endpoints, but the read shape
+# is shared so the write allowlist mirrors it.
+ALLOWED_SOURCE_TYPES = {'projects.project', 'stock.stockitem', 'equipment.equipment'}
+
+
+class SourceContentTypeField(serializers.Field):
+    """Read/write the polymorphic source type as an 'app_label.model' string."""
+
+    def to_representation(self, value):
+        return f"{value.app_label}.{value.model}"
+
+    def to_internal_value(self, data):
+        key = str(data).strip().lower()
+        if key not in ALLOWED_SOURCE_TYPES:
+            raise serializers.ValidationError(
+                f"Unsupported source type. Allowed: {', '.join(sorted(ALLOWED_SOURCE_TYPES))}."
+            )
+        app_label, model = key.split('.')
+        return ContentType.objects.get_by_natural_key(app_label, model)
+
+
 class ManualExpenseSerializer(serializers.Serializer):
     """Input for POST /api/interactions/expenses/manual/."""
 
@@ -44,9 +66,12 @@ class InteractionSerializer(serializers.ModelSerializer):
         write_only=True,
         required=True
     )
-    project_title = serializers.SerializerMethodField()
-    source_type = serializers.SerializerMethodField()
-    source_id = serializers.UUIDField(source='source_object_id', read_only=True)
+    source_type = SourceContentTypeField(
+        source='source_content_type', required=False, allow_null=True
+    )
+    source_id = serializers.UUIDField(
+        source='source_object_id', required=False, allow_null=True
+    )
     source_label = serializers.SerializerMethodField()
     zone_names = serializers.SerializerMethodField()
     document_count = serializers.SerializerMethodField()
@@ -93,7 +118,6 @@ class InteractionSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'household', 'subject', 'content', 'type', 'status',
             'is_private', 'occurred_at', 'tags', 'tags_input', 'metadata', 'enriched_text',
-            'project', 'project_title',
             'source_type', 'source_id', 'source_label',
             'zone_ids', 'zone_names', 'document_count', 'linked_document_ids', 'document_ids',
             'contacts', 'contact_ids', 'structures', 'structure_ids',
@@ -107,18 +131,27 @@ class InteractionSerializer(serializers.ModelSerializer):
         interaction_type = data.get('type') or (self.instance.type if self.instance else None)
         if interaction_type != 'todo' and not data.get('occurred_at') and not (self.instance and self.instance.occurred_at):
             raise serializers.ValidationError({'occurred_at': 'This field is required for this interaction type.'})
-        return data
-    
-    def get_project_title(self, obj):
-        if obj.project_id:
-            return obj.project.title if obj.project else None
-        return None
 
-    def get_source_type(self, obj):
-        if obj.source_content_type_id is None:
-            return None
-        ct = obj.source_content_type
-        return f"{ct.app_label}.{ct.model}"
+        has_ct = 'source_content_type' in data
+        has_oid = 'source_object_id' in data
+        if has_ct or has_oid:
+            ct = data['source_content_type'] if has_ct else getattr(self.instance, 'source_content_type', None)
+            oid = data['source_object_id'] if has_oid else getattr(self.instance, 'source_object_id', None)
+            if (ct is None) != (oid is None):
+                raise serializers.ValidationError(
+                    {'source_id': 'source_type and source_id must be provided together.'}
+                )
+        return data
+
+    def _validate_source_in_household(self, source_ct, source_object_id, household_id):
+        """The linked source object must exist in the interaction's household."""
+        if source_ct is None or source_object_id is None:
+            return
+        model = source_ct.model_class()
+        if not model.objects.filter(pk=source_object_id, household_id=household_id).exists():
+            raise serializers.ValidationError(
+                {'source_id': 'Source object not found in this household.'}
+            )
 
     def get_source_label(self, obj):
         source = obj.source
@@ -238,6 +271,12 @@ class InteractionSerializer(serializers.ModelSerializer):
         structure_ids = validated_data.pop('structure_ids', [])
         equipment_ids = validated_data.pop('equipment_ids', [])
 
+        self._validate_source_in_household(
+            validated_data.get('source_content_type'),
+            validated_data.get('source_object_id'),
+            validated_data.get('household_id') or getattr(validated_data.get('household'), 'id', None),
+        )
+
         with transaction.atomic():
             interaction = Interaction.objects.create(**validated_data)
 
@@ -264,6 +303,12 @@ class InteractionSerializer(serializers.ModelSerializer):
         contact_ids = validated_data.pop('contact_ids', None)
         structure_ids = validated_data.pop('structure_ids', None)
         equipment_ids = validated_data.pop('equipment_ids', None)
+
+        self._validate_source_in_household(
+            validated_data.get('source_content_type', instance.source_content_type),
+            validated_data.get('source_object_id', instance.source_object_id),
+            instance.household_id,
+        )
 
         # Update interaction fields
         for attr, value in validated_data.items():

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -237,8 +237,9 @@ def create_note_interaction(
 
     Used by the agent's ``create_entity`` tool (entity_type='note'). The subject
     is provided by the user (no gettext template). Optionally linked to a project
-    (e.g. an anchored conversation) and/or zones. No expense metadata: a note
-    carries no amount/supplier, so ``metadata`` stays at its model default.
+    (e.g. an anchored conversation) via the polymorphic source FK, and/or zones.
+    No expense metadata: a note carries no amount/supplier, so ``metadata`` stays
+    at its model default.
 
     Args:
         household: Household instance (required).
@@ -251,6 +252,14 @@ def create_note_interaction(
     """
     if not subject or not subject.strip():
         raise ValueError("create_note_interaction: subject is required")
+
+    source_ct = None
+    source_object_id = None
+    if project is not None:
+        from projects.models import Project
+
+        source_ct = ContentType.objects.get_for_model(Project)
+        source_object_id = getattr(project, "pk", project)
 
     zones: list[Zone] = []
     if zone_ids:
@@ -268,7 +277,8 @@ def create_note_interaction(
             content=content or "",
             type="note",
             occurred_at=occurred_at or timezone.now(),
-            project_id=getattr(project, "pk", project),
+            source_content_type=source_ct,
+            source_object_id=source_object_id,
         )
         for zone in zones:
             InteractionZone.objects.create(interaction=interaction, zone=zone)

--- a/apps/interactions/tests/test_api_interactions.py
+++ b/apps/interactions/tests/test_api_interactions.py
@@ -1,6 +1,8 @@
+import uuid
 from datetime import timedelta
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -51,6 +53,11 @@ def household(db, owner):
 @pytest.fixture
 def owner_client(owner):
     return _client_for(owner)
+
+
+@pytest.fixture
+def other_household(db):
+    return _create_household("Foreign House")
 
 
 @pytest.fixture
@@ -572,43 +579,100 @@ class TestInteractionLinks:
         }
 
 @pytest.mark.django_db
-class TestInteractionProjectLink:
-    def test_create_interaction_with_project_links_correctly(self, owner_client, household, owner, primary_zone):
-        project = Project.objects.create(
+class TestInteractionSourceLink:
+    def _project(self, household, owner, title='Rénovation cuisine'):
+        return Project.objects.create(
             household=household,
             created_by=owner,
-            title='Rénovation cuisine',
+            title=title,
             type='renovation',
             status='active',
         )
 
+    def _linked_interaction(self, household, owner, project, subject='Tâche du projet'):
+        return Interaction.objects.create(
+            household=household,
+            created_by=owner,
+            subject=subject,
+            type='todo',
+            occurred_at=timezone.now(),
+            source_content_type=ContentType.objects.get_for_model(Project),
+            source_object_id=project.id,
+        )
+
+    def test_create_interaction_with_project_source_links_correctly(self, owner_client, household, owner, primary_zone):
+        project = self._project(household, owner)
+
         url = reverse("interaction-list")
         response = owner_client.post(
             url,
-            _interaction_payload([primary_zone.id], type="todo", project=str(project.id)),
+            _interaction_payload(
+                [primary_zone.id],
+                type="todo",
+                source_type="projects.project",
+                source_id=str(project.id),
+            ),
             format="json",
         )
 
         assert response.status_code == status.HTTP_201_CREATED
+        assert response.data["source_type"] == "projects.project"
+        assert response.data["source_id"] == str(project.id)
         interaction = Interaction.objects.get(id=response.data["id"])
-        assert interaction.project == project
+        assert interaction.source == project
 
-    def test_list_interactions_filtered_by_project(self, owner_client, household, owner, primary_zone):
-        project = Project.objects.create(
-            household=household,
-            created_by=owner,
-            title='Projet filtrage',
-            type='other',
-            status='active',
+    def test_create_interaction_with_unsupported_source_type_rejected(self, owner_client, household, owner, primary_zone):
+        url = reverse("interaction-list")
+        response = owner_client.post(
+            url,
+            _interaction_payload(
+                [primary_zone.id],
+                type="todo",
+                source_type="accounts.user",
+                source_id=str(uuid.uuid4()),
+            ),
+            format="json",
         )
-        linked = Interaction.objects.create(
-            household=household,
-            created_by=owner,
-            subject='Tâche du projet',
-            type='todo',
-            occurred_at=timezone.now(),
-            project=project,
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "source_type" in response.data
+
+    def test_create_interaction_with_source_type_alone_rejected(self, owner_client, household, owner, primary_zone):
+        url = reverse("interaction-list")
+        response = owner_client.post(
+            url,
+            _interaction_payload(
+                [primary_zone.id],
+                type="todo",
+                source_type="projects.project",
+            ),
+            format="json",
         )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "source_id" in response.data
+
+    def test_create_interaction_with_foreign_household_source_rejected(self, owner_client, household, owner, primary_zone, other_household):
+        foreign_project = self._project(other_household, owner, title='Projet étranger')
+
+        url = reverse("interaction-list")
+        response = owner_client.post(
+            url,
+            _interaction_payload(
+                [primary_zone.id],
+                type="todo",
+                source_type="projects.project",
+                source_id=str(foreign_project.id),
+            ),
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "source_id" in response.data
+
+    def test_list_interactions_filtered_by_source(self, owner_client, household, owner, primary_zone):
+        project = self._project(household, owner, title='Projet filtrage')
+        linked = self._linked_interaction(household, owner, project)
         linked.zones.add(primary_zone)
         unlinked = Interaction.objects.create(
             household=household,
@@ -622,7 +686,7 @@ class TestInteractionProjectLink:
         url = reverse("interaction-list")
         response = owner_client.get(
             url,
-            {"project": str(project.id)},
+            {"source_type": "projects.project", "source_id": str(project.id)},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -630,22 +694,28 @@ class TestInteractionProjectLink:
         assert str(linked.id) in result_ids
         assert str(unlinked.id) not in result_ids
 
-    def test_patch_interaction_does_not_erase_project(self, owner_client, household, owner, primary_zone):
-        project = Project.objects.create(
-            household=household,
-            created_by=owner,
-            title='Projet stable',
-            type='other',
-            status='active',
-        )
+    def test_list_interactions_with_invalid_source_params_returns_empty(self, owner_client, household, owner, primary_zone):
         interaction = Interaction.objects.create(
             household=household,
             created_by=owner,
-            subject='Tâche initiale',
+            subject='Tâche',
             type='todo',
             occurred_at=timezone.now(),
-            project=project,
         )
+        interaction.zones.add(primary_zone)
+
+        url = reverse("interaction-list")
+        response = owner_client.get(url, {"source_type": "not-a-model"})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("results", response.data) == []
+
+        response = owner_client.get(url, {"source_id": "not-a-uuid"})
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data.get("results", response.data) == []
+
+    def test_patch_interaction_does_not_erase_source(self, owner_client, household, owner, primary_zone):
+        project = self._project(household, owner, title='Projet stable')
+        interaction = self._linked_interaction(household, owner, project, subject='Tâche initiale')
         interaction.zones.add(primary_zone)
 
         url = reverse("interaction-detail", kwargs={"pk": interaction.id})
@@ -658,4 +728,4 @@ class TestInteractionProjectLink:
         assert response.status_code == status.HTTP_200_OK
         interaction.refresh_from_db()
         assert interaction.subject == "Tâche mise à jour"
-        assert interaction.project == project
+        assert interaction.source == project

--- a/apps/interactions/tests/test_import_supabase_interactions.py
+++ b/apps/interactions/tests/test_import_supabase_interactions.py
@@ -2,6 +2,7 @@ import uuid
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.management import call_command
 from django.test import TestCase
 from django.utils import timezone
@@ -114,7 +115,8 @@ class ImportSupabaseInteractionsCommandTests(TestCase):
         self.assertEqual(len(interaction.subject), 500)
         self.assertEqual(interaction.content, "")
         self.assertEqual(interaction.metadata, {})
-        self.assertEqual(interaction.project_id, project_id)
+        self.assertEqual(interaction.source_object_id, project_id)
+        self.assertEqual(interaction.source_content_type, ContentType.objects.get_for_model(Project))
         self.assertEqual(interaction.created_by_id, 1)
         self.assertEqual(interaction.updated_by_id, 1)
 

--- a/apps/interactions/tests/test_services.py
+++ b/apps/interactions/tests/test_services.py
@@ -269,7 +269,7 @@ class TestCreateNoteInteraction:
             project=project,
         )
         assert note.content == "carreaux 20x20 chez X"
-        assert note.project_id == project.pk
+        assert note.source == project
 
     def test_zone_link(self, user, household, membership, zone):
         note = create_note_interaction(

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -1,8 +1,10 @@
 """
 Interaction views for REST API.
 """
+import uuid
 from datetime import datetime, time, timedelta, timezone as dt_timezone
 
+from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
 from django.utils import timezone
 from rest_framework import viewsets, filters, status
@@ -64,7 +66,7 @@ class InteractionViewSet(viewsets.ModelViewSet):
     """
     permission_classes = [IsHouseholdMember]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['type', 'status', 'is_private', 'project', 'created_by']
+    filterset_fields = ['type', 'status', 'is_private', 'created_by']
     search_fields = ['subject', 'content', 'enriched_text', 'tags__tag__name']
     ordering_fields = ['occurred_at', 'created_at', 'subject']
     ordering = ['-occurred_at']
@@ -79,7 +81,7 @@ class InteractionViewSet(viewsets.ModelViewSet):
         """Filter interactions to households where current user is a member."""
         queryset = Interaction.objects.for_user_households(self.request.user).select_related(
             'created_by'
-        ).prefetch_related('zones', 'documents', 'project', 'tags__tag')
+        ).prefetch_related('zones', 'documents', 'source', 'tags__tag')
 
         selected_household = self.request.household
         if selected_household:
@@ -89,6 +91,22 @@ class InteractionViewSet(viewsets.ModelViewSet):
         zone_id = self.request.query_params.get('zone')
         if zone_id:
             queryset = queryset.filter(zones__id=zone_id)
+
+        # Filter by polymorphic source (e.g. ?source_type=projects.project&source_id=<uuid>)
+        source_type = self.request.query_params.get('source_type')
+        if source_type:
+            try:
+                app_label, model = source_type.strip().lower().split('.')
+                source_ct = ContentType.objects.get_by_natural_key(app_label, model)
+            except (ValueError, ContentType.DoesNotExist):
+                return queryset.none()
+            queryset = queryset.filter(source_content_type=source_ct)
+        source_id = self.request.query_params.get('source_id')
+        if source_id:
+            try:
+                queryset = queryset.filter(source_object_id=uuid.UUID(source_id))
+            except ValueError:
+                return queryset.none()
 
         # Filter by contact
         contact_id = self.request.query_params.get('contact')

--- a/apps/projects/apps.py
+++ b/apps/projects/apps.py
@@ -7,12 +7,21 @@ def _project_related(project):
     Walks the reverse relations to gather the project's documents, expenses /
     interactions, tasks and zones. Each returned instance is turned into a
     citable Hit through its own registered spec (unregistered types are skipped).
+    Interactions are linked via the polymorphic source FK, not a reverse relation.
     """
+    from django.contrib.contenttypes.models import ContentType
+    from interactions.models import Interaction
+
     items = []
     items.extend(
         pd.document for pd in project.project_documents.select_related("document")
     )
-    items.extend(project.interactions.all())
+    items.extend(
+        Interaction.objects.filter(
+            source_content_type=ContentType.objects.get_for_model(type(project)),
+            source_object_id=project.pk,
+        )
+    )
     items.extend(project.tasks.all())
     items.extend(pz.zone for pz in project.project_zones.select_related("zone"))
     return items

--- a/docs/parcours/PARCOURS_08_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_08_BACKLOG_TECHNIQUE.md
@@ -1,14 +1,14 @@
 # Parcours 08 — Backlog technique V1
 
-> **À démarrer** — la fondation est posée par la branche `feat/interaction-source-polymorphic` (FK polymorphe sur `Interaction`, service `create_expense_interaction`, composant frontend partagé `PurchaseForm`). Issue parente du chantier de fondation : **#119**. Issue qui définit le périmètre de **non-traitement** (catégorisation différée) : **#120**.
+> **✅ Livré** — la fondation (#119 : FK polymorphe sur `Interaction`, service `create_expense_interaction`, composant frontend partagé `PurchaseForm`) et les trois lots sont mergés. Suite : **#131** (PR 1 livrée) supprime l'ancienne FK directe `Interaction.project` — la source polymorphe est désormais l'unique liaison, l'API filtre par `?source_type=&source_id=`. Issue qui définit le périmètre de **non-traitement** (catégorisation différée) : **#120**.
 
 ## Tableau de bord
 
 | Lot | Sujet | Statut | Issue |
 |---|---|---|---|
-| 1.0 | Vue dépense agrégée + endpoint summary | ⏳ À démarrer | #122 |
-| 1.1 | Quick-add depuis Project | ⏳ À démarrer | #123 |
-| 1.2 | Dépense ad-hoc + split du service | ⏳ À démarrer | #124 |
+| 1.0 | Vue dépense agrégée + endpoint summary | ✅ Livré | #122 |
+| 1.1 | Quick-add depuis Project | ✅ Livré | #123 |
+| 1.2 | Dépense ad-hoc + split du service | ✅ Livré | #124 |
 
 **Issues annexes liées** :
 

--- a/docs/parcours/PARCOURS_08_SUIVRE_LES_DEPENSES.md
+++ b/docs/parcours/PARCOURS_08_SUIVRE_LES_DEPENSES.md
@@ -1,6 +1,6 @@
 # Parcours 08 — Voir et enregistrer ses dépenses depuis n'importe où dans le foyer
 
-> **À démarrer** — la branche `feat/interaction-source-polymorphic` (PR à merger) pose la fondation technique : FK polymorphe sur `Interaction` + service helper `create_expense_interaction` + composant frontend `PurchaseForm` partagé. Le présent parcours capitalise dessus pour livrer la vue dépense + l'extension aux projets + la dépense ad-hoc. Backlog technique : [PARCOURS_08_BACKLOG_TECHNIQUE.md](../../docs/parcours/PARCOURS_08_BACKLOG_TECHNIQUE.md).
+> **✅ Livré** — fondation technique mergée (FK polymorphe sur `Interaction`, service `create_expense_interaction`, composant frontend `PurchaseForm` partagé — #119, migration `0015`) et les trois lots (#122, #123, #124) sont en prod. Depuis #131 (PR 1), la FK polymorphe est la **seule** liaison dépense↔projet : l'ancienne FK directe `Interaction.project` a été supprimée (migrations `0016`/`0017`), l'API filtre par `?source_type=&source_id=`. Backlog technique : [PARCOURS_08_BACKLOG_TECHNIQUE.md](../../docs/parcours/PARCOURS_08_BACKLOG_TECHNIQUE.md).
 
 ## Résumé
 

--- a/e2e/project-purchase.spec.ts
+++ b/e2e/project-purchase.spec.ts
@@ -3,12 +3,14 @@ import { test, expect } from '@playwright/test';
 /**
  * Parcours 08 — Lot 1.1 : enregistrer une dépense liée à un projet.
  *
- * Issue: https://github.com/jammindev/house/issues/123
+ * Issues: https://github.com/jammindev/house/issues/123
+ *         https://github.com/jammindev/house/issues/131 (onglet Dépenses)
  *
- * Le test crée un projet, déclenche le quick-add depuis sa card, vérifie que
+ * Le test déclenche le quick-add depuis la card d'un projet, vérifie que
  * l'`Interaction(type=expense, kind='project_purchase')` est créée et listée
- * dans /app/interactions, et que `actual_cost_cached` est incrémenté côté
- * card (BudgetBar visible).
+ * dans /app/interactions ET dans l'onglet Dépenses du projet (liaison via la
+ * source polymorphe — c'était le bug de désync de #131), et qu'elle apparaît
+ * dans la vue dépenses.
  */
 
 test('parcours achat projet — Rénovation salle de bain 450€ Leroy Merlin', async ({ page }) => {
@@ -36,6 +38,13 @@ test('parcours achat projet — Rénovation salle de bain 450€ Leroy Merlin', 
   await page.locator('#purchase-supplier').fill(supplier);
   await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
   await expect(dialog).toBeHidden();
+
+  // Vérifier que la dépense apparaît dans l'onglet Dépenses du projet
+  // (régression #131 : les achats du dialog n'y étaient pas visibles)
+  await page.getByText(projectTitle, { exact: true }).first().click();
+  await expect(page).toHaveURL(/\/app\/projects\/[0-9a-f-]+/);
+  await page.getByRole('button', { name: 'Dépenses', exact: true }).click();
+  await expect(page.getByText(`Achat — ${projectTitle}`).first()).toBeVisible();
 
   // Vérifier que l'interaction expense est listée dans /app/interactions
   await page.goto('/app/interactions');

--- a/ui/src/features/interactions/InteractionCard.tsx
+++ b/ui/src/features/interactions/InteractionCard.tsx
@@ -82,15 +82,15 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
             </div>
           ) : null}
 
-          {item.project && item.project_title ? (
+          {item.source_type === 'projects.project' && item.source_id && item.source_label ? (
             <div className="mt-1 text-xs text-muted-foreground">
               <span>{t('interactions.project_label')}: </span>
               <Link
-                to={`/app/projects/${item.project}`}
+                to={`/app/projects/${item.source_id}`}
                 state={pushBack(location)}
                 className="text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               >
-                {item.project_title}
+                {item.source_label}
               </Link>
             </div>
           ) : null}

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -142,14 +142,14 @@ export default function InteractionDetailPage() {
             </InfoField>
           )}
 
-          {interaction.project && interaction.project_title && (
+          {interaction.source_type === 'projects.project' && interaction.source_id && interaction.source_label && (
             <InfoField label={t('interactions.project_label')}>
               <Link
-                to={`/app/projects/${interaction.project}`}
+                to={`/app/projects/${interaction.source_id}`}
                 state={pushBack(location)}
                 className="text-primary hover:underline"
               >
-                {interaction.project_title}
+                {interaction.source_label}
               </Link>
             </InfoField>
           )}

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -150,7 +150,9 @@ export default function InteractionNewPage() {
         occurred_at: occurredAt.toISOString(),
         zone_ids: [zoneId],
         tags_input: tags,
-        project: paramProjectId || null,
+        ...(paramProjectId
+          ? { source_type: 'projects.project', source_id: paramProjectId }
+          : {}),
         contact_ids: contactId ? [contactId] : [],
         structure_ids: structureId ? [structureId] : [],
         equipment_ids: equipmentId ? [equipmentId] : [],

--- a/ui/src/features/projects/ProjectDashboard.tsx
+++ b/ui/src/features/projects/ProjectDashboard.tsx
@@ -296,7 +296,8 @@ function QuickNoteForm({ project }: { project: ProjectListItem }) {
         type: 'note',
         occurred_at: new Date().toISOString(),
         zone_ids: zoneIds,
-        project: project.id,
+        source_type: 'projects.project',
+        source_id: project.id,
       },
       {
         onSuccess: () => {

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -26,8 +26,6 @@ export interface InteractionListItem {
   zone_names: string[];
   document_count: number;
   created_by_name?: string;
-  project?: string | null;
-  project_title?: string | null;
   metadata?: Record<string, unknown>;
   source_type?: string | null;
   source_id?: string | null;
@@ -47,7 +45,8 @@ export interface CreateInteractionInput {
   tags_input?: string[];
   metadata?: Record<string, unknown>;
   document_ids?: string[];
-  project?: string | null;
+  source_type?: string | null;
+  source_id?: string | null;
   contact_ids?: string[];
   structure_ids?: string[];
   equipment_ids?: string[];

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -205,7 +205,8 @@ export async function fetchProjectInteractions(
   type?: string,
 ): Promise<ProjectInteractionItem[]> {
   const params: Record<string, string | number> = {
-    project: projectId,
+    source_type: 'projects.project',
+    source_id: projectId,
     ordering: '-occurred_at',
     limit: 100,
   };


### PR DESCRIPTION
Closes #131

## Quoi

PR 1 du découpage de #131 : suppression de la FK directe `Interaction.project` au profit de la seule liaison polymorphe `(source_content_type, source_object_id)` — le lien que stock et équipement utilisent déjà depuis `0015`.

Deux chemins de création coexistaient (dialog « achat projet » → source polymorphe ; formulaire complet → FK directe), d'où un bug visible : l'onglet **Dépenses** d'un projet ne voyait pas les achats faits via le dialog. Un seul chemin subsiste désormais.

### Backend
- **Migrations en 2 temps** : `0016` copie `project_id` → colonnes source (uniquement quand aucune source n'est déjà posée), `0017` drop FK + index. Séparées car dans une même transaction Postgres refuse l'`ALTER TABLE` après les updates (« pending trigger events », FK deferrable) — attrapé par le run E2E.
- **Serializer** : `project`/`project_title` supprimés ; `source_type`/`source_id` deviennent écrivables, avec allowlist (`projects.project`, `stock.stockitem`, `equipment.equipment`) et contrôle que l'objet source appartient au foyer de l'interaction.
- **API** : filtres `?source_type=&source_id=` remplacent `?project=` (params invalides → liste vide, pas de 500) ; prefetch de la source polymorphe.
- **Agent** : `create_note_interaction` (conversation ancrée sur un projet) lie via la source ; `_project_related` (tool `get_related`) requête via la source au lieu du reverse FK. La timeline projet couvre bien tous les types d'interaction (notes incluses), pas que les dépenses.
- **Import Supabase** : `project_id` legacy mappé sur la source polymorphe.
- **Admin** : lignes commentées du champ `project` supprimées → #46 devient sans objet.

### Frontend
- `InteractionNewPage` et la note rapide de `ProjectDashboard` envoient `source_type`/`source_id`.
- `fetchProjectInteractions` filtre par source → l'onglet Dépenses du projet voit les achats du dialog.
- `InteractionCard` / `InteractionDetailPage` affichent le lien projet via `source_*`.

## Critères de l'issue (scope PR 1)

- ✅ Migration data `project_id` → `source_*` quand source null + drop field/index
- ✅ Serializer : `project`/`project_title` retirés, write `source_type`/`source_id`, filtres `?source_type=&source_id=`
- ✅ Frontend : `fetchProjectInteractions`, `InteractionNewPage`, `InteractionCard` parlent `source_*` directement
- ✅ Tests : `test_api_project_purchase` (inchangé, déjà sur source), tests write + filtre polymorphes et rejets (type non autorisé, `source_type` seul, foyer étranger), `e2e/project-purchase.spec.ts` vérifie l'onglet Dépenses
- ✅ i18n : aucune nouvelle clé
- ✅ Addendum (commentaire du 2026-07-07) : chemin d'écriture agent (`create_note_interaction`) + `InteractionCard` basculés

## Hors scope

- PR 2 : `actual_cost_cached` calculé (SUM des interactions par source)
- PR 3 : point d'entrée UX unique pour l'achat projet
- 3 tests E2E `tasks.spec.ts` échouent en local **sur `main` aussi** (vérifié sur baseline, page de détail > 5 s) — préexistant, non lié
- Drift de migration préexistant détecté par `makemigrations --check` sur `notifications` (alter field `type`) — non lié

## Validation

- `pytest` : 1397 passed, 2 skipped
- `npm run lint` : 0 erreur (5 warnings préexistants hors fichiers touchés)
- `tsc -b` : OK
- E2E : `project-purchase`, `interaction-detail`, `stock-purchase`, `equipment-purchase` verts
