### PR TITLE
fix(telegram): conversations par session + /reset non destructif

### DIFF
--- a/apps/telegram/outbound.py
+++ b/apps/telegram/outbound.py
@@ -3,10 +3,11 @@ Server-initiated Telegram messages (proactive pings).
 
 The inbound flow (`service.py`) always reacts to a webhook update; this module
 is the opposite direction: the app speaks first. The message is delivered to
-the user's chat AND persisted as an assistant turn in THE channel conversation
-of (household, user) — so when the user replies, the regular inbound pipeline
-(`agent.service.ask` + bounded history) sees the question the bot just asked
-and can act on the answer with full context.
+the user's chat AND persisted as an assistant turn in the current session's
+channel conversation (`resolve_channel_conversation`) — so when the user
+replies, the regular inbound pipeline (`agent.service.ask` + bounded history)
+sees the question the bot just asked and can act on the answer with full
+context. A ping after a long gap or on a new day opens a fresh session.
 """
 from __future__ import annotations
 
@@ -29,9 +30,9 @@ def send_agent_message(account: TelegramAccount, household, text: str) -> bool:
     delivery problems are the caller's signal to retry later, not a crash.
     """
     from agent.conversations import derive_title
-    from agent.models import AgentConversation, AgentMessage
+    from agent.models import AgentMessage
 
-    from .service import CHANNEL_ENTITY_TYPE, CHANNEL_OBJECT_ID
+    from .service import resolve_channel_conversation
 
     if get_client().send_message(account.chat_id, text) is None:
         logger.warning(
@@ -39,12 +40,7 @@ def send_agent_message(account: TelegramAccount, household, text: str) -> bool:
         )
         return False
 
-    conversation, _created = AgentConversation.objects.get_or_create(
-        household=household,
-        created_by=account.user,
-        context_entity_type=CHANNEL_ENTITY_TYPE,
-        context_object_id=CHANNEL_OBJECT_ID,
-    )
+    conversation = resolve_channel_conversation(household, account.user)
     AgentMessage.objects.create(
         conversation=conversation,
         role=AgentMessage.Role.AGENT,

--- a/apps/telegram/service.py
+++ b/apps/telegram/service.py
@@ -14,11 +14,12 @@ from __future__ import annotations
 
 import logging
 import threading
+from datetime import timedelta
 
 from django.conf import settings
 from django.core.cache import cache
 from django.db import close_old_connections
-from django.utils import translation
+from django.utils import timezone, translation
 from django.utils.translation import gettext as _
 from django.utils.translation import gettext_lazy
 
@@ -35,11 +36,76 @@ UPDATE_DEDUP_TTL_SECONDS = 15 * 60
 
 SUPPORTED_LANGUAGES = {"en", "fr", "de", "es"}
 
-# Anchor pair identifying THE Telegram conversation of (household, user). The
-# anchor fields act as a channel discriminator here — this is not a household
-# entity, so it is never passed to `ask()` as context_entity.
+# Anchor pair tagging a conversation as belonging to the Telegram channel of
+# (household, user). It is a channel discriminator, NOT a household entity, so
+# it is never passed to `ask()` as context_entity. Several channel conversations
+# can coexist per user — one per session (see `resolve_channel_conversation`).
 CHANNEL_ENTITY_TYPE = "channel"
 CHANNEL_OBJECT_ID = "telegram"
+
+# A channel conversation is a "session": consecutive turns close in time. Past
+# this idle gap — or across a calendar-day boundary — the next turn opens a
+# fresh conversation instead of dragging stale context (e.g. yesterday's
+# "j'ai noté 2 œufs aujourd'hui") into today's history.
+SESSION_MAX_IDLE = timedelta(hours=6)
+
+
+def _channel_conversations(household, user):
+    """Every channel conversation of (household, user), newest-active first."""
+    from agent.models import AgentConversation
+
+    return AgentConversation.objects.filter(
+        household=household,
+        created_by=user,
+        context_entity_type=CHANNEL_ENTITY_TYPE,
+        context_object_id=CHANNEL_OBJECT_ID,
+    )
+
+
+def _session_expired(conversation, now) -> bool:
+    """True when `conversation`'s last activity is a different day or too old."""
+    ref = conversation.last_message_at or conversation.created_at
+    local_now, local_ref = timezone.localtime(now), timezone.localtime(ref)
+    if local_now.date() != local_ref.date():
+        return True
+    return (now - ref) > SESSION_MAX_IDLE
+
+
+def resolve_channel_conversation(household, user, *, force_new=False):
+    """The channel conversation the next Telegram turn belongs to.
+
+    Reuses the current session's conversation while it stays fresh (same day,
+    within `SESSION_MAX_IDLE`); otherwise opens a NEW one so each session keeps
+    a clean, self-contained history. Both directions go through here — inbound
+    replies and outbound pings — so a session groups the ping and its answer.
+
+    `force_new` (used by `/reset`) forces a fresh conversation WITHOUT deleting
+    anything; an already-empty latest one is reused so repeated resets don't pile
+    up blank rows.
+    """
+    from agent.models import AgentConversation
+
+    latest = _channel_conversations(household, user).first()  # recency-ordered
+    if latest is None:
+        return AgentConversation.objects.create(
+            household=household,
+            created_by=user,
+            context_entity_type=CHANNEL_ENTITY_TYPE,
+            context_object_id=CHANNEL_OBJECT_ID,
+        )
+    has_messages = latest.messages.exists()
+    if force_new:
+        needs_new = has_messages
+    else:
+        needs_new = has_messages and _session_expired(latest, timezone.now())
+    if needs_new:
+        return AgentConversation.objects.create(
+            household=household,
+            created_by=user,
+            context_entity_type=CHANNEL_ENTITY_TYPE,
+            context_object_id=CHANNEL_OBJECT_ID,
+        )
+    return latest
 
 # SOURCE OF TRUTH for the bot's command menu (the `/` autocomplete in Telegram).
 # `telegram_set_commands` pushes this list to Telegram (setMyCommands) at every
@@ -149,21 +215,15 @@ def _handle_question(account: TelegramAccount, chat_id: int, text: str) -> None:
 
 
 def _handle_reset(account: TelegramAccount, chat_id: int) -> None:
-    """`/reset` — drop the channel conversation, the next message starts fresh.
+    """`/reset` — open a fresh conversation; the next message starts a new thread.
 
-    Same effect as deleting a conversation from the web sidebar (hard delete,
-    messages cascade); the bot recreates one lazily on the next question.
+    Non-destructive: the previous conversation is kept (still visible in the web
+    history), we merely stop threading into it. A brand-new empty conversation
+    becomes the active one, so the next turn lands in a clean session.
     """
-    from agent.models import AgentConversation
-
     household = _resolve_household(account.user)
     if household is not None:
-        AgentConversation.objects.filter(
-            household=household,
-            created_by=account.user,
-            context_entity_type=CHANNEL_ENTITY_TYPE,
-            context_object_id=CHANNEL_OBJECT_ID,
-        ).delete()
+        resolve_channel_conversation(household, account.user, force_new=True)
     get_client().send_message(
         chat_id, _("Fresh start — your next message opens a new conversation.")
     )
@@ -204,7 +264,6 @@ def _process_question(account: TelegramAccount, chat_id: int, text: str) -> None
     from agent import service as agent_service
     from agent.conversations import ask_inputs, persist_turns
     from agent.llm import LLMError, LLMTimeoutError
-    from agent.models import AgentConversation
 
     client = get_client()
     try:
@@ -216,12 +275,7 @@ def _process_question(account: TelegramAccount, chat_id: int, text: str) -> None
                 )
                 return
             client.send_chat_action(chat_id, "typing")
-            conversation, _created = AgentConversation.objects.get_or_create(
-                household=household,
-                created_by=account.user,
-                context_entity_type=CHANNEL_ENTITY_TYPE,
-                context_object_id=CHANNEL_OBJECT_ID,
-            )
+            conversation = resolve_channel_conversation(household, account.user)
             # The channel anchor is a discriminator, not a household entity —
             # history flows, context_entity deliberately does not.
             history, _anchor = ask_inputs(conversation)

--- a/apps/telegram/tests/test_bridge.py
+++ b/apps/telegram/tests/test_bridge.py
@@ -1,9 +1,12 @@
 """The agent bridge: linked question -> service.ask -> persisted turns -> reply."""
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest import mock
 
 import pytest
+
+from django.utils import timezone
 
 from agent.llm import LLMTimeoutError
 from agent.models import AgentConversation, AgentMessage
@@ -122,16 +125,84 @@ class TestCooldown:
 
 
 class TestReset:
-    def test_reset_deletes_channel_conversation(self, bot, monkeypatch, linked_account, household, user):
+    def test_reset_opens_fresh_conversation_without_deleting(
+        self, bot, monkeypatch, linked_account, household, user
+    ):
         _patch_ask(monkeypatch, return_value=_answer())
         service.handle_update(text_update(linked_account.chat_id, "question", update_id=1))
-        assert _channel_conversation(household, user).exists()
+        first = _channel_conversation(household, user).get()
 
         service.handle_update(text_update(linked_account.chat_id, "/reset", update_id=2))
-        assert not _channel_conversation(household, user).exists()
-        # Reset confirmation was sent.
+
+        # Non-destructive: the old conversation stays, a fresh empty one is opened.
+        convs = _channel_conversation(household, user)
+        assert convs.count() == 2
+        assert convs.filter(pk=first.pk).exists()
+        fresh = convs.exclude(pk=first.pk).get()
+        assert not fresh.messages.exists()
+        # Answer + reset confirmation.
         assert bot.send_message.call_count == 2
 
     def test_reset_without_conversation_is_fine(self, bot, linked_account):
         service.handle_update(text_update(linked_account.chat_id, "/reset"))
         assert bot.send_message.call_count == 1
+
+    def test_reset_twice_reuses_the_empty_fresh_conversation(
+        self, bot, monkeypatch, linked_account, household, user
+    ):
+        _patch_ask(monkeypatch, return_value=_answer())
+        service.handle_update(text_update(linked_account.chat_id, "question", update_id=1))
+        service.handle_update(text_update(linked_account.chat_id, "/reset", update_id=2))
+        service.handle_update(text_update(linked_account.chat_id, "/reset", update_id=3))
+
+        # The second reset reuses the still-empty conversation — no pile-up.
+        assert _channel_conversation(household, user).count() == 2
+
+    def test_message_after_reset_threads_into_the_fresh_conversation(
+        self, bot, monkeypatch, linked_account, household, user, settings
+    ):
+        settings.TELEGRAM_COOLDOWN_SECONDS = 0
+        _patch_ask(monkeypatch, return_value=_answer())
+        service.handle_update(text_update(linked_account.chat_id, "q1", update_id=1))
+        first = _channel_conversation(household, user).get()
+        service.handle_update(text_update(linked_account.chat_id, "/reset", update_id=2))
+        service.handle_update(text_update(linked_account.chat_id, "q2", update_id=3))
+
+        first.refresh_from_db()
+        assert [m.content for m in first.messages.all()] == ["q1", "Réponse."]
+        fresh = _channel_conversation(household, user).exclude(pk=first.pk).get()
+        assert "q2" in [m.content for m in fresh.messages.all()]
+
+
+class TestSessionGrouping:
+    def test_stale_session_opens_a_new_conversation(
+        self, bot, monkeypatch, linked_account, household, user, settings
+    ):
+        settings.TELEGRAM_COOLDOWN_SECONDS = 0
+        _patch_ask(monkeypatch, return_value=_answer())
+        service.handle_update(text_update(linked_account.chat_id, "q1", update_id=1))
+        conv = _channel_conversation(household, user).get()
+        # Simulate the session being from a previous day.
+        AgentConversation.objects.filter(pk=conv.pk).update(
+            last_message_at=timezone.now() - timedelta(days=1)
+        )
+
+        service.handle_update(text_update(linked_account.chat_id, "q2", update_id=2))
+
+        # A fresh session is opened rather than reusing yesterday's.
+        assert _channel_conversation(household, user).count() == 2
+
+    def test_fresh_session_history_is_empty(
+        self, bot, monkeypatch, linked_account, household, user, settings
+    ):
+        settings.TELEGRAM_COOLDOWN_SECONDS = 0
+        ask = _patch_ask(monkeypatch, return_value=_answer())
+        service.handle_update(text_update(linked_account.chat_id, "q1", update_id=1))
+        conv = _channel_conversation(household, user).get()
+        AgentConversation.objects.filter(pk=conv.pk).update(
+            last_message_at=timezone.now() - timedelta(days=1)
+        )
+        service.handle_update(text_update(linked_account.chat_id, "q2", update_id=2))
+
+        # The second ask sees no history — the new session starts clean.
+        assert ask.call_args.kwargs["history"] == []

--- a/apps/telegram/tests/test_outbound.py
+++ b/apps/telegram/tests/test_outbound.py
@@ -1,9 +1,12 @@
 """Proactive outbound: deliver first, then persist in the channel conversation."""
 from __future__ import annotations
 
+from datetime import timedelta
 from unittest import mock
 
 import pytest
+
+from django.utils import timezone
 
 from agent.models import AgentConversation, AgentMessage
 from telegram import service
@@ -61,6 +64,30 @@ class TestSendAgentMessage:
         conversation.refresh_from_db()
         assert conversation.title == "Déjà là"  # never overwritten
         assert conversation.messages.count() == 1
+
+    def test_ping_opens_a_new_session_when_previous_is_stale(
+        self, outbound_client, linked_account, household, user
+    ):
+        stale = AgentConversation.objects.create(
+            household=household,
+            created_by=user,
+            context_entity_type=service.CHANNEL_ENTITY_TYPE,
+            context_object_id=service.CHANNEL_OBJECT_ID,
+            title="Hier",
+        )
+        AgentMessage.objects.create(
+            conversation=stale, role=AgentMessage.Role.AGENT, content="hier"
+        )
+        AgentConversation.objects.filter(pk=stale.pk).update(
+            last_message_at=timezone.now() - timedelta(days=1)
+        )
+
+        send_agent_message(linked_account, household, "🥚 Combien d'œufs ?")
+
+        # Today's ping starts its own conversation instead of appending to hier.
+        assert _channel_conversation(household, user).count() == 2
+        fresh = _channel_conversation(household, user).exclude(pk=stale.pk).get()
+        assert fresh.messages.get().content == "🥚 Combien d'œufs ?"
 
     def test_failed_delivery_persists_nothing(self, outbound_client, linked_account,
                                               household, user):

--- a/docs/MODULES/telegram.md
+++ b/docs/MODULES/telegram.md
@@ -30,7 +30,7 @@ TelegramAccount.chat_id → user  (chat inconnu → réponse fixe, zéro donnée
    ▼  thread daemon (Telegram retente sinon ; ask() = 10–30 s)
 household résolu (active_household / 1er membership)
    ▼
-AgentConversation get-or-create (ancre channel/telegram = discriminateur, PAS passée à ask())
+resolve_channel_conversation (session courante ; ancre channel/telegram = discriminateur, PAS passée à ask())
    ▼
 agent.service.ask(text, household, user=…, history=…)  ← même entrée que l'API web
    ▼
@@ -102,9 +102,26 @@ jour tout seul.
 
 `outbound.py::send_agent_message(account, household, text)` — le seul chemin
 d'envoi initié serveur : délivre via `client.send_message` **puis** persiste le
-tour assistant dans LA conversation canal (rien n'est persisté si Telegram
-rejette). Consommé par le module [pings](./pings.md) (scheduler + préférences) ;
-la réponse de l'utilisateur suit le flux entrant standard ci-dessus.
+tour assistant dans la conversation canal de la session courante (rien n'est
+persisté si Telegram rejette). Consommé par le module [pings](./pings.md)
+(scheduler + préférences) ; la réponse de l'utilisateur suit le flux entrant
+standard ci-dessus.
+
+## Sessions & `/reset`
+
+Le canal n'est **pas** une conversation unique qui grossit sans fin : entrant et
+sortant passent par `resolve_channel_conversation(household, user)`, qui **réutilise**
+la conversation tant que la session reste fraîche (même jour **et** moins de
+`SESSION_MAX_IDLE` = 6 h depuis le dernier tour) et **en ouvre une nouvelle** sinon.
+Objectif : qu'un « j'ai noté 2 œufs **aujourd'hui** » d'hier ne pollue pas
+l'historique (`ask_inputs`) de la session d'aujourd'hui — chaque session a un
+contexte propre. Côté web, une conversation par session/jour, empilée dans
+l'historique.
+
+`/reset` est **non destructif** : il appelle `resolve_channel_conversation(…,
+force_new=True)` → ouvre une conversation vierge sans rien supprimer (l'ancienne
+reste consultable). Deux `/reset` d'affilée réutilisent la conversation encore
+vide (pas d'empilement de lignes blanches).
 
 Opt-out conversationnel : un message `stop` (ou `/stop`, mot seul, insensible à
 la casse) désactive toutes les `PingPreference` du user — intercepté en dur


### PR DESCRIPTION
## Problème

Tout Telegram était mappé sur **une seule conversation** persistante par (foyer, user), via une ancre fixe `("channel","telegram")` et un `get_or_create`. Deux conséquences :

1. **Bug de contexte périmé** (signalé par Ben) : l'historique (`ask_inputs`, 20 derniers tours) traînait un « j'ai noté 2 œufs **aujourd'hui** » datant d'hier → aujourd'hui l'agent croyait la saisie déjà faite et refusait.
2. `/reset` faisait un **hard delete** de toute la conversation (transcript perdu, irréversible).

## Correctif

- **`resolve_channel_conversation(household, user, *, force_new=False)`** : entrant (`_process_question`) et sortant (`send_agent_message`) y passent tous les deux. Réutilise la conversation tant que la session est fraîche (**même jour ET < 6 h** depuis le dernier tour), en ouvre une nouvelle sinon. → chaque session a un contexte propre, plus de « aujourd'hui d'hier ».
- **`/reset` non destructif** : ouvre une conversation vierge sans rien supprimer (l'ancienne reste dans l'historique web). Deux resets d'affilée réutilisent la conversation encore vide (pas d'empilement).
- Doc `docs/MODULES/telegram.md` : section « Sessions & /reset ».

Aucune perte de données : les tâches/œufs/relevés créés par l'agent sont des objets séparés, jamais touchés. Seul le découpage des transcripts change.

## Tests
- Suite telegram complète verte (112, +5 nouveaux) : grouping de session (jour périmé), `/reset` non destructif, reset répété, message post-reset threadé sur la conversation neuve, ping sur session périmée.

> Développé dans un worktree isolé (session météo en parallèle sur le checkout principal) — cette PR ne contient que `apps/telegram/` + la doc.