### PR TITLE
fix(design-system): prevent auto-focus keyboard popup on mobile sheet

### DIFF
--- a/ui/src/design-system/sheet-dialog.tsx
+++ b/ui/src/design-system/sheet-dialog.tsx
@@ -4,7 +4,9 @@ import {
   type ReactElement,
   type ReactNode,
   useCallback,
+  useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from "react"
 
@@ -87,6 +89,22 @@ export function SheetDialog({
   const [internalOpen, setInternalOpen] = useState(false)
   const isControlled = controlledOpen !== undefined
   const open = isControlled ? controlledOpen : internalOpen
+  const contentRef = useRef<HTMLDivElement | null>(null)
+
+  // Sur mobile, aucun champ ne doit être focus à l'ouverture (sinon le clavier
+  // sort tout seul). `onOpenAutoFocus` (plus bas) couvre les formulaires sans
+  // `autoFocus` explicite. Mais quand un input porte l'attribut `autoFocus`,
+  // React le focus dès le commit — avant l'effet de Radix, qui voit alors le
+  // focus déjà à l'intérieur et ne déclenche jamais `onOpenAutoFocus`. Ce
+  // layout effect s'exécute après ce commit mais avant le paint : on retire le
+  // focus du champ sans faire clignoter le clavier.
+  useLayoutEffect(() => {
+    if (!open || !isMobile) return
+    const active = document.activeElement as HTMLElement | null
+    if (active && contentRef.current?.contains(active)) {
+      active.blur()
+    }
+  }, [open, isMobile])
 
   const setOpen = useCallback(
     (next: boolean) => {
@@ -126,8 +144,10 @@ export function SheetDialog({
       {triggerWithHandler}
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent
+          ref={contentRef}
           variant={isMobile ? "mobileSheet" : "default"}
           hideDefaultCloseButton={isMobile}
+          onOpenAutoFocus={isMobile ? (event) => event.preventDefault() : undefined}
           onInteractOutside={(event) => {
             const originalTarget = (event as CustomEvent).detail?.originalEvent?.target
             if (originalTarget instanceof Element && originalTarget.closest("[data-allow-interact]")) {


### PR DESCRIPTION
## Summary

Prevent the mobile keyboard from automatically appearing when a `SheetDialog` opens, even when an input field has the `autoFocus` attribute. This improves the UX by avoiding unexpected keyboard popups that obscure content.

## Changes

- Added `useLayoutEffect` hook to blur any focused element within the sheet content on mobile when the dialog opens
- Added `contentRef` to track the sheet's content container
- Prevented default auto-focus behavior on mobile by passing `onOpenAutoFocus` handler to `DialogContent`
- The layout effect runs after React's commit phase but before paint, ensuring the blur happens without visible keyboard flicker

## Implementation Details

The fix uses a two-pronged approach:

1. **Layout effect blur**: Catches cases where an input has an explicit `autoFocus` attribute. React focuses it during commit, before Radix's `onOpenAutoFocus` fires. The layout effect removes focus without visual artifacts.

2. **onOpenAutoFocus prevention**: Prevents Radix from auto-focusing the first focusable element on mobile, covering forms without explicit `autoFocus` attributes.

This ensures consistent behavior across all input scenarios on mobile devices while preserving normal focus management on desktop.

https://claude.ai/code/session_01G6ApdivunXdK8BwPZg7s9D