### PR TITLE
fix(general): coupure réseau mieux gérée dans les formulaires — erreur immédiate, Annuler toujours actif, session préservée

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -429,6 +429,19 @@ export default function FeatureDialog({ open, onOpenChange, existing }: Props) {
 }
 ```
 
+Boutons du footer — **ne jamais désactiver « Annuler »/« Fermer » pendant
+`isPending`** : si la mutation traîne ou reste bloquée, l'utilisateur doit
+toujours pouvoir sortir du dialog. Seul le bouton submit se désactive :
+
+```tsx
+<Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+  {t('common.cancel')}
+</Button>
+<Button type="submit" disabled={isPending}>
+  {t('common.save')}
+</Button>
+```
+
 ---
 
 ## Assistant IA ancré sur une entité (agent générique)

--- a/ui/src/features/agent/MemoryPage.tsx
+++ b/ui/src/features/agent/MemoryPage.tsx
@@ -180,7 +180,6 @@ function MemoryEditor({ memory, onDone }: { memory: AgentMemory; onDone: () => v
             size="sm"
             variant="ghost"
             onClick={onDone}
-            disabled={updateMemory.isPending}
             aria-label={t('common.cancel')}
           >
             <X className="h-4 w-4" />

--- a/ui/src/features/chickens/ChickenDialog.tsx
+++ b/ui/src/features/chickens/ChickenDialog.tsx
@@ -168,7 +168,7 @@ export default function ChickenDialog({ open, onOpenChange, existing }: ChickenD
           </FormField>
 
           <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={isPending || !name.trim()}>

--- a/ui/src/features/chickens/ChickenEventDialog.tsx
+++ b/ui/src/features/chickens/ChickenEventDialog.tsx
@@ -186,7 +186,7 @@ export default function ChickenEventDialog({
           ) : null}
 
           <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={isPending}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={isPending || !title.trim()}>

--- a/ui/src/features/directory/ContactDialog.tsx
+++ b/ui/src/features/directory/ContactDialog.tsx
@@ -173,7 +173,6 @@ export default function ContactDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={loading}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/directory/StructureDialog.tsx
+++ b/ui/src/features/directory/StructureDialog.tsx
@@ -148,7 +148,6 @@ export default function StructureDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={loading}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/documents/DocumentEditDialog.tsx
+++ b/ui/src/features/documents/DocumentEditDialog.tsx
@@ -110,7 +110,6 @@ export default function DocumentEditDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={updateDocument.isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/documents/DocumentUploadDialog.tsx
+++ b/ui/src/features/documents/DocumentUploadDialog.tsx
@@ -188,7 +188,6 @@ export default function DocumentUploadDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={createDocument.isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/equipment/EquipmentDialog.tsx
+++ b/ui/src/features/equipment/EquipmentDialog.tsx
@@ -392,7 +392,6 @@ export default function EquipmentDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/insurance/InsuranceDialog.tsx
+++ b/ui/src/features/insurance/InsuranceDialog.tsx
@@ -300,7 +300,7 @@ export default function InsuranceDialog({ open, onOpenChange, onSaved, existing 
           </FormField>
 
           <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={submitting}>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {t('common.cancel')}
             </Button>
             <Button type="submit" disabled={submitting}>

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -216,7 +216,6 @@ export default function InteractionEditPage() {
           type="button"
           variant="outline"
           onClick={() => navigate(-1)}
-          disabled={submitting}
         >
           {t('common.cancel')}
         </Button>
@@ -469,7 +468,6 @@ export default function InteractionEditPage() {
             type="button"
             variant="outline"
             onClick={() => navigate(-1)}
-            disabled={submitting}
           >
             {t('common.cancel')}
           </Button>

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -192,7 +192,6 @@ export default function InteractionNewPage() {
             else if (paramProjectId) navigate(`/app/projects/${paramProjectId}`);
             else navigate('/app/interactions');
           }}
-          disabled={submitting}
         >
           {t('common.cancel')}
         </Button>
@@ -445,7 +444,6 @@ export default function InteractionNewPage() {
               else if (paramProjectId) navigate(`/app/projects/${paramProjectId}`);
               else navigate('/app/interactions');
             }}
-            disabled={submitting}
           >
             {t('common.cancel')}
           </Button>

--- a/ui/src/features/interactions/PurchaseForm.tsx
+++ b/ui/src/features/interactions/PurchaseForm.tsx
@@ -211,7 +211,6 @@ export default function PurchaseForm({
           type="button"
           variant="outline"
           onClick={onCancel}
-          disabled={isPending}
         >
           {t('common.cancel')}
         </Button>

--- a/ui/src/features/projects/GroupDialog.tsx
+++ b/ui/src/features/projects/GroupDialog.tsx
@@ -101,7 +101,6 @@ export default function GroupDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={loading}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/projects/ProjectAttachDocumentDialog.tsx
+++ b/ui/src/features/projects/ProjectAttachDocumentDialog.tsx
@@ -131,7 +131,6 @@ export default function ProjectAttachDocumentDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={attachMutation.isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/projects/ProjectDialog.tsx
+++ b/ui/src/features/projects/ProjectDialog.tsx
@@ -235,7 +235,6 @@ export default function ProjectDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={loading}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/settings/components/HouseholdManagement/components/HouseholdCard.tsx
+++ b/ui/src/features/settings/components/HouseholdManagement/components/HouseholdCard.tsx
@@ -253,7 +253,7 @@ export function HouseholdCard({
         description={t('common.confirmArchive', { defaultValue: 'Archive this household? It will no longer be accessible.' })}
       >
         <div className="flex justify-end gap-2 pt-2">
-          <Button type="button" variant="ghost" onClick={onClosePanel} disabled={loading}>
+          <Button type="button" variant="ghost" onClick={onClosePanel}>
             {t('common.cancel', { defaultValue: 'Cancel' })}
           </Button>
           <Button

--- a/ui/src/features/settings/components/ProfileSection.tsx
+++ b/ui/src/features/settings/components/ProfileSection.tsx
@@ -217,7 +217,7 @@ export function ProfileSection() {
                 <Check className="mr-2 h-4 w-4" />
                 {saving ? t('settings.updating') : t('common.save')}
               </Button>
-              <Button size="sm" type="button" variant="outline" onClick={handleCancel} disabled={saving}>
+              <Button size="sm" type="button" variant="outline" onClick={handleCancel}>
                 <X className="mr-2 h-4 w-4" />
                 {t('common.cancel')}
               </Button>

--- a/ui/src/features/stock/StockCategoryDialog.tsx
+++ b/ui/src/features/stock/StockCategoryDialog.tsx
@@ -140,7 +140,6 @@ export default function StockCategoryDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/stock/StockItemDialog.tsx
+++ b/ui/src/features/stock/StockItemDialog.tsx
@@ -283,7 +283,6 @@ export default function StockItemDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/tasks/NewTaskDialog.tsx
+++ b/ui/src/features/tasks/NewTaskDialog.tsx
@@ -392,7 +392,6 @@ export default function NewTaskDialog({
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={loading}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/features/zones/ZoneDialog.tsx
+++ b/ui/src/features/zones/ZoneDialog.tsx
@@ -175,7 +175,6 @@ export default function ZoneDialog({ open, onOpenChange, existing }: ZoneDialogP
               type="button"
               variant="outline"
               onClick={() => onOpenChange(false)}
-              disabled={isPending}
             >
               {t('common.cancel')}
             </Button>

--- a/ui/src/lib/axios.ts
+++ b/ui/src/lib/axios.ts
@@ -13,24 +13,36 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
+function logout() {
+  localStorage.removeItem('access_token');
+  localStorage.removeItem('refresh_token');
+  localStorage.removeItem('_impersonator_tokens');
+  window.location.href = '/login';
+}
+
 api.interceptors.response.use(
   (response) => response,
   async (error) => {
     const original = error.config;
     if (error.response?.status === 401 && !original._retry) {
       original._retry = true;
-      try {
-        const refresh = localStorage.getItem('refresh_token');
-        if (!refresh) throw new Error('No refresh token');
-        const { data } = await axios.post('/api/auth/token/refresh/', { refresh });
-        localStorage.setItem('access_token', data.access);
-        original.headers.Authorization = `Bearer ${data.access}`;
-        return api(original);
-      } catch {
-        localStorage.removeItem('access_token');
-        localStorage.removeItem('refresh_token');
-        localStorage.removeItem('_impersonator_tokens');
-        window.location.href = '/login';
+      const refresh = localStorage.getItem('refresh_token');
+      if (!refresh) {
+        logout();
+      } else {
+        try {
+          const { data } = await axios.post('/api/auth/token/refresh/', { refresh });
+          localStorage.setItem('access_token', data.access);
+          original.headers.Authorization = `Bearer ${data.access}`;
+          return api(original);
+        } catch (refreshError) {
+          // Ne déconnecter que si le serveur a réellement refusé le refresh token.
+          // Sans réponse (coupure réseau pendant le refresh), la session est
+          // peut-être encore valide — on laisse l'erreur d'origine remonter.
+          if (axios.isAxiosError(refreshError) && refreshError.response) {
+            logout();
+          }
+        }
       }
     }
     return Promise.reject(error);

--- a/ui/src/lib/components/DocumentSelector.tsx
+++ b/ui/src/lib/components/DocumentSelector.tsx
@@ -328,7 +328,7 @@ export function DocumentSelector({
                     ? t('documentSelector.upload_submitting', { defaultValue: 'Uploading…' })
                     : t('documentSelector.upload_submit', { defaultValue: 'Upload and link' })}
                 </Button>
-                <Button type="button" variant="ghost" size="sm" onClick={() => setUploadOpen(false)} disabled={uploading}>
+                <Button type="button" variant="ghost" size="sm" onClick={() => setUploadOpen(false)}>
                   <X className="mr-1 h-4 w-4" />
                   {t('common.cancel', { defaultValue: 'Cancel' })}
                 </Button>

--- a/ui/src/lib/queryClient.ts
+++ b/ui/src/lib/queryClient.ts
@@ -7,5 +7,11 @@ export const queryClient = new QueryClient({
       retry: 1,
       refetchOnWindowFocus: false,
     },
+    mutations: {
+      // Par défaut ('online'), une mutation soumise hors-ligne est mise en pause :
+      // la promesse ne settle jamais, isPending reste true et aucun onError ne
+      // s'exécute — dialog figé sans message. 'always' la fait échouer immédiatement.
+      networkMode: 'always',
+    },
   },
 });


### PR DESCRIPTION
## Quoi

Cas vécu : création d'une poule pendant une coupure internet → la modale reste figée, sans aucun message d'erreur (boutons désactivés, y compris « Annuler »). Trois causes traitées, toutes transverses à l'app :

1. **Mutations React Query en pause offline** — le `networkMode` par défaut (`'online'`) met une mutation soumise hors-ligne en *pause* : la promesse ne settle jamais, `isPending` reste `true`, aucun `onError`/toast ne s'exécute. Passage à `networkMode: 'always'` pour les mutations dans `queryClient.ts` : la requête part, échoue immédiatement, le toast d'erreur s'affiche et le dialog redevient utilisable.

2. **Boutons « Annuler »/« Fermer » désactivés pendant `isPending`** — l'utilisateur était emprisonné dans le dialog dès que la mutation traînait. Suppression du `disabled` sur les boutons de dismiss dans 22 fichiers (les boutons submit gardent le leur). Règle ajoutée au pattern « Dialogs » de `CLAUDE.md`.

3. **Refresh token fragile aux coupures** — dans l'interceptor axios, tout échec du POST de refresh (y compris une simple erreur réseau) purgait les tokens et redirigeait vers `/login`. Désormais la session n'est détruite que si le serveur a **réellement refusé** le refresh (réponse 4xx reçue) ; une coupure réseau pendant le refresh laisse simplement remonter l'erreur d'origine.

## Vérifications

- `pytest` : 1777 passed, 2 skipped
- `npm run lint` : 0 erreurs (5 warnings préexistants)
- `npx tsc -b ui/tsconfig.json` : OK
- `npm run build` : OK

## Hors scope

- Toast spécifique « Pas de connexion » (distinct du `saveFailed` générique) et bandeau offline global — améliorations possibles ultérieures.
