### PR TITLE
feat(agent): tool get_weather — l'assistant répond avec la météo du foyer

### DIFF
--- a/apps/weather/agent.py
+++ b/apps/weather/agent.py
@@ -1,0 +1,116 @@
+"""
+Weather agent tool (parcours 17, Lot 5) — ``get_weather``.
+
+The weather module has no household-scoped model, so it cannot ride the
+``searchables`` registry (which indexes DB rows). Instead it exposes a dedicated
+read-only agent tool, registered from ``weather/apps.py::ready()`` via
+``agent.tools.register`` — the same "declare from the owning app, never touch
+apps/agent/" pattern the other apps use for writables/listables.
+
+The tool result is rendered as neutral data (English labels + numbers); the model
+phrases the final answer in the user's language, exactly like search results.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.tools import AgentTool, ToolResult
+
+GET_WEATHER = "get_weather"
+
+_GET_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+_GET_WEATHER_DESCRIPTION = (
+    "Get the local weather for this household: current conditions, a 7-day "
+    "forecast (min/max temperature, rain probability), and any active weather "
+    "alerts (frost, heatwave, strong wind, storm). Call this for ANY question "
+    "about the weather, forecast, temperature, rain, wind, sun, or whether the "
+    "conditions suit an outdoor activity (mowing, painting, a walk). Returns a "
+    "note that the weather is not configured when the household has no location."
+)
+
+
+def _fmt(value, suffix: str = "") -> str:
+    if value is None:
+        return "?"
+    if isinstance(value, float):
+        value = round(value)
+    return f"{value}{suffix}"
+
+
+def _get_weather_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client=None,
+    context_entity: tuple[str, str] | None = None,
+) -> ToolResult:
+    from .alerts import evaluate_weather_alerts
+    from .services import WeatherUnavailable, get_forecast
+
+    if household is None or "weather" in (getattr(household, "disabled_modules", None) or []):
+        return ToolResult(rendered="(weather module is not enabled for this household)")
+    if household.latitude is None or household.longitude is None:
+        return ToolResult(
+            rendered="(weather is not configured: no location is set for this household — "
+            "the user can set it in Settings)"
+        )
+
+    try:
+        forecast = get_forecast(household.latitude, household.longitude)
+    except WeatherUnavailable:
+        return ToolResult(rendered="(weather is temporarily unavailable — try again later)")
+
+    lines: list[str] = []
+    label = getattr(household, "location_label", "") or "the household location"
+    lines.append(f"Weather for {label} (timezone {forecast.get('timezone') or '?'}):")
+
+    current = forecast.get("current") or {}
+    lines.append(
+        "Current: {temp}°C (feels like {app}°C), {cond}, wind {wind} km/h, humidity {hum}%.".format(
+            temp=_fmt(current.get("temperature")),
+            app=_fmt(current.get("apparent_temperature")),
+            cond=current.get("condition") or "unknown",
+            wind=_fmt(current.get("wind_speed")),
+            hum=_fmt(current.get("humidity")),
+        )
+    )
+
+    daily = forecast.get("daily") or []
+    if daily:
+        lines.append("7-day forecast:")
+        for day in daily:
+            lines.append(
+                "- {date}: {tmin}–{tmax}°C, {cond}, rain {precip}%, wind gusts {gust} km/h".format(
+                    date=day.get("date"),
+                    tmin=_fmt(day.get("temp_min")),
+                    tmax=_fmt(day.get("temp_max")),
+                    cond=day.get("condition") or "unknown",
+                    precip=_fmt(day.get("precipitation_probability_max")),
+                    gust=_fmt(day.get("wind_gusts_max")),
+                )
+            )
+
+    alerts = evaluate_weather_alerts(household)
+    if alerts:
+        kinds = ", ".join(sorted({a["kind"] for a in alerts}))
+        lines.append(f"Active weather alerts: {kinds}.")
+    else:
+        lines.append("Active weather alerts: none.")
+
+    return ToolResult(rendered="\n".join(lines))
+
+
+def build_get_weather_tool() -> AgentTool:
+    """Factory for the ``get_weather`` agent tool (registered from apps.py)."""
+    return AgentTool(
+        name=GET_WEATHER,
+        description=_GET_WEATHER_DESCRIPTION,
+        input_schema=_GET_WEATHER_SCHEMA,
+        handler=_get_weather_handler,
+    )

--- a/apps/weather/apps.py
+++ b/apps/weather/apps.py
@@ -9,7 +9,6 @@ class WeatherConfig(AppConfig):
     def ready(self):
         # Parcours 17 Lot 4 — proactive weather-alert ping (frost/heatwave/wind/
         # storm). Reuses the existing ping scheduler; gated by the weather module.
-        # No household-scoped model: no searchables/writables/listables (Lot 5).
         from datetime import time as dt_time
 
         from pings.registry import PingSpec, register as register_ping
@@ -22,3 +21,12 @@ class WeatherConfig(AppConfig):
             build_message=build_weather_alert_ping,
             default_send_at=dt_time(8, 0),  # morning heads-up, household-local
         ))
+
+        # Parcours 17 Lot 5 — read-only agent tool. No household-scoped model, so
+        # a dedicated tool rather than a SearchableSpec. Declared here, never
+        # touching apps/agent/ (same pattern as writables/listables).
+        from agent.tools import register as register_tool
+
+        from .agent import build_get_weather_tool
+
+        register_tool(build_get_weather_tool())

--- a/apps/weather/tests/test_agent_tool.py
+++ b/apps/weather/tests/test_agent_tool.py
@@ -1,0 +1,104 @@
+# weather/tests/test_agent_tool.py
+"""Tests for the get_weather agent tool (parcours 17, Lot 5).
+
+Covers registration + the handler's branches (not configured, module disabled,
+forecast render, alerts line, upstream unavailable). The forecast is mocked — no
+real Open-Meteo call.
+"""
+import pytest
+
+from weather import agent as weather_agent
+from weather import alerts as weather_alerts
+
+from .factories import HouseholdFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _forecast(daily):
+    return {
+        "timezone": "Europe/Paris",
+        "current": {
+            "temperature": 12.0,
+            "apparent_temperature": 10.0,
+            "condition": "cloudy",
+            "wind_speed": 15.0,
+            "humidity": 70,
+        },
+        "daily": daily,
+    }
+
+
+def _day(date="2026-01-10", *, tmin=8.0, tmax=18.0, gust=10.0, code=1, precip=0):
+    return {
+        "date": date,
+        "weather_code": code,
+        "condition": "clear",
+        "temp_max": tmax,
+        "temp_min": tmin,
+        "precipitation_probability_max": precip,
+        "wind_gusts_max": gust,
+        "sunrise": None,
+        "sunset": None,
+    }
+
+
+def _call(household):
+    return weather_agent._get_weather_handler(household=household, tool_input={}).rendered
+
+
+# ── registration ─────────────────────────────────────────────────────────────
+
+def test_tool_registered():
+    from agent import tools
+
+    assert weather_agent.GET_WEATHER in tools.REGISTRY
+    schema = tools.REGISTRY[weather_agent.GET_WEATHER].to_schema()
+    assert schema["name"] == "get_weather"
+    assert "forecast" in schema["description"].lower()
+
+
+# ── handler branches ─────────────────────────────────────────────────────────
+
+def test_not_configured_no_location():
+    hh = HouseholdFactory()  # no coords
+    assert "not configured" in _call(hh)
+
+
+def test_module_disabled():
+    hh = HouseholdFactory(latitude=48.85, longitude=2.35, disabled_modules=["weather"])
+    assert "not enabled" in _call(hh)
+
+
+def test_renders_forecast(monkeypatch):
+    from weather import services
+
+    monkeypatch.setattr(services, "get_forecast", lambda lat, lon, **k: _forecast([_day()]))
+    hh = HouseholdFactory(latitude=48.85, longitude=2.35, location_label="Paris")
+    rendered = _call(hh)
+    assert "Weather for Paris" in rendered
+    assert "Current:" in rendered
+    assert "7-day forecast:" in rendered
+    assert "Active weather alerts: none." in rendered
+
+
+def test_lists_active_alerts(monkeypatch):
+    from weather import services
+
+    monkeypatch.setattr(services, "get_forecast",
+                        lambda lat, lon, **k: _forecast([_day(tmin=-4.0, tmax=38.0)]))
+    hh = HouseholdFactory(latitude=48.85, longitude=2.35, location_label="Paris")
+    rendered = _call(hh)
+    assert "Active weather alerts:" in rendered
+    assert "frost" in rendered and "heatwave" in rendered
+
+
+def test_unavailable(monkeypatch):
+    from weather import services
+
+    def _raise(*a, **k):
+        raise services.WeatherUnavailable("down")
+
+    monkeypatch.setattr(services, "get_forecast", _raise)
+    hh = HouseholdFactory(latitude=1.0, longitude=1.0, location_label="X")
+    assert "temporarily unavailable" in _call(hh)

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -31,6 +31,11 @@ Un **4ᵉ tool, d'écriture**, complète les trois de lecture :
   `metadata.created_entities` pour l'Undo côté client. Livré au **lot 8** (voir
   `docs/parcours/PARCOURS_07_LOT8_ACTIONS_ECRITURE.md`).
 
+Une app peut aussi **enregistrer son propre tool de lecture** via
+`agent.tools.register(AgentTool(...))` depuis son `apps.py::ready()`, sans toucher
+`apps/agent/` — utile pour une source sans modèle DB (donc hors `searchables`).
+Exemple : `get_weather` (module météo, parcours 17 Lot 5) rend prévisions + alertes.
+
 ## Registry d'écriture `writables` — rendre une entité créable
 
 Miroir de `searchables`, pour l'écriture. Chaque app déclare depuis

--- a/docs/MODULES/weather.md
+++ b/docs/MODULES/weather.md
@@ -64,9 +64,15 @@ est volontairement vide.
   `payload.day`). Le `daily[]` du forecast expose `wind_gusts_max` pour le seuil vent.
   Aucun nouveau modèle, aucun cron : réutilise le scheduler `send_scheduled_pings`.
 
+- **Agent (Lot 5, livré)** : tool de lecture `get_weather` (`apps/weather/agent.py`,
+  enregistré depuis `apps.py::ready()` via `agent.tools.register` — **sans toucher
+  `apps/agent/`**). Handler → `get_forecast` + `evaluate_weather_alerts`, rend des
+  données neutres (le modèle localise). Pas de `SearchableSpec` (aucun modèle DB) ;
+  toujours déclaré, répond « non configuré » sans localisation. Pas d'i18n backend
+  (données neutres, comme les résultats de recherche).
+
 ## Limitations connues / lots suivants (parcours 17)
 
-- **Lot 5** — contexte météo exposé à l'agent (searchable/tool lecture).
 - **Lot 6** — corrélations conso (électricité/eau) avec l'historique météo.
 - Une seule localisation par foyer (pas par zone) ; °C uniquement ; pas d'historique (arrive au Lot 6).
 - Cache LocMem non partagé entre workers en prod — acceptable (données non critiques, TTL court) ; passer sur un cache partagé si l'app scale horizontalement.

--- a/docs/parcours/PARCOURS_17_METEO.md
+++ b/docs/parcours/PARCOURS_17_METEO.md
@@ -35,7 +35,7 @@ externes en direct (Open-Meteo) et les met en cache. Conséquences sur le patter
 | **2** | Page météo (horaire du jour + prévisions 7 jours) | **V1** |
 | 3 | Tâches météo-conscientes (tag + suggestion de créneau sec) | **livré** (2026-07-14) |
 | 4 | Alertes météo (gel/canicule/vent/orage) via module alertes + pings | **livré** (2026-07-14) |
-| 5 | Contexte météo exposé à l'agent IA (tool `get_weather`) | **cadré** (à implémenter) |
+| 5 | Contexte météo exposé à l'agent IA (tool `get_weather`) | **livré** (2026-07-14) |
 | 6 | Corrélations conso (électricité/eau) avec l'historique météo | **cadré** (à implémenter) |
 
 ## Lot 1 — Fondations
@@ -145,7 +145,19 @@ structurés et rend côté front.
 - Seuils configurables (V2), alerte poulailler dédiée (peut se greffer plus tard
   via un message contextualisé si module chickens actif), historique des alertes.
 
-## Lot 5 — Contexte météo pour l'agent IA (cadrage — à valider avant code)
+## Lot 5 — Contexte météo pour l'agent IA (livré 2026-07-14)
+
+> **Livré** : tool `get_weather` dans `apps/weather/agent.py`, enregistré depuis
+> `weather/apps.py::ready()` via `agent.tools.register` — **aucune modification de
+> `apps/agent/`**. Handler → `weather.services.get_forecast` +
+> `weather.alerts.evaluate_weather_alerts`, rend un bloc de données neutres
+> (conditions + 7 j + alertes actives) que le modèle reformule dans la langue de
+> l'utilisateur. Cas « non configuré » (pas de localisation) / « module désactivé »
+> / « indisponible » gérés dans le handler. Toujours déclaré (pas de gating par
+> foyer) : réponse explicite quand la météo n'est pas configurée. Décisions du
+> cadrage retenues : tool dédié, pas de tool d'historique, gating simple.
+
+### Cadrage initial (conservé pour mémoire)
 
 Objectif : que l'assistant conversationnel puisse **répondre avec la météo**
 (« quand tondre cette semaine ? », « faut-il protéger les tomates ce week-end ? »,


### PR DESCRIPTION
Closes #282

Parcours 17, **Lot 5 — Contexte météo pour l'agent**. L'assistant peut répondre aux questions météo (« quand tondre ? », « quel temps ce week-end ? »).

## Quoi
- Tool de lecture `get_weather` (`apps/weather/agent.py`) enregistré depuis `weather/apps.py::ready()` via `agent.tools.register` — **aucune modification de `apps/agent/`** (la météo n'ayant pas de modèle DB, elle ne peut pas passer par `searchables` ; un tool dédié est le bon véhicule, comme les apps enregistrent leurs writables/listables).
- Handler → `weather.services.get_forecast` + `weather.alerts.evaluate_weather_alerts` ; rend conditions actuelles + prévisions 7 j + alertes actives en **données neutres** que le modèle reformule dans la langue de l'utilisateur (comme les résultats de recherche → pas d'i18n backend).
- Cas gérés : pas de localisation → « non configuré » ; module désactivé → « non activé » ; Open-Meteo injoignable → « indisponible ». Toujours déclaré (pas de gating par foyer — V1 simple, conforme au cadrage).

## Décisions du cadrage (issue #282) retenues
Tool dédié `get_weather` (vs injection contexte) · pas de tool d'historique en V1 · gating simple (réponse « non configuré »).

## Tests
- `apps/weather/tests/test_agent_tool.py` : enregistrement + branches du handler (non configuré, module désactivé, forecast, alertes actives, indisponible). Suite complète : **1918 passed** (aucun test agent cassé par le nouveau tool).
- `python manage.py check` OK. Backend-only, pas de changement frontend.

## Hors scope
Écriture depuis l'agent, tool d'historique météo (recoupe le Lot 6), actions automatiques.