### PR TITLE
feat(agent): recherche web via le tool serveur web_search

### DIFF
--- a/apps/agent/llm.py
+++ b/apps/agent/llm.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, NoReturn, Protocol
 from uuid import UUID
 
@@ -24,6 +24,13 @@ from django.conf import settings
 from ai_usage.services import log_ai_usage
 
 logger = logging.getLogger(__name__)
+
+# Anthropic server-side web search tool. The model calls it, Anthropic runs the
+# search and returns results (with source URLs) in the same round-trip — no
+# client-side handler. The `_20260209` version does dynamic result filtering,
+# which requires the agent on Sonnet 4.6+.
+WEB_SEARCH_TOOL_TYPE = "web_search_20260209"
+WEB_SEARCH_TOOL_NAME = "web_search"
 
 
 class LLMTimeoutError(Exception):
@@ -73,6 +80,9 @@ class LLMRunResponse:
     output_tokens: int | None
     duration_ms: int
     model: str
+    # Sources returned by the server-side ``web_search`` tool this round-trip:
+    # ``[{"url", "title"}, ...]``. Empty when web search was off or unused.
+    web_sources: list[dict] = field(default_factory=list)
 
 
 class LLMClient(Protocol):
@@ -104,6 +114,7 @@ class LLMClient(Protocol):
         user_id: int | None = None,
         max_tokens: int = 1024,
         metadata: dict[str, Any] | None = None,
+        web_search: bool = False,
     ) -> LLMRunResponse:
         ...
 
@@ -293,19 +304,22 @@ class AnthropicClient:
         user_id: int | None = None,
         max_tokens: int = 1024,
         metadata: dict[str, Any] | None = None,
+        web_search: bool = False,
     ) -> LLMRunResponse:
         """One tool-enabled round-trip. The tool-use loop lives in the caller.
 
         This makes a single ``messages.create`` call with the provided
         conversation ``messages`` and ``tools``, logs it into ``AIUsageLog``, and
         returns the assistant turn (normalized), the requested tool calls, and
-        the stop reason so the caller can decide whether to loop.
+        the stop reason so the caller can decide whether to loop. When
+        ``web_search`` is set (and ``tools`` is non-empty), the server-side
+        ``web_search`` tool is offered alongside the registered tools.
         """
         started = time.monotonic()
         try:
             client = self._client()
             message = client.messages.create(
-                **self._run_create_kwargs(system, messages, tools, max_tokens)
+                **self._run_create_kwargs(system, messages, tools, max_tokens, web_search)
             )
         except Exception as exc:
             self._log_and_raise_failure(
@@ -337,6 +351,7 @@ class AnthropicClient:
         user_id: int | None = None,
         max_tokens: int = 1024,
         metadata: dict[str, Any] | None = None,
+        web_search: bool = False,
     ):
         """Streaming variant of ``run()``.
 
@@ -350,7 +365,7 @@ class AnthropicClient:
         try:
             client = self._client()
             with client.messages.stream(
-                **self._run_create_kwargs(system, messages, tools, max_tokens)
+                **self._run_create_kwargs(system, messages, tools, max_tokens, web_search)
             ) as stream:
                 for text in stream.text_stream:
                     yield ("delta", text)
@@ -378,7 +393,12 @@ class AnthropicClient:
         )
 
     def _run_create_kwargs(
-        self, system: str, messages: list[dict], tools: list[dict], max_tokens: int
+        self,
+        system: str,
+        messages: list[dict],
+        tools: list[dict],
+        max_tokens: int,
+        web_search: bool = False,
     ) -> dict[str, Any]:
         """The ``messages.create``/``messages.stream`` kwargs shared by run/run_stream."""
         create_kwargs: dict[str, Any] = {
@@ -396,9 +416,25 @@ class AnthropicClient:
             ],
             "messages": messages,
         }
-        if tools:
-            create_kwargs["tools"] = tools
+        # Only offer web search alongside the registered tools — never on the
+        # final, tool-less pass where the caller forces a text answer.
+        effective_tools = list(tools) if tools else []
+        if effective_tools and web_search:
+            effective_tools += self._server_tools()
+        if effective_tools:
+            create_kwargs["tools"] = effective_tools
         return create_kwargs
+
+    def _server_tools(self) -> list[dict]:
+        """Anthropic server-side tool schemas to add to the tool list (web search)."""
+        tool: dict[str, Any] = {"type": WEB_SEARCH_TOOL_TYPE, "name": WEB_SEARCH_TOOL_NAME}
+        try:
+            max_uses = int(getattr(settings, "AGENT_WEB_SEARCH_MAX_USES", 5) or 0)
+        except (TypeError, ValueError):
+            max_uses = 0
+        if max_uses > 0:
+            tool["max_uses"] = max_uses
+        return [tool]
 
     def _finalize_run(
         self,
@@ -414,6 +450,7 @@ class AnthropicClient:
         duration_ms = int((time.monotonic() - started) * 1000)
         assistant_blocks = _normalize_blocks(message)
         tool_calls = _extract_tool_calls(message)
+        web_sources = _extract_web_sources(message)
         text = _extract_text(message)
         stop_reason = getattr(message, "stop_reason", "") or ""
         usage = getattr(message, "usage", None)
@@ -442,6 +479,7 @@ class AnthropicClient:
             output_tokens=output_tokens,
             duration_ms=duration_ms,
             model=self.model,
+            web_sources=web_sources,
         )
 
     def _log_and_raise_failure(
@@ -521,7 +559,43 @@ def _normalize_blocks(message) -> list[dict]:
                     "input": _block_get(block, "input") or {},
                 }
             )
+        elif btype in ("server_tool_use", "web_search_tool_result"):
+            # Server-side tool blocks (web search) must be replayed VERBATIM so a
+            # `pause_turn` continuation resumes correctly. Dump the exact SDK
+            # shape rather than hand-rebuild it — it carries fields we don't model.
+            blocks.append(_dump_block(block))
     return blocks
+
+
+def _dump_block(block) -> dict:
+    """Serialize an SDK content block to a replay-safe dict (verbatim)."""
+    if hasattr(block, "model_dump"):
+        return block.model_dump(mode="json", exclude_none=True)
+    if isinstance(block, dict):
+        return block
+    return {}
+
+
+def _extract_web_sources(message) -> list[dict]:
+    """Collect ``{url, title}`` from the message's ``web_search_tool_result`` blocks.
+
+    Errored searches carry a single error object instead of a result list — skip
+    those. Deduping across the whole turn is the caller's job.
+    """
+    sources: list[dict] = []
+    for block in getattr(message, "content", []) or []:
+        if _block_get(block, "type") != "web_search_tool_result":
+            continue
+        content = _block_get(block, "content")
+        if not isinstance(content, list):
+            continue  # error shape (web_search_tool_result_error)
+        for item in content:
+            if _block_get(item, "type") != "web_search_result":
+                continue
+            url = _block_get(item, "url")
+            if url:
+                sources.append({"url": url, "title": _block_get(item, "title") or url})
+    return sources
 
 
 def _extract_tool_calls(message) -> list[ToolCall]:

--- a/apps/agent/prompts.py
+++ b/apps/agent/prompts.py
@@ -140,6 +140,25 @@ the full text of a document only summarised there).
 """
 
 
+# Appended when web search is enabled (settings.AGENT_WEB_SEARCH_ENABLED). Adds a
+# fourth response mode: reach out to the public web for facts that are neither in
+# the household data nor stable general knowledge. Household tools still own
+# household facts; the web tool owns current/external ones.
+WEB_SEARCH_ADDENDUM = """
+
+You also have a `web_search` tool that searches the PUBLIC WEB and returns
+results with their source URLs. Use it ONLY when answering well needs
+information that is (a) not in this family's data and (b) beyond stable general
+knowledge — current facts, recent events, prices, product specs, precise how-to
+details, or anything time-sensitive or that you are not confident about. Do NOT
+search for household facts (use the household tools) or for stable general
+knowledge you already know (answer directly). When you rely on web results, base
+your answer on them and name the source; never present old memory as a current
+fact. Web sources are shown to the user separately — you do not need a <cite/>
+marker for them (those are only for household items).
+"""
+
+
 # The memory tool + rules. Two variants: when the user's agent_memory_enabled
 # flag is ON, the model captures durable facts spontaneously; when OFF, only an
 # explicit "remember that…" from the user may write a memory (and nothing is
@@ -219,14 +238,18 @@ def build_system_prompt(
     anchored: bool = False,
     memory_mode: str | None = None,
     memories: list | None = None,
+    web_search: bool = False,
 ) -> str:
     """Return the system prompt, optionally extended for an anchored conversation.
 
     ``memory_mode`` is ``"auto"`` (capture spontaneously + inject memories),
     ``"manual"`` (explicit requests only, nothing injected) or ``None`` (no
-    user on this call — the memory tool is not described at all).
+    user on this call — the memory tool is not described at all). ``web_search``
+    appends the web-search capability when the server-side tool is enabled.
     """
     prompt = SYSTEM_PROMPT + ANCHORED_ADDENDUM if anchored else SYSTEM_PROMPT
+    if web_search:
+        prompt += WEB_SEARCH_ADDENDUM
     if memory_mode == "auto":
         prompt += MEMORY_TOOL_ADDENDUM + MEMORY_AUTO_ADDENDUM
         if memories:

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -153,13 +153,18 @@ def ask_stream(
         else:
             memory_mode = "manual"
 
+    web_search_on = _web_search_enabled()
     system_prompt = build_system_prompt(
-        anchored=anchored, memory_mode=memory_mode, memories=memories
+        anchored=anchored,
+        memory_mode=memory_mode,
+        memories=memories,
+        web_search=web_search_on,
     )
     messages = _build_messages(cleaned, history, entity_context)
     created_entities: list[dict] = []
     updated_entities: list[dict] = []
     memory_events: list[dict] = []
+    web_sources: list[dict] = []
     write_signatures: set = set()
     answer_text = ""
     stop_reason = ""
@@ -169,11 +174,15 @@ def ask_stream(
     duration_ms = 0
     tool_calls = 0
     iterations = 0
+    resuming_pause = False
 
     for iterations in range(1, max_iterations + 1):
         # On the final allowed pass, drop the tools so the model is forced to
-        # produce a text answer rather than requesting yet another search.
-        offered_tools = tool_schemas if iterations < max_iterations else []
+        # produce a text answer rather than requesting yet another search —
+        # UNLESS we're resuming a paused server search, which needs the tools
+        # (incl. web_search) still declared to continue.
+        offered_tools = tool_schemas if (iterations < max_iterations or resuming_pause) else []
+        resuming_pause = False
 
         run_kwargs = dict(
             system=system_prompt,
@@ -184,6 +193,7 @@ def ask_stream(
             user_id=getattr(user, "id", None),
             max_tokens=DEFAULT_MAX_TOKENS,
             metadata={"iteration": iterations},
+            web_search=web_search_on,
         )
         try:
             # Stream when the client supports it, forwarding text chunks as they
@@ -212,6 +222,15 @@ def ask_stream(
         model = response.model
         stop_reason = response.stop_reason
         answer_text = response.text.strip()
+        web_sources.extend(getattr(response, "web_sources", None) or [])
+
+        # The server-side web search loop paused mid-turn (hit its own iteration
+        # limit). Replay the assistant turn — which includes the trailing
+        # server_tool_use block — with no client tool_result; the server resumes.
+        if response.stop_reason == "pause_turn":
+            messages.append({"role": "assistant", "content": response.assistant_blocks})
+            resuming_pause = True
+            continue
 
         if response.stop_reason != "tool_use" or not response.tool_calls:
             break
@@ -263,7 +282,8 @@ def ask_stream(
 
     hits = list(hit_pool.values())
     citations = _resolve_citations(answer_text, hits)
-    answer_kind = _classify_answer(tool_calls, hits, citations)
+    web_sources = _dedupe_web_sources(web_sources)
+    answer_kind = _classify_answer(tool_calls, hits, citations, web_sources)
 
     yield {"type": "result", "result": AnswerResult(
         answer=answer_text or _dont_know_message(),
@@ -286,6 +306,8 @@ def ask_stream(
             "created_entities": created_entities,
             "updated_entities": updated_entities,
             "memory_events": memory_events,
+            # Public web sources the model used this turn (web_search tool).
+            "web_sources": web_sources,
         },
     )}
 
@@ -375,21 +397,35 @@ def _build_messages(
     return messages
 
 
-def _classify_answer(tool_calls: int, hits: list, citations: list) -> str:
+def _classify_answer(tool_calls: int, hits: list, citations: list, web_sources: list) -> str:
     """Coarse label for observability (metadata.answer_kind).
 
     - ``direct``  : no tool call (dialogue or general knowledge)
-    - ``idk``     : searched but found nothing
+    - ``web``     : answered from a web search, with no household data
+    - ``idk``     : searched household data but found nothing
     - ``household``: searched, found data, and cited it
     - ``uncited`` : searched, found data, but produced no citation
     """
     if tool_calls == 0:
-        return "direct"
+        return "web" if web_sources else "direct"
     if not hits:
-        return "idk"
+        return "web" if web_sources else "idk"
     if citations:
         return "household"
     return "uncited"
+
+
+def _dedupe_web_sources(sources: list[dict]) -> list[dict]:
+    """Drop duplicate web sources by URL, preserving first-seen order."""
+    seen: set[str] = set()
+    unique: list[dict] = []
+    for source in sources:
+        url = (source or {}).get("url")
+        if not url or url in seen:
+            continue
+        seen.add(url)
+        unique.append(source)
+    return unique
 
 
 def _max_tool_iterations() -> int:
@@ -402,6 +438,11 @@ def _max_tool_iterations() -> int:
 
 def _llm_enabled() -> bool:
     return bool(getattr(settings, "ANTHROPIC_API_KEY", "") or "")
+
+
+def _web_search_enabled() -> bool:
+    """Whether the agent may use the server-side web search tool (settings flag)."""
+    return bool(getattr(settings, "AGENT_WEB_SEARCH_ENABLED", False))
 
 
 def _dont_know_message() -> str:

--- a/apps/agent/tests/test_llm.py
+++ b/apps/agent/tests/test_llm.py
@@ -357,3 +357,85 @@ class TestFactory:
     def test_unknown_provider_raises(self):
         with pytest.raises(LLMError):
             get_llm_client(provider="ollama")
+
+
+class TestWebSearchTool:
+    def _run(self, client, fake, monkeypatch, household, **overrides):
+        monkeypatch.setattr(client, "_client", lambda: fake)
+        kwargs = dict(
+            system="sys",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"name": "search_household"}],
+            feature="agent_ask",
+            household_id=household.id,
+        )
+        kwargs.update(overrides)
+        return client.run(**kwargs)
+
+    def test_injects_web_search_tool_when_enabled(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        fake = _FakeClient(response=_fake_run_message([_text_block("ok")]))
+        self._run(client, fake, monkeypatch, household, web_search=True)
+
+        tools = fake.messages.last_kwargs["tools"]
+        assert {"name": "search_household"} in tools
+        assert {"type": "web_search_20260209", "name": "web_search", "max_uses": 5} in tools
+
+    def test_not_injected_when_web_search_off(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        fake = _FakeClient(response=_fake_run_message([_text_block("ok")]))
+        self._run(client, fake, monkeypatch, household, web_search=False)
+
+        assert fake.messages.last_kwargs["tools"] == [{"name": "search_household"}]
+
+    def test_not_injected_on_toolless_pass(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        fake = _FakeClient(response=_fake_run_message([_text_block("ok")]))
+        self._run(client, fake, monkeypatch, household, tools=[], web_search=True)
+
+        # No custom tools = the final forced-answer pass; web search stays off too.
+        assert "tools" not in fake.messages.last_kwargs
+
+    def test_max_uses_zero_omits_cap(self, with_api_key, settings, monkeypatch, household):
+        settings.AGENT_WEB_SEARCH_MAX_USES = 0
+        client = AnthropicClient()
+        fake = _FakeClient(response=_fake_run_message([_text_block("ok")]))
+        self._run(client, fake, monkeypatch, household, web_search=True)
+
+        ws = [t for t in fake.messages.last_kwargs["tools"] if t.get("type") == "web_search_20260209"]
+        assert ws and "max_uses" not in ws[0]
+
+    def test_preserves_server_blocks_and_extracts_sources(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        server_use = {"type": "server_tool_use", "id": "s1", "name": "web_search", "input": {"query": "x"}}
+        web_result = {
+            "type": "web_search_tool_result",
+            "tool_use_id": "s1",
+            "content": [
+                {"type": "web_search_result", "url": "https://ex.com/a", "title": "A"},
+                {"type": "web_search_result", "url": "https://ex.com/b", "title": "B"},
+            ],
+        }
+        content = [_text_block("Voici."), server_use, web_result]
+        fake = _FakeClient(response=_fake_run_message(content, "end_turn"))
+        result = self._run(client, fake, monkeypatch, household, web_search=True)
+
+        assert {"type": "text", "text": "Voici."} in result.assistant_blocks
+        assert server_use in result.assistant_blocks
+        assert web_result in result.assistant_blocks
+        assert result.web_sources == [
+            {"url": "https://ex.com/a", "title": "A"},
+            {"url": "https://ex.com/b", "title": "B"},
+        ]
+
+    def test_errored_search_yields_no_sources(self, with_api_key, monkeypatch, household):
+        client = AnthropicClient()
+        errored = {
+            "type": "web_search_tool_result",
+            "tool_use_id": "s1",
+            "content": {"type": "web_search_tool_result_error", "error_code": "max_uses_exceeded"},
+        }
+        fake = _FakeClient(response=_fake_run_message([_text_block("oops"), errored], "end_turn"))
+        result = self._run(client, fake, monkeypatch, household, web_search=True)
+
+        assert result.web_sources == []

--- a/apps/agent/tests/test_prompts.py
+++ b/apps/agent/tests/test_prompts.py
@@ -48,6 +48,16 @@ class TestSystemPrompt:
         assert "GENERAL KNOWLEDGE" in upper
 
 
+class TestWebSearchAddendum:
+    def test_absent_by_default(self):
+        assert "web_search" not in build_system_prompt()
+
+    def test_present_when_enabled(self):
+        prompt = build_system_prompt(web_search=True)
+        assert "web_search" in prompt
+        assert "PUBLIC WEB" in prompt
+
+
 class TestCurrentDate:
     def test_system_prompt_carries_todays_date(self):
         today = timezone.localdate()

--- a/apps/agent/tests/test_service.py
+++ b/apps/agent/tests/test_service.py
@@ -809,3 +809,80 @@ class TestHouseholdScope:
         # The tool searched `household`, not `other` → no hits, no citation.
         assert result.citations == []
         assert result.metadata["hits_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Web search (server-side tool)
+# ---------------------------------------------------------------------------
+
+
+def _run_pause(web_sources, *, blocks=None) -> LLMRunResponse:
+    """A `pause_turn` turn: the server web-search loop paused mid-turn."""
+    return LLMRunResponse(
+        assistant_blocks=blocks
+        or [{"type": "server_tool_use", "id": "s1", "name": "web_search", "input": {"query": "q"}}],
+        tool_calls=[],
+        text="",
+        stop_reason="pause_turn",
+        input_tokens=3,
+        output_tokens=1,
+        duration_ms=1,
+        model="stub-model",
+        web_sources=web_sources,
+    )
+
+
+class TestWebSearch:
+    def test_flag_passed_to_run_when_enabled(self, with_api_key, settings, household, owner):
+        settings.AGENT_WEB_SEARCH_ENABLED = True
+        stub = _ToolUseClient(script=[_run_text("Bonjour")])
+        service.ask("salut", household, user=owner, client=stub)
+        assert stub.run_calls[0]["web_search"] is True
+
+    def test_flag_off_by_default(self, with_api_key, household, owner):
+        stub = _ToolUseClient(script=[_run_text("Bonjour")])
+        service.ask("salut", household, user=owner, client=stub)
+        assert stub.run_calls[0]["web_search"] is False
+
+    def test_pause_turn_resumes_and_collects_web_sources(
+        self, with_api_key, settings, household, owner
+    ):
+        settings.AGENT_WEB_SEARCH_ENABLED = True
+        source = {"url": "https://ex.com/a", "title": "A"}
+        stub = _ToolUseClient(script=[_run_pause([source]), _run_text("La réponse web.")])
+
+        result = service.ask("actu du jour ?", household, user=owner, client=stub)
+
+        # The pause_turn turn was replayed (2 run calls) and resumed to an answer.
+        assert len(stub.run_calls) == 2
+        assert result.answer == "La réponse web."
+        assert result.metadata["web_sources"] == [source]
+        assert result.metadata["answer_kind"] == "web"
+
+    def test_pause_resume_on_last_iteration_keeps_tools(
+        self, with_api_key, settings, household, owner
+    ):
+        # max=2: iter1 pauses, iter2 is the "final forced-answer" pass. Resuming a
+        # paused search must keep tools declared (else the server can't continue).
+        settings.AGENT_WEB_SEARCH_ENABLED = True
+        settings.AGENT_MAX_TOOL_ITERATIONS = 2
+        stub = _ToolUseClient(script=[_run_pause([]), _run_text("Fini.")])
+
+        service.ask("actu ?", household, user=owner, client=stub)
+
+        assert len(stub.run_calls) == 2
+        # The resume pass (2nd, the last iteration) still offers the tools.
+        assert stub.run_calls[1]["tools"]
+        assert stub.run_calls[1]["web_search"] is True
+
+    def test_web_sources_deduped_by_url(self, with_api_key, settings, household, owner):
+        settings.AGENT_WEB_SEARCH_ENABLED = True
+        dup = {"url": "https://ex.com/a", "title": "A"}
+        final = _run_text("Réponse.")
+        final.web_sources = [dup, {"url": "https://ex.com/b", "title": "B"}]
+        stub = _ToolUseClient(script=[_run_pause([dup]), final])
+
+        result = service.ask("actu ?", household, user=owner, client=stub)
+
+        urls = [s["url"] for s in result.metadata["web_sources"]]
+        assert urls == ["https://ex.com/a", "https://ex.com/b"]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -223,6 +223,15 @@ AGENT_MAX_TOOL_ITERATIONS = 4
 # eligible for cleanup by `manage.py cleanup_agent_conversations`. 0 disables it.
 AGENT_CONVERSATION_RETENTION_DAYS = 365
 
+# Agent web search (Anthropic server-side `web_search` tool). Off by default: it
+# calls the public web (cost + external content) and its dynamic result filtering
+# requires the agent to run on Sonnet 4.6+ (set LLM_TEXT_MODEL accordingly).
+# When ON, the model may search the web for current/external facts it can't
+# answer from household data or stable general knowledge. `MAX_USES` caps the
+# number of searches per question (0 = no cap).
+AGENT_WEB_SEARCH_ENABLED = False
+AGENT_WEB_SEARCH_MAX_USES = 5
+
 # Telegram bot channel for the agent. Empty token = channel disabled: the
 # webhook rejects everything and no outbound call is ever made.
 # Overridden per environment in local.py / production.py.

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -65,6 +65,9 @@ LLM_PROVIDER = env("LLM_PROVIDER", default="anthropic")
 LLM_TEXT_MODEL = env("LLM_TEXT_MODEL", default="claude-haiku-4-5-20251001")
 LLM_VISION_MODEL = env("LLM_VISION_MODEL", default="claude-haiku-4-5-20251001")
 
+# Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
+AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)
+
 # Telegram bot channel — leave blank to disable (default).
 TELEGRAM_BOT_TOKEN = env("TELEGRAM_BOT_TOKEN", default="")
 TELEGRAM_BOT_USERNAME = env("TELEGRAM_BOT_USERNAME", default="")

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -80,6 +80,9 @@ LLM_PROVIDER = env("LLM_PROVIDER", default="anthropic")
 LLM_TEXT_MODEL = env("LLM_TEXT_MODEL", default="claude-haiku-4-5-20251001")
 LLM_VISION_MODEL = env("LLM_VISION_MODEL", default="claude-haiku-4-5-20251001")
 
+# Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
+AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)
+
 # Telegram bot channel — leave blank to disable.
 TELEGRAM_BOT_TOKEN = env("TELEGRAM_BOT_TOKEN", default="")
 TELEGRAM_BOT_USERNAME = env("TELEGRAM_BOT_USERNAME", default="")

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -152,6 +152,35 @@ vivent dans leurs propres modèles et **priment** toujours en cas de conflit.
   `useAgentMemoryEvents` (toast undo) + `MemoryNotice` (ligne 📌 persistante dans
   la bulle, rejouée depuis `metadata.memory_events`).
 
+## Recherche web (tool serveur Anthropic, 2026-07)
+
+L'agent peut consulter le **web public** via le tool **serveur** Anthropic
+`web_search` (`web_search_20260209`) — pas un `AgentTool` du registry : Anthropic
+exécute la recherche côté serveur et renvoie les résultats (avec URLs sources)
+dans le même round-trip, sans handler client.
+
+- **Activation** : `AGENT_WEB_SEARCH_ENABLED` (défaut **False**). Off par défaut
+  car (a) ça appelle le web (coût + contenu externe) et (b) le *dynamic filtering*
+  des résultats exige l'agent sur **Sonnet 4.6+** (`LLM_TEXT_MODEL`). `AGENT_WEB_SEARCH_MAX_USES`
+  borne le nombre de recherches par question (0 = pas de plafond).
+- **Injection** : `AnthropicClient._run_create_kwargs` ajoute le schéma serveur à
+  la liste des tools **uniquement** quand des tools custom sont aussi offerts —
+  jamais sur la passe finale sans tool (réponse forcée). Le service passe
+  `web_search=_web_search_enabled()` à `run`/`run_stream`. Le registry provider-neutre
+  (`tools.schemas()`) reste inchangé ; le détail Anthropic vit dans `llm.py`.
+- **Boucle** : les blocs `server_tool_use` / `web_search_tool_result` sont
+  préservés verbatim par `_normalize_blocks` (via `_dump_block`) pour rejouer un
+  `pause_turn` ; `service.ask` gère `stop_reason == "pause_turn"` en rejouant le
+  tour assistant sans tool_result (le serveur reprend).
+- **Sources** : `_extract_web_sources` collecte `{url, title}` depuis les blocs
+  résultat ; `service.ask` les dédoublonne par URL dans `metadata.web_sources`.
+  Le front les rend sous la bulle (`WebSourcesPanel`, clé `agent.web_sources_label`),
+  distinct des citations foyer (`<cite/>`). `answer_kind = "web"` quand la réponse
+  vient du web sans donnée foyer.
+- **Prompt** : `WEB_SEARCH_ADDENDUM` (ajouté par `build_system_prompt(web_search=True)`)
+  cadre l'usage : web seulement pour le factuel courant/externe, jamais pour les
+  faits foyer ni la connaissance générale stable.
+
 ## API
 
 Sous `/api/agent/` :

--- a/ui/src/features/agent/ChatBubble.tsx
+++ b/ui/src/features/agent/ChatBubble.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import { Bot, User } from 'lucide-react';
+import { Bot, Globe, User } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown, { defaultUrlTransform, type Components } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import AgentCitation from './AgentCitation';
-import type { AgentCitation as Citation, AgentMemoryEvent } from './api';
+import type { AgentCitation as Citation, AgentMemoryEvent, AgentWebSource } from './api';
 
 const CITE_REGEX = /<cite\s+id="([^"]+)"\s*\/?>/gi;
 const CITE_HREF_PREFIX = 'cite:';
@@ -23,6 +23,8 @@ interface AgentBubbleProps {
   truncated?: boolean;
   /** Memories written this turn — rendered as a persistent 📌 line. */
   memoryEvents?: AgentMemoryEvent[];
+  /** Public web pages the agent used this turn — rendered as a sources list. */
+  webSources?: AgentWebSource[];
 }
 
 interface LoadingBubbleProps {
@@ -88,7 +90,38 @@ export default function ChatBubble(props: Props) {
       {props.citations.length > 0 ? (
         <CitationsPanel citations={props.citations} />
       ) : null}
+      {props.webSources && props.webSources.length > 0 ? (
+        <WebSourcesPanel sources={props.webSources} />
+      ) : null}
     </AgentBubbleShell>
+  );
+}
+
+// External web pages the agent consulted via the web_search tool. Distinct from
+// CitationsPanel (internal household items) — these open the public web.
+function WebSourcesPanel({ sources }: { sources: AgentWebSource[] }) {
+  const { t } = useTranslation();
+  return (
+    <div className="mt-2 border-t border-border pt-2" data-testid="agent-web-sources">
+      <p className="mb-1.5 flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <Globe className="h-3 w-3" />
+        {t('agent.web_sources_label')}
+      </p>
+      <ol className="list-decimal space-y-0.5 pl-5 text-xs">
+        {sources.map((s) => (
+          <li key={s.url} className="break-words">
+            <a
+              href={s.url}
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary underline underline-offset-2"
+            >
+              {s.title || s.url}
+            </a>
+          </li>
+        ))}
+      </ol>
+    </div>
   );
 }
 

--- a/ui/src/features/agent/ChatPanel.tsx
+++ b/ui/src/features/agent/ChatPanel.tsx
@@ -18,6 +18,7 @@ import type {
   AgentConversationDetail,
   AgentMemoryEvent,
   AgentMessageRow,
+  AgentWebSource,
 } from './api';
 
 interface UserMessage {
@@ -34,6 +35,8 @@ interface AgentMessage {
   truncated?: boolean;
   /** Memories the agent wrote this turn — rendered as a persistent 📌 line. */
   memoryEvents?: AgentMemoryEvent[];
+  /** Public web sources the agent used this turn (web_search tool). */
+  webSources?: AgentWebSource[];
 }
 
 interface ErrorMessage {
@@ -57,6 +60,7 @@ function toMessage(row: AgentMessageRow): Message {
     citations: row.citations,
     truncated: Boolean(row.metadata?.truncated),
     memoryEvents: row.metadata?.memory_events,
+    webSources: row.metadata?.web_sources,
   };
 }
 
@@ -214,6 +218,7 @@ export default function ChatPanel({
             citations: agentMsg.citations,
             truncated: Boolean(agentMsg.metadata?.truncated),
             memoryEvents: agentMsg.metadata?.memory_events,
+            webSources: agentMsg.metadata?.web_sources,
           },
         ]);
         notifyCreated(agentMsg.metadata?.created_entities);
@@ -269,6 +274,7 @@ export default function ChatPanel({
                   citations={msg.citations}
                   truncated={msg.truncated}
                   memoryEvents={msg.memoryEvents}
+                  webSources={msg.webSources}
                 />
               );
             }

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -44,6 +44,12 @@ export interface AgentMemoryEvent {
   previous?: string;
 }
 
+/** A public web page the agent used this turn (via the web_search tool). */
+export interface AgentWebSource {
+  url: string;
+  title: string;
+}
+
 export interface AgentAnswerMetadata {
   duration_ms?: number;
   tokens_in?: number;
@@ -56,6 +62,8 @@ export interface AgentAnswerMetadata {
   created_entities?: AgentCreatedEntity[];
   updated_entities?: AgentUpdatedEntity[];
   memory_events?: AgentMemoryEvent[];
+  /** Public web sources the agent cited this turn (web_search tool). */
+  web_sources?: AgentWebSource[];
   [key: string]: unknown;
 }
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2272,6 +2272,7 @@
       "empty_hint": "Der Assistent kennt dieses Element und alles, was damit verknüpft ist, bereits — seine Details, Dokumente, Ausgaben und Aufgaben — und nennt seine Quellen."
     },
     "citations_label": "Quellen",
+    "web_sources_label": "Web-Quellen",
     "privacy": {
       "title": "Bevor du loslegst",
       "intro": "Der Agent liest die Daten deines Haushalts, um deine Fragen zu beantworten. Wichtig zu wissen:",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2272,6 +2272,7 @@
       "empty_hint": "The assistant already knows this item and everything linked to it — its details, documents, expenses and tasks — and cites its sources."
     },
     "citations_label": "Sources",
+    "web_sources_label": "Web sources",
     "privacy": {
       "title": "Before you start",
       "intro": "The agent reads the data of your household to answer your questions. A few things to know:",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2272,6 +2272,7 @@
       "empty_hint": "El asistente ya conoce este elemento y todo lo vinculado a él — sus detalles, documentos, gastos y tareas — y cita sus fuentes."
     },
     "citations_label": "Fuentes",
+    "web_sources_label": "Fuentes web",
     "privacy": {
       "title": "Antes de empezar",
       "intro": "El agente lee los datos de tu hogar para responder a tus preguntas. Algunas cosas a saber:",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2272,6 +2272,7 @@
       "empty_hint": "L'assistant connaît déjà cet élément et tout ce qui lui est lié — ses détails, documents, dépenses et tâches — et cite ses sources."
     },
     "citations_label": "Sources",
+    "web_sources_label": "Sources web",
     "privacy": {
       "title": "Avant de commencer",
       "intro": "L'agent lit les données de ton foyer pour répondre à tes questions. Quelques infos utiles :",


### PR DESCRIPTION
## Quoi

Donne à l'agent conversationnel la capacité de **chercher sur le web public**, via le tool **serveur** Anthropic `web_search` (`web_search_20260209`) — Anthropic exécute la recherche côté serveur et renvoie les résultats avec leurs URLs sources dans le même round-trip (pas de handler client, citations natives).

Choix mono-utilisateur : tool serveur (code minimal, dynamic filtering, citations gratuites) plutôt qu'une API tierce, l'agent passant sur Sonnet côté config.

**Backend**
- `AGENT_WEB_SEARCH_ENABLED` (**off par défaut**) + `AGENT_WEB_SEARCH_MAX_USES` — settings base/local/production.
- `llm.py` : injection du schéma serveur uniquement quand des tools custom sont offerts (jamais sur la passe finale sans tool) ; préservation verbatim des blocs `server_tool_use`/`web_search_tool_result` (`_dump_block`) pour rejouer un `pause_turn` ; `LLMRunResponse.web_sources` via `_extract_web_sources`. Le registry provider-neutre reste intact.
- `service.py` : passe `web_search=` à la boucle, gère `stop_reason == "pause_turn"` (reprise sans `tool_result`, tools maintenus même sur la dernière itération), dédoublonne `metadata.web_sources`, `answer_kind="web"`.
- `prompts.py` : `WEB_SEARCH_ADDENDUM` conditionnel (web seulement pour le factuel courant/externe, jamais les faits foyer).

**Frontend**
- `metadata.web_sources` typé et rendu sous la bulle (`WebSourcesPanel`, liens externes), distinct des citations foyer. Clé i18n `agent.web_sources_label` × 4 langues.

**Activation** : off par défaut. Requiert `AGENT_WEB_SEARCH_ENABLED=true` + `LLM_TEXT_MODEL=claude-sonnet-4-6` (dynamic filtering).

## Critères

- ✅ Tool serveur `web_search` branché dans la boucle, gaté par réglage
- ✅ `pause_turn` + blocs serveur gérés sans casser la boucle
- ✅ Sources web remontées et rendues côté UI, i18n 4 langues
- ✅ Tests : injection/gating, normalisation des blocs, extraction/dedup sources, boucle `pause_turn` (dont reprise dernière itération), addendum prompt
- ✅ Doc `docs/MODULES/agent.md`

## Hors scope

Pas d'API de recherche tierce ni d'isolation modèle par-opération (justifié pour le multi-foyer, pas pour un mono-utilisateur). Pas de toggle household (réglage d'infra, pas de module UI).
