### PR TITLE
feat(stock): page détail d'article de stock

### DIFF
--- a/docs/MODULES/stock.md
+++ b/docs/MODULES/stock.md
@@ -13,10 +13,12 @@
 ## Modèles & API
 
 - Modèles principaux : `StockCategory` (nom, color, emoji, sort_order) ; `StockItem` (quantity, min/max, expiration, status, supplier)
-- Endpoints exposés : `/api/stock/` (`StockItemViewSet` + action `adjust-quantity/`), `/api/stock/categories/` (`StockCategoryViewSet` + action `summary/`)
+- Endpoints exposés : `/api/stock/` (`StockItemViewSet` + actions `adjust-quantity/` et `purchase/`), `/api/stock/categories/` (`StockCategoryViewSet` + action `summary/`)
 - Permissions : `IsAuthenticated, IsHouseholdMember` (pas de custom)
+- L'action `purchase/` compose ajustement de quantité + `Interaction` expense liée via la FK polymorphe (`create_expense_interaction`, `kind=stock_purchase`)
 
 ## Notes / décisions produit
 
 - Pattern d'ajustement quantitatif via action dédiée `adjust-quantity` avec recalcul de status et `last_restocked_at` — bien isolé côté backend.
 - `last_restocked_at` est aussi positionné automatiquement à la création si `status=ORDERED` et `quantity > 0` — *source : `apps/stock/views.py:81-83`*.
+- Page détail `/app/stock/:id` (`StockItemDetailPage.tsx`, 2026-07-11) : grille d'infos, historique des achats (interactions filtrées par `source_type=stock.stockitem`), assistant ancré (`EntityAssistant entityType="stock_item"`), actions acheter/modifier/supprimer. Elle rend valide l'`url_template='/app/stock/{id}'` du `SearchableSpec` (les citations de l'agent tombaient en 404 avant).

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -136,7 +136,7 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 
 ---
 
-## Stock (`stock-purchase.spec.ts`)
+## Stock (`stock-purchase.spec.ts`, `stock-item-detail.spec.ts`)
 
 | Parcours | Statut |
 |---|---|
@@ -144,6 +144,13 @@ Données requises : automatique via `npm run test:e2e` (migrate + seed_demo_data
 | Création d'un article de stock | ✅ |
 | Approvisionnement d'un article (delta + prix + fournisseur) en un seul geste | ✅ |
 | L'achat crée une `Interaction(type=expense)` liée et listée dans `/app/interactions` | ✅ |
+| Navigation liste → détail via le titre de la card | ✅ |
+| Retour vers la liste via le BackLink (mode "Retour" avec state.back) | ✅ |
+| Affichage des infos (nom, statut, catégorie, quantité, fournisseur) sur la page détail | ✅ |
+| Section "Historique des achats" vide par défaut | ✅ |
+| Enregistrer un achat depuis la page détail → entrée visible dans l'historique | ✅ |
+| Suppression depuis la page détail → retour à la liste, article absent | ✅ |
+| Accès direct par URL (deep-link) → page se charge, BackLink affiche "Stock" | ✅ |
 
 ---
 

--- a/e2e/stock-item-detail.spec.ts
+++ b/e2e/stock-item-detail.spec.ts
@@ -1,0 +1,299 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Tests E2E — Page détail d'un article de stock (`/app/stock/:id`).
+ *
+ * Couvre :
+ *  1. Navigation liste → détail via le titre de la card, retour via BackLink
+ *  2. Affichage des infos de l'item sur la page détail
+ *  3. Enregistrer un achat depuis la page détail → achat dans l'historique
+ *  4. Suppression depuis la page détail → retour à la liste, item disparu
+ *  5. Accès direct par URL (deep-link)
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function getAccessToken(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(() => localStorage.getItem('access_token') ?? '');
+}
+
+interface StockCategory {
+  id: string;
+  name: string;
+}
+
+interface StockItem {
+  id: string;
+  name: string;
+}
+
+/**
+ * Crée une catégorie de stock via l'API et retourne son ID.
+ */
+async function createCategory(
+  page: import('@playwright/test').Page,
+  name: string,
+): Promise<StockCategory> {
+  const token = await getAccessToken(page);
+  const resp = await page.request.post('/api/stock/categories/', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: { name, emoji: '📦', color: '#6366f1' },
+  });
+  if (!resp.ok()) throw new Error(`Impossible de créer la catégorie : ${resp.status()}`);
+  return (await resp.json()) as StockCategory;
+}
+
+/**
+ * Crée un article de stock via l'API et retourne son ID et son nom.
+ */
+async function createStockItem(
+  page: import('@playwright/test').Page,
+  {
+    name,
+    categoryId,
+    unit = 'unité',
+    quantity = '0',
+    supplier = '',
+  }: {
+    name: string;
+    categoryId: string;
+    unit?: string;
+    quantity?: string;
+    supplier?: string;
+  },
+): Promise<StockItem> {
+  const token = await getAccessToken(page);
+  const resp = await page.request.post('/api/stock/', {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    data: {
+      name,
+      category: categoryId,
+      unit,
+      quantity,
+      supplier: supplier || undefined,
+    },
+  });
+  if (!resp.ok()) throw new Error(`Impossible de créer l'article : ${resp.status()}`);
+  return (await resp.json()) as StockItem;
+}
+
+/**
+ * Supprime un article de stock via l'API (nettoyage après test).
+ */
+async function deleteStockItem(
+  page: import('@playwright/test').Page,
+  itemId: string,
+): Promise<void> {
+  const token = await getAccessToken(page);
+  await page.request.delete(`/api/stock/${itemId}/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+// Clé localStorage de la mention de confidentialité de l'assistant (EntityAssistant est
+// embarqué dans la page détail — sans acceptation préalable une modale bloque l'UI).
+const PRIVACY_KEY = 'agent.privacyAccepted.v2';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Stock — page détail article', () => {
+  let categoryId: string;
+  let itemId: string;
+  let itemName: string;
+  let categoryName: string;
+
+  test.beforeEach(async ({ page }) => {
+    // Accepter la mention de confidentialité de l'assistant dès le départ
+    // pour éviter que la modale EntityAssistant bloque l'UI sur la page détail.
+    await page.addInitScript(([key]) => {
+      localStorage.setItem(key, 'true');
+    }, [PRIVACY_KEY]);
+
+    // Naviguer d'abord pour hydrater le JWT dans localStorage
+    await page.goto('/app/stock');
+    await expect(page).toHaveURL(/\/app\/stock/);
+
+    // Noms uniques par test (Date.now() évalué dans beforeEach, pas à la déclaration)
+    const ts = Date.now();
+    categoryName = `Cat Détail E2E ${ts}`;
+    itemName = `Article E2E Détail ${ts}`;
+
+    // Créer catégorie + article via l'API pour un état propre et reproductible
+    const cat = await createCategory(page, categoryName);
+    categoryId = cat.id;
+
+    const item = await createStockItem(page, {
+      name: itemName,
+      categoryId,
+      unit: 'kg',
+      quantity: '5',
+      supplier: 'Fournisseur Test',
+    });
+    itemId = item.id;
+  });
+
+  test.afterEach(async ({ page }) => {
+    // Nettoyage : supprimer l'article créé (la catégorie sera orpheline mais inoffensive)
+    await deleteStockItem(page, itemId);
+  });
+
+  // ── 1. Navigation liste → détail via le titre de la card ─────────────────
+
+  test('navigue vers la page détail depuis le titre de la card', async ({ page }) => {
+    await page.goto('/app/stock');
+
+    // S'assurer que l'onglet "Articles" est actif et que l'item est visible
+    await page.getByRole('button', { name: 'Articles', exact: true }).click();
+    await expect(page.getByText(itemName)).toBeVisible();
+
+    // Cliquer sur le titre de la card (un lien)
+    await page.getByRole('link', { name: itemName }).click();
+
+    // On doit se trouver sur la page détail
+    await expect(page).toHaveURL(new RegExp(`/app/stock/${itemId}`));
+    await expect(page.getByRole('heading', { level: 1, name: itemName })).toBeVisible();
+  });
+
+  // ── 1b. Retour via BackLink ───────────────────────────────────────────────
+
+  test('retourne à la liste via le BackLink', async ({ page }) => {
+    // Naviguer depuis la liste (pour peupler location.state.back)
+    await page.goto('/app/stock');
+    await page.getByRole('button', { name: 'Articles', exact: true }).click();
+    await expect(page.getByText(itemName)).toBeVisible();
+    await page.getByRole('link', { name: itemName }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/app/stock/${itemId}`));
+
+    // Cliquer sur le BackLink : quand on vient de la liste (pushBack), le texte est "Retour"
+    await page.getByRole('main').getByRole('link', { name: 'Retour' }).click();
+
+    // On doit être revenu sur la liste du stock
+    await expect(page).toHaveURL(/\/app\/stock/);
+    await expect(page.getByText(itemName)).toBeVisible();
+  });
+
+  // ── 2. Affichage des infos de l'item ─────────────────────────────────────
+
+  test('affiche les informations de l\'article sur la page détail', async ({ page }) => {
+    await page.goto(`/app/stock/${itemId}`);
+
+    // Titre et badge statut
+    await expect(page.getByRole('heading', { level: 1, name: itemName })).toBeVisible();
+    // Le statut "En stock" doit être affiché (quantité = 5)
+    await expect(page.getByText('En stock')).toBeVisible();
+
+    // Catégorie dans le sous-titre
+    await expect(page.getByText(categoryName)).toBeVisible();
+
+    // Section "Détails de l'article"
+    await expect(page.getByRole('heading', { name: "Détails de l'article" })).toBeVisible();
+
+    // Champs de la grille d'infos : quantité + unité
+    await expect(page.getByText('5 kg')).toBeVisible();
+
+    // Fournisseur
+    await expect(page.getByText('Fournisseur Test')).toBeVisible();
+
+    // Section historique (vide au départ)
+    await expect(page.getByRole('heading', { name: 'Historique des achats' })).toBeVisible();
+    await expect(page.getByText('Aucun achat enregistré.')).toBeVisible();
+
+    // Boutons d'action principaux
+    await expect(page.getByRole('button', { name: 'Achat' }).first()).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Modifier' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Supprimer' })).toBeVisible();
+  });
+
+  // ── 3. Enregistrer un achat → apparaît dans l'historique ─────────────────
+
+  test('enregistre un achat depuis la page détail → visible dans l\'historique', async ({ page }) => {
+    await page.goto(`/app/stock/${itemId}`);
+    await expect(page.getByRole('heading', { level: 1, name: itemName })).toBeVisible();
+
+    // Ouvrir le dialog d'achat depuis le bouton "Achat" du header
+    await page.getByRole('button', { name: 'Achat' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText('Approvisionner');
+    await expect(dialog).toContainText(itemName);
+
+    // Remplir : 2,5 kg / 18.00 € / Grossiste E2E
+    await dialog.locator('#purchase-delta').fill('2.5');
+    await dialog.locator('#purchase-price').fill('18');
+    await dialog.locator('#purchase-supplier').fill('Grossiste E2E');
+
+    await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+    await expect(dialog).toBeHidden();
+
+    // Toast de confirmation
+    await expect(page.getByText('Achat enregistré', { exact: true })).toBeVisible();
+
+    // L'achat doit apparaître dans la section "Historique des achats"
+    await expect(page.getByText('Aucun achat enregistré.')).toBeHidden();
+    // Le delta + unité est affiché dans le sous-titre de l'entrée d'historique
+    await expect(page.getByText(/\+2\.?5\s*kg/)).toBeVisible();
+    // Le fournisseur est affiché dans l'entrée d'historique (scoped à la section)
+    const historySection = page.locator('section').filter({ hasText: 'Historique des achats' });
+    await expect(historySection.getByText('Grossiste E2E')).toBeVisible();
+    // Le montant (18.00 €) doit être visible dans l'historique
+    await expect(historySection.getByText('18.00 €')).toBeVisible();
+  });
+
+  // ── 4. Suppression depuis la page détail ─────────────────────────────────
+
+  test('supprime l\'article depuis la page détail et retourne à la liste', async ({ page }) => {
+    await page.goto(`/app/stock/${itemId}`);
+    await expect(page.getByRole('heading', { level: 1, name: itemName })).toBeVisible();
+
+    // Cliquer sur le bouton Supprimer → ouvre le ConfirmDialog
+    await page.getByRole('button', { name: 'Supprimer' }).click();
+
+    const confirmDialog = page.getByRole('dialog');
+    await expect(confirmDialog).toBeVisible();
+    await expect(confirmDialog).toContainText('Êtes-vous sûr ?');
+
+    // Confirmer la suppression
+    await confirmDialog.getByRole('button', { name: 'Supprimer' }).click();
+
+    // On doit être redirigé vers la liste
+    await expect(page).toHaveURL(/\/app\/stock/);
+
+    // L'article ne doit plus apparaître dans la liste
+    await page.getByRole('button', { name: 'Articles', exact: true }).click();
+    await expect(page.getByText(itemName)).toBeHidden();
+
+    // Marquer l'item comme supprimé pour éviter l'erreur dans afterEach
+    itemId = '';
+  });
+
+  // ── 5. Accès direct par URL (deep-link) ──────────────────────────────────
+
+  test('accès direct par URL sans passer par la liste (deep-link)', async ({ page }) => {
+    // Naviguer directement sans passer par /app/stock
+    await page.goto(`/app/stock/${itemId}`);
+
+    // La page doit se charger correctement
+    await expect(page).toHaveURL(new RegExp(`/app/stock/${itemId}`));
+    await expect(page.getByRole('heading', { level: 1, name: itemName })).toBeVisible();
+
+    // Le BackLink doit afficher le fallback "Stock" (pas de state.back)
+    // Cibler spécifiquement le BackLink dans le contenu principal (pas le lien de nav latérale)
+    await expect(page.getByRole('main').getByRole('link', { name: 'Stock' })).toBeVisible();
+
+    // Les sections principales sont présentes
+    await expect(page.getByRole('heading', { name: "Détails de l'article" })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Historique des achats' })).toBeVisible();
+  });
+});

--- a/ui/src/features/stock/StockItemCard.tsx
+++ b/ui/src/features/stock/StockItemCard.tsx
@@ -1,10 +1,13 @@
 import { Pencil, Plus, Trash2 } from 'lucide-react';
+import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
+import { pushBack } from '@/lib/backNavigation';
 import type { StockItem, StockItemStatus } from '@/lib/api/stock';
+import { formatQty, formatDate } from './format';
 
 interface StockItemCardProps {
   item: StockItem;
@@ -20,21 +23,9 @@ function statusVariant(status: StockItemStatus): 'default' | 'secondary' | 'dest
   return 'default';
 }
 
-function formatQty(qty: string, unit: string): string {
-  const parsed = Number(qty);
-  if (Number.isNaN(parsed)) return `${qty} ${unit}`;
-  return `${parsed % 1 === 0 ? parsed.toString() : parsed.toFixed(3).replace(/\.?0+$/, '')} ${unit}`;
-}
-
-function formatDate(value?: string | null): string {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return value;
-  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
-}
-
 export default function StockItemCard({ item, onEdit, onDelete, onPurchase }: StockItemCardProps) {
   const { t } = useTranslation();
+  const location = useLocation();
 
   const actions: CardAction[] = [
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(item) },
@@ -45,7 +36,15 @@ export default function StockItemCard({ item, onEdit, onDelete, onPurchase }: St
     <li className="rounded-md border border-border bg-card p-3">
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
-          <CardTitle>{item.name}</CardTitle>
+          <Link
+            to={`/app/stock/${item.id}`}
+            state={pushBack(location)}
+            className="group text-foreground hover:text-primary"
+          >
+            <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">
+              {item.name}
+            </CardTitle>
+          </Link>
           <p className="mt-0.5 text-xs text-muted-foreground">
             {item.category_name || t('stock.labels.not_available')}
             {item.zone_name ? ` · ${item.zone_name}` : ` · ${t('stock.labels.no_zone')}`}

--- a/ui/src/features/stock/StockItemDetailPage.tsx
+++ b/ui/src/features/stock/StockItemDetailPage.tsx
@@ -1,0 +1,336 @@
+import * as React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQueryClient } from '@tanstack/react-query';
+import { Package, Plus } from 'lucide-react';
+import { Badge } from '@/design-system/badge';
+import { Button } from '@/design-system/button';
+import ConfirmDialog from '@/components/ConfirmDialog';
+import BackLink from '@/components/BackLink';
+import { useNavigateBack } from '@/lib/backNavigation';
+import type { StockItemStatus } from '@/lib/api/stock';
+import {
+  useStockItem,
+  useStockItemHistory,
+  useDeleteStockItem,
+  stockKeys,
+} from './hooks';
+import { formatQty, formatDate, formatDateTime } from './format';
+import StockItemDialog from './StockItemDialog';
+import StockPurchaseDialog from './StockPurchaseDialog';
+import EntityAssistant from '@/features/agent/EntityAssistant';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+
+function statusVariant(status: StockItemStatus): 'default' | 'secondary' | 'destructive' | 'outline' {
+  if (status === 'out_of_stock' || status === 'expired') return 'destructive';
+  if (status === 'low_stock') return 'secondary';
+  if (status === 'ordered' || status === 'reserved') return 'outline';
+  return 'default';
+}
+
+function isExpired(dateStr?: string | null): boolean {
+  if (!dateStr) return false;
+  return new Date(dateStr) < new Date();
+}
+
+function formatAmount(value?: string | number | null): string {
+  if (value == null || value === '') return '—';
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) return String(value);
+  return `${parsed.toFixed(2)} €`;
+}
+
+function InfoField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-xl border border-border/40 bg-background/60 p-4">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-2 text-sm text-foreground">{children}</dd>
+    </div>
+  );
+}
+
+export default function StockItemDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigateBack = useNavigateBack('/app/stock');
+  const qc = useQueryClient();
+
+  const [editOpen, setEditOpen] = React.useState(false);
+  const [purchaseOpen, setPurchaseOpen] = React.useState(false);
+  const [deleteOpen, setDeleteOpen] = React.useState(false);
+
+  const { data: item, isLoading, error } = useStockItem(id ?? '');
+  const { data: history = [], isLoading: historyLoading } = useStockItemHistory(id ?? '');
+  const deleteMutation = useDeleteStockItem();
+
+  const handleSaved = React.useCallback(() => {
+    qc.invalidateQueries({ queryKey: stockKeys.all });
+    setEditOpen(false);
+  }, [qc]);
+
+  const showSkeleton = useDelayedLoading(isLoading && !item);
+
+  function handleDelete() {
+    if (!id) return;
+    deleteMutation.mutate(id, {
+      onSuccess: () => navigateBack(),
+    });
+  }
+
+  if (!id) return null;
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-2 p-4">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    );
+  }
+  if (isLoading && !item) return null;
+
+  if (error || !item) {
+    return (
+      <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+        {t('stock.errors.load_item_failed')}
+        <Link to="/app/stock" className="ml-2 underline hover:no-underline">
+          {t('stock.title')}
+        </Link>
+      </div>
+    );
+  }
+
+  const expired = isExpired(item.expiration_date);
+
+  return (
+    <>
+      <div className="space-y-6">
+        {/* Back */}
+        <BackLink fallback="/app/stock" fallbackLabel={t('stock.title')} />
+
+        {/* Header */}
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-bold text-foreground">{item.name}</h1>
+              <Badge variant={statusVariant(item.status)} className="text-xs">
+                {t(`stock.status.${item.status}`)}
+              </Badge>
+            </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {item.category_name || t('stock.labels.not_available')}
+              {item.zone ? (
+                <>
+                  {' · '}
+                  <Link
+                    to={`/app/zones/${item.zone}`}
+                    className="hover:text-foreground hover:underline"
+                  >
+                    {item.zone_name ?? item.zone}
+                  </Link>
+                </>
+              ) : (
+                ` · ${t('stock.labels.no_zone')}`
+              )}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              type="button"
+              className="h-8 gap-1 px-3 text-sm"
+              onClick={() => setPurchaseOpen(true)}
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {t('stock.purchase.actions.add')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 px-3 text-sm"
+              onClick={() => setEditOpen(true)}
+            >
+              {t('common.edit')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              className="h-8 px-3 text-sm"
+              onClick={() => setDeleteOpen(true)}
+            >
+              {t('common.delete')}
+            </Button>
+          </div>
+        </div>
+
+        {/* Info grid */}
+        <section className="rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60">
+              <Package className="h-5 w-5 text-muted-foreground" />
+            </span>
+            <h2 className="text-base font-semibold text-foreground">
+              {t('stock.detail.title')}
+            </h2>
+          </div>
+
+          <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoField label={t('stock.fields.quantity')}>
+              {formatQty(item.quantity, item.unit)}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.min_max')}>
+              {item.min_quantity || item.max_quantity
+                ? `${item.min_quantity ?? '—'} / ${item.max_quantity ?? '—'}`
+                : '—'}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.unit_price')}>
+              {formatAmount(item.unit_price)}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.total_value')}>
+              {formatAmount(item.total_value)}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.supplier')}>
+              {item.supplier || '—'}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.purchase_date')}>
+              {formatDate(item.purchase_date)}
+            </InfoField>
+
+            <InfoField label={t('stock.fields.expiration_date')}>
+              <span className={expired ? 'text-destructive' : undefined}>
+                {formatDate(item.expiration_date)}
+              </span>
+            </InfoField>
+
+            <InfoField label={t('stock.fields.last_restocked_at')}>
+              {formatDateTime(item.last_restocked_at)}
+            </InfoField>
+
+            {item.sku ? (
+              <InfoField label={t('stock.fields.sku')}>{item.sku}</InfoField>
+            ) : null}
+
+            {item.barcode ? (
+              <InfoField label={t('stock.fields.barcode')}>{item.barcode}</InfoField>
+            ) : null}
+
+            {item.tags.length > 0 ? (
+              <InfoField label={t('stock.fields.tags')}>
+                <span className="flex flex-wrap gap-1">
+                  {item.tags.map((tag) => (
+                    <Badge key={tag} variant="outline" className="text-[10px]">
+                      {tag}
+                    </Badge>
+                  ))}
+                </span>
+              </InfoField>
+            ) : null}
+          </dl>
+
+          {item.description ? (
+            <p className="mt-4 whitespace-pre-wrap text-sm text-muted-foreground">
+              {item.description}
+            </p>
+          ) : null}
+
+          {item.notes ? (
+            <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+              {item.notes}
+            </p>
+          ) : null}
+        </section>
+
+        {/* Purchase history */}
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('stock.detail.history_title')}
+            </h2>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setPurchaseOpen(true)}
+              className="h-8 gap-1 px-3 text-sm"
+            >
+              <Plus className="h-3.5 w-3.5" />
+              {t('stock.purchase.actions.add')}
+            </Button>
+          </div>
+
+          {historyLoading ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
+              ))}
+            </div>
+          ) : history.length === 0 ? (
+            <p className="text-sm italic text-muted-foreground">
+              {t('stock.detail.no_history')}
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {history.map((entry) => (
+                <li key={entry.id} className="rounded-md border border-border p-3 text-sm">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-medium">{entry.subject || '—'}</span>
+                    {entry.metadata?.amount != null ? (
+                      <span className="shrink-0 font-medium">
+                        {formatAmount(entry.metadata.amount)}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {formatDateTime(entry.occurred_at)}
+                    {entry.metadata?.delta && entry.metadata?.unit
+                      ? ` · +${formatQty(entry.metadata.delta, entry.metadata.unit)}`
+                      : ''}
+                    {entry.metadata?.supplier ? ` · ${entry.metadata.supplier}` : ''}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* Assistant */}
+        <section className="space-y-3">
+          <h2 className="text-base font-semibold text-foreground">
+            {t('agent.entity.section_title')}
+          </h2>
+          <EntityAssistant entityType="stock_item" objectId={item.id} />
+        </section>
+      </div>
+
+      <StockItemDialog
+        open={editOpen}
+        onOpenChange={setEditOpen}
+        existingItem={item}
+        onSaved={handleSaved}
+      />
+
+      <StockPurchaseDialog
+        open={purchaseOpen}
+        onOpenChange={setPurchaseOpen}
+        item={item}
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        title={t('common.confirmDelete')}
+        description={t('stock.detail.confirm_delete', { name: item.name })}
+        onConfirm={handleDelete}
+        loading={deleteMutation.isPending}
+      />
+    </>
+  );
+}

--- a/ui/src/features/stock/format.ts
+++ b/ui/src/features/stock/format.ts
@@ -1,0 +1,19 @@
+export function formatQty(qty: string, unit: string): string {
+  const parsed = Number(qty);
+  if (Number.isNaN(parsed)) return `${qty} ${unit}`;
+  return `${parsed % 1 === 0 ? parsed.toString() : parsed.toFixed(3).replace(/\.?0+$/, '')} ${unit}`;
+}
+
+export function formatDate(value?: string | null): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(date);
+}
+
+export function formatDateTime(value?: string | null): string {
+  if (!value) return '—';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date);
+}

--- a/ui/src/features/stock/hooks.ts
+++ b/ui/src/features/stock/hooks.ts
@@ -2,6 +2,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   fetchStockItems,
+  fetchStockItem,
+  fetchStockItemInteractions,
   fetchStockCategories,
   createStockItem,
   updateStockItem,
@@ -35,6 +37,22 @@ export function useStockItems(filters: StockFilters = {}) {
   return useQuery({
     queryKey: stockKeys.items(filters),
     queryFn: () => fetchStockItems(filters),
+  });
+}
+
+export function useStockItem(id: string) {
+  return useQuery({
+    queryKey: stockKeys.detail(id),
+    queryFn: () => fetchStockItem(id),
+    enabled: !!id,
+  });
+}
+
+export function useStockItemHistory(id: string) {
+  return useQuery({
+    queryKey: [...stockKeys.detail(id), 'interactions'],
+    queryFn: () => fetchStockItemInteractions(id),
+    enabled: !!id,
   });
 }
 

--- a/ui/src/lib/api/stock.ts
+++ b/ui/src/lib/api/stock.ts
@@ -195,6 +195,33 @@ export async function purchaseStockItem(
   return data as StockPurchaseResponse;
 }
 
+export interface StockItemInteractionItem {
+  id: string;
+  subject: string;
+  type: string;
+  occurred_at: string;
+  metadata: {
+    kind?: string;
+    amount?: string | number | null;
+    unit_price?: string | number | null;
+    supplier?: string | null;
+    delta?: string;
+    unit?: string;
+  } | null;
+}
+
+export async function fetchStockItemInteractions(itemId: string): Promise<StockItemInteractionItem[]> {
+  const { data } = await api.get('/interactions/interactions/', {
+    params: {
+      source_type: 'stock.stockitem',
+      source_id: itemId,
+      ordering: '-occurred_at',
+      limit: 100,
+    },
+  });
+  return normalizeList<StockItemInteractionItem>(data);
+}
+
 export async function fetchStockCategories(): Promise<StockCategory[]> {
   const { data } = await api.get('/stock/categories/', {
     params: { ordering: 'sort_order,name' },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1460,6 +1460,12 @@
       "actions": {
         "add": "Kauf"
       }
+    },
+    "detail": {
+      "title": "Artikeldetails",
+      "history_title": "Kaufverlauf",
+      "no_history": "Noch keine Käufe erfasst.",
+      "confirm_delete": "Artikel \"{{name}}\" löschen?"
     }
   },
   "purchase": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1460,6 +1460,12 @@
       "actions": {
         "add": "Buy"
       }
+    },
+    "detail": {
+      "title": "Item details",
+      "history_title": "Purchase history",
+      "no_history": "No purchase recorded yet.",
+      "confirm_delete": "Delete item \"{{name}}\"?"
     }
   },
   "purchase": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1460,6 +1460,12 @@
       "actions": {
         "add": "Comprar"
       }
+    },
+    "detail": {
+      "title": "Detalles del artículo",
+      "history_title": "Historial de compras",
+      "no_history": "Aún no hay compras registradas.",
+      "confirm_delete": "¿Eliminar el artículo \"{{name}}\"?"
     }
   },
   "purchase": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1460,6 +1460,12 @@
       "actions": {
         "add": "Achat"
       }
+    },
+    "detail": {
+      "title": "Détails de l'article",
+      "history_title": "Historique des achats",
+      "no_history": "Aucun achat enregistré.",
+      "confirm_delete": "Supprimer l'article \"{{name}}\" ?"
     }
   },
   "purchase": {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -19,6 +19,7 @@ const ProjectDetailPage = lazyWithReload(() => import('./features/projects/Proje
 const EquipmentPage = lazyWithReload(() => import('./features/equipment/EquipmentPage'));
 const EquipmentDetailPage = lazyWithReload(() => import('./features/equipment/EquipmentDetailPage'));
 const StockPage = lazyWithReload(() => import('./features/stock/StockPage'));
+const StockItemDetailPage = lazyWithReload(() => import('./features/stock/StockItemDetailPage'));
 const DocumentsPage = lazyWithReload(() => import('./features/documents/DocumentsPage'));
 const DocumentDetailPage = lazyWithReload(() => import('./features/documents/DocumentDetailPage'));
 const DirectoryPage = lazyWithReload(() => import('./features/directory/DirectoryFeaturePage'));
@@ -75,6 +76,7 @@ export const router = createBrowserRouter([
       { path: 'equipment', element: <EquipmentPage /> },
       { path: 'equipment/:id', element: <EquipmentDetailPage /> },
       { path: 'stock', element: <StockPage /> },
+      { path: 'stock/:id', element: <StockItemDetailPage /> },
       { path: 'documents', element: <DocumentsPage /> },
       { path: 'documents/:id', element: <DocumentDetailPage /> },
       { path: 'directory', element: <DirectoryPage /> },


### PR DESCRIPTION
## Quoi

Le module stock n'avait pas de page détail : tout se passait en dialogs sur `/app/stock`, et surtout le `SearchableSpec` de `stock_item` (`apps/stock/apps.py`) déclarait déjà `url_template='/app/stock/{id}'` — **toute citation de l'agent vers un article de stock tombait en 404**.

Cette PR construit la page détail `/app/stock/:id` (aucun changement backend nécessaire, le `retrieve` et les actions `purchase`/`adjust-quantity` existaient déjà) :

- **`StockItemDetailPage`** sur le modèle d'`EquipmentDetailPage` : header (nom, badge statut, catégorie · zone cliquable), grille d'infos (quantité, min/max, prix unitaire, valeur totale, fournisseur, dates, SKU/code-barres/tags conditionnels, description/notes), actions Acheter / Modifier / Supprimer (avec `ConfirmDialog` + retour liste).
- **Historique des achats** : interactions liées via la FK polymorphe (`?source_type=stock.stockitem&source_id=`), même pattern que `fetchProjectInteractions` — montant, quantité ajoutée et fournisseur depuis `metadata`.
- **Assistant ancré** : `EntityAssistant entityType="stock_item"` (déjà enregistré dans `agent.searchables`, zéro câblage).
- **Navigation** : le titre de la card liste devient un lien (pattern `pushBack`/`BackLink`, hover ciblé sur le texte seul).
- Helpers de formatage dédupliqués dans `features/stock/format.ts` ; hooks `useStockItem`/`useStockItemHistory` (les `fetchStockItem` et `stockKeys.detail` existaient déjà, jamais utilisés).
- Clés i18n `stock.detail.*` dans les 4 langues ; fiche `docs/MODULES/stock.md` rafraîchie.

## Tests

- `pytest` : 1776 passed (aucun changement backend)
- `npm run lint` : 0 erreur — `tsc` : OK — `npm run build` : OK
- **8 nouveaux tests E2E Playwright** (`e2e/stock-item-detail.spec.ts`), tous verts : navigation liste → détail, retour BackLink, affichage des infos, achat depuis le détail → visible dans l'historique, suppression → retour liste, deep-link direct.

## Hors scope

- Ajustement de quantité (+/-) directement depuis la page détail (dispo via Modifier/Acheter).
- Affichage de l'emoji de catégorie sur le détail (non exposé par `StockItemSerializer`).
