### PR TITLE
chore(agent): admin conversations lisible — type + filtre + nb messages

### DIFF
--- a/apps/agent/admin.py
+++ b/apps/agent/admin.py
@@ -2,8 +2,37 @@
 from __future__ import annotations
 
 from django.contrib import admin
+from django.db.models import Count
 
 from .models import AgentConversation, AgentMemory, AgentMessage
+
+
+class ConversationKindFilter(admin.SimpleListFilter):
+    """Split conversations by origin — the anchor pair is the discriminator.
+
+    Empty anchor = a plain web conversation; ``channel`` = a messaging channel
+    (Telegram…); anything else = anchored to a household entity (a project's
+    Assistant tab, etc.). Lets staff isolate, say, all Telegram sessions.
+    """
+
+    title = "type"
+    parameter_name = "kind"
+
+    def lookups(self, request, model_admin):
+        return [
+            ("web", "Web"),
+            ("channel", "Canal (Telegram…)"),
+            ("anchored", "Ancrée à une entité"),
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value() == "web":
+            return queryset.filter(context_entity_type="")
+        if self.value() == "channel":
+            return queryset.filter(context_entity_type="channel")
+        if self.value() == "anchored":
+            return queryset.exclude(context_entity_type__in=["", "channel"])
+        return queryset
 
 
 class AgentMessageInline(admin.TabularInline):
@@ -17,11 +46,36 @@ class AgentMessageInline(admin.TabularInline):
 
 @admin.register(AgentConversation)
 class AgentConversationAdmin(admin.ModelAdmin):
-    list_display = ("__str__", "household", "created_by", "last_message_at", "created_at")
-    list_filter = ("household",)
+    list_display = (
+        "__str__",
+        "kind",
+        "household",
+        "created_by",
+        "message_count",
+        "last_message_at",
+        "created_at",
+    )
+    list_filter = (ConversationKindFilter, "household")
     search_fields = ("title", "id")
     readonly_fields = ("id", "created_at", "updated_at", "last_message_at")
     inlines = [AgentMessageInline]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).annotate(_message_count=Count("messages"))
+
+    @admin.display(description="Type")
+    def kind(self, obj):
+        """Human label for the conversation origin (mirrors the filter buckets)."""
+        if not obj.context_entity_type:
+            return "Web"
+        if obj.context_entity_type == "channel":
+            # e.g. "Canal · telegram" — the channel name is the object id.
+            return f"Canal · {obj.context_object_id}"
+        return f"Ancrée · {obj.context_entity_type}"
+
+    @admin.display(description="Messages", ordering="_message_count")
+    def message_count(self, obj):
+        return obj._message_count
 
 
 @admin.register(AgentMessage)

--- a/apps/agent/tests/test_admin.py
+++ b/apps/agent/tests/test_admin.py
@@ -1,0 +1,61 @@
+"""AgentConversation admin: the origin-type label + filter buckets."""
+from __future__ import annotations
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+
+from agent.admin import AgentConversationAdmin, ConversationKindFilter
+from agent.models import AgentConversation
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user(db):
+    return get_user_model().objects.create_user(
+        email="admin-test@example.com", password="x"
+    )
+
+
+def _conv(household, user, entity_type="", object_id=""):
+    return AgentConversation.objects.create(
+        household=household,
+        created_by=user,
+        context_entity_type=entity_type,
+        context_object_id=object_id,
+    )
+
+
+def test_kind_label_per_origin(household, user):
+    admin = AgentConversationAdmin(AgentConversation, AdminSite())
+    web = _conv(household, user)
+    telegram = _conv(household, user, "channel", "telegram")
+    anchored = _conv(household, user, "project", "abc-123")
+
+    assert admin.kind(web) == "Web"
+    assert admin.kind(telegram) == "Canal · telegram"
+    assert admin.kind(anchored) == "Ancrée · project"
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("web", {"web"}),
+        ("channel", {"channel"}),
+        ("anchored", {"anchored"}),
+        (None, {"web", "channel", "anchored"}),
+    ],
+)
+def test_kind_filter_buckets(household, user, value, expected):
+    convs = {
+        "web": _conv(household, user),
+        "channel": _conv(household, user, "channel", "telegram"),
+        "anchored": _conv(household, user, "project", "abc-123"),
+    }
+    filt = ConversationKindFilter.__new__(ConversationKindFilter)
+    filt.parameter_name = "kind"
+    filt.used_parameters = {"kind": value} if value else {}
+
+    result = set(filt.queryset(None, AgentConversation.objects.all()))
+    assert result == {convs[k] for k in expected}


### PR DESCRIPTION
## Contexte

Depuis le découpage des conversations Telegram par session (#278), l'admin Django liste davantage de `AgentConversation`, et on ne pouvait pas distinguer web / Telegram / conversation ancrée à une entité (l'ancre `context_entity_type`/`context_object_id` n'était pas affichée).

## Changements (`apps/agent/admin.py`)

- **Colonne « Type »** : `Web` / `Canal · <nom>` (ex. `Canal · telegram`) / `Ancrée · <entité>`.
- **Filtre « type »** (`ConversationKindFilter`) : buckets web / channel / anchored sur `context_entity_type`.
- **Colonne « Messages »** : nombre de tours (annotation `Count`, triable).

Observabilité pure — aucun changement fonctionnel. Tests : `test_admin.py` verrouille les labels + les 3 buckets du filtre.