### PR TITLE
feat(general): pages de détail — onglets (TabShell) pour poules, documents, équipement, stock, tâches, trackers

### DIFF
--- a/ui/src/features/chickens/ChickenDetailPage.tsx
+++ b/ui/src/features/chickens/ChickenDetailPage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import PageHeader from '@/components/PageHeader';
 import BackLink from '@/components/BackLink';
+import { TabShell } from '@/components/TabShell';
 import EntityAssistant from '@/features/agent/EntityAssistant';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
@@ -23,6 +24,9 @@ import ChickenDialog from './ChickenDialog';
 import ChickenEventDialog from './ChickenEventDialog';
 import ChickenPurchaseDialog from './ChickenPurchaseDialog';
 import EventTimeline from './EventTimeline';
+
+type Tab = 'info' | 'events' | 'assistant';
+const TABS: Tab[] = ['info', 'events', 'assistant'];
 
 export default function ChickenDetailPage() {
   const { id = '' } = useParams();
@@ -113,48 +117,71 @@ export default function ChickenDetailPage() {
         </Button>
       </PageHeader>
 
-      <div className="space-y-4">
-        <Card className="p-4">
-          <div className="flex flex-wrap items-center gap-2">
-            <ChickenStatusBadge status={chicken.status} />
-          </div>
-          <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-2">
-            {facts
-              .filter((fact) => fact.value)
-              .map((fact) => (
-                <div key={fact.label} className="flex items-baseline justify-between gap-3 sm:justify-start">
-                  <dt className="text-xs text-muted-foreground">{fact.label}</dt>
-                  <dd className="text-sm text-foreground">{fact.value}</dd>
+      <TabShell<Tab>
+        tabs={TABS.map((tab) => ({ key: tab, label: t(`chickens.tabs.${tab}`) }))}
+        sessionKey={`chicken-detail.${chicken.id}.tab`}
+        defaultTab="info"
+      >
+        {(tab) => (
+          <>
+            {tab === 'info' ? (
+              <Card className="p-4">
+                <div className="flex flex-wrap items-center gap-2">
+                  <ChickenStatusBadge status={chicken.status} />
                 </div>
-              ))}
-          </dl>
-          {chicken.notes ? (
-            <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">{chicken.notes}</p>
-          ) : null}
-        </Card>
+                <dl className="mt-3 grid gap-x-6 gap-y-2 sm:grid-cols-2">
+                  {facts
+                    .filter((fact) => fact.value)
+                    .map((fact) => (
+                      <div
+                        key={fact.label}
+                        className="flex items-baseline justify-between gap-3 sm:justify-start"
+                      >
+                        <dt className="text-xs text-muted-foreground">{fact.label}</dt>
+                        <dd className="text-sm text-foreground">{fact.value}</dd>
+                      </div>
+                    ))}
+                </dl>
+                {chicken.notes ? (
+                  <p className="mt-3 whitespace-pre-wrap text-sm text-muted-foreground">
+                    {chicken.notes}
+                  </p>
+                ) : null}
+              </Card>
+            ) : null}
 
-        <div className="flex items-center justify-between">
-          <h2 className="text-sm font-semibold text-foreground">{t('chickens.events.title')}</h2>
-          <Button variant="outline" size="sm" onClick={() => setEventDialogOpen(true)}>
-            {t('chickens.events.actions.new')}
-          </Button>
-        </div>
+            {tab === 'events' ? (
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h2 className="text-sm font-semibold text-foreground">
+                    {t('chickens.events.title')}
+                  </h2>
+                  <Button variant="outline" size="sm" onClick={() => setEventDialogOpen(true)}>
+                    {t('chickens.events.actions.new')}
+                  </Button>
+                </div>
 
-        {events.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('chickens.events.empty')}</p>
-        ) : (
-          <EventTimeline
-            events={events}
-            onEdit={(event) => {
-              setEditingEvent(event);
-              setEventDialogOpen(true);
-            }}
-            onDelete={handleDeleteEvent}
-          />
+                {events.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">{t('chickens.events.empty')}</p>
+                ) : (
+                  <EventTimeline
+                    events={events}
+                    onEdit={(event) => {
+                      setEditingEvent(event);
+                      setEventDialogOpen(true);
+                    }}
+                    onDelete={handleDeleteEvent}
+                  />
+                )}
+              </div>
+            ) : null}
+
+            {tab === 'assistant' ? (
+              <EntityAssistant entityType="chicken" objectId={chicken.id} />
+            ) : null}
+          </>
         )}
-
-        <EntityAssistant entityType="chicken" objectId={chicken.id} />
-      </div>
+      </TabShell>
 
       <ChickenDialog open={editOpen} onOpenChange={setEditOpen} existing={chicken} />
       <ChickenEventDialog

--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import BackLink from '@/components/BackLink';
+import { TabShell } from '@/components/TabShell';
 import { useNavigateBack } from '@/lib/backNavigation';
 import { formatFileSize } from '@/lib/api/documents';
 import {
@@ -27,6 +28,9 @@ function formatDate(value?: string | null): string {
   if (Number.isNaN(d.getTime())) return value;
   return new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(d);
 }
+
+type Tab = 'info' | 'activity' | 'assistant';
+const TABS: Tab[] = ['info', 'activity', 'assistant'];
 
 export default function DocumentDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -134,137 +138,147 @@ export default function DocumentDetailPage() {
           </div>
         </div>
 
-        {/* File info */}
-        <Card>
-          <CardContent className="pt-4 space-y-2 text-sm">
-            {fileSize && (
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <span className="font-medium text-foreground">{fileSize}</span>
-              </div>
-            )}
-            {doc.mime_type && (
-              <div className="text-muted-foreground">
-                <span className="font-mono text-xs">{doc.mime_type}</span>
-              </div>
-            )}
-            {doc.notes && (
-              <p className="text-muted-foreground">{doc.notes}</p>
-            )}
-            {doc.file_url ? (
-              <a
-                href={doc.file_url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-              >
-                <Download className="h-3.5 w-3.5" />
-                {t('documents.detail.download')}
-              </a>
-            ) : null}
-          </CardContent>
-        </Card>
+        {/* Tabs */}
+        <TabShell<Tab>
+          tabs={TABS.map((tab) => ({ key: tab, label: t(`documents.tabs.${tab}`) }))}
+          sessionKey={`document-detail.${doc.id}.tab`}
+          defaultTab="info"
+        >
+          {(tab) => (
+            <>
+              {tab === 'info' ? (
+                <div className="space-y-4">
+                  <Card>
+                    <CardContent className="pt-4 space-y-2 text-sm">
+                      {fileSize && (
+                        <div className="flex items-center gap-2 text-muted-foreground">
+                          <span className="font-medium text-foreground">{fileSize}</span>
+                        </div>
+                      )}
+                      {doc.mime_type && (
+                        <div className="text-muted-foreground">
+                          <span className="font-mono text-xs">{doc.mime_type}</span>
+                        </div>
+                      )}
+                      {doc.notes && <p className="text-muted-foreground">{doc.notes}</p>}
+                      {doc.file_url ? (
+                        <a
+                          href={doc.file_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                        >
+                          <Download className="h-3.5 w-3.5" />
+                          {t('documents.detail.download')}
+                        </a>
+                      ) : null}
+                    </CardContent>
+                  </Card>
 
-        {/* OCR text */}
-        {showOcrSection && (
-          <Card>
-            <CardContent className="pt-4">
-              <details className="group" {...(ocrText ? { open: true } : {})}>
-                <summary className="flex cursor-pointer items-center justify-between gap-2 text-sm font-medium text-foreground">
-                  <span>{t('documents.ocr.title')}</span>
-                  {ocrMethod && ocrMethod !== 'skipped' && (
-                    <Badge variant="outline" className="h-5 text-[10px]">
-                      {ocrMethod}
-                    </Badge>
+                  {showOcrSection && (
+                    <Card>
+                      <CardContent className="pt-4">
+                        <details className="group" {...(ocrText ? { open: true } : {})}>
+                          <summary className="flex cursor-pointer items-center justify-between gap-2 text-sm font-medium text-foreground">
+                            <span>{t('documents.ocr.title')}</span>
+                            {ocrMethod && ocrMethod !== 'skipped' && (
+                              <Badge variant="outline" className="h-5 text-[10px]">
+                                {ocrMethod}
+                              </Badge>
+                            )}
+                          </summary>
+                          <div className="mt-3 text-sm">
+                            {ocrText ? (
+                              <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-sans text-xs text-foreground">
+                                {ocrText}
+                              </pre>
+                            ) : (
+                              <p className="italic text-muted-foreground">
+                                {t('documents.ocr.empty')}
+                              </p>
+                            )}
+                            <div className="mt-3">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="h-8 px-3 text-xs"
+                                onClick={handleReprocess}
+                                disabled={reprocessMutation.isPending}
+                              >
+                                <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
+                                {reprocessMutation.isPending
+                                  ? t('documents.ocr.reprocessing')
+                                  : t('documents.ocr.reprocess')}
+                              </Button>
+                            </div>
+                          </div>
+                        </details>
+                      </CardContent>
+                    </Card>
                   )}
-                </summary>
-                <div className="mt-3 text-sm">
-                  {ocrText ? (
-                    <pre className="max-h-96 overflow-auto whitespace-pre-wrap break-words rounded-md bg-muted p-3 font-sans text-xs text-foreground">
-                      {ocrText}
-                    </pre>
-                  ) : (
-                    <p className="italic text-muted-foreground">{t('documents.ocr.empty')}</p>
-                  )}
-                  <div className="mt-3">
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="h-8 px-3 text-xs"
-                      onClick={handleReprocess}
-                      disabled={reprocessMutation.isPending}
-                    >
-                      <RefreshCcw className="mr-1.5 h-3.5 w-3.5" />
-                      {reprocessMutation.isPending
-                        ? t('documents.ocr.reprocessing')
-                        : t('documents.ocr.reprocess')}
-                    </Button>
-                  </div>
                 </div>
-              </details>
-            </CardContent>
-          </Card>
-        )}
+              ) : null}
 
-        {/* Linked interactions */}
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <h2 className="text-base font-semibold text-foreground">
-              {t('documents.detail.linked_interactions')}
-            </h2>
-            <Link
-              to={`/app/interactions/new?source_document_id=${id}`}
-              className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {t('documents.detail.add_activity')}
-            </Link>
-          </div>
-
-          {doc.linked_interactions.length === 0 ? (
-            <p className="text-sm italic text-muted-foreground">
-              {t('documents.detail.no_linked_interactions')}
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {doc.linked_interactions.map((item) => (
-                <li key={item.id} className="rounded-md border p-3 text-sm">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <span className="font-medium">{item.subject || '—'}</span>
-                      {item.occurred_at && (
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          {formatDate(item.occurred_at)}
-                        </p>
-                      )}
-                    </div>
-                    <div className="flex shrink-0 items-center gap-1">
-                      {item.type && (
-                        <Badge variant="outline" className="h-5 text-[10px]">
-                          {t(`interactions.type.${item.type}`)}
-                        </Badge>
-                      )}
-                      <Link
-                        to={`/app/interactions/${item.id}/edit`}
-                        className="ml-1 inline-flex items-center text-xs text-muted-foreground hover:text-foreground"
-                        aria-label={t('common.edit')}
-                      >
-                        <ExternalLink className="h-3.5 w-3.5" />
-                      </Link>
-                    </div>
+              {tab === 'activity' ? (
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <h2 className="text-base font-semibold text-foreground">
+                      {t('documents.detail.linked_interactions')}
+                    </h2>
+                    <Link
+                      to={`/app/interactions/new?source_document_id=${id}`}
+                      className="inline-flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground hover:bg-primary/90"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      {t('documents.detail.add_activity')}
+                    </Link>
                   </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </div>
 
-        {/* Assistant */}
-        <div className="space-y-2">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('agent.entity.section_title')}
-          </h2>
-          <EntityAssistant entityType="document" objectId={doc.id} />
-        </div>
+                  {doc.linked_interactions.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">
+                      {t('documents.detail.no_linked_interactions')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {doc.linked_interactions.map((item) => (
+                        <li key={item.id} className="rounded-md border p-3 text-sm">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <span className="font-medium">{item.subject || '—'}</span>
+                              {item.occurred_at && (
+                                <p className="mt-0.5 text-xs text-muted-foreground">
+                                  {formatDate(item.occurred_at)}
+                                </p>
+                              )}
+                            </div>
+                            <div className="flex shrink-0 items-center gap-1">
+                              {item.type && (
+                                <Badge variant="outline" className="h-5 text-[10px]">
+                                  {t(`interactions.type.${item.type}`)}
+                                </Badge>
+                              )}
+                              <Link
+                                to={`/app/interactions/${item.id}/edit`}
+                                className="ml-1 inline-flex items-center text-xs text-muted-foreground hover:text-foreground"
+                                aria-label={t('common.edit')}
+                              >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                              </Link>
+                            </div>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ) : null}
+
+              {tab === 'assistant' ? (
+                <EntityAssistant entityType="document" objectId={doc.id} />
+              ) : null}
+            </>
+          )}
+        </TabShell>
       </div>
 
       <DocumentEditDialog

--- a/ui/src/features/equipment/EquipmentDetailPage.tsx
+++ b/ui/src/features/equipment/EquipmentDetailPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import BackLink from '@/components/BackLink';
+import { TabShell } from '@/components/TabShell';
 import { useNavigateBack } from '@/lib/backNavigation';
 import {
   useEquipment,
@@ -64,6 +65,11 @@ function InfoField({ label, children }: { label: string; children: React.ReactNo
     </div>
   );
 }
+
+// ── Tabs ───────────────────────────────────────────────────
+
+type Tab = 'info' | 'history' | 'assistant';
+const TABS: Tab[] = ['info', 'history', 'assistant'];
 
 // ── Main page ──────────────────────────────────────────────
 
@@ -174,179 +180,190 @@ export default function EquipmentDetailPage() {
           </div>
         </div>
 
-        {/* Info grid */}
-        <section className="rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm">
-          <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60">
-              <Wrench className="h-5 w-5 text-slate-600" />
-            </span>
-            <div>
-              <h2 className="text-base font-semibold text-foreground">
-                {t('equipment.detail.title')}
-              </h2>
-            </div>
-          </div>
-
-          <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <InfoField label={t('equipment.detail.fields.category')}>
-              {equipment.category || '—'}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.zone')}>
-              {equipment.zone ? (
-                <Link
-                  to={`/app/zones/${equipment.zone}`}
-                  className="hover:text-foreground hover:underline"
-                >
-                  {equipment.zone_name ?? equipment.zone}
-                </Link>
-              ) : (
-                t('equipment.no_zone')
-              )}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.manufacturer')}>
-              {equipment.manufacturer || '—'}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.model')}>
-              {equipment.model || '—'}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.serial_number')}>
-              {equipment.serial_number || '—'}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.condition')}>
-              {equipment.condition || '—'}
-            </InfoField>
-
-            <InfoField label={t('equipment.detail.fields.purchase_date')}>
-              {formatDate(equipment.purchase_date)}
-            </InfoField>
-
-            {equipment.purchase_price != null ? (
-              <InfoField label={t('equipment.form.fields.purchase_price')}>
-                {Number(equipment.purchase_price).toFixed(2)} €
-              </InfoField>
-            ) : null}
-          </dl>
-        </section>
-
-        {/* Warranty block */}
-        {(equipment.warranty_expires_on || equipment.warranty_provider) ? (
-          <Card>
-            <CardContent className="pt-4">
-              <h3 className="mb-3 text-sm font-semibold text-foreground">
-                {t('equipment.detail.fields.warranty')}
-              </h3>
-              <div className="space-y-2 text-sm">
-                {equipment.warranty_expires_on ? (
-                  <p className={warrantyExpired ? 'text-red-600' : 'text-green-600'}>
-                    {warrantyExpired
-                      ? t('equipment.detail.warranty_expired')
-                      : t('equipment.detail.warranty_ok', {
-                          date: formatDate(equipment.warranty_expires_on),
-                        })}
-                  </p>
-                ) : null}
-                {equipment.warranty_provider ? (
-                  <p className="text-muted-foreground">
-                    {t('equipment.form.fields.warranty_provider')}: {equipment.warranty_provider}
-                  </p>
-                ) : null}
-              </div>
-            </CardContent>
-          </Card>
-        ) : null}
-
-        {/* Maintenance block */}
-        {(equipment.last_service_at || equipment.next_service_due) ? (
-          <Card>
-            <CardContent className="pt-4">
-              <h3 className="mb-3 text-sm font-semibold text-foreground">
-                {t('equipment.detail.fields.next_service')}
-              </h3>
-              <div className="space-y-2 text-sm">
-                {equipment.last_service_at ? (
-                  <p className="text-muted-foreground">
-                    {t('equipment.detail.fields.last_service')}: {formatDate(equipment.last_service_at)}
-                  </p>
-                ) : null}
-                {equipment.next_service_due ? (
-                  <p className={serviceOverdue ? 'text-red-600' : 'text-foreground'}>
-                    {serviceOverdue
-                      ? t('equipment.detail.maintenance_overdue', {
-                          date: formatDate(equipment.next_service_due),
-                        })
-                      : t('equipment.detail.maintenance_due', {
-                          date: formatDate(equipment.next_service_due),
-                        })}
-                  </p>
-                ) : null}
-              </div>
-            </CardContent>
-          </Card>
-        ) : null}
-
-        {/* Intervention history */}
-        <section className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-base font-semibold text-foreground">
-              {t('equipment.detail.history_title')}
-            </h2>
-            <Link
-              to={logInteractionHref}
-              className="inline-flex h-8 items-center rounded-md border border-input bg-background px-3 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
-            >
-              {t('equipment.detail.add_intervention')}
-            </Link>
-          </div>
-
-          {historyLoading ? (
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-12 animate-pulse rounded-lg bg-slate-100" />
-              ))}
-            </div>
-          ) : history.length === 0 ? (
-            <p className="text-sm italic text-muted-foreground">
-              {t('equipment.detail.no_history')}
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {history.map((item) => (
-                <li key={item.interaction} className="rounded-md border p-3 text-sm">
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="font-medium">{item.interaction_subject || '—'}</span>
-                    <div className="flex shrink-0 gap-1">
-                      {item.interaction_type ? (
-                        <Badge variant="outline" className="h-5 text-[10px]">
-                          {t(`equipment.interaction_type.${item.interaction_type}`, {
-                            defaultValue: item.interaction_type,
-                          })}
-                        </Badge>
-                      ) : null}
+        {/* Tabs */}
+        <TabShell<Tab>
+          tabs={TABS.map((tab) => ({ key: tab, label: t(`equipment.tabs.${tab}`) }))}
+          sessionKey={`equipment-detail.${equipment.id}.tab`}
+          defaultTab="info"
+        >
+          {(tab) => (
+            <>
+              {tab === 'info' ? (
+                <div className="space-y-6">
+                  <section className="rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm">
+                    <div className="flex items-center gap-3">
+                      <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60">
+                        <Wrench className="h-5 w-5 text-slate-600" />
+                      </span>
+                      <div>
+                        <h2 className="text-base font-semibold text-foreground">
+                          {t('equipment.detail.title')}
+                        </h2>
+                      </div>
                     </div>
-                  </div>
-                  {item.interaction_occurred_at ? (
-                    <p className="mt-1 text-[10px] text-muted-foreground">
-                      {formatDateTime(item.interaction_occurred_at)}
-                    </p>
-                  ) : null}
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
 
-        {/* Assistant */}
-        <section className="space-y-3">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('agent.entity.section_title')}
-          </h2>
-          <EntityAssistant entityType="equipment" objectId={equipment.id} />
-        </section>
+                    <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                      <InfoField label={t('equipment.detail.fields.category')}>
+                        {equipment.category || '—'}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.zone')}>
+                        {equipment.zone ? (
+                          <Link
+                            to={`/app/zones/${equipment.zone}`}
+                            className="hover:text-foreground hover:underline"
+                          >
+                            {equipment.zone_name ?? equipment.zone}
+                          </Link>
+                        ) : (
+                          t('equipment.no_zone')
+                        )}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.manufacturer')}>
+                        {equipment.manufacturer || '—'}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.model')}>
+                        {equipment.model || '—'}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.serial_number')}>
+                        {equipment.serial_number || '—'}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.condition')}>
+                        {equipment.condition || '—'}
+                      </InfoField>
+
+                      <InfoField label={t('equipment.detail.fields.purchase_date')}>
+                        {formatDate(equipment.purchase_date)}
+                      </InfoField>
+
+                      {equipment.purchase_price != null ? (
+                        <InfoField label={t('equipment.form.fields.purchase_price')}>
+                          {Number(equipment.purchase_price).toFixed(2)} €
+                        </InfoField>
+                      ) : null}
+                    </dl>
+                  </section>
+
+                  {(equipment.warranty_expires_on || equipment.warranty_provider) ? (
+                    <Card>
+                      <CardContent className="pt-4">
+                        <h3 className="mb-3 text-sm font-semibold text-foreground">
+                          {t('equipment.detail.fields.warranty')}
+                        </h3>
+                        <div className="space-y-2 text-sm">
+                          {equipment.warranty_expires_on ? (
+                            <p className={warrantyExpired ? 'text-red-600' : 'text-green-600'}>
+                              {warrantyExpired
+                                ? t('equipment.detail.warranty_expired')
+                                : t('equipment.detail.warranty_ok', {
+                                    date: formatDate(equipment.warranty_expires_on),
+                                  })}
+                            </p>
+                          ) : null}
+                          {equipment.warranty_provider ? (
+                            <p className="text-muted-foreground">
+                              {t('equipment.form.fields.warranty_provider')}:{' '}
+                              {equipment.warranty_provider}
+                            </p>
+                          ) : null}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ) : null}
+
+                  {(equipment.last_service_at || equipment.next_service_due) ? (
+                    <Card>
+                      <CardContent className="pt-4">
+                        <h3 className="mb-3 text-sm font-semibold text-foreground">
+                          {t('equipment.detail.fields.next_service')}
+                        </h3>
+                        <div className="space-y-2 text-sm">
+                          {equipment.last_service_at ? (
+                            <p className="text-muted-foreground">
+                              {t('equipment.detail.fields.last_service')}:{' '}
+                              {formatDate(equipment.last_service_at)}
+                            </p>
+                          ) : null}
+                          {equipment.next_service_due ? (
+                            <p className={serviceOverdue ? 'text-red-600' : 'text-foreground'}>
+                              {serviceOverdue
+                                ? t('equipment.detail.maintenance_overdue', {
+                                    date: formatDate(equipment.next_service_due),
+                                  })
+                                : t('equipment.detail.maintenance_due', {
+                                    date: formatDate(equipment.next_service_due),
+                                  })}
+                            </p>
+                          ) : null}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {tab === 'history' ? (
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-base font-semibold text-foreground">
+                      {t('equipment.detail.history_title')}
+                    </h2>
+                    <Link
+                      to={logInteractionHref}
+                      className="inline-flex h-8 items-center rounded-md border border-input bg-background px-3 text-sm font-medium shadow-sm hover:bg-accent hover:text-accent-foreground"
+                    >
+                      {t('equipment.detail.add_intervention')}
+                    </Link>
+                  </div>
+
+                  {historyLoading ? (
+                    <div className="space-y-2">
+                      {[1, 2, 3].map((i) => (
+                        <div key={i} className="h-12 animate-pulse rounded-lg bg-slate-100" />
+                      ))}
+                    </div>
+                  ) : history.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">
+                      {t('equipment.detail.no_history')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {history.map((item) => (
+                        <li key={item.interaction} className="rounded-md border p-3 text-sm">
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="font-medium">{item.interaction_subject || '—'}</span>
+                            <div className="flex shrink-0 gap-1">
+                              {item.interaction_type ? (
+                                <Badge variant="outline" className="h-5 text-[10px]">
+                                  {t(`equipment.interaction_type.${item.interaction_type}`, {
+                                    defaultValue: item.interaction_type,
+                                  })}
+                                </Badge>
+                              ) : null}
+                            </div>
+                          </div>
+                          {item.interaction_occurred_at ? (
+                            <p className="mt-1 text-[10px] text-muted-foreground">
+                              {formatDateTime(item.interaction_occurred_at)}
+                            </p>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ) : null}
+
+              {tab === 'assistant' ? (
+                <EntityAssistant entityType="equipment" objectId={equipment.id} />
+              ) : null}
+            </>
+          )}
+        </TabShell>
       </div>
 
       <EquipmentDialog

--- a/ui/src/features/stock/StockItemDetailPage.tsx
+++ b/ui/src/features/stock/StockItemDetailPage.tsx
@@ -7,6 +7,7 @@ import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import BackLink from '@/components/BackLink';
+import { TabShell } from '@/components/TabShell';
 import { useNavigateBack } from '@/lib/backNavigation';
 import type { StockItemStatus } from '@/lib/api/stock';
 import {
@@ -50,6 +51,9 @@ function InfoField({ label, children }: { label: string; children: React.ReactNo
     </div>
   );
 }
+
+type Tab = 'info' | 'history' | 'assistant';
+const TABS: Tab[] = ['info', 'history', 'assistant'];
 
 export default function StockItemDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -166,148 +170,157 @@ export default function StockItemDetailPage() {
           </div>
         </div>
 
-        {/* Info grid */}
-        <section className="rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm">
-          <div className="flex items-center gap-3">
-            <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60">
-              <Package className="h-5 w-5 text-muted-foreground" />
-            </span>
-            <h2 className="text-base font-semibold text-foreground">
-              {t('stock.detail.title')}
-            </h2>
-          </div>
-
-          <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            <InfoField label={t('stock.fields.quantity')}>
-              {formatQty(item.quantity, item.unit)}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.min_max')}>
-              {item.min_quantity || item.max_quantity
-                ? `${item.min_quantity ?? '—'} / ${item.max_quantity ?? '—'}`
-                : '—'}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.unit_price')}>
-              {formatAmount(item.unit_price)}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.total_value')}>
-              {formatAmount(item.total_value)}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.supplier')}>
-              {item.supplier || '—'}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.purchase_date')}>
-              {formatDate(item.purchase_date)}
-            </InfoField>
-
-            <InfoField label={t('stock.fields.expiration_date')}>
-              <span className={expired ? 'text-destructive' : undefined}>
-                {formatDate(item.expiration_date)}
-              </span>
-            </InfoField>
-
-            <InfoField label={t('stock.fields.last_restocked_at')}>
-              {formatDateTime(item.last_restocked_at)}
-            </InfoField>
-
-            {item.sku ? (
-              <InfoField label={t('stock.fields.sku')}>{item.sku}</InfoField>
-            ) : null}
-
-            {item.barcode ? (
-              <InfoField label={t('stock.fields.barcode')}>{item.barcode}</InfoField>
-            ) : null}
-
-            {item.tags.length > 0 ? (
-              <InfoField label={t('stock.fields.tags')}>
-                <span className="flex flex-wrap gap-1">
-                  {item.tags.map((tag) => (
-                    <Badge key={tag} variant="outline" className="text-[10px]">
-                      {tag}
-                    </Badge>
-                  ))}
-                </span>
-              </InfoField>
-            ) : null}
-          </dl>
-
-          {item.description ? (
-            <p className="mt-4 whitespace-pre-wrap text-sm text-muted-foreground">
-              {item.description}
-            </p>
-          ) : null}
-
-          {item.notes ? (
-            <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
-              {item.notes}
-            </p>
-          ) : null}
-        </section>
-
-        {/* Purchase history */}
-        <section className="space-y-3">
-          <div className="flex items-center justify-between gap-3">
-            <h2 className="text-base font-semibold text-foreground">
-              {t('stock.detail.history_title')}
-            </h2>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setPurchaseOpen(true)}
-              className="h-8 gap-1 px-3 text-sm"
-            >
-              <Plus className="h-3.5 w-3.5" />
-              {t('stock.purchase.actions.add')}
-            </Button>
-          </div>
-
-          {historyLoading ? (
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
-              ))}
-            </div>
-          ) : history.length === 0 ? (
-            <p className="text-sm italic text-muted-foreground">
-              {t('stock.detail.no_history')}
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {history.map((entry) => (
-                <li key={entry.id} className="rounded-md border border-border p-3 text-sm">
-                  <div className="flex items-start justify-between gap-2">
-                    <span className="font-medium">{entry.subject || '—'}</span>
-                    {entry.metadata?.amount != null ? (
-                      <span className="shrink-0 font-medium">
-                        {formatAmount(entry.metadata.amount)}
-                      </span>
-                    ) : null}
+        {/* Tabs */}
+        <TabShell<Tab>
+          tabs={TABS.map((tab) => ({ key: tab, label: t(`stock.detail.tabs.${tab}`) }))}
+          sessionKey={`stock-detail.${item.id}.tab`}
+          defaultTab="info"
+        >
+          {(tab) => (
+            <>
+              {tab === 'info' ? (
+                <section className="rounded-2xl border border-border/60 bg-card/70 p-5 shadow-sm">
+                  <div className="flex items-center gap-3">
+                    <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/60">
+                      <Package className="h-5 w-5 text-muted-foreground" />
+                    </span>
+                    <h2 className="text-base font-semibold text-foreground">
+                      {t('stock.detail.title')}
+                    </h2>
                   </div>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    {formatDateTime(entry.occurred_at)}
-                    {entry.metadata?.delta && entry.metadata?.unit
-                      ? ` · +${formatQty(entry.metadata.delta, entry.metadata.unit)}`
-                      : ''}
-                    {entry.metadata?.supplier ? ` · ${entry.metadata.supplier}` : ''}
-                  </p>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
 
-        {/* Assistant */}
-        <section className="space-y-3">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('agent.entity.section_title')}
-          </h2>
-          <EntityAssistant entityType="stock_item" objectId={item.id} />
-        </section>
+                  <dl className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    <InfoField label={t('stock.fields.quantity')}>
+                      {formatQty(item.quantity, item.unit)}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.min_max')}>
+                      {item.min_quantity || item.max_quantity
+                        ? `${item.min_quantity ?? '—'} / ${item.max_quantity ?? '—'}`
+                        : '—'}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.unit_price')}>
+                      {formatAmount(item.unit_price)}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.total_value')}>
+                      {formatAmount(item.total_value)}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.supplier')}>
+                      {item.supplier || '—'}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.purchase_date')}>
+                      {formatDate(item.purchase_date)}
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.expiration_date')}>
+                      <span className={expired ? 'text-destructive' : undefined}>
+                        {formatDate(item.expiration_date)}
+                      </span>
+                    </InfoField>
+
+                    <InfoField label={t('stock.fields.last_restocked_at')}>
+                      {formatDateTime(item.last_restocked_at)}
+                    </InfoField>
+
+                    {item.sku ? (
+                      <InfoField label={t('stock.fields.sku')}>{item.sku}</InfoField>
+                    ) : null}
+
+                    {item.barcode ? (
+                      <InfoField label={t('stock.fields.barcode')}>{item.barcode}</InfoField>
+                    ) : null}
+
+                    {item.tags.length > 0 ? (
+                      <InfoField label={t('stock.fields.tags')}>
+                        <span className="flex flex-wrap gap-1">
+                          {item.tags.map((tag) => (
+                            <Badge key={tag} variant="outline" className="text-[10px]">
+                              {tag}
+                            </Badge>
+                          ))}
+                        </span>
+                      </InfoField>
+                    ) : null}
+                  </dl>
+
+                  {item.description ? (
+                    <p className="mt-4 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {item.description}
+                    </p>
+                  ) : null}
+
+                  {item.notes ? (
+                    <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                      {item.notes}
+                    </p>
+                  ) : null}
+                </section>
+              ) : null}
+
+              {tab === 'history' ? (
+                <section className="space-y-3">
+                  <div className="flex items-center justify-between gap-3">
+                    <h2 className="text-base font-semibold text-foreground">
+                      {t('stock.detail.history_title')}
+                    </h2>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setPurchaseOpen(true)}
+                      className="h-8 gap-1 px-3 text-sm"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      {t('stock.purchase.actions.add')}
+                    </Button>
+                  </div>
+
+                  {historyLoading ? (
+                    <div className="space-y-2">
+                      {[1, 2, 3].map((i) => (
+                        <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
+                      ))}
+                    </div>
+                  ) : history.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">
+                      {t('stock.detail.no_history')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {history.map((entry) => (
+                        <li key={entry.id} className="rounded-md border border-border p-3 text-sm">
+                          <div className="flex items-start justify-between gap-2">
+                            <span className="font-medium">{entry.subject || '—'}</span>
+                            {entry.metadata?.amount != null ? (
+                              <span className="shrink-0 font-medium">
+                                {formatAmount(entry.metadata.amount)}
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {formatDateTime(entry.occurred_at)}
+                            {entry.metadata?.delta && entry.metadata?.unit
+                              ? ` · +${formatQty(entry.metadata.delta, entry.metadata.unit)}`
+                              : ''}
+                            {entry.metadata?.supplier ? ` · ${entry.metadata.supplier}` : ''}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ) : null}
+
+              {tab === 'assistant' ? (
+                <EntityAssistant entityType="stock_item" objectId={item.id} />
+              ) : null}
+            </>
+          )}
+        </TabShell>
       </div>
 
       <StockItemDialog

--- a/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/ui/src/features/tasks/TaskDetailPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import BackLink from '@/components/BackLink';
+import { TabShell } from '@/components/TabShell';
 import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useAuth } from '@/lib/auth/useAuth';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
@@ -51,6 +52,11 @@ function InfoField({ label, children }: { label: string; children: React.ReactNo
     </div>
   );
 }
+
+// ── Tabs ───────────────────────────────────────────────────
+
+type Tab = 'info' | 'documents' | 'activity' | 'assistant';
+const TABS: Tab[] = ['info', 'documents', 'activity', 'assistant'];
 
 // ── Main page ──────────────────────────────────────────────
 
@@ -199,171 +205,180 @@ export default function TaskDetailPage() {
           )}
         </div>
 
-        {/* Info grid */}
-        <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          <InfoField label={t('tasks.fieldStatus')}>
-            <TaskStatusBadge
-              status={task.status}
-              onChange={handleStatusChange}
-              disabled={!canChangeStatus}
-            />
-          </InfoField>
+        {/* Tabs */}
+        <TabShell<Tab>
+          tabs={TABS.map((tab) => ({ key: tab, label: t(`tasks.tabs.${tab}`) }))}
+          sessionKey={`task-detail.${task.id}.tab`}
+          defaultTab="info"
+        >
+          {(tab) => (
+            <>
+              {tab === 'info' ? (
+                <div className="space-y-6">
+                  <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                    <InfoField label={t('tasks.fieldStatus')}>
+                      <TaskStatusBadge
+                        status={task.status}
+                        onChange={handleStatusChange}
+                        disabled={!canChangeStatus}
+                      />
+                    </InfoField>
 
-          {showAssignee && (
-            <InfoField label={t('tasks.fieldAssignedTo')}>
-              <TaskAssigneeBadge
-                task={task}
-                members={householdMembers}
-                onChange={handleAssigneeChange}
-                disabled={!isCreator}
-              />
-            </InfoField>
-          )}
-
-          <InfoField label={t('tasks.fieldDate')}>
-            <span className={overdue ? 'font-medium text-destructive' : undefined}>
-              {formatDate(task.due_date)}
-            </span>
-          </InfoField>
-
-          <InfoField label={t('tasks.fieldZone')}>
-            {zoneName || t('tasks.noZone')}
-          </InfoField>
-
-          <InfoField label={t('tasks.fieldPriority')}>
-            {t(priorityLabelKey(task.priority))}
-          </InfoField>
-
-          {task.project && task.project_title && (
-            <InfoField label={t('tasks.fieldProject')}>
-              <Link
-                to={`/app/projects/${task.project}`}
-                state={pushBack(location)}
-                className="text-primary hover:underline"
-              >
-                {task.project_title}
-              </Link>
-            </InfoField>
-          )}
-        </dl>
-
-        {/* Notes */}
-        <Card>
-          <CardContent className="pt-4">
-            <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground">
-              <FileText className="h-4 w-4 text-muted-foreground" />
-              {t('tasks.fieldContent')}
-            </h2>
-            {task.content ? (
-              <p className="whitespace-pre-line text-sm leading-relaxed text-foreground">
-                {task.content}
-              </p>
-            ) : (
-              <p className="text-sm italic text-muted-foreground">{t('tasks.noNotes')}</p>
-            )}
-          </CardContent>
-        </Card>
-
-        {/* Weather suggestion (parcours 17, Lot 3) — outdoor dry-weather tasks */}
-        <TaskWeatherHint task={task} />
-
-        {/* Linked documents */}
-        <section className="space-y-2">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('tasks.linkedDocuments')}
-          </h2>
-          {task.linked_documents.length === 0 ? (
-            <p className="text-sm italic text-muted-foreground">{t('tasks.noLinkedDocuments')}</p>
-          ) : (
-            <ul className="space-y-2">
-              {task.linked_documents.map((doc) => (
-                <li key={doc.id} className="rounded-md border border-border p-3 text-sm">
-                  <div className="flex items-start justify-between gap-2">
-                    <Link
-                      to={`/app/documents/${doc.document_id}`}
-                      state={pushBack(location)}
-                      className="min-w-0 flex-1 truncate font-medium text-foreground hover:text-primary hover:underline"
-                    >
-                      {doc.name || '—'}
-                    </Link>
-                    {doc.file_url && (
-                      <a
-                        href={doc.file_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
-                        aria-label={t('documents.detail.download')}
-                      >
-                        <Download className="h-3.5 w-3.5" />
-                      </a>
+                    {showAssignee && (
+                      <InfoField label={t('tasks.fieldAssignedTo')}>
+                        <TaskAssigneeBadge
+                          task={task}
+                          members={householdMembers}
+                          onChange={handleAssigneeChange}
+                          disabled={!isCreator}
+                        />
+                      </InfoField>
                     )}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
 
-        {/* Linked interactions */}
-        <section className="space-y-2">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('tasks.linkedInteractions')}
-          </h2>
-          {task.linked_interactions.length === 0 ? (
-            <p className="text-sm italic text-muted-foreground">
-              {t('tasks.noLinkedInteractions')}
-            </p>
-          ) : (
-            <ul className="space-y-2">
-              {task.linked_interactions.map((item) => (
-                <li key={item.id} className="rounded-md border border-border p-3 text-sm">
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="min-w-0 flex-1">
-                      <span className="font-medium text-foreground">{item.subject || '—'}</span>
-                      {item.occurred_at && (
-                        <p className="mt-0.5 text-xs text-muted-foreground">
-                          {formatDate(item.occurred_at)}
+                    <InfoField label={t('tasks.fieldDate')}>
+                      <span className={overdue ? 'font-medium text-destructive' : undefined}>
+                        {formatDate(task.due_date)}
+                      </span>
+                    </InfoField>
+
+                    <InfoField label={t('tasks.fieldZone')}>
+                      {zoneName || t('tasks.noZone')}
+                    </InfoField>
+
+                    <InfoField label={t('tasks.fieldPriority')}>
+                      {t(priorityLabelKey(task.priority))}
+                    </InfoField>
+
+                    {task.project && task.project_title && (
+                      <InfoField label={t('tasks.fieldProject')}>
+                        <Link
+                          to={`/app/projects/${task.project}`}
+                          state={pushBack(location)}
+                          className="text-primary hover:underline"
+                        >
+                          {task.project_title}
+                        </Link>
+                      </InfoField>
+                    )}
+                  </dl>
+
+                  <Card>
+                    <CardContent className="pt-4">
+                      <h2 className="mb-2 flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                        {t('tasks.fieldContent')}
+                      </h2>
+                      {task.content ? (
+                        <p className="whitespace-pre-line text-sm leading-relaxed text-foreground">
+                          {task.content}
+                        </p>
+                      ) : (
+                        <p className="text-sm italic text-muted-foreground">
+                          {t('tasks.noNotes')}
                         </p>
                       )}
+                    </CardContent>
+                  </Card>
+
+                  {/* Weather suggestion (parcours 17, Lot 3) — outdoor dry-weather tasks */}
+                  <TaskWeatherHint task={task} />
+                </div>
+              ) : null}
+
+              {tab === 'documents' ? (
+                <div className="space-y-2">
+                  {isCreator && (
+                    <div className="flex justify-end">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-8 px-3 text-sm"
+                        onClick={() => setAttachmentsOpen(true)}
+                      >
+                        <Paperclip className="mr-1.5 h-3.5 w-3.5" />
+                        {t('tasks.manageAttachments')}
+                        {totalAttachments > 0 ? ` (${totalAttachments})` : ''}
+                      </Button>
                     </div>
-                    <Link
-                      to={`/app/interactions/${item.interaction_id}`}
-                      state={pushBack(location)}
-                      className="ml-1 inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
-                      aria-label={t('common.view')}
-                    >
-                      <ExternalLink className="h-3.5 w-3.5" />
-                    </Link>
-                  </div>
-                </li>
-              ))}
-            </ul>
+                  )}
+                  {task.linked_documents.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">
+                      {t('tasks.noLinkedDocuments')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {task.linked_documents.map((doc) => (
+                        <li key={doc.id} className="rounded-md border border-border p-3 text-sm">
+                          <div className="flex items-start justify-between gap-2">
+                            <Link
+                              to={`/app/documents/${doc.document_id}`}
+                              state={pushBack(location)}
+                              className="min-w-0 flex-1 truncate font-medium text-foreground hover:text-primary hover:underline"
+                            >
+                              {doc.name || '—'}
+                            </Link>
+                            {doc.file_url && (
+                              <a
+                                href={doc.file_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
+                                aria-label={t('documents.detail.download')}
+                              >
+                                <Download className="h-3.5 w-3.5" />
+                              </a>
+                            )}
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ) : null}
+
+              {tab === 'activity' ? (
+                <div className="space-y-2">
+                  {task.linked_interactions.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">
+                      {t('tasks.noLinkedInteractions')}
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {task.linked_interactions.map((item) => (
+                        <li key={item.id} className="rounded-md border border-border p-3 text-sm">
+                          <div className="flex items-start justify-between gap-2">
+                            <div className="min-w-0 flex-1">
+                              <span className="font-medium text-foreground">
+                                {item.subject || '—'}
+                              </span>
+                              {item.occurred_at && (
+                                <p className="mt-0.5 text-xs text-muted-foreground">
+                                  {formatDate(item.occurred_at)}
+                                </p>
+                              )}
+                            </div>
+                            <Link
+                              to={`/app/interactions/${item.interaction_id}`}
+                              state={pushBack(location)}
+                              className="ml-1 inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
+                              aria-label={t('common.view')}
+                            >
+                              <ExternalLink className="h-3.5 w-3.5" />
+                            </Link>
+                          </div>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ) : null}
+
+              {tab === 'assistant' ? (
+                <EntityAssistant entityType="task" objectId={task.id} />
+              ) : null}
+            </>
           )}
-        </section>
-
-        {/* Attachments management */}
-        {isCreator && (
-          <div>
-            <Button
-              type="button"
-              variant="outline"
-              className="h-8 px-3 text-sm"
-              onClick={() => setAttachmentsOpen(true)}
-            >
-              <Paperclip className="mr-1.5 h-3.5 w-3.5" />
-              {t('tasks.manageAttachments')}
-              {totalAttachments > 0 ? ` (${totalAttachments})` : ''}
-            </Button>
-          </div>
-        )}
-
-        {/* Assistant */}
-        <section className="space-y-2">
-          <h2 className="text-base font-semibold text-foreground">
-            {t('agent.entity.section_title')}
-          </h2>
-          <EntityAssistant entityType="task" objectId={task.id} />
-        </section>
+        </TabShell>
       </div>
 
       <NewTaskDialog

--- a/ui/src/features/trackers/TrackerDetailPage.tsx
+++ b/ui/src/features/trackers/TrackerDetailPage.tsx
@@ -7,6 +7,7 @@ import BackLink from '@/components/BackLink';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import PageHeader from '@/components/PageHeader';
 import Sparkline from '@/components/Sparkline';
+import { TabShell } from '@/components/TabShell';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
 import {
@@ -86,6 +87,9 @@ function EntryRow({
     </div>
   );
 }
+
+type Tab = 'entries' | 'assistant';
+const TABS: Tab[] = ['entries', 'assistant'];
 
 export default function TrackerDetailPage() {
   const { id = '' } = useParams();
@@ -187,45 +191,59 @@ export default function TrackerDetailPage() {
         </div>
       ) : null}
 
-      {sparkPoints.length > 1 ? (
-        <Card className="mb-4 p-4">
-          <span className="block text-primary">
-            <Sparkline
-              points={sparkPoints}
-              width={600}
-              height={120}
-              strokeWidth={2}
-              className="h-auto w-full"
-            />
-          </span>
-        </Card>
-      ) : null}
+      <TabShell<Tab>
+        tabs={TABS.map((tab) => ({ key: tab, label: t(`trackers.tabs.${tab}`) }))}
+        sessionKey={`tracker-detail.${tracker.id}.tab`}
+        defaultTab="entries"
+      >
+        {(tab) => (
+          <>
+            {tab === 'entries' ? (
+              <div className="space-y-4">
+                {sparkPoints.length > 1 ? (
+                  <Card className="p-4">
+                    <span className="block text-primary">
+                      <Sparkline
+                        points={sparkPoints}
+                        width={600}
+                        height={120}
+                        strokeWidth={2}
+                        className="h-auto w-full"
+                      />
+                    </span>
+                  </Card>
+                ) : null}
 
-      <Card className="p-4">
-        <h2 className="mb-2 text-sm font-medium text-foreground">
-          {t('trackers.entriesTitle')}
-        </h2>
-        {visibleEntries.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('trackers.noEntries')}</p>
-        ) : (
-          <div>
-            {visibleEntries.map((entry, index) => (
-              <EntryRow
-                key={entry.id}
-                entry={entry}
-                previous={visibleEntries[index + 1] ?? null}
-                tracker={tracker}
-                onEdit={openEditEntry}
-                onDelete={handleDeleteEntry}
-              />
-            ))}
-          </div>
+                <Card className="p-4">
+                  <h2 className="mb-2 text-sm font-medium text-foreground">
+                    {t('trackers.entriesTitle')}
+                  </h2>
+                  {visibleEntries.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">{t('trackers.noEntries')}</p>
+                  ) : (
+                    <div>
+                      {visibleEntries.map((entry, index) => (
+                        <EntryRow
+                          key={entry.id}
+                          entry={entry}
+                          previous={visibleEntries[index + 1] ?? null}
+                          tracker={tracker}
+                          onEdit={openEditEntry}
+                          onDelete={handleDeleteEntry}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </Card>
+              </div>
+            ) : null}
+
+            {tab === 'assistant' ? (
+              <EntityAssistant entityType="tracker" objectId={tracker.id} />
+            ) : null}
+          </>
         )}
-      </Card>
-
-      <div className="mt-4">
-        <EntityAssistant entityType="tracker" objectId={tracker.id} />
-      </div>
+      </TabShell>
 
       <TrackerDialog open={editOpen} onOpenChange={setEditOpen} existing={tracker} />
       <EntryDialog

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -714,6 +714,12 @@
       "suggestionTitle": "Beste Tage",
       "goodDaysIntro": "Kommende trockene Tage:",
       "noDryDays": "In den nächsten 7 Tagen ist kein trockener Tag zu erwarten."
+    },
+    "tabs": {
+      "info": "Info",
+      "documents": "Dokumente",
+      "activity": "Aktivität",
+      "assistant": "Assistent"
     }
   },
   "trackers": {
@@ -751,6 +757,10 @@
       "all": "Alle",
       "general": "Allgemein",
       "projects": "Projekte"
+    },
+    "tabs": {
+      "entries": "Einträge",
+      "assistant": "Assistent"
     }
   },
   "settings": {
@@ -1481,7 +1491,12 @@
       "title": "Aktivität aus diesem Dokument erstellen",
       "cta": "Aktivität erstellen"
     },
-    "createTask": "Aufgabe erstellen"
+    "createTask": "Aufgabe erstellen",
+    "tabs": {
+      "info": "Info",
+      "activity": "Aktivität",
+      "assistant": "Assistent"
+    }
   },
   "equipment": {
     "app_title": "Geräte-Mini-App",
@@ -1637,6 +1652,11 @@
       "actions": {
         "add": "Kauf"
       }
+    },
+    "tabs": {
+      "info": "Info",
+      "history": "Verlauf",
+      "assistant": "Assistent"
     }
   },
   "dashboard": {
@@ -1890,7 +1910,12 @@
       "title": "Artikeldetails",
       "history_title": "Kaufverlauf",
       "no_history": "Noch keine Käufe erfasst.",
-      "confirm_delete": "Artikel \"{{name}}\" löschen?"
+      "confirm_delete": "Artikel \"{{name}}\" löschen?",
+      "tabs": {
+        "info": "Info",
+        "history": "Verlauf",
+        "assistant": "Assistent"
+      }
     }
   },
   "purchase": {
@@ -2275,6 +2300,11 @@
       "title": "Kosten",
       "per_egg": "{{amount}} € / Ei",
       "totals": "{{total}} € gesamt · {{year}} € dieses Jahr"
+    },
+    "tabs": {
+      "info": "Info",
+      "events": "Journal",
+      "assistant": "Assistent"
     }
   },
   "alerts": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -714,6 +714,12 @@
       "suggestionTitle": "Best days",
       "goodDaysIntro": "Dry days coming up:",
       "noDryDays": "No dry day expected in the next 7 days."
+    },
+    "tabs": {
+      "info": "Info",
+      "documents": "Documents",
+      "activity": "Activity",
+      "assistant": "Assistant"
     }
   },
   "trackers": {
@@ -751,6 +757,10 @@
       "all": "All",
       "general": "General",
       "projects": "Projects"
+    },
+    "tabs": {
+      "entries": "Entries",
+      "assistant": "Assistant"
     }
   },
   "settings": {
@@ -1481,7 +1491,12 @@
       "title": "Create an activity from this document",
       "cta": "Create activity"
     },
-    "createTask": "Create task"
+    "createTask": "Create task",
+    "tabs": {
+      "info": "Info",
+      "activity": "Activity",
+      "assistant": "Assistant"
+    }
   },
   "equipment": {
     "app_title": "Equipment mini-app",
@@ -1637,6 +1652,11 @@
       "actions": {
         "add": "Buy"
       }
+    },
+    "tabs": {
+      "info": "Info",
+      "history": "History",
+      "assistant": "Assistant"
     }
   },
   "dashboard": {
@@ -1890,7 +1910,12 @@
       "title": "Item details",
       "history_title": "Purchase history",
       "no_history": "No purchase recorded yet.",
-      "confirm_delete": "Delete item \"{{name}}\"?"
+      "confirm_delete": "Delete item \"{{name}}\"?",
+      "tabs": {
+        "info": "Info",
+        "history": "History",
+        "assistant": "Assistant"
+      }
     }
   },
   "purchase": {
@@ -2275,6 +2300,11 @@
       "title": "Cost",
       "per_egg": "{{amount}} € / egg",
       "totals": "{{total}} € total · {{year}} € this year"
+    },
+    "tabs": {
+      "info": "Info",
+      "events": "Journal",
+      "assistant": "Assistant"
     }
   },
   "alerts": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -714,6 +714,12 @@
       "suggestionTitle": "Mejores días",
       "goodDaysIntro": "Próximos días secos:",
       "noDryDays": "No se espera ningún día seco en los próximos 7 días."
+    },
+    "tabs": {
+      "info": "Info",
+      "documents": "Documentos",
+      "activity": "Actividad",
+      "assistant": "Asistente"
     }
   },
   "trackers": {
@@ -751,6 +757,10 @@
       "all": "Todos",
       "general": "Generales",
       "projects": "Proyectos"
+    },
+    "tabs": {
+      "entries": "Entradas",
+      "assistant": "Asistente"
     }
   },
   "settings": {
@@ -1481,7 +1491,12 @@
       "title": "Crear una actividad desde este documento",
       "cta": "Crear actividad"
     },
-    "createTask": "Crear tarea"
+    "createTask": "Crear tarea",
+    "tabs": {
+      "info": "Info",
+      "activity": "Actividad",
+      "assistant": "Asistente"
+    }
   },
   "equipment": {
     "app_title": "Mini-app Equipos",
@@ -1637,6 +1652,11 @@
       "actions": {
         "add": "Comprar"
       }
+    },
+    "tabs": {
+      "info": "Info",
+      "history": "Historial",
+      "assistant": "Asistente"
     }
   },
   "dashboard": {
@@ -1890,7 +1910,12 @@
       "title": "Detalles del artículo",
       "history_title": "Historial de compras",
       "no_history": "Aún no hay compras registradas.",
-      "confirm_delete": "¿Eliminar el artículo \"{{name}}\"?"
+      "confirm_delete": "¿Eliminar el artículo \"{{name}}\"?",
+      "tabs": {
+        "info": "Info",
+        "history": "Historial",
+        "assistant": "Asistente"
+      }
     }
   },
   "purchase": {
@@ -2275,6 +2300,11 @@
       "title": "Coste",
       "per_egg": "{{amount}} € / huevo",
       "totals": "{{total}} € en total · {{year}} € este año"
+    },
+    "tabs": {
+      "info": "Info",
+      "events": "Diario",
+      "assistant": "Asistente"
     }
   },
   "alerts": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -714,6 +714,12 @@
       "suggestionTitle": "Meilleurs jours",
       "goodDaysIntro": "Jours secs à venir :",
       "noDryDays": "Aucun jour sec prévu dans les 7 prochains jours."
+    },
+    "tabs": {
+      "info": "Infos",
+      "documents": "Documents",
+      "activity": "Activité",
+      "assistant": "Assistant"
     }
   },
   "trackers": {
@@ -751,6 +757,10 @@
       "all": "Tous",
       "general": "Généraux",
       "projects": "Projets"
+    },
+    "tabs": {
+      "entries": "Entrées",
+      "assistant": "Assistant"
     }
   },
   "settings": {
@@ -1481,7 +1491,12 @@
       "title": "Créer une activité depuis ce document",
       "cta": "Créer une activité"
     },
-    "createTask": "Créer une tâche"
+    "createTask": "Créer une tâche",
+    "tabs": {
+      "info": "Infos",
+      "activity": "Activité",
+      "assistant": "Assistant"
+    }
   },
   "equipment": {
     "app_title": "Mini-app Équipements",
@@ -1637,6 +1652,11 @@
       "actions": {
         "add": "Achat"
       }
+    },
+    "tabs": {
+      "info": "Infos",
+      "history": "Historique",
+      "assistant": "Assistant"
     }
   },
   "dashboard": {
@@ -1890,7 +1910,12 @@
       "title": "Détails de l'article",
       "history_title": "Historique des achats",
       "no_history": "Aucun achat enregistré.",
-      "confirm_delete": "Supprimer l'article \"{{name}}\" ?"
+      "confirm_delete": "Supprimer l'article \"{{name}}\" ?",
+      "tabs": {
+        "info": "Infos",
+        "history": "Historique",
+        "assistant": "Assistant"
+      }
     }
   },
   "purchase": {
@@ -2275,6 +2300,11 @@
       "title": "Coût",
       "per_egg": "{{amount}} € / œuf",
       "totals": "{{total}} € au total · {{year}} € cette année"
+    },
+    "tabs": {
+      "info": "Infos",
+      "events": "Journal",
+      "assistant": "Assistant"
     }
   },
   "alerts": {


### PR DESCRIPTION
## Quoi

Étend le pattern `TabShell` (déjà introduit pour les zones) aux pages de détail
restantes qui ne l'utilisaient pas encore : poules, documents, équipement,
stock, tâches, trackers. Chaque page bascule vers des onglets `info / documents
/ activité / assistant` au lieu d'un layout à sections empilées, pour
harmoniser l'expérience de détail sur toutes les entités du foyer.

- Ajout des clés i18n `*.tabs.*` correspondantes dans les 4 locales (en, fr, de, es)
- Pas de changement de logique métier ni d'API — refactor UI uniquement

## Critères

- ✅ Chaque page de détail concernée utilise `TabShell` avec les mêmes onglets que le pattern existant (zones)
- ✅ Traductions ajoutées dans les 4 locales, pas de `defaultValue`
- ✅ `pytest`, `npm run lint`, `npx tsc -b ui/tsconfig.json` verts (les 8 échecs pytest dans `apps/agent/tests/test_retention.py` et `test_admin.py` sont pré-existants sur `main`, sans rapport avec ce changement)

## Hors scope

- Pas de nouvel onglet ajouté (seulement application du pattern existant)
- `package-lock.json` volontairement non touché (bruit généré par `npm install` local, sans rapport avec le changement)
