### PR TITLE
refactor(projects): actual_cost calculé depuis les Interactions liées (#234)

### DIFF
--- a/apps/projects/serializers.py
+++ b/apps/projects/serializers.py
@@ -10,6 +10,7 @@ from .models import (
     ProjectZone,
     UserPinnedProject,
 )
+from .services import project_actual_cost
 
 
 class ProjectPurchaseSerializer(serializers.Serializer):
@@ -63,6 +64,10 @@ class ProjectSerializer(serializers.ModelSerializer):
         required=False,
     )
     project_group_name = serializers.SerializerMethodField()
+    # Calculé (SUM des Interaction expense liées par la source polymorphe, #234) —
+    # la colonne DB du même nom n'est plus jamais écrite. Le nom de champ API est
+    # conservé pour ne pas casser les clients.
+    actual_cost_cached = serializers.SerializerMethodField()
     # Le modèle a default="" mais pas blank=True : DRF rejette les chaînes vides
     # par défaut. Le formulaire React envoie systématiquement description="" quand
     # l'utilisateur n'écrit rien — rendre le champ optionnel + blank-OK ici.
@@ -96,6 +101,12 @@ class ProjectSerializer(serializers.ModelSerializer):
             "updated_by",
         ]
         read_only_fields = ["id", "household", "created_at", "updated_at", "created_by", "updated_by"]
+
+    def get_actual_cost_cached(self, obj):
+        total = getattr(obj, "actual_cost_computed", None)
+        if total is None:
+            total = project_actual_cost(obj)
+        return str(Decimal(total).quantize(Decimal("0.01")))
 
     def get_is_pinned(self, obj):
         request = self.context.get("request")

--- a/apps/projects/services.py
+++ b/apps/projects/services.py
@@ -1,0 +1,57 @@
+"""
+Project cost computation.
+
+The actual cost is no longer a maintained counter: it is the SUM of the
+`metadata.amount` of the expense Interactions linked to the project via the
+polymorphic source FK (#131 / #234). The DB column `actual_cost_cached` is
+kept for now but never written anymore — every creation/edit/deletion path
+(purchase dialog, agent, undo) is reflected without sync logic.
+
+Amounts are stored as str(Decimal) in metadata (service convention, see
+`interactions.aggregations`), hence the Postgres cast before summing.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import DecimalField, OuterRef, Subquery, Sum, Value
+from django.db.models.fields.json import KeyTextTransform
+from django.db.models.functions import Cast, Coalesce
+
+from interactions.models import Interaction
+
+_AMOUNT_FIELD = DecimalField(max_digits=14, decimal_places=2)
+_ZERO = Value(Decimal("0.00"), output_field=_AMOUNT_FIELD)
+
+
+def _expense_amounts(project_ref):
+    from .models import Project
+
+    return Interaction.objects.filter(
+        type="expense",
+        source_content_type=ContentType.objects.get_for_model(Project),
+        source_object_id=project_ref,
+    ).annotate(
+        amount_decimal=Cast(KeyTextTransform("amount", "metadata"), _AMOUNT_FIELD)
+    )
+
+
+def annotate_actual_cost(queryset):
+    """Annotate each project with ``actual_cost_computed`` (one subquery, no N+1)."""
+    totals = (
+        _expense_amounts(OuterRef("pk"))
+        .values("source_object_id")
+        .annotate(total=Sum("amount_decimal"))
+        .values("total")[:1]
+    )
+    return queryset.annotate(
+        actual_cost_computed=Coalesce(Subquery(totals, output_field=_AMOUNT_FIELD), _ZERO)
+    )
+
+
+def project_actual_cost(project) -> Decimal:
+    """Single-project fallback when the annotation is absent (e.g. fresh instance)."""
+    return _expense_amounts(project.pk).aggregate(
+        total=Coalesce(Sum("amount_decimal"), _ZERO)
+    )["total"]

--- a/apps/projects/tests/test_api_project_purchase.py
+++ b/apps/projects/tests/test_api_project_purchase.py
@@ -54,7 +54,7 @@ def _purchase_url(project):
 
 
 @pytest.mark.django_db
-def test_register_purchase_increments_actual_cost_and_creates_expense(
+def test_register_purchase_reflects_computed_actual_cost_and_creates_expense(
     client, user, household, project, membership
 ):
     client.force_login(user)
@@ -87,31 +87,71 @@ def test_register_purchase_increments_actual_cost_and_creates_expense(
     assert interaction.metadata["supplier"] == "Leroy Merlin"
     assert interaction.metadata["project_title"] == "Kitchen reno"
 
+    # The DB column is dead: never written anymore (#234)
     project.refresh_from_db()
-    assert project.actual_cost_cached == Decimal("450.00")
+    assert project.actual_cost_cached == Decimal("0.00")
 
 
 @pytest.mark.django_db
-def test_register_purchase_accumulates_actual_cost(client, user, project, membership):
+def test_actual_cost_accumulates_over_purchases(client, user, project, membership):
     client.force_login(user)
-    project.actual_cost_cached = Decimal("100.00")
-    project.save(update_fields=["actual_cost_cached"])
+
+    first = client.post(
+        _purchase_url(project), data={"amount": "100.00"}, content_type="application/json"
+    )
+    assert first.status_code == 201, first.content
+    assert first.json()["actual_cost_cached"] == "100.00"
+
+    second = client.post(
+        _purchase_url(project), data={"amount": "50.50"}, content_type="application/json"
+    )
+    assert second.status_code == 201, second.content
+    assert second.json()["actual_cost_cached"] == "150.50"
+
+
+@pytest.mark.django_db
+def test_actual_cost_reflects_expense_deletion(client, user, project, membership):
+    client.force_login(user)
 
     response = client.post(
-        _purchase_url(project),
-        data={"amount": "50.50"},
-        content_type="application/json",
+        _purchase_url(project), data={"amount": "80.00"}, content_type="application/json"
     )
     assert response.status_code == 201, response.content
-    project.refresh_from_db()
-    assert project.actual_cost_cached == Decimal("150.50")
+    Interaction.objects.get(id=response.json()["interaction_id"]).delete()
+
+    detail = client.get(reverse("project-detail", kwargs={"pk": project.id}))
+    assert detail.status_code == 200
+    assert detail.json()["actual_cost_cached"] == "0.00"
 
 
 @pytest.mark.django_db
-def test_register_purchase_without_amount_does_not_touch_cost(client, user, project, membership):
+def test_actual_cost_counts_every_source_linked_expense(client, user, household, project, membership):
+    """Expenses created outside register_purchase count too — the whole point of #234."""
+    from django.utils import timezone
+
     client.force_login(user)
-    project.actual_cost_cached = Decimal("100.00")
-    project.save(update_fields=["actual_cost_cached"])
+    Interaction.objects.create(
+        household=household,
+        created_by=user,
+        subject="Achat direct",
+        type="expense",
+        occurred_at=timezone.now(),
+        metadata={"kind": "manual", "amount": "19.99", "supplier": ""},
+        source_content_type=ContentType.objects.get_for_model(Project),
+        source_object_id=project.id,
+    )
+
+    detail = client.get(reverse("project-detail", kwargs={"pk": project.id}))
+    assert detail.status_code == 200
+    assert detail.json()["actual_cost_cached"] == "19.99"
+
+
+@pytest.mark.django_db
+def test_register_purchase_without_amount_does_not_change_cost(client, user, project, membership):
+    client.force_login(user)
+    client.post(
+        _purchase_url(project), data={"amount": "100.00"}, content_type="application/json"
+    )
 
     response = client.post(
         _purchase_url(project),
@@ -121,8 +161,7 @@ def test_register_purchase_without_amount_does_not_touch_cost(client, user, proj
     assert response.status_code == 201, response.content
     payload = response.json()
     assert "interaction_id" in payload
-    project.refresh_from_db()
-    assert project.actual_cost_cached == Decimal("100.00")
+    assert payload["actual_cost_cached"] == "100.00"
     interaction = Interaction.objects.get(id=payload["interaction_id"])
     assert interaction.metadata["amount"] is None
 

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -1,6 +1,3 @@
-from decimal import Decimal
-
-from django.db import transaction
 from django.utils import timezone
 from rest_framework import status as drf_status, viewsets
 from rest_framework.decorators import action
@@ -24,6 +21,7 @@ from .serializers import (
     ProjectPurchaseSerializer,
     ProjectZoneSerializer,
 )
+from .services import annotate_actual_cost
 
 
 class _HouseholdScopedViewSet(viewsets.ModelViewSet):
@@ -63,7 +61,7 @@ class ProjectViewSet(_HouseholdScopedViewSet):
         status = self.request.query_params.get('status', '').strip()
         if status:
             queryset = queryset.filter(status=status)
-        return queryset
+        return annotate_actual_cost(queryset)
 
     def perform_create(self, serializer):
         household = self.request.household
@@ -96,38 +94,29 @@ class ProjectViewSet(_HouseholdScopedViewSet):
 
     @action(detail=True, methods=["post"], url_path="register-purchase")
     def register_purchase(self, request, pk=None):
-        """Increment Project.actual_cost_cached + create an expense Interaction.
+        """Create an Interaction(type=expense) linked to the project.
 
-        Single-action endpoint: increments the project's cached actual cost
-        AND creates an Interaction(type=expense) linked via the polymorphic
-        source FK.
+        The project's actual cost is computed from its expense interactions
+        (#234) — this endpoint only creates the interaction, nothing to sync.
         """
         project = self.get_object()
         serializer = ProjectPurchaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        amount = serializer.validated_data.get("amount")
-        supplier = serializer.validated_data.get("supplier", "") or ""
-        occurred_at = serializer.validated_data.get("occurred_at") or timezone.now()
-        notes = serializer.validated_data.get("notes", "") or ""
+        interaction = create_expense_interaction(
+            source=project,
+            user=request.user,
+            amount=serializer.validated_data.get("amount"),
+            supplier=serializer.validated_data.get("supplier", "") or "",
+            occurred_at=serializer.validated_data.get("occurred_at") or timezone.now(),
+            notes=serializer.validated_data.get("notes", "") or "",
+            kind="project_purchase",
+            extra_metadata={"project_title": project.title},
+        )
 
-        with transaction.atomic():
-            if amount is not None:
-                project.actual_cost_cached = (project.actual_cost_cached or Decimal("0")) + amount
-                project.updated_by = request.user
-                project.save(update_fields=["actual_cost_cached", "updated_by", "updated_at"])
-
-            interaction = create_expense_interaction(
-                source=project,
-                user=request.user,
-                amount=amount,
-                supplier=supplier,
-                occurred_at=occurred_at,
-                notes=notes,
-                kind="project_purchase",
-                extra_metadata={"project_title": project.title},
-            )
-
+        # Re-fetch through the annotated queryset so the response includes the
+        # freshly created expense in actual_cost_cached.
+        project = self.get_queryset().get(pk=project.pk)
         payload = ProjectSerializer(project, context={"request": request}).data
         payload["interaction_id"] = str(interaction.id)
         return Response(payload, status=drf_status.HTTP_201_CREATED)


### PR DESCRIPTION
Closes #234

## Quoi

PR 2 du chantier #131 : le coût réel d'un projet n'est plus un compteur incrémenté à la main mais la **somme calculée** des `metadata.amount` des `Interaction(type=expense)` liées au projet via la source polymorphe. Toute création, édition, suppression (dialog, agent, undo, form) est reflétée sans logique de synchronisation — le compteur ne peut plus dériver.

- `apps/projects/services.py` (nouveau) : `annotate_actual_cost(queryset)` — subquery `SUM` avec cast Postgres du `metadata.amount` (même convention que `interactions/aggregations.py`), une seule requête pour toute la liste (pas de N+1) ; `project_actual_cost(project)` en fallback pour les instances hors queryset annoté (ex. création).
- `ProjectSerializer.actual_cost_cached` → `SerializerMethodField`. **Nom de champ API conservé** (aucun impact front ni types générés) ; effet de bord bienvenu : le champ n'est plus écrivable par les clients.
- `register_purchase` ne touche plus la colonne : il crée l'interaction puis re-sérialise le projet via le queryset annoté.
- La colonne DB `actual_cost_cached` reste en place mais n'est **plus jamais écrite** (pas de migration dans cette PR — suppression possible plus tard).

## Critères de l'issue

- ✅ Annotation queryset (pas de N+1 sur la liste de 200 projets)
- ✅ `register_purchase` ne touche plus la colonne DB
- ✅ `metadata.amount` string → cast Postgres, logique alignée sur `expenses/summary`
- ✅ Dépenses sans montant comptent pour 0 (cast de NULL → exclu du SUM, Coalesce 0.00)
- ✅ Tests : accumulation, reflet des suppressions, dépenses créées hors `register_purchase`, colonne DB inchangée après achat
- ⚪ Migration de suppression de colonne : **non incluse** volontairement (décision « garder morte dans un premier temps » — trancher plus tard, éventuel renommage API en même temps)

## Hors scope

- PR 3 (#235) : point d'entrée UX unique pour l'achat projet
- L'import Supabase legacy écrit encore la colonne morte (sans effet sur l'API)

## Validation

- `pytest` : 1508 passed, 2 skipped
- `npm run lint` : 0 erreur ; `tsc -b` : OK
- E2E `project-purchase` : vert
