### PR TITLE
feat(projects): point d'entrée unique pour l'achat projet (#235)

### DIFF
--- a/e2e/project-purchase.spec.ts
+++ b/e2e/project-purchase.spec.ts
@@ -46,6 +46,15 @@ test('parcours achat projet — Rénovation salle de bain 450€ Leroy Merlin', 
   await page.getByRole('button', { name: 'Dépenses', exact: true }).click();
   await expect(page.getByText(`Achat — ${projectTitle}`).first()).toBeVisible();
 
+  // Point d'entrée unique (#235) : le bouton « Dépense » de l'onglet ouvre le
+  // dialog d'achat (pas le form complet)
+  await page.getByRole('button', { name: 'Dépense', exact: true }).last().click();
+  const tabDialog = page.getByRole('dialog');
+  await expect(tabDialog).toBeVisible();
+  await expect(tabDialog).toContainText('Enregistrer une dépense');
+  await tabDialog.getByRole('button', { name: 'Annuler' }).click();
+  await expect(tabDialog).toBeHidden();
+
   // Vérifier que l'interaction expense est listée dans /app/interactions
   await page.goto('/app/interactions');
   await expect(page.getByText(`Achat — ${projectTitle}`).first()).toBeVisible();

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -49,11 +49,19 @@ export default function InteractionNewPage() {
   const createMutation = useCreateInteraction();
 
   // Read initial values from query params
-  const paramType = searchParams.get('type') ?? 'note';
+  const rawParamType = searchParams.get('type') ?? 'note';
   const paramZoneId = searchParams.get('zone_id') ?? '';
   const paramProjectId = searchParams.get('project_id') ?? '';
   const paramEquipmentId = searchParams.get('equipment_id') ?? '';
   const paramSourceInteractionId = searchParams.get('source_interaction_id') ?? '';
+
+  // Une dépense liée à un projet passe exclusivement par le dialog d'achat
+  // (ProjectPurchaseDialog, #235) — le form complet ne propose pas ce type
+  // quand un projet est imposé via l'URL.
+  const paramType = paramProjectId && rawParamType === 'expense' ? 'note' : rawParamType;
+  const typeOptions = paramProjectId
+    ? TYPE_OPTIONS.filter((v) => v !== 'expense')
+    : TYPE_OPTIONS;
 
   const [subject, setSubject] = React.useState('');
   const [type, setType] = React.useState(paramType);
@@ -218,7 +226,7 @@ export default function InteractionNewPage() {
               value={type}
               onChange={(e) => setType(e.target.value)}
             >
-              {TYPE_OPTIONS.map((v) => (
+              {typeOptions.map((v) => (
                 <option key={v} value={v}>
                   {t(`equipment.interaction_type.${v}`, { defaultValue: v })}
                 </option>

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -56,12 +56,14 @@ function TabInteractions({
   emptyKey,
   addUrl,
   addLabel,
+  onAdd,
 }: {
   projectId: string;
   type?: string;
   emptyKey: string;
   addUrl?: string;
   addLabel?: string;
+  onAdd?: () => void;
 }) {
   const { t } = useTranslation();
   const location = useLocation();
@@ -85,7 +87,18 @@ function TabInteractions({
 
   return (
     <div className="space-y-3">
-      {addUrl ? (
+      {onAdd ? (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onAdd}
+            className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {addLabel}
+          </button>
+        </div>
+      ) : addUrl ? (
         <div className="flex justify-end">
           <Link
             to={addUrl}
@@ -334,6 +347,8 @@ export default function ProjectDetailPage() {
                     projectId={project.id}
                     type="expense"
                     emptyKey="projects.empty_expenses"
+                    onAdd={() => setPurchaseOpen(true)}
+                    addLabel={t('projects.purchase.actions.add')}
                   />
                 ) : null}
 


### PR DESCRIPTION
Closes #235

## Quoi

PR 3 et dernier volet du chantier #131 : un **seul point d'entrée** pour enregistrer un achat lié à un projet — le dialog rapide (`ProjectPurchaseDialog`).

- L'onglet **Dépenses** du détail projet gagne un bouton « Dépense » qui ouvre le dialog (`TabInteractions` accepte un `onAdd` en plus d'`addUrl`, même rendu visuel). C'était le seul onglet sans action d'ajout.
- `InteractionNewPage` ne propose plus le type `expense` quand `project_id` est imposé par l'URL — c'était le dernier chemin détourné (onglet Historique → « Ajouter une activité » → choisir « expense »), qui produisait un `metadata.kind='manual'` au lieu de `project_purchase`. Un accès direct `?type=expense&project_id=` retombe sur `note`.
- Les dépenses ad-hoc **sans** projet (`/app/expenses`, form complet sans `project_id`) sont inchangées.

## Critères de l'issue

- ✅ Plus aucun point d'entrée `?type=expense&project_id=` (aucun lien statique n'existait ; le chemin via le sélecteur de type est fermé)
- ✅ Onglets Notes / Historique conservent le form complet avec `project_id` pour les autres types (liaison source polymorphe, comportement inchangé)
- ✅ Cohérence des `metadata.kind` : tout achat projet est désormais `project_purchase`
- ✅ i18n : aucune nouvelle clé (réutilise `projects.purchase.actions.add`)
- ✅ E2E : `project-purchase.spec.ts` vérifie que le bouton de l'onglet ouvre le dialog

## Validation

- `pytest` : 1508 passed, 2 skipped
- `npm run lint` : 0 erreur ; `tsc -b` : OK
- E2E `project-purchase` : 3 passed
