### PR TITLE
feat(releases): génération auto du changelog au déploiement (mode --from-stdin)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,14 @@ jobs:
         run: |
           cd ~/jammin-dev/apps/house
           /usr/local/bin/docker compose -f docker-compose.prod.yml exec -T web python manage.py migrate
+
+      # Alimente la page « Nouveautés » (/app/changelog). Le conteneur n'a pas le
+      # .git (exclu par .dockerignore) : le runner, lui, l'a → on pipe le git log
+      # via stdin. continue-on-error : un échec ici ne doit jamais bloquer le deploy.
+      - name: Generate changelog
+        continue-on-error: true
+        run: |
+          cd ~/jammin-dev/apps/house
+          git log --pretty=format:'%H%x1f%cI%x1f%s%x1e' | \
+            /usr/local/bin/docker compose -f docker-compose.prod.yml exec -T web \
+            python manage.py generate_changelog --from-stdin

--- a/apps/releases/management/commands/generate_changelog.py
+++ b/apps/releases/management/commands/generate_changelog.py
@@ -6,7 +6,13 @@ Exemples :
     python manage.py generate_changelog --no-llm       # sans repolissage IA
     python manage.py generate_changelog --dry-run      # parse + affiche, n'écrit rien
     python manage.py generate_changelog --rebuild      # purge puis reconstruit tout
+
+    # En prod (conteneur sans .git) : le runner pipe le git log via stdin.
+    git log --pretty=format:'%H%x1f%cI%x1f%s%x1e' | \
+        python manage.py generate_changelog --from-stdin
 """
+import sys
+
 from django.core.management.base import BaseCommand
 
 from releases.models import ChangelogEntry
@@ -47,6 +53,11 @@ class Command(BaseCommand):
             default=None,
             help="Limiter au N commits les plus récents.",
         )
+        parser.add_argument(
+            "--from-stdin",
+            action="store_true",
+            help="Lire le git log depuis stdin (conteneur sans .git — usage prod).",
+        )
 
     def handle(self, *args, **options):
         if options["dry_run"]:
@@ -64,12 +75,18 @@ class Command(BaseCommand):
             deleted, _ = ChangelogEntry.objects.all().delete()
             self.stdout.write(self.style.WARNING(f"{deleted} entrée(s) supprimée(s)."))
 
-        since = None if (options["all"] or options["rebuild"]) else "auto"
-        created = generate_changelog(
-            since_sha=since,
-            limit=options["limit"],
-            use_llm=not options["no_llm"],
-        )
+        if options["from_stdin"]:
+            created = generate_changelog(
+                raw_log=sys.stdin.read(),
+                use_llm=not options["no_llm"],
+            )
+        else:
+            since = None if (options["all"] or options["rebuild"]) else "auto"
+            created = generate_changelog(
+                since_sha=since,
+                limit=options["limit"],
+                use_llm=not options["no_llm"],
+            )
         self.stdout.write(
             self.style.SUCCESS(f"{len(created)} nouvelle(s) entrée(s) de changelog.")
         )

--- a/apps/releases/services.py
+++ b/apps/releases/services.py
@@ -198,15 +198,25 @@ def generate_changelog(
     since_sha: str | None = "auto",
     limit: int | None = None,
     use_llm: bool = True,
+    raw_log: str | None = None,
 ) -> list[ChangelogEntry]:
     """Génère les entrées manquantes depuis le git log et met à jour l'état.
 
     ``since_sha='auto'`` (défaut) : ne traite que les commits postérieurs à la
     dernière entrée connue. ``None`` : tout l'historique (backfill). Une valeur
     explicite : depuis ce SHA. Idempotent — les commits déjà stockés sont ignorés.
+
+    ``raw_log`` : sortie de ``git log`` déjà capturée (format interne), à utiliser
+    au lieu de lancer ``git`` soi-même. Indispensable en prod : le conteneur n'a
+    pas le ``.git`` (exclu par ``.dockerignore``), le runner de déploiement pipe
+    donc l'historique via stdin. Quand fourni, ``since_sha``/``limit`` sont ignorés
+    (la déduplication par ``commit_sha`` assure l'idempotence).
     """
-    resolved_since = _resolve_since(since_sha)
-    raw = read_git_log(since_sha=resolved_since, limit=limit)
+    if raw_log is None:
+        resolved_since = _resolve_since(since_sha)
+        raw = read_git_log(since_sha=resolved_since, limit=limit)
+    else:
+        raw = raw_log
     commits = parse_git_log(raw)
 
     existing = set(
@@ -231,7 +241,7 @@ def generate_changelog(
         for c, summary in zip(fresh, summaries)
     ]
 
-    _update_state()
+    _update_state(raw if raw_log is not None else None)
     return created
 
 
@@ -242,9 +252,13 @@ def _resolve_since(since_sha: str | None) -> str | None:
     return latest.commit_sha if latest else None
 
 
-def _update_state() -> None:
-    """Enregistre le tip de main courant comme état live."""
-    head = read_git_log(limit=1)
+def _update_state(raw: str | None = None) -> None:
+    """Enregistre le tip de main courant comme état live.
+
+    ``raw`` : log déjà capturé (mode stdin) — son premier record est le HEAD
+    (git log est anti-chronologique). Sinon on relit ``git log`` localement.
+    """
+    head = raw if raw is not None else read_git_log(limit=1)
     for record in head.split(_RECORD_SEP):
         record = record.strip("\n")
         if not record:

--- a/apps/releases/tests/test_services.py
+++ b/apps/releases/tests/test_services.py
@@ -101,3 +101,40 @@ class TestGenerateChangelog:
             key=lambda e: e.module,
         )
         assert feat.summary == "nouvelle fonctionnalité"
+
+
+class TestGenerateFromStdin:
+    """Mode prod : historique fourni via ``raw_log`` (stdin), sans lancer git."""
+
+    def test_uses_raw_log_without_touching_git(self, db, monkeypatch):
+        def _boom(**kwargs):
+            raise AssertionError("read_git_log ne doit pas être appelé en mode raw_log")
+
+        monkeypatch.setattr(services, "read_git_log", _boom)
+        raw = _raw(
+            ("sha_a", ISO, "feat(agent): streaming (#50)"),
+            ("sha_b", ISO, "chore: bump"),
+        )
+        created = services.generate_changelog(raw_log=raw, use_llm=False)
+        assert len(created) == 1
+        assert created[0].module == "agent"
+
+    def test_updates_state_from_first_record(self, db, monkeypatch):
+        monkeypatch.setattr(
+            services, "read_git_log",
+            lambda **kw: (_ for _ in ()).throw(AssertionError("git interdit")),
+        )
+        raw = _raw(
+            ("head_sha", ISO, "feat(x): a (#1)"),
+            ("older_sha", ISO, "fix(y): b (#2)"),
+        )
+        services.generate_changelog(raw_log=raw, use_llm=False)
+        assert ChangelogState.load().head_sha == "head_sha"
+
+    def test_idempotent_across_repeated_pipes(self, db, monkeypatch):
+        monkeypatch.setattr(services, "read_git_log", lambda **kw: "")
+        raw = _raw(("s1", ISO, "feat(z): c (#9)"))
+        services.generate_changelog(raw_log=raw, use_llm=False)
+        again = services.generate_changelog(raw_log=raw, use_llm=False)
+        assert again == []
+        assert ChangelogEntry.objects.count() == 1


### PR DESCRIPTION
## Quoi

Câble le remplissage **automatique** de la page « Nouveautés » (`/app/changelog`) au déploiement. Suite directe de #244, qui avait livré la page mais la laissait **vide en prod** (le conteneur n'a pas le `.git`, exclu par `.dockerignore` → `generate_changelog` n'avait rien à parser dedans).

## Détails

**Code — mode `--from-stdin`**
- `generate_changelog(raw_log=...)` : utilise un `git log` déjà capturé au lieu de lancer `git` (que le conteneur ne peut pas). Idempotent (dédup par `commit_sha`), met à jour l'état live depuis le premier record.
- Nouvelle option CLI `--from-stdin` : lit l'historique sur stdin.

**CI — étape de génération au deploy**
- Étape ajoutée au job `deploy` (après les migrations), sur le runner self-hosted qui **a** le `.git` :
  ```
  git log --pretty=format:'%H%x1f%cI%x1f%s%x1e' | \
    docker compose exec -T web python manage.py generate_changelog --from-stdin
  ```
- **`continue-on-error: true`** : un échec de génération ne bloque **jamais** le déploiement des autres features.

## Effet au merge

- Ce déploiement **backfill toute la prod** pour la première fois (résumés reformulés par Claude, la clé est en prod).
- Chaque futur push sur `main` ajoute les nouvelles entrées automatiquement.

## Vérifications

- ✅ `pytest` (+3 tests dédiés au mode stdin ; 23 au total sur `releases`), lint, tsc.
- ✅ **Pipe testé en réel** en local : `git log … | manage.py generate_changelog --from-stdin` → 341 entrées régénérées.
- ✅ Cloisonné à `house` : le `git log` tourne dans le repo house, écrit dans la base house. Aucune autre app du VPS touchée.

_Pas d'issue GitHub liée (feature cadrée en conversation). Complète #244._
