### PR TITLE
feat(agent): refonte UX — conversation neuve par défaut, plein-écran mobile, liste triée

### DIFF
--- a/apps/agent/serializers.py
+++ b/apps/agent/serializers.py
@@ -37,14 +37,27 @@ class AgentMessageSerializer(serializers.ModelSerializer):
 
 
 class ConversationListSerializer(serializers.ModelSerializer):
-    """Lightweight row for the conversation list (no messages)."""
+    """Lightweight row for the conversation list (no messages).
+
+    ``last_message_preview`` (the newest message's text, annotated in the view)
+    lets the sidebar show a one-line snippet under the title — a recency cue à la
+    ChatGPT/Claude without loading the whole thread.
+    """
 
     message_count = serializers.IntegerField(read_only=True)
+    last_message_preview = serializers.CharField(read_only=True, default="")
 
     class Meta:
         model = AgentConversation
-        fields = ["id", "title", "last_message_at", "created_at", "message_count"]
-        read_only_fields = ["id", "last_message_at", "created_at", "message_count"]
+        fields = [
+            "id",
+            "title",
+            "last_message_at",
+            "created_at",
+            "message_count",
+            "last_message_preview",
+        ]
+        read_only_fields = fields
 
 
 class ConversationDetailSerializer(serializers.ModelSerializer):

--- a/apps/agent/tests/test_conversations_api.py
+++ b/apps/agent/tests/test_conversations_api.py
@@ -110,6 +110,22 @@ class TestCreateAndList:
         row = next(r for r in _rows(resp) if r["id"] == str(conversation.id))
         assert row["message_count"] == 1
 
+    def test_list_includes_last_message_preview(self, owner_client, conversation):
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.USER, content="première"
+        )
+        AgentMessage.objects.create(
+            conversation=conversation, role=AgentMessage.Role.AGENT, content="dernière réponse"
+        )
+        resp = owner_client.get(BASE)
+        row = next(r for r in _rows(resp) if r["id"] == str(conversation.id))
+        assert row["last_message_preview"] == "dernière réponse"
+
+    def test_list_preview_empty_when_no_messages(self, owner_client, conversation):
+        resp = owner_client.get(BASE)
+        row = next(r for r in _rows(resp) if r["id"] == str(conversation.id))
+        assert row["last_message_preview"] in ("", None)
+
 
 class TestRetrieve:
     def test_retrieve_includes_messages(self, owner_client, conversation):

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -5,7 +5,8 @@ import json
 import logging
 
 from django.http import StreamingHttpResponse
-from django.db.models import Count
+from django.db.models import Count, OuterRef, Subquery
+from django.db.models.functions import Coalesce
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ValidationError
@@ -19,7 +20,7 @@ from . import memory as memory_service
 from . import searchables, service, tools
 from .conversations import ask_inputs as _ask_inputs, persist_turns as _persist_turns
 from .llm import LLMError, LLMTimeoutError
-from .models import AgentConversation, AgentMemory
+from .models import AgentConversation, AgentMemory, AgentMessage
 from .throttles import AgentBurstRateThrottle, AgentSustainedRateThrottle
 from .serializers import (
     AskRequestSerializer,
@@ -125,6 +126,16 @@ class ConversationViewSet(viewsets.ModelViewSet):
         household = getattr(self.request, "household", None)
         if household is not None:
             qs = qs.filter(household=household)
+        if self.action == "list":
+            # One-line preview of the newest turn, for the sidebar. Explicit
+            # ordering here (not just Meta) because the Count() annotation adds a
+            # GROUP BY — pin recency-first so an aggregate never reshuffles rows.
+            newest = AgentMessage.objects.filter(
+                conversation=OuterRef("pk")
+            ).order_by("-created_at")
+            qs = qs.annotate(
+                last_message_preview=Subquery(newest.values("content")[:1])
+            ).order_by(Coalesce("last_message_at", "created_at").desc(), "-created_at")
         if self.action in {"retrieve", "messages", "messages_stream", "for_context"}:
             qs = qs.prefetch_related("messages")
         return qs

--- a/e2e/agent.spec.ts
+++ b/e2e/agent.spec.ts
@@ -331,9 +331,13 @@ test('la sidebar liste les conversations et permet de basculer', async ({ page }
 
   await page.goto('/app/agent');
 
-  // Au montage, la plus récente (conv-a) est ouverte.
+  // Au montage : écran vierge (à la ChatGPT), les conversations restent listées.
   await expect(page.getByTestId('agent-conversation-list')).toContainText('Chaudière');
   await expect(page.getByTestId('agent-conversation-list')).toContainText('Assurance');
+  await expect(page.getByTestId('agent-bubble-agent')).toHaveCount(0);
+
+  // Ouvre une conversation depuis la liste.
+  await page.getByTestId('agent-conversation-item').filter({ hasText: 'Chaudière' }).getByRole('button').first().click();
   await expect(page.getByTestId('agent-bubble-agent')).toContainText('Réponse chaudière');
 
   // Bascule vers l'autre conversation.
@@ -346,6 +350,9 @@ test('« nouvelle conversation » vide l\'écran', async ({ page }) => {
   await mockSidebar(page);
 
   await page.goto('/app/agent');
+
+  // Ouvre une conversation, puis repasse en création.
+  await page.getByTestId('agent-conversation-item').filter({ hasText: 'Chaudière' }).getByRole('button').first().click();
   await expect(page.getByTestId('agent-bubble-agent')).toContainText('Réponse chaudière');
 
   await page.getByTestId('agent-new-conversation').first().click();

--- a/ui/src/features/agent/AgentPage.tsx
+++ b/ui/src/features/agent/AgentPage.tsx
@@ -1,33 +1,24 @@
 import * as React from 'react';
-import { History } from 'lucide-react';
+import { History, Plus } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/PageHeader';
 import { Button } from '@/design-system/button';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import ChatPanel from './ChatPanel';
 import ConversationList from './ConversationList';
-import { useConversation, useConversations, useCreateConversation } from './hooks';
+import { useConversation, useCreateConversation } from './hooks';
+import { useAgentSuggestions } from './suggestions';
 
 export default function AgentPage() {
   const { t } = useTranslation();
 
-  const conversationsQuery = useConversations();
+  // Always open on a fresh, empty conversation (à la ChatGPT/Claude): the past
+  // threads stay one tap away in the list, but the landing screen is a blank
+  // page — never an arbitrary old conversation auto-reopened.
   const [currentId, setCurrentId] = React.useState<string | null>(null);
   const conversationQuery = useConversation(currentId);
   const createConversation = useCreateConversation();
-
-  // Auto-select the latest conversation only once, on first load — so clicking
-  // "New conversation" (currentId → null) isn't immediately overridden.
-  const initializedRef = React.useRef(false);
-
-  React.useEffect(() => {
-    if (!initializedRef.current && conversationsQuery.data) {
-      initializedRef.current = true;
-      if (conversationsQuery.data.length > 0) {
-        setCurrentId(conversationsQuery.data[0].id);
-      }
-    }
-  }, [conversationsQuery.data]);
+  const suggestions = useAgentSuggestions();
 
   const handleSelect = React.useCallback((id: string) => {
     setCurrentId(id);
@@ -45,39 +36,66 @@ export default function AgentPage() {
     return conversation.id;
   }, [createConversation]);
 
+  // Title shown in the mobile bar: the open conversation's, or a "new" label.
+  const currentTitle = currentId
+    ? conversationQuery.data?.title || t('agent.untitled')
+    : t('agent.new_conversation');
+
+  const historyButton = (extraClass: string) => (
+    <SheetDialog
+      title={t('agent.conversations')}
+      trigger={
+        <Button
+          variant="outline"
+          size="icon"
+          className={extraClass}
+          aria-label={t('agent.conversations')}
+          data-testid="agent-conversations-toggle"
+        >
+          <History className="h-4 w-4" />
+        </Button>
+      }
+    >
+      {({ close }) => (
+        <ConversationList
+          currentId={currentId}
+          onSelect={(id) => {
+            handleSelect(id);
+            close();
+          }}
+          onNew={() => {
+            handleNew();
+            close();
+          }}
+          onCurrentDeleted={handleNew}
+        />
+      )}
+    </SheetDialog>
+  );
+
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <PageHeader title={t('agent.title')} description={t('agent.description')}>
-        <SheetDialog
-          title={t('agent.conversations')}
-          trigger={
-            <Button
-              variant="outline"
-              size="icon"
-              className="md:hidden"
-              aria-label={t('agent.conversations')}
-              data-testid="agent-conversations-toggle"
-            >
-              <History className="h-4 w-4" />
-            </Button>
-          }
+      {/* Desktop: full page header + persistent sidebar. */}
+      <div className="hidden md:block">
+        <PageHeader title={t('agent.title')} description={t('agent.description')} />
+      </div>
+
+      {/* Mobile: a thin bar (history · title · new) so the chat gets the screen. */}
+      <div className="mb-2 flex items-center gap-2 md:hidden">
+        {historyButton('')}
+        <span className="min-w-0 flex-1 truncate text-center text-sm font-medium text-foreground">
+          {currentTitle}
+        </span>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleNew}
+          aria-label={t('agent.new_conversation')}
+          data-testid="agent-new-conversation-mobile"
         >
-          {({ close }) => (
-            <ConversationList
-              currentId={currentId}
-              onSelect={(id) => {
-                handleSelect(id);
-                close();
-              }}
-              onNew={() => {
-                handleNew();
-                close();
-              }}
-              onCurrentDeleted={handleNew}
-            />
-          )}
-        </SheetDialog>
-      </PageHeader>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
 
       <div className="flex min-h-0 flex-1 gap-4">
         <aside className="hidden w-64 shrink-0 border-r border-border pr-3 md:flex md:flex-col">
@@ -96,6 +114,7 @@ export default function AgentPage() {
           creating={createConversation.isPending}
           emptyTitle={t('agent.empty_title')}
           emptyHint={t('agent.empty_hint')}
+          suggestions={suggestions}
           testIdPrefix="agent"
           className="flex-1"
         />

--- a/ui/src/features/agent/ChatPanel.tsx
+++ b/ui/src/features/agent/ChatPanel.tsx
@@ -90,6 +90,8 @@ interface ChatPanelProps {
   creating?: boolean;
   emptyTitle: string;
   emptyHint: string;
+  /** Clickable starter questions shown on the empty screen (household mode). */
+  suggestions?: string[];
   /** Prefix for data-testid attributes ('agent' or 'agent-entity'). */
   testIdPrefix: string;
   className?: string;
@@ -108,6 +110,7 @@ export default function ChatPanel({
   creating = false,
   emptyTitle,
   emptyHint,
+  suggestions,
   testIdPrefix,
   className,
 }: ChatPanelProps) {
@@ -170,14 +173,15 @@ export default function ChatPanel({
     textareaRef.current?.focus();
   }, []);
 
-  // `retryQuestion` re-submits a failed turn: the user bubble is already in the
-  // transcript, so we only clear the stale error bubbles instead of re-adding it.
+  // `text` overrides the draft (a suggestion chip or a retry). `retry` re-submits
+  // a failed turn: the user bubble is already in the transcript, so we only clear
+  // the stale error bubbles instead of re-adding it.
   const submit = React.useCallback(
-    async (retryQuestion?: string) => {
-      const trimmed = (retryQuestion ?? draft).trim();
+    async (opts?: { text?: string; retry?: boolean }) => {
+      const trimmed = (opts?.text ?? draft).trim();
       if (!trimmed || isBusy) return;
       if (!conversationId && !ensureConversation) return;
-      if (retryQuestion) {
+      if (opts?.retry) {
         setMessages((prev) => prev.filter((m) => m.variant !== 'error'));
       } else {
         setDraft('');
@@ -247,6 +251,14 @@ export default function ChatPanel({
     }
   };
 
+  // Focus the composer when the screen is ready to type on — on mount and each
+  // time a fresh, empty conversation is opened (privacy accepted, not busy).
+  React.useEffect(() => {
+    if (!needsPrivacy && messages.length === 0 && !isBusy) {
+      textareaRef.current?.focus();
+    }
+  }, [needsPrivacy, conversationId, messages.length, isBusy]);
+
   const isEmpty = messages.length === 0 && !isBusy;
   const disabled = needsPrivacy || isBusy || (!conversationId && !ensureConversation);
 
@@ -259,7 +271,13 @@ export default function ChatPanel({
         data-testid={`${testIdPrefix}-messages`}
       >
         {isEmpty ? (
-          <EmptyHint title={emptyTitle} hint={emptyHint} />
+          <EmptyHint
+            title={emptyTitle}
+            hint={emptyHint}
+            suggestions={disabled ? [] : suggestions}
+            onPick={(text) => void submit({ text })}
+            testIdPrefix={testIdPrefix}
+          />
         ) : (
           messages.map((msg) => {
             if (msg.variant === 'user') {
@@ -283,7 +301,7 @@ export default function ChatPanel({
                 key={msg.id}
                 text={msg.text}
                 testIdPrefix={testIdPrefix}
-                onRetry={() => void submit(msg.question)}
+                onRetry={() => void submit({ text: msg.question, retry: true })}
               />
             );
           })
@@ -325,14 +343,44 @@ export default function ChatPanel({
   );
 }
 
-function EmptyHint({ title, hint }: { title: string; hint: string }) {
+function EmptyHint({
+  title,
+  hint,
+  suggestions,
+  onPick,
+  testIdPrefix,
+}: {
+  title: string;
+  hint: string;
+  suggestions?: string[];
+  onPick: (text: string) => void;
+  testIdPrefix: string;
+}) {
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-2 py-12 text-center text-muted-foreground">
+    <div className="flex h-full flex-col items-center justify-center gap-3 py-12 text-center text-muted-foreground">
       <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary">
         <Sparkles className="h-6 w-6" />
       </div>
       <p className="text-sm font-medium text-foreground">{title}</p>
       <p className="max-w-md text-sm">{hint}</p>
+      {suggestions && suggestions.length > 0 ? (
+        <div
+          className="flex max-w-md flex-wrap justify-center gap-2 pt-2"
+          data-testid={`${testIdPrefix}-suggestions`}
+        >
+          {suggestions.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => onPick(s)}
+              className="rounded-full border border-border bg-card px-3 py-1.5 text-sm text-foreground transition-colors hover:border-primary hover:text-primary"
+              data-testid={`${testIdPrefix}-suggestion`}
+            >
+              {s}
+            </button>
+          ))}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ui/src/features/agent/ConversationList.tsx
+++ b/ui/src/features/agent/ConversationList.tsx
@@ -19,6 +19,37 @@ interface Props {
   onCurrentDeleted: () => void;
 }
 
+/** Recency bucket keys, newest first — drive the i18n group headers. */
+type Bucket = 'today' | 'yesterday' | 'last7' | 'last30' | 'older';
+
+/** Which recency bucket a conversation falls in, by its last activity. */
+function bucketOf(conv: AgentConversationRow): Bucket {
+  const ts = new Date(conv.last_message_at ?? conv.created_at).getTime();
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const day = 86_400_000;
+  if (ts >= startOfToday) return 'today';
+  if (ts >= startOfToday - day) return 'yesterday';
+  if (ts >= startOfToday - 7 * day) return 'last7';
+  if (ts >= startOfToday - 30 * day) return 'last30';
+  return 'older';
+}
+
+/**
+ * Group the (already recency-sorted) rows into consecutive buckets. Relies on
+ * the server order — we never re-sort, just split at bucket boundaries.
+ */
+function groupByBucket(items: AgentConversationRow[]): { bucket: Bucket; rows: AgentConversationRow[] }[] {
+  const groups: { bucket: Bucket; rows: AgentConversationRow[] }[] = [];
+  for (const conv of items) {
+    const bucket = bucketOf(conv);
+    const last = groups[groups.length - 1];
+    if (last && last.bucket === bucket) last.rows.push(conv);
+    else groups.push({ bucket, rows: [conv] });
+  }
+  return groups;
+}
+
 export default function ConversationList({ currentId, onSelect, onNew, onCurrentDeleted }: Props) {
   const { t } = useTranslation();
   const qc = useQueryClient();
@@ -57,6 +88,52 @@ export default function ConversationList({ currentId, onSelect, onNew, onCurrent
   };
 
   const items = conversations ?? [];
+  const groups = groupByBucket(items);
+
+  const renderRow = (conv: AgentConversationRow) => {
+    const active = conv.id === currentId;
+    const actions: CardAction[] = [
+      { label: t('common.edit'), icon: Pencil, onClick: () => openRename(conv) },
+      {
+        label: t('common.delete'),
+        icon: Trash2,
+        onClick: () => handleDelete(conv),
+        variant: 'danger',
+      },
+    ];
+    return (
+      <div
+        key={conv.id}
+        className={cn(
+          'group flex items-center gap-1 rounded-lg px-1',
+          active ? 'bg-primary/10' : 'hover:bg-muted',
+        )}
+        data-testid="agent-conversation-item"
+      >
+        <button
+          type="button"
+          onClick={() => onSelect(conv.id)}
+          className="flex min-w-0 flex-1 flex-col gap-0.5 px-2 py-2 text-left"
+        >
+          <span
+            className={cn(
+              'flex items-center gap-2 text-sm',
+              active ? 'text-primary' : 'text-foreground',
+            )}
+          >
+            <MessageSquare className="h-3.5 w-3.5 shrink-0 opacity-60" />
+            <span className="truncate">{conv.title || t('agent.untitled')}</span>
+          </span>
+          {conv.last_message_preview ? (
+            <span className="truncate pl-[1.375rem] text-xs text-muted-foreground">
+              {conv.last_message_preview}
+            </span>
+          ) : null}
+        </button>
+        <CardActions actions={actions} />
+      </div>
+    );
+  };
 
   return (
     <div className="flex h-full min-h-0 flex-col gap-2">
@@ -79,41 +156,14 @@ export default function ConversationList({ currentId, onSelect, onNew, onCurrent
             {t('agent.conversations_empty')}
           </p>
         ) : (
-          items.map((conv) => {
-            const active = conv.id === currentId;
-            const actions: CardAction[] = [
-              { label: t('common.edit'), icon: Pencil, onClick: () => openRename(conv) },
-              {
-                label: t('common.delete'),
-                icon: Trash2,
-                onClick: () => handleDelete(conv),
-                variant: 'danger',
-              },
-            ];
-            return (
-              <div
-                key={conv.id}
-                className={cn(
-                  'group flex items-center gap-1 rounded-lg px-1',
-                  active ? 'bg-primary/10' : 'hover:bg-muted',
-                )}
-                data-testid="agent-conversation-item"
-              >
-                <button
-                  type="button"
-                  onClick={() => onSelect(conv.id)}
-                  className={cn(
-                    'flex min-w-0 flex-1 items-center gap-2 px-2 py-2 text-left text-sm',
-                    active ? 'text-primary' : 'text-foreground',
-                  )}
-                >
-                  <MessageSquare className="h-3.5 w-3.5 shrink-0 opacity-60" />
-                  <span className="truncate">{conv.title || t('agent.untitled')}</span>
-                </button>
-                <CardActions actions={actions} />
-              </div>
-            );
-          })
+          groups.map((group) => (
+            <div key={group.bucket} className="space-y-1">
+              <p className="px-2 pt-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {t(`agent.groups.${group.bucket}`)}
+              </p>
+              {group.rows.map(renderRow)}
+            </div>
+          ))
         )}
       </div>
 

--- a/ui/src/features/agent/api.ts
+++ b/ui/src/features/agent/api.ts
@@ -84,6 +84,8 @@ export interface AgentConversationRow {
   last_message_at: string | null;
   created_at: string;
   message_count?: number;
+  /** One-line snippet of the newest turn, shown under the title in the sidebar. */
+  last_message_preview?: string;
 }
 
 /** Full conversation with its ordered messages. */

--- a/ui/src/features/agent/suggestions.ts
+++ b/ui/src/features/agent/suggestions.ts
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useDisabledModules } from '@/lib/modules';
+
+/**
+ * Starter questions for the empty agent screen, adapted to the household's
+ * active modules (parcours 15). Each entry names the module that gives it
+ * meaning: when that module is disabled, the suggestion is dropped so we never
+ * propose "combien d'œufs…" to a foyer without the chickens module.
+ *
+ * `module: null` = always relevant (works whatever the modules). The list is
+ * ordered by priority: we keep the first `limit` still-enabled suggestions, so
+ * the mix stays stable across renders (no random reshuffle).
+ *
+ * The text lives in i18n under `agent.suggestions.*` — the value IS the question
+ * submitted verbatim when the chip is clicked.
+ */
+const SUGGESTIONS: { key: string; module: string | null }[] = [
+  { key: 'tasks_due', module: 'tasks' },
+  { key: 'last_expense', module: 'expenses' },
+  { key: 'equipment_warranty', module: 'equipment' },
+  { key: 'electricity_trend', module: 'electricity' },
+  { key: 'eggs_this_week', module: 'chickens' },
+  { key: 'stock_low', module: 'stock' },
+  { key: 'find_document', module: 'documents' },
+  { key: 'project_cost', module: 'projects' },
+];
+
+/** Up to `limit` starter questions relevant to the foyer's enabled modules. */
+export function useAgentSuggestions(limit = 4): string[] {
+  const { t } = useTranslation();
+  const { disabled } = useDisabledModules();
+
+  return React.useMemo(
+    () =>
+      SUGGESTIONS.filter((s) => s.module === null || !disabled.has(s.module))
+        .slice(0, limit)
+        .map((s) => t(`agent.suggestions.${s.key}`)),
+    [disabled, limit, t],
+  );
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2318,6 +2318,23 @@
         "title": "📌 Eintrag vergessen",
         "notice": "Ein Eintrag wurde vergessen."
       }
+    },
+    "groups": {
+      "today": "Heute",
+      "yesterday": "Gestern",
+      "last7": "Letzte 7 Tage",
+      "last30": "Letzte 30 Tage",
+      "older": "Älter"
+    },
+    "suggestions": {
+      "tasks_due": "Welche Aufgaben stehen diese Woche an?",
+      "last_expense": "Was waren meine letzten Ausgaben?",
+      "equipment_warranty": "Welche Geräte sind noch in der Garantie?",
+      "electricity_trend": "Ist mein Stromverbrauch gestiegen?",
+      "eggs_this_week": "Wie viele Eier diese Woche?",
+      "stock_low": "Was geht in meinem Vorrat zur Neige?",
+      "find_document": "Finde ein wichtiges Dokument",
+      "project_cost": "Wie viel hat mein letztes Projekt gekostet?"
     }
   },
   "expenses": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2318,6 +2318,23 @@
         "title": "📌 Memory forgotten",
         "notice": "Forgot a memory."
       }
+    },
+    "groups": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "last7": "Previous 7 days",
+      "last30": "Previous 30 days",
+      "older": "Older"
+    },
+    "suggestions": {
+      "tasks_due": "What tasks are due this week?",
+      "last_expense": "What are my latest expenses?",
+      "equipment_warranty": "Which equipment is still under warranty?",
+      "electricity_trend": "Has my electricity use gone up?",
+      "eggs_this_week": "How many eggs this week?",
+      "stock_low": "What's running low in my stock?",
+      "find_document": "Find an important document",
+      "project_cost": "How much did my last project cost?"
     }
   },
   "expenses": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2318,6 +2318,23 @@
         "title": "📌 Recuerdo olvidado",
         "notice": "Se olvidó un recuerdo."
       }
+    },
+    "groups": {
+      "today": "Hoy",
+      "yesterday": "Ayer",
+      "last7": "Últimos 7 días",
+      "last30": "Últimos 30 días",
+      "older": "Más antiguo"
+    },
+    "suggestions": {
+      "tasks_due": "¿Qué tareas hay que hacer esta semana?",
+      "last_expense": "¿Cuáles son mis últimos gastos?",
+      "equipment_warranty": "¿Qué equipos siguen en garantía?",
+      "electricity_trend": "¿Ha aumentado mi consumo de electricidad?",
+      "eggs_this_week": "¿Cuántos huevos esta semana?",
+      "stock_low": "¿Qué se está agotando en mi stock?",
+      "find_document": "Encuentra un documento importante",
+      "project_cost": "¿Cuánto costó mi último proyecto?"
     }
   },
   "expenses": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2318,6 +2318,23 @@
         "title": "📌 Souvenir oublié",
         "notice": "Un souvenir a été oublié."
       }
+    },
+    "groups": {
+      "today": "Aujourd'hui",
+      "yesterday": "Hier",
+      "last7": "7 derniers jours",
+      "last30": "30 derniers jours",
+      "older": "Plus ancien"
+    },
+    "suggestions": {
+      "tasks_due": "Quelles tâches sont à faire cette semaine ?",
+      "last_expense": "Quelles sont mes dernières dépenses ?",
+      "equipment_warranty": "Quels équipements sont encore sous garantie ?",
+      "electricity_trend": "Ma consommation d'électricité a-t-elle augmenté ?",
+      "eggs_this_week": "Combien d'œufs cette semaine ?",
+      "stock_low": "Qu'est-ce qui manque dans mon stock ?",
+      "find_document": "Retrouve un document important",
+      "project_cost": "Combien m'a coûté mon dernier projet ?"
     }
   },
   "expenses": {


### PR DESCRIPTION
## Contexte

Audit + refonte UX/UI de la page Agent (`/app/agent`), inspirée des chats SaaS éprouvés (ChatGPT / Claude / Perplexity) adaptés au concept « assistant du foyer ». Répond à 3 problèmes signalés : header qui mange l'écran sur mobile, tri des conversations peu lisible, réouverture sur une ancienne conversation arbitraire.

## Changements

**A. Conversation neuve par défaut**
- Suppression de l'auto-sélection de `conversations[0]` au montage. La page ouvre toujours sur un écran vierge ; l'historique reste à un tap.

**B. Header plein-écran mobile**
- Sur mobile, le `PageHeader` lourd (titre `text-2xl` + sous-titre redondant avec `empty_hint` + séparateur) est remplacé par une barre fine `[historique] · titre courant · [+ nouveau]`. Le chat + composer prennent tout l'écran. Desktop conserve header + sidebar.

**C. Liste des conversations lisible**
- Groupes par récence (Aujourd'hui / Hier / 7 j / 30 j / Plus ancien) + aperçu du dernier message sous le titre.
- Nouveau champ `last_message_preview` annoté côté API (`Subquery` du dernier message), exposé par `ConversationListSerializer`.

**D. Fiabilité + fluidité**
- Tri par récence explicite côté viewset (robuste au `GROUP BY` induit par `Count`).
- Suggestions de questions cliquables sur l'écran vide, **filtrées selon les modules actifs du foyer** (parcours 15).
- Auto-focus du composer à l'ouverture.

## Tests
- Backend : suite agent complète verte (386) + 2 nouveaux tests pour `last_message_preview`.
- Front : lint + `tsc` OK.
- E2E : `agent.spec.ts` mis à jour pour le nouveau comportement (écran vierge par défaut).

> Note : développé en parallèle d'un autre chantier (module météo) sur le même checkout — cette PR ne contient **que** les fichiers de l'agent.