### PR TITLE
fix(telegram): ouvre le deep-link en navigation same-tab (popup bloqué sur iOS)

### DIFF
--- a/ui/src/features/settings/components/TelegramSection.tsx
+++ b/ui/src/features/settings/components/TelegramSection.tsx
@@ -18,7 +18,11 @@ export function TelegramSection() {
 
   async function handleConnect() {
     const { deep_link } = await linkToken.mutateAsync();
-    window.open(deep_link, '_blank', 'noopener');
+    // Same-tab navigation, not window.open: a popup opened AFTER the await is
+    // outside the click's user-gesture tick and gets blocked on iOS Safari and
+    // installed PWAs (the button appeared to do nothing). Navigating to the
+    // t.me deep link isn't popup-blocked and hands off to the Telegram app.
+    window.location.href = deep_link;
   }
 
   const linkedSince = status.linked_at


### PR DESCRIPTION
## Quoi

Le bouton « Connecter Telegram » (Réglages) ne faisait **rien sur iPhone**. Le handler appelait `window.open()` **après** un `await` (récupération du link-token), donc hors du tick de user-gesture du clic — iOS Safari et les PWA installées bloquent silencieusement ce popup.

Fix : naviguer l'onglet courant vers le deep-link (`window.location.href = deep_link`) au lieu d'ouvrir un popup. Une navigation vers un lien `t.me` n'est pas soumise au bloqueur et passe la main à l'app Telegram — c'est aussi le comportement idéal sur mobile (le vrai cas d'usage de la liaison).

## Test

- `npm run lint` (0 erreur, warnings préexistants hors périmètre), `tsc -b` vert.
- Recette manuelle : depuis iPhone, Réglages → Connecter Telegram → ouvre bien `alfred_house_app_bot`.