### PR TITLE
fix(ui): empile le header (titre/sous-titre + actions) sur mobile

### DIFF
--- a/ui/src/components/PageHeader.tsx
+++ b/ui/src/components/PageHeader.tsx
@@ -19,14 +19,16 @@ export default function PageHeader({ title, description, children }: PageHeaderP
 
   return (
     <div className="mb-6">
-      <div className="flex items-start justify-between gap-3 mb-4">
-        <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
           <h1 className="text-2xl font-bold text-foreground">{title}</h1>
           {description ? (
             <p className="mt-1 text-sm text-muted-foreground">{description}</p>
           ) : null}
         </div>
-        {children ? <div className="flex shrink-0 items-center gap-2">{children}</div> : null}
+        {children ? (
+          <div className="flex flex-wrap items-center gap-2 sm:shrink-0">{children}</div>
+        ) : null}
       </div>
       <Separator />
     </div>


### PR DESCRIPTION
## Problème

Sur mobile, le composant partagé `PageHeader` forçait le titre, le sous-titre et les boutons d'action sur **une seule ligne horizontale** (`flex ... justify-between`). Résultat : les boutons (`shrink-0`) débordaient hors de l'écran et le sous-titre était comprimé dans une colonne étroite.

Constaté sur la page Électricité (titre « Électricité » + sélecteur « Tableau principal » + bouton « + Nouveau »), mais le composant est partagé par toutes les pages (Tasks, Water, Expenses…).

## Changement

`ui/src/components/PageHeader.tsx` :
- Le header passe en **colonne** sur mobile (`flex-col`) → titre + sous-titre pleine largeur, puis la rangée d'actions en dessous.
- À partir de `sm`, retour au layout **côte à côte** d'origine (`sm:flex-row sm:items-start sm:justify-between`) — aucun changement sur desktop.
- La rangée d'actions passe en `flex-wrap` pour que le sélecteur et le bouton s'enroulent au lieu de déborder.

## Tests

Changement purement CSS (classes Tailwind). Dépendances npm non installées dans l'environnement, `npm run lint`/`build` non exécutés.

https://claude.ai/code/session_018se3PRTFGRngJpvKB8sywv

---
_Generated by [Claude Code](https://claude.ai/code/session_018se3PRTFGRngJpvKB8sywv)_