### PR TITLE
fix(ui): empile le header (titre/sous-titre + actions) sur mobile

### DIFF
--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -19,14 +19,16 @@ export default function PageHeader({ title, description, children }: PageHeaderP
 
   return (
     <div className="mb-6">
-      <div className="flex items-start justify-between gap-3 mb-4">
-        <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold text-foreground">{title}</h1>
           {description ? (
             <p className="mt-1 text-sm text-muted-foreground">{description}</p>
           ) : null}
         </div>
-        {children ? <div className="flex shrink-0 items-center gap-2">{children}</div> : null}
+        {children ? (
+          <div className="flex flex-wrap items-center gap-2 sm:shrink-0">{children}</div>
+        ) : null}
       </div>
       <Separator />
     </div>


### PR DESCRIPTION
Sur mobile, le titre, le sous-titre et les boutons d'action étaient forcés
sur une seule ligne horizontale : les boutons (shrink-0) débordaient hors de
l'écran tandis que le sous-titre était comprimé dans une colonne étroite.
Le header passe désormais en colonne sous sm et repasse côte à côte à partir
de sm, avec une rangée d'actions qui wrap.

Claude-Session: https://claude.ai/code/session_018se3PRTFGRngJpvKB8sywv