### PR TITLE
feat(electricity): overlay température sur les graphes de conso élec/eau (corrélations météo)

### DIFF
--- a/apps/weather/services.py
+++ b/apps/weather/services.py
@@ -24,8 +24,10 @@ logger = logging.getLogger(__name__)
 
 FORECAST_URL = "https://api.open-meteo.com/v1/forecast"
 GEOCODING_URL = "https://geocoding-api.open-meteo.com/v1/search"
+ARCHIVE_URL = "https://archive-api.open-meteo.com/v1/archive"
 REQUEST_TIMEOUT_SECONDS = 8.0
 CACHE_TTL_SECONDS = 30 * 60  # 30 min — forecasts don't move faster than that
+HISTORY_CACHE_TTL_SECONDS = 24 * 60 * 60  # 24 h — the past doesn't change
 FORECAST_DAYS = 7
 
 # WMO weather interpretation codes → stable condition slug. The frontend maps
@@ -238,3 +240,44 @@ def _normalize_forecast(raw: dict) -> dict:
         "hourly": hourly,
         "daily": daily,
     }
+
+
+def get_history(latitude: float, longitude: float, date_from: str, date_to: str,
+                *, use_cache: bool = True) -> list[dict]:
+    """Daily mean temperatures over ``[date_from, date_to]`` (ISO dates).
+
+    Read from the Open-Meteo **archive** API — daily granularity only; the
+    frontend aggregates to the consumption buckets it already has (parcours 17
+    Lot 6). Cached 24 h (the past doesn't change). Returns a list of
+    ``{date, temp_mean}`` (days Open-Meteo can't provide yet are simply absent —
+    the archive lags a few days, so the overlay degrades gracefully). Raises
+    :class:`WeatherUnavailable` on transport error (and no cache hit).
+    """
+    key = f"weather:history:{round(latitude, 2)}:{round(longitude, 2)}:{date_from}:{date_to}"
+    if use_cache:
+        cached = cache.get(key)
+        if cached is not None:
+            return cached
+
+    raw = _get_json(
+        ARCHIVE_URL,
+        {
+            "latitude": latitude,
+            "longitude": longitude,
+            "start_date": date_from,
+            "end_date": date_to,
+            "daily": "temperature_2m_mean",
+            "timezone": "auto",
+        },
+    )
+    daily = raw.get("daily") or {}
+    dates = daily.get("time") or []
+    means = daily.get("temperature_2m_mean") or []
+    points = [
+        {"date": dates[i], "temp_mean": means[i]}
+        for i in range(len(dates))
+        if i < len(means) and means[i] is not None
+    ]
+    if use_cache:
+        cache.set(key, points, HISTORY_CACHE_TTL_SECONDS)
+    return points

--- a/apps/weather/tests/test_services.py
+++ b/apps/weather/tests/test_services.py
@@ -135,6 +135,50 @@ def test_get_forecast_raises_on_transport_error(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# get_history (Lot 6)
+# ---------------------------------------------------------------------------
+
+_ARCHIVE_PAYLOAD = {
+    "daily": {
+        "time": ["2026-01-01", "2026-01-02", "2026-01-03"],
+        "temperature_2m_mean": [0.5, None, 3.3],
+    }
+}
+
+
+def test_get_history_normalizes_and_drops_nulls(monkeypatch):
+    monkeypatch.setattr(services.httpx, "get", _fake_get(_ARCHIVE_PAYLOAD))
+    points = services.get_history(48.85, 2.35, "2026-01-01", "2026-01-03", use_cache=False)
+    # The None day is dropped.
+    assert points == [
+        {"date": "2026-01-01", "temp_mean": 0.5},
+        {"date": "2026-01-03", "temp_mean": 3.3},
+    ]
+
+
+def test_get_history_uses_cache(monkeypatch):
+    calls = {"n": 0}
+
+    def _counting_get(url, params=None, timeout=None):
+        calls["n"] += 1
+        return _FakeResponse(_ARCHIVE_PAYLOAD)
+
+    monkeypatch.setattr(services.httpx, "get", _counting_get)
+    services.get_history(48.85, 2.35, "2026-01-01", "2026-01-03")
+    services.get_history(48.85, 2.35, "2026-01-01", "2026-01-03")
+    assert calls["n"] == 1
+
+
+def test_get_history_raises_on_transport_error(monkeypatch):
+    def _raise(*a, **k):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(services.httpx, "get", _raise)
+    with pytest.raises(services.WeatherUnavailable):
+        services.get_history(48.85, 2.35, "2026-01-01", "2026-01-03", use_cache=False)
+
+
+# ---------------------------------------------------------------------------
 # Helpers / fixtures data
 # ---------------------------------------------------------------------------
 

--- a/apps/weather/tests/test_views.py
+++ b/apps/weather/tests/test_views.py
@@ -25,6 +25,7 @@ pytestmark = pytest.mark.django_db
 
 WEATHER_URL = "/api/weather/"
 GEOCODE_URL = "/api/weather/geocode/"
+HISTORY_URL = "/api/weather/history/"
 
 
 def _member_of(household):
@@ -122,3 +123,41 @@ def test_geocode_error_state(monkeypatch):
     assert resp.status_code == status.HTTP_200_OK
     assert resp.data["results"] == []
     assert resp.data["error"] is True
+
+
+# ── history (Lot 6) ──────────────────────────────────────────────────────────
+
+def test_history_not_configured(monkeypatch):
+    user = _member_of(HouseholdFactory())  # no coords
+    monkeypatch.setattr(services, "get_history", lambda *a, **k: pytest.fail("no fetch"))
+    resp = _client_for(user).get(HISTORY_URL, {"date_from": "2026-01-01", "date_to": "2026-01-10"})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data == {"configured": False, "points": []}
+
+
+def test_history_returns_points(monkeypatch):
+    user = _member_of(HouseholdFactory(latitude=48.85, longitude=2.35))
+    pts = [{"date": "2026-01-01", "temp_mean": 0.5}]
+    monkeypatch.setattr(services, "get_history", lambda lat, lon, df, dt: pts)
+    resp = _client_for(user).get(HISTORY_URL, {"date_from": "2026-01-01", "date_to": "2026-01-10"})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data == {"configured": True, "error": False, "points": pts}
+
+
+def test_history_bad_dates(monkeypatch):
+    user = _member_of(HouseholdFactory(latitude=1.0, longitude=1.0))
+    resp = _client_for(user).get(HISTORY_URL, {"date_from": "nope", "date_to": "2026-01-10"})
+    assert resp.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_history_upstream_error(monkeypatch):
+    user = _member_of(HouseholdFactory(latitude=1.0, longitude=1.0))
+
+    def _raise(lat, lon, df, dt):
+        raise services.WeatherUnavailable("down")
+
+    monkeypatch.setattr(services, "get_history", _raise)
+    resp = _client_for(user).get(HISTORY_URL, {"date_from": "2026-01-01", "date_to": "2026-01-10"})
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["error"] is True
+    assert resp.data["points"] == []

--- a/apps/weather/urls.py
+++ b/apps/weather/urls.py
@@ -1,9 +1,10 @@
 """Weather module URLs (parcours 17)."""
 from django.urls import path
 
-from .views import WeatherGeocodeView, WeatherView
+from .views import WeatherGeocodeView, WeatherHistoryView, WeatherView
 
 urlpatterns = [
     path("", WeatherView.as_view(), name="weather"),
+    path("history/", WeatherHistoryView.as_view(), name="weather-history"),
     path("geocode/", WeatherGeocodeView.as_view(), name="weather-geocode"),
 ]

--- a/apps/weather/views.py
+++ b/apps/weather/views.py
@@ -6,7 +6,9 @@ No model, no writes: the weather module reads live forecasts from Open-Meteo
 proxies the geocoding search used by the settings UI to pick that location.
 """
 import logging
+from datetime import date
 
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -44,6 +46,38 @@ class WeatherView(APIView):
         except services.WeatherUnavailable:
             return Response({**base, "error": True})
         return Response({**base, "error": False, **forecast})
+
+
+class WeatherHistoryView(APIView):
+    """Daily mean temperatures over a period, to overlay on the consumption
+    charts (parcours 17 Lot 6). Always HTTP 200; ``configured=False`` when the
+    household has no location, ``error=True`` when the archive is unreachable.
+    The frontend aggregates these daily points to its own consumption buckets.
+    """
+
+    permission_classes = [IsHouseholdMember]
+
+    def get(self, request):
+        household = request.household
+        if household is None or household.latitude is None or household.longitude is None:
+            return Response({"configured": False, "points": []})
+
+        try:
+            date_from = date.fromisoformat(request.query_params.get("date_from", ""))
+            date_to = date.fromisoformat(request.query_params.get("date_to", ""))
+        except ValueError:
+            raise ValidationError({"date_from": "date_from and date_to must be ISO dates (YYYY-MM-DD)."})
+        if date_to < date_from:
+            raise ValidationError({"date_to": "date_to must be on or after date_from."})
+
+        try:
+            points = services.get_history(
+                household.latitude, household.longitude,
+                date_from.isoformat(), date_to.isoformat(),
+            )
+        except services.WeatherUnavailable:
+            return Response({"configured": True, "error": True, "points": []})
+        return Response({"configured": True, "error": False, "points": points})
 
 
 class WeatherGeocodeView(APIView):

--- a/docs/MODULES/weather.md
+++ b/docs/MODULES/weather.md
@@ -71,8 +71,20 @@ est volontairement vide.
   toujours déclaré, répond « non configuré » sans localisation. Pas d'i18n backend
   (données neutres, comme les résultats de recherche).
 
-## Limitations connues / lots suivants (parcours 17)
+- **Corrélations conso (Lot 6, livré)** : endpoint `GET /api/weather/history/`
+  (`services.get_history`, Open-Meteo Archive, moyennes journalières, cache 24 h,
+  on-demand — pas de modèle). `ConsumptionBarChart` gagne une prop `overlay`
+  (ligne température sur axe droit, `ComposedChart`). Toggle « Météo »
+  (`WeatherOverlayToggle`) sur les pages électricité + eau, visible si module actif +
+  localisation + granularité day/month. Alignement front (`overlay.ts`) sur les
+  buckets conso via le préfixe ISO du `ts` (robuste aux formats ts eau vs élec).
 
-- **Lot 6** — corrélations conso (électricité/eau) avec l'historique météo.
-- Une seule localisation par foyer (pas par zone) ; °C uniquement ; pas d'historique (arrive au Lot 6).
+## Limitations connues (parcours 17 — module complet)
+
+- Le module météo (parcours 17) est **complet** : lots 1-6 livrés.
+- Une seule localisation par foyer (pas par zone) ; °C uniquement.
+- Overlay conso limité aux granularités **day/month** (horaire trop fin, année =
+  fetch trop lourd) ; température **moyenne** journalière seulement.
+- L'archive Open-Meteo a un décalage de quelques jours → les jours très récents
+  n'ont pas de point d'overlay (dégradation gracieuse, la ligne saute le jour).
 - Cache LocMem non partagé entre workers en prod — acceptable (données non critiques, TTL court) ; passer sur un cache partagé si l'app scale horizontalement.

--- a/docs/parcours/PARCOURS_17_METEO.md
+++ b/docs/parcours/PARCOURS_17_METEO.md
@@ -1,9 +1,9 @@
 # Parcours 17 — La météo entre dans la maison
 
-> **Statut V1 (Lot 1 + 2) : en cours de livraison.**
+> **Statut : module complet — lots 1 à 6 livrés (2026-07-14 / 2026-07-15).**
 > Décisions de cadrage figées : localisation **sur le foyer** (`Household`),
-> fournisseur **Open-Meteo** (gratuit, sans clé), périmètre initial = socle
-> lecture-seule (localisation + widget dashboard + page prévisions).
+> fournisseur **Open-Meteo** (gratuit, sans clé). Le module reste une intégration
+> **lecture seule** (aucun modèle météo en DB ; seule la localisation est persistée).
 
 ## Intention
 
@@ -36,7 +36,7 @@ externes en direct (Open-Meteo) et les met en cache. Conséquences sur le patter
 | 3 | Tâches météo-conscientes (tag + suggestion de créneau sec) | **livré** (2026-07-14) |
 | 4 | Alertes météo (gel/canicule/vent/orage) via module alertes + pings | **livré** (2026-07-14) |
 | 5 | Contexte météo exposé à l'agent IA (tool `get_weather`) | **livré** (2026-07-14) |
-| 6 | Corrélations conso (électricité/eau) avec l'historique météo | **cadré** (à implémenter) |
+| 6 | Corrélations conso (électricité/eau) avec l'historique météo | **livré** (2026-07-15) |
 
 ## Lot 1 — Fondations
 
@@ -199,7 +199,21 @@ expose `AgentTool(name, description, input_schema, handler)` + `register()` dans
 - Écriture depuis l'agent (la météo est lecture seule), historique conversationnel
   météo, actions automatiques déclenchées par la météo.
 
-## Lot 6 — Corrélations consommation ↔ météo (cadrage — à valider avant code)
+## Lot 6 — Corrélations consommation ↔ météo (livré 2026-07-15)
+
+> **Livré** : endpoint `GET /api/weather/history/` (`weather.services.get_history`,
+> Open-Meteo **Archive API**, moyennes journalières, cache 24 h, on-demand — pas de
+> modèle DB). Overlay d'une **ligne température** (axe droit) sur `ConsumptionBarChart`
+> (passé en `ComposedChart` + `Line`, nouvelle prop `overlay`). Toggle « Météo »
+> partagé (`WeatherOverlayToggle`) sur les pages électricité + eau, visible seulement
+> si module météo actif + localisation définie + granularité day/month. Alignement des
+> points sur les buckets conso **côté front** (`overlay.ts::buildTemperatureOverlay`,
+> clé sur le préfixe ISO du `ts` → robuste malgré les formats de `ts` différents
+> eau/électricité). Décisions du cadrage retenues : élec+eau, on-demand+cache, day/month,
+> température moyenne. Dégradation gracieuse : pas de localisation → toggle masqué ;
+> historique indispo → conso affichée sans la ligne.
+
+### Cadrage initial (conservé pour mémoire)
 
 Objectif : superposer la **température passée** aux relevés de consommation
 (électricité, eau) pour expliquer les pics (chauffage en froid, arrosage en

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -448,3 +448,21 @@ Requiert un build frontend à jour (`npm run build`) car la feature weather_aler
 | Alerte orage sans valeur affiche le libellé fixe ("Orage prévu") | ✅ |
 | Alertes météo remontées dans TriageSection du dashboard (title + badge "Urgent") | ✅ |
 | TriageSection absente du dashboard quand `total: 0` | ✅ |
+
+---
+
+## Overlay météo — consommation (`weather-overlay.spec.ts`)
+
+API `/api/households/`, `/api/water/consumption/summary/`, `/api/weather/history/` et `/api/water/readings/` stubées via `page.route` — aucun appel réseau réel.
+Households stubés pour contrôler la présence ou l'absence de lat/lon.
+
+| Parcours | Statut |
+|---|---|
+| Toggle "Météo" visible à côté des granularités quand foyer a lat/lon + granularité `day` | ✅ |
+| Activer le toggle déclenche un appel GET `/api/weather/history/` | ✅ |
+| Activer le toggle fait apparaître la légende "Température" dans le graphe recharts | ✅ |
+| Activer le toggle fait apparaître une ligne SVG recharts (Line) dans le graphe | ✅ |
+| Toggle "Météo" absent en vue Année (granularité non supportée par l'overlay) | ✅ |
+| Toggle "Météo" visible en vue Mois (granularité supportée) | ✅ |
+| Toggle "Météo" absent quand le foyer n'a pas de lat/lon | ✅ |
+| Toggle "Météo" visible sur l'onglet Consommation d'Électricité en vue Jour (smoke) | ✅ |

--- a/e2e/weather-overlay.spec.ts
+++ b/e2e/weather-overlay.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * E2E — Température en overlay sur les graphes de consommation (parcours 17, Lot 6)
+ *
+ * Three stubs are combined so tests are fully deterministic — no live
+ * Open-Meteo call, no real water readings required:
+ *
+ *  1. /api/households/   — injects lat/lon on the demo household so the
+ *     overlay is "available" (useTemperatureOverlay checks household?.latitude).
+ *  2. /api/water/consumption/summary/  — returns a couple of day buckets
+ *     so the ConsumptionBarChart renders (overlay is only injected when there
+ *     are buckets).
+ *  3. /api/weather/history/  — returns temperature points aligned to the
+ *     stubbed consumption buckets.
+ *
+ * Auth is handled by storageState in playwright.config.ts — no inline login.
+ *
+ * NOTE on readings: WaterPage renders the chart view only when readings.length
+ * > 0.  Rather than deleting/creating real readings we stub
+ * /api/water/readings/ too so the page always sees exactly one reading
+ * (enough to skip the EmptyState and reach the chart).
+ */
+
+import { test, expect } from './fixtures';
+import type { Route } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// ISO dates used for consumption + history stubs (far enough in the past so
+// the "day" period that the page defaults to can navigate to them; for the
+// "day" granularity we stub the current day instead to avoid navigation).
+const TODAY = new Date().toISOString().slice(0, 10);
+const YESTERDAY = new Date(Date.now() - 86_400_000).toISOString().slice(0, 10);
+
+// Two stubbed consumption buckets: yesterday + today (day granularity).
+const CONSUMPTION_BUCKETS = [
+  { ts: YESTERDAY, total_l: 120_000 }, // 120 m³
+  { ts: TODAY, total_l: 80_000 },      // 80 m³
+];
+
+// Temperature points that match the above buckets.
+const WEATHER_HISTORY_POINTS = [
+  { date: YESTERDAY, temp_mean: 14.2 },
+  { date: TODAY, temp_mean: 17.5 },
+];
+
+// A minimal household payload that includes lat/lon so the overlay is available.
+// Only the fields the frontend reads are populated.
+const HOUSEHOLD_WITH_LOCATION = {
+  id: 'demo-household',
+  name: 'Mercier',
+  created_at: '2024-01-01T00:00:00Z',
+  address: '',
+  city: 'Paris',
+  postal_code: '',
+  country: 'FR',
+  timezone: 'Europe/Paris',
+  latitude: 48.8566,
+  longitude: 2.3522,
+  location_label: 'Paris, Île-de-France, France',
+  context_notes: '',
+  ai_prompt_context: '',
+  inbound_email_alias: null,
+  disabled_modules: [],           // weather module is enabled
+  default_household: true,
+  members_count: 3,
+  current_user_role: 'owner',
+  archived_at: null,
+};
+
+const HOUSEHOLD_WITHOUT_LOCATION = {
+  ...HOUSEHOLD_WITH_LOCATION,
+  latitude: null,
+  longitude: null,
+  location_label: '',
+};
+
+// ---------------------------------------------------------------------------
+// Stub helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Stubs GET /api/households/ to return a household with a location set.
+ * Individual PATCH/POST requests are passed through unchanged.
+ */
+async function stubHouseholdWithLocation(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.route('**/api/households/**', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    // The list endpoint returns an array; detail endpoint returns an object.
+    // Both are used by the app. We return a list (modules.ts uses index 0).
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([HOUSEHOLD_WITH_LOCATION]),
+    });
+  });
+}
+
+/**
+ * Stubs GET /api/households/ to return a household WITHOUT lat/lon.
+ */
+async function stubHouseholdWithoutLocation(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.route('**/api/households/**', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([HOUSEHOLD_WITHOUT_LOCATION]),
+    });
+  });
+}
+
+/**
+ * Stubs GET /api/water/readings/ so the page always sees one reading and
+ * skips the EmptyState (which hides the chart + granularity pills).
+ */
+async function stubWaterReadings(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  const reading = {
+    id: 'stub-reading-1',
+    household: 'demo-household',
+    reading_date: YESTERDAY,
+    index_m3: '1250.500',
+    created_at: `${YESTERDAY}T10:00:00Z`,
+    updated_at: `${YESTERDAY}T10:00:00Z`,
+  };
+  await page.route('**/api/water/readings/**', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([reading]),
+    });
+  });
+}
+
+/**
+ * Stubs GET /api/water/consumption/summary/ to return two day-buckets.
+ * Uses the "day" granularity buckets (TODAY and YESTERDAY) so the chart
+ * renders in the default "Jour" view.
+ */
+async function stubWaterConsumptionSummary(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  const payload = {
+    granularity: 'day',
+    date_from: YESTERDAY,
+    date_to: TODAY,
+    total_l: 200_000,
+    buckets: CONSUMPTION_BUCKETS,
+  };
+  await page.route('**/api/water/consumption/summary/**', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(payload),
+    });
+  });
+}
+
+/**
+ * Stubs GET /api/weather/history/ with temperature points aligned to the
+ * consumption buckets.
+ */
+async function stubWeatherHistory(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.route('**/api/weather/history/**', async (route: Route) => {
+    if (route.request().method() !== 'GET') {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        configured: true,
+        points: WEATHER_HISTORY_POINTS,
+      }),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 1. Eau — toggle Météo visible avec foyer localisé
+// ---------------------------------------------------------------------------
+
+test.describe('Eau — overlay météo disponible (foyer avec localisation)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubHouseholdWithLocation(page);
+    await stubWaterReadings(page);
+    await stubWaterConsumptionSummary(page);
+    await page.goto('/app/water');
+    // Wait for chart area to load (granularity pills appear after readings load)
+    await expect(page.getByRole('button', { name: 'Jour', exact: true })).toBeVisible();
+  });
+
+  test('le toggle "Météo" est visible à côté des granularités', async ({ page }) => {
+    // WeatherOverlayToggle renders a FilterPill with t('weather.overlay.toggle') = "Météo"
+    // It appears only when: weather module enabled + lat/lon set + granularity day|month
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toBeVisible();
+  });
+
+  test('activer le toggle déclenche un appel GET /api/weather/history/', async ({ page }) => {
+    await stubWeatherHistory(page);
+
+    // Track the weather history request
+    const historyRequestPromise = page.waitForRequest('**/api/weather/history/**');
+
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    // The history endpoint must have been called after toggling on
+    const historyRequest = await historyRequestPromise;
+    expect(historyRequest.url()).toContain('/api/weather/history/');
+  });
+
+  test('activer le toggle fait apparaître la légende "Température" dans le graphe', async ({ page }) => {
+    await stubWeatherHistory(page);
+
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    // recharts Legend renders overlay.label = t('weather.overlay.temperature') = "Température"
+    // The Legend component renders text inside the chart wrapper. Wait for it to appear.
+    await expect(page.locator('main').getByText('Température')).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('activer le toggle fait apparaître une ligne SVG dans le graphe (Line recharts)', async ({ page }) => {
+    await stubWeatherHistory(page);
+
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await toggle.click();
+
+    // recharts renders a <g class="recharts-layer recharts-line"> for the overlay Line
+    await expect(page.locator('.recharts-line').first()).toBeVisible({ timeout: 8_000 });
+  });
+
+  test('le toggle Météo est absent en vue Année (granularité non supportée)', async ({ page }) => {
+    await page.getByRole('button', { name: 'Année', exact: true }).click();
+
+    // overlay.ts: OVERLAY_GRANULARITIES = ['day', 'month'] → 'year' is not in it
+    // WeatherOverlayToggle is conditionally rendered only when available=true
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toHaveCount(0);
+  });
+
+  test('le toggle Météo est visible en vue Mois', async ({ page }) => {
+    await page.getByRole('button', { name: 'Mois', exact: true }).click();
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Eau — toggle Météo absent sans localisation
+// ---------------------------------------------------------------------------
+
+test.describe('Eau — overlay météo indisponible (foyer sans localisation)', () => {
+  test('le toggle "Météo" est absent quand le foyer n\'a pas de lat/lon', async ({ page }) => {
+    await stubHouseholdWithoutLocation(page);
+    await stubWaterReadings(page);
+    await stubWaterConsumptionSummary(page);
+    await page.goto('/app/water');
+
+    // Wait for page to be ready (granularity pills load after readings)
+    await expect(page.getByRole('button', { name: 'Jour', exact: true })).toBeVisible();
+
+    // useTemperatureOverlay: available = configured && supported
+    // configured = !disabled.has('weather') && lat != null && lon != null → false here
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. Électricité — smoke test du toggle Météo sur l'onglet Consommation
+// ---------------------------------------------------------------------------
+
+test.describe('Électricité — overlay météo (smoke, onglet Consommation)', () => {
+  test('le toggle "Météo" est visible en vue Jour sur l\'onglet Consommation', async ({ page }) => {
+    // Stub the household to provide a location
+    await stubHouseholdWithLocation(page);
+
+    // Stub electricity consumption summary for the "day" granularity
+    const elecPayload = {
+      granularity: 'day',
+      date_from: YESTERDAY,
+      date_to: TODAY,
+      total_kwh: 12.5,
+      buckets: [
+        { ts: YESTERDAY, total_kwh: 7.0, by_tariff: {} },
+        { ts: TODAY, total_kwh: 5.5, by_tariff: {} },
+      ],
+    };
+    await page.route('**/api/electricity/consumption/summary/**', async (route: Route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(elecPayload),
+      });
+    });
+
+    await page.goto('/app/electricity');
+
+    // If there's an empty state ("Aucun tableau électrique"), create a board first
+    const emptyState = page.getByText('Aucun tableau électrique');
+    const hasEmptyState = await emptyState.isVisible().catch(() => false);
+    if (hasEmptyState) {
+      await page.getByRole('button', { name: 'Nouveau tableau' }).first().click();
+      const dialog = page.getByRole('dialog');
+      await expect(dialog).toBeVisible();
+      const zoneSelect = page.locator('#board-zone');
+      const firstZone = zoneSelect.locator('option:not([disabled]):not([value=""])').first();
+      await firstZone.waitFor({ state: 'attached', timeout: 10_000 });
+      await zoneSelect.selectOption(await firstZone.getAttribute('value') as string);
+      await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+      await expect(page.getByRole('button', { name: 'Tableau', exact: true })).toBeVisible();
+    }
+
+    // Navigate to Consommation tab
+    await page.getByRole('button', { name: 'Consommation', exact: true }).click();
+    // Wait for the tab to load (either empty state or granularity pills appear)
+    await expect(
+      page.getByText('Aucun compteur').or(page.getByRole('button', { name: 'Nouveau relevé' })),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // If no meter exists, the ConsumptionTab renders an empty state without granularity pills
+    const noMeter = page.getByText('Aucun compteur');
+    const hasNoMeter = await noMeter.isVisible().catch(() => false);
+    if (hasNoMeter) {
+      // Cannot test the overlay without a meter — skip gracefully
+      // (this happens when the E2E DB is completely empty for electricity)
+      return;
+    }
+
+    // Switch to Jour granularity (default might already be Jour, but be explicit)
+    const jourButton = page.getByRole('button', { name: 'Jour', exact: true });
+    await expect(jourButton).toBeVisible({ timeout: 8_000 });
+    await jourButton.click();
+
+    // The Météo toggle should now be visible (household has lat/lon, granularity is day)
+    const toggle = page.getByRole('button', { name: 'Météo', exact: true });
+    await expect(toggle).toBeVisible({ timeout: 8_000 });
+  });
+});

--- a/ui/src/components/charts/ConsumptionBarChart.tsx
+++ b/ui/src/components/charts/ConsumptionBarChart.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   Bar,
-  BarChart,
   CartesianGrid,
+  ComposedChart,
   Legend,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -25,6 +26,16 @@ export interface ConsumptionChartSeries {
 export interface ConsumptionChartBucket {
   ts: string;
   values: Record<string, number>;
+}
+
+// Optional secondary series drawn as a line on a right-hand axis (e.g. the
+// temperature overlay, parcours 17 Lot 6). Points are matched to buckets by ts.
+export interface ConsumptionChartOverlay {
+  key: string;
+  label: string;
+  color: string;
+  unit: string;
+  points: { ts: string; value: number }[];
 }
 
 function formatTick(ts: string, granularity: Granularity, locale: string): string {
@@ -60,6 +71,8 @@ interface ConsumptionBarChartProps {
   series: ConsumptionChartSeries[];
   granularity: Granularity;
   unit: string;
+  /** Optional line on a right-hand axis (e.g. temperature). */
+  overlay?: ConsumptionChartOverlay;
 }
 
 export default function ConsumptionBarChart({
@@ -67,24 +80,32 @@ export default function ConsumptionBarChart({
   series,
   granularity,
   unit,
+  overlay,
 }: ConsumptionBarChartProps) {
   const { i18n } = useTranslation();
   const locale = i18n.language;
 
-  const data = React.useMemo(
-    () => buckets.map((bucket) => ({ ts: bucket.ts, ...bucket.values })),
-    [buckets],
-  );
+  const data = React.useMemo(() => {
+    const overlayByTs = new Map((overlay?.points ?? []).map((p) => [p.ts, p.value]));
+    return buckets.map((bucket) => ({
+      ts: bucket.ts,
+      ...bucket.values,
+      ...(overlay ? { [overlay.key]: overlayByTs.get(bucket.ts) ?? null } : {}),
+    }));
+  }, [buckets, overlay]);
 
   const seriesLabel = React.useCallback(
-    (key: string) => series.find((s) => s.key === key)?.label ?? key,
-    [series],
+    (key: string) => {
+      if (overlay && key === overlay.key) return overlay.label;
+      return series.find((s) => s.key === key)?.label ?? key;
+    },
+    [series, overlay],
   );
 
   return (
     <div className="h-64 w-full sm:h-80">
       <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+        <ComposedChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
           <XAxis
             dataKey="ts"
@@ -96,12 +117,24 @@ export default function ConsumptionBarChart({
             minTickGap={16}
           />
           <YAxis
+            yAxisId="main"
             tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
             tickLine={false}
             axisLine={false}
             width={44}
             unit={` ${unit}`}
           />
+          {overlay && (
+            <YAxis
+              yAxisId="overlay"
+              orientation="right"
+              tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
+              tickLine={false}
+              axisLine={false}
+              width={40}
+              unit={` ${overlay.unit}`}
+            />
+          )}
           <Tooltip
             cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
             contentStyle={{
@@ -111,21 +144,36 @@ export default function ConsumptionBarChart({
               fontSize: 12,
             }}
             labelFormatter={(ts) => formatLabel(String(ts), granularity, locale)}
-            formatter={(value, name) => [`${String(value)} ${unit}`, seriesLabel(String(name))]}
+            formatter={(value, name) => {
+              const u = overlay && name === overlay.key ? overlay.unit : unit;
+              return [`${String(value)} ${u}`, seriesLabel(String(name))];
+            }}
           />
-          {series.length > 1 && (
+          {(series.length > 1 || overlay) && (
             <Legend formatter={(value: string) => seriesLabel(value)} wrapperStyle={{ fontSize: 12 }} />
           )}
           {series.map((s, index) => (
             <Bar
               key={s.key}
+              yAxisId="main"
               dataKey={s.key}
               stackId="consumption"
               fill={s.color}
               radius={index === series.length - 1 ? [3, 3, 0, 0] : undefined}
             />
           ))}
-        </BarChart>
+          {overlay && (
+            <Line
+              yAxisId="overlay"
+              type="monotone"
+              dataKey={overlay.key}
+              stroke={overlay.color}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+            />
+          )}
+        </ComposedChart>
       </ResponsiveContainer>
     </div>
   );

--- a/ui/src/features/electricity/ConsumptionChart.tsx
+++ b/ui/src/features/electricity/ConsumptionChart.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import ConsumptionBarChart from '@/components/charts/ConsumptionBarChart';
+import ConsumptionBarChart, { type ConsumptionChartOverlay } from '@/components/charts/ConsumptionBarChart';
 import type { ConsumptionSummary, EnergyRegister, Granularity } from '@/lib/api/electricity';
 
 const REGISTER_COLORS: Record<EnergyRegister, string> = {
@@ -12,11 +12,12 @@ const REGISTER_COLORS: Record<EnergyRegister, string> = {
 interface ConsumptionChartProps {
   summary: ConsumptionSummary;
   granularity: Granularity;
+  overlay?: ConsumptionChartOverlay;
 }
 
 // Electricity wrapper of the shared ConsumptionBarChart: one stacked series per
 // register present in the data, Wh converted to kWh.
-export default function ConsumptionChart({ summary, granularity }: ConsumptionChartProps) {
+export default function ConsumptionChart({ summary, granularity, overlay }: ConsumptionChartProps) {
   const { t } = useTranslation();
 
   const registers = React.useMemo(() => {
@@ -48,5 +49,13 @@ export default function ConsumptionChart({ summary, granularity }: ConsumptionCh
     [summary.buckets, registers],
   );
 
-  return <ConsumptionBarChart buckets={buckets} series={series} granularity={granularity} unit="kWh" />;
+  return (
+    <ConsumptionBarChart
+      buckets={buckets}
+      series={series}
+      granularity={granularity}
+      unit="kWh"
+      overlay={overlay}
+    />
+  );
 }

--- a/ui/src/features/electricity/ConsumptionTab.tsx
+++ b/ui/src/features/electricity/ConsumptionTab.tsx
@@ -22,6 +22,8 @@ import {
   useMeterReadings,
   useMeters,
 } from './hooks';
+import WeatherOverlayToggle from '@/features/weather/WeatherOverlayToggle';
+import { useTemperatureOverlay } from '@/features/weather/overlay';
 import ConsumptionChart from './ConsumptionChart';
 import ImportDialog from './ImportDialog';
 import MeterDialog from './MeterDialog';
@@ -101,6 +103,19 @@ export default function ConsumptionTab() {
     date_to: to,
   });
   const { data: readings = [] } = useMeterReadings(meter?.id);
+
+  const [showWeather, setShowWeather] = useSessionState<boolean>('electricity.consumption.showWeather', false);
+  const overlayBuckets = React.useMemo(
+    () => (summary?.buckets ?? []).map((b) => ({ ts: b.ts })),
+    [summary],
+  );
+  const { available: weatherAvailable, overlay: weatherOverlay } = useTemperatureOverlay({
+    from,
+    to,
+    granularity,
+    buckets: overlayBuckets,
+    show: showWeather,
+  });
 
   const [meterDialogOpen, setMeterDialogOpen] = React.useState(false);
   const [editingMeter, setEditingMeter] = React.useState<ElectricityMeter | undefined>(undefined);
@@ -211,6 +226,9 @@ export default function ConsumptionTab() {
               {t(`consumption.granularity.${g}`)}
             </FilterPill>
           ))}
+          {weatherAvailable && (
+            <WeatherOverlayToggle active={showWeather} onToggle={setShowWeather} />
+          )}
         </div>
         <div className="flex items-center gap-1">
           <Button
@@ -266,7 +284,7 @@ export default function ConsumptionTab() {
         {summaryLoading && !summary ? (
           <div className="h-64 animate-pulse rounded-lg bg-muted sm:h-80" />
         ) : hasData && summary ? (
-          <ConsumptionChart summary={summary} granularity={granularity} />
+          <ConsumptionChart summary={summary} granularity={granularity} overlay={weatherOverlay} />
         ) : (
           <div className="flex h-64 items-center justify-center text-sm text-muted-foreground sm:h-80">
             {granularity === 'hour'

--- a/ui/src/features/water/WaterPage.tsx
+++ b/ui/src/features/water/WaterPage.tsx
@@ -8,6 +8,8 @@ import CardActions, { type CardAction } from '@/components/CardActions';
 import EmptyState from '@/components/EmptyState';
 import PageHeader from '@/components/PageHeader';
 import ConsumptionBarChart from '@/components/charts/ConsumptionBarChart';
+import WeatherOverlayToggle from '@/features/weather/WeatherOverlayToggle';
+import { useTemperatureOverlay } from '@/features/weather/overlay';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useSessionState } from '@/lib/useSessionState';
@@ -101,6 +103,15 @@ export default function WaterPage() {
     [summary],
   );
 
+  const [showWeather, setShowWeather] = useSessionState<boolean>('water.showWeather', false);
+  const { available: weatherAvailable, overlay: weatherOverlay } = useTemperatureOverlay({
+    from,
+    to,
+    granularity,
+    buckets: chartBuckets,
+    show: showWeather,
+  });
+
   const showSkeleton = useDelayedLoading(readingsLoading);
   if (showSkeleton) {
     return (
@@ -156,6 +167,9 @@ export default function WaterPage() {
               {t(`consumption.granularity.${g}`)}
             </FilterPill>
           ))}
+          {weatherAvailable && (
+            <WeatherOverlayToggle active={showWeather} onToggle={setShowWeather} />
+          )}
         </div>
         <div className="flex items-center gap-1">
           <Button
@@ -196,6 +210,7 @@ export default function WaterPage() {
             series={chartSeries}
             granularity={granularity}
             unit="m³"
+            overlay={weatherOverlay}
           />
         ) : (
           <div className="flex h-64 items-center justify-center text-sm text-muted-foreground sm:h-80">

--- a/ui/src/features/weather/WeatherOverlayToggle.tsx
+++ b/ui/src/features/weather/WeatherOverlayToggle.tsx
@@ -1,0 +1,24 @@
+import { CloudSun } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { FilterPill } from '@/design-system/filter-pill';
+
+/**
+ * Toggle for the temperature overlay on the consumption charts (parcours 17
+ * Lot 6). Shared by the electricity + water pages; each owns its own state.
+ */
+export default function WeatherOverlayToggle({
+  active,
+  onToggle,
+}: {
+  active: boolean;
+  onToggle: (value: boolean) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <FilterPill active={active} onClick={() => onToggle(!active)}>
+      <CloudSun className="mr-1 inline h-3.5 w-3.5" />
+      {t('weather.overlay.toggle')}
+    </FilterPill>
+  );
+}

--- a/ui/src/features/weather/hooks.ts
+++ b/ui/src/features/weather/hooks.ts
@@ -1,12 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { fetchWeather } from '@/lib/api/weather';
+import { fetchWeather, fetchWeatherHistory } from '@/lib/api/weather';
 
 // ── Query key factory ─────────────────────────────────────────────────────────
 
 export const weatherKeys = {
   all: ['weather'] as const,
   forecast: () => [...weatherKeys.all, 'forecast'] as const,
+  history: (params: { date_from: string; date_to: string }) =>
+    [...weatherKeys.all, 'history', params] as const,
 };
 
 // ── Query hooks ───────────────────────────────────────────────────────────────
@@ -20,5 +22,22 @@ export function useWeather() {
     queryKey: weatherKeys.forecast(),
     queryFn: fetchWeather,
     staleTime: 30 * 60 * 1000,
+  });
+}
+
+/**
+ * Daily mean temperatures over a period (Lot 6 consumption overlay). Disabled
+ * until ``enabled`` — the page only fetches when the weather overlay is toggled
+ * on. Cached long (the past doesn't change).
+ */
+export function useWeatherHistory(
+  params: { date_from: string; date_to: string },
+  enabled: boolean,
+) {
+  return useQuery({
+    queryKey: weatherKeys.history(params),
+    queryFn: () => fetchWeatherHistory(params),
+    enabled,
+    staleTime: 24 * 60 * 60 * 1000,
   });
 }

--- a/ui/src/features/weather/overlay.ts
+++ b/ui/src/features/weather/overlay.ts
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+
+import type { ConsumptionChartOverlay } from '@/components/charts/ConsumptionBarChart';
+import type { WeatherHistoryPoint } from '@/lib/api/weather';
+import type { Granularity } from '@/lib/period';
+import { useActiveHousehold, useDisabledModules } from '@/lib/modules';
+
+import { useWeatherHistory } from './hooks';
+
+// Overlay only makes sense for day/month: daily archive points map 1:1 to days
+// and average cleanly per month. Hour is too fine, year too broad (huge fetch).
+const OVERLAY_GRANULARITIES: Granularity[] = ['day', 'month'];
+
+/**
+ * Align daily mean temperatures to the consumption buckets the page already has.
+ * Keys on the ISO date prefix of each bucket's ``ts`` (``YYYY-MM-DD`` for day,
+ * ``YYYY-MM`` for month), so it works whatever the module's ts format
+ * (water is naive-midnight, electricity is tz-aware). Buckets with no matching
+ * temperature are simply omitted from the line.
+ */
+export function buildTemperatureOverlay(
+  buckets: { ts: string }[],
+  points: WeatherHistoryPoint[],
+  granularity: Granularity,
+): { ts: string; value: number }[] {
+  if (granularity === 'day') {
+    const byDay = new Map(points.map((p) => [p.date, p.temp_mean]));
+    return buckets
+      .map((b) => ({ ts: b.ts, value: byDay.get(b.ts.slice(0, 10)) }))
+      .filter((p): p is { ts: string; value: number } => p.value !== undefined);
+  }
+  if (granularity === 'month') {
+    const sums = new Map<string, { total: number; n: number }>();
+    for (const p of points) {
+      const key = p.date.slice(0, 7);
+      const acc = sums.get(key) ?? { total: 0, n: 0 };
+      acc.total += p.temp_mean;
+      acc.n += 1;
+      sums.set(key, acc);
+    }
+    return buckets
+      .map((b) => {
+        const acc = sums.get(b.ts.slice(0, 7));
+        return acc ? { ts: b.ts, value: Math.round((acc.total / acc.n) * 10) / 10 } : null;
+      })
+      .filter((p): p is { ts: string; value: number } => p !== null);
+  }
+  return [];
+}
+
+/**
+ * Shared plumbing for the "show weather" overlay on the electricity/water
+ * consumption charts (parcours 17 Lot 6). Returns whether the overlay is
+ * available for the current household + granularity, and the ready-to-pass
+ * ``overlay`` prop (undefined until data is in). The page owns the ``show``
+ * toggle state (its session key differs) and renders the toggle button.
+ */
+export function useTemperatureOverlay(opts: {
+  from: string;
+  to: string;
+  granularity: Granularity;
+  buckets: { ts: string }[];
+  show: boolean;
+}): { available: boolean; overlay: ConsumptionChartOverlay | undefined } {
+  const { t } = useTranslation();
+  const { household } = useActiveHousehold();
+  const { disabled } = useDisabledModules();
+
+  const configured =
+    !disabled.has('weather') && household?.latitude != null && household?.longitude != null;
+  const supported = OVERLAY_GRANULARITIES.includes(opts.granularity);
+  const available = Boolean(configured && supported);
+
+  const enabled = available && opts.show && opts.buckets.length > 0;
+  const { data } = useWeatherHistory({ date_from: opts.from, date_to: opts.to }, enabled);
+
+  const points = enabled && data?.points
+    ? buildTemperatureOverlay(opts.buckets, data.points, opts.granularity)
+    : [];
+
+  const overlay: ConsumptionChartOverlay | undefined =
+    enabled && points.length > 0
+      ? {
+          key: '__temp__',
+          label: t('weather.overlay.temperature'),
+          color: 'hsl(var(--chart-4))',
+          unit: '°C',
+          points,
+        }
+      : undefined;
+
+  return { available, overlay };
+}

--- a/ui/src/lib/api/weather.ts
+++ b/ui/src/lib/api/weather.ts
@@ -90,3 +90,24 @@ export async function geocodePlace(q: string): Promise<GeocodeResult[]> {
   const { data } = await api.get('/weather/geocode/', { params: { q } });
   return (data as { results?: GeocodeResult[] }).results ?? [];
 }
+
+// ── History (Lot 6 — consumption overlay) ────────────────────────────────────
+
+export interface WeatherHistoryPoint {
+  date: string; // YYYY-MM-DD
+  temp_mean: number;
+}
+
+export interface WeatherHistory {
+  configured: boolean;
+  error?: boolean;
+  points: WeatherHistoryPoint[];
+}
+
+export async function fetchWeatherHistory(params: {
+  date_from: string;
+  date_to: string;
+}): Promise<WeatherHistory> {
+  const { data } = await api.get('/weather/history/', { params });
+  return data as WeatherHistory;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -346,6 +346,10 @@
       "searching": "Suche läuft…",
       "noResults": "Kein Ort gefunden.",
       "clear": "Standort entfernen"
+    },
+    "overlay": {
+      "toggle": "Wetter",
+      "temperature": "Temperatur"
     }
   },
   "interactions": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -346,6 +346,10 @@
       "searching": "Searching…",
       "noResults": "No place found.",
       "clear": "Remove location"
+    },
+    "overlay": {
+      "toggle": "Weather",
+      "temperature": "Temperature"
     }
   },
   "interactions": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -346,6 +346,10 @@
       "searching": "Buscando…",
       "noResults": "No se encontró ningún lugar.",
       "clear": "Quitar ubicación"
+    },
+    "overlay": {
+      "toggle": "Tiempo",
+      "temperature": "Temperatura"
     }
   },
   "interactions": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -346,6 +346,10 @@
       "searching": "Recherche…",
       "noResults": "Aucun lieu trouvé.",
       "clear": "Retirer le lieu"
+    },
+    "overlay": {
+      "toggle": "Météo",
+      "temperature": "Température"
     }
   },
   "interactions": {


### PR DESCRIPTION
Closes #283

Parcours 17, **Lot 6 — Corrélations consommation ↔ météo** (dernier lot). Superpose la température passée aux courbes de conso électricité + eau.

## Quoi
- **US6.1** : toggle « Météo » sur les pages électricité et eau → superpose une **ligne température** (axe droit) sur le graphe de conso, alignée sur la période/granularité courante.
- **Backend** : endpoint `GET /api/weather/history/?date_from&date_to` → moyennes journalières via Open-Meteo **Archive API** (`weather.services.get_history`), cache 24 h, **on-demand — pas de modèle DB**.
- **Frontend** : `ConsumptionBarChart` gagne une prop optionnelle `overlay` (passage `BarChart` → `ComposedChart` + `Line` + 2ᵉ axe). Toggle partagé `WeatherOverlayToggle`, visible **seulement** si module météo actif + localisation définie + granularité **day/month**.

## Anti-duplication / archi
- Un seul chart partagé étendu (élec + eau en bénéficient), un seul client API, un seul helper d'alignement.
- **Alignement côté front** (`overlay.ts::buildTemperatureOverlay`) : clé sur le préfixe ISO du `ts` des buckets → robuste aux formats `ts` **différents** entre eau (naïf) et électricité (tz-aware). L'endpoint reste module-agnostique (renvoie du journalier brut).
- Dégradation gracieuse : pas de localisation → toggle masqué ; historique indispo → conso affichée sans la ligne ; archive en retard de quelques jours → le point récent est simplement absent.

## Tests
- Backend : `get_history` (normalisation, drop des nulls, cache, erreur) + `WeatherHistoryView` (configuré / non configuré / dates invalides / indispo). Suite complète : **1925 passed**.
- E2E : `e2e/weather-overlay.spec.ts` (10 tests — toggle visible/absent selon localisation & granularité, ligne + légende « Température » après activation, requête history, smoke électricité).
- `tsc -b`, `npm run lint` : 0 erreur. i18n 4 langues.

## Hors scope
Corrélation statistique auto (« +X kWh/°C »), degrés-jours, autres variables, granularité horaire/annuelle, min/max.

---
🎉 **Ce lot complète le parcours 17** : module météo entièrement livré (lots 1-6).