### PR TITLE
feat(chickens): stats & santé du troupeau — courbe, coût au œuf, alerte de chute

### DIFF
--- a/apps/alerts/services.py
+++ b/apps/alerts/services.py
@@ -159,6 +159,21 @@ def _weather_alerts(household) -> list[dict]:
     ]
 
 
+def _egg_drop_alerts(household, today: date) -> list[dict]:
+    """Abnormal egg-laying drop (parcours 14 Lot 6.3), qualified by cause.
+
+    On-read channel of the chickens app's pure evaluator; rendered client-side
+    from the structured fields (cause/drop_pct), so no server-side i18n here.
+    Skipped when the chickens module is disabled for the household.
+    """
+    if "chickens" in (household.disabled_modules or []):
+        return []
+    from chickens.alerts import evaluate_egg_drop_alert
+
+    alert = evaluate_egg_drop_alert(household, today)
+    return [alert] if alert is not None else []
+
+
 def build_alerts_summary(household, today: date | None = None) -> dict:
     today = today or timezone.localdate()
     overdue_tasks = _overdue_tasks(household, today)
@@ -166,17 +181,20 @@ def build_alerts_summary(household, today: date | None = None) -> dict:
     due_maintenances = _due_maintenances(household, today)
     low_stock = _low_stock(household)
     weather_alerts = _weather_alerts(household)
+    egg_drop_alerts = _egg_drop_alerts(household, today)
     return {
         "overdue_tasks": overdue_tasks,
         "expiring_warranties": expiring_warranties,
         "due_maintenances": due_maintenances,
         "low_stock": low_stock,
         "weather_alerts": weather_alerts,
+        "egg_drop_alerts": egg_drop_alerts,
         "total": (
             len(overdue_tasks)
             + len(expiring_warranties)
             + len(due_maintenances)
             + len(low_stock)
             + len(weather_alerts)
+            + len(egg_drop_alerts)
         ),
     }

--- a/apps/chickens/agent.py
+++ b/apps/chickens/agent.py
@@ -1,0 +1,102 @@
+"""
+Chicken stats agent tool (parcours 14, Lot 6.4) — ``get_chicken_stats``.
+
+Laying/health stats are **aggregates**, not listable rows, so — like the weather
+module's ``get_weather`` — the chickens app exposes a dedicated read-only tool
+rather than riding the ``searchables``/``listables`` registries. Registered from
+``chickens/apps.py::ready()`` via ``agent.tools.register``; ``apps/agent/`` is
+never touched.
+
+The result is neutral data (English labels + numbers); the model phrases the
+final answer in the user's language, exactly like search results.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from agent.tools import AgentTool, ToolResult
+
+GET_CHICKEN_STATS = "get_chicken_stats"
+
+_GET_CHICKEN_STATS_SCHEMA = {
+    "type": "object",
+    "properties": {},
+    "required": [],
+}
+
+_GET_CHICKEN_STATS_DESCRIPTION = (
+    "Get the household flock stats: headcount, eggs collected today / this week / "
+    "average per laying day (7 and 30 days), the egg-log coverage (how many days "
+    "were actually recorded), the cost per egg, and whether an abnormal drop in "
+    "laying is currently detected (with its likely cause: molt, weather, or "
+    "unknown). Call this for ANY question about egg production, laying trends, "
+    "whether the hens are laying less than usual, flock size, or how much an egg "
+    "costs. Returns a note when the chickens module is disabled."
+)
+
+
+def _fmt(value) -> str:
+    if value is None:
+        return "?"
+    if isinstance(value, float):
+        return f"{round(value, 2)}"
+    return f"{value}"
+
+
+def _get_chicken_stats_handler(
+    *,
+    household,
+    user=None,
+    tool_input: dict[str, Any],
+    client=None,
+    context_entity: tuple[str, str] | None = None,
+) -> ToolResult:
+    if household is None or "chickens" in (getattr(household, "disabled_modules", None) or []):
+        return ToolResult(rendered="(the chickens module is not enabled for this household)")
+
+    from .alerts import evaluate_egg_drop_alert
+    from .services import egg_stats, flock_summary
+
+    summary = flock_summary(household)
+    stats = egg_stats(household, period=30)
+    cov = stats["coverage"]
+    cost = summary["cost"]
+
+    lines: list[str] = ["Flock stats:"]
+    lines.append(f"- Hens in flock: {summary['active_count']}")
+    lines.append(f"- Eggs today: {_fmt(summary['eggs_today'])}")
+    lines.append(f"- Eggs last 7 days (total): {summary['eggs_7d']}")
+    lines.append(f"- Average per laying day: 7d={_fmt(stats['avg_7d'])}, 30d={_fmt(stats['avg_30d'])}")
+    lines.append(f"- This month (total): {stats['month_total']}")
+    lines.append(
+        f"- Log coverage (last 30 days): {cov['logged_days']}/{cov['total_days']} days recorded"
+    )
+    if cost.get("per_egg"):
+        lines.append(
+            f"- Cost per egg: {cost['per_egg']} (feed {cost.get('feed_total', '?')} + "
+            f"flock {cost.get('flock_total', '?')}, over {cost['eggs_total']} eggs)"
+        )
+    else:
+        lines.append("- Cost per egg: not enough data yet")
+
+    alert = evaluate_egg_drop_alert(household)
+    if alert is not None:
+        lines.append(
+            f"- ABNORMAL DROP detected: laying down {alert['drop_pct']}% "
+            f"(recent avg {alert['recent_avg']} vs baseline {alert['baseline_avg']}), "
+            f"likely cause: {alert['cause']}."
+        )
+    else:
+        lines.append("- No abnormal laying drop detected.")
+
+    return ToolResult(rendered="\n".join(lines))
+
+
+def build_get_chicken_stats_tool() -> AgentTool:
+    """Factory for the ``get_chicken_stats`` agent tool (registered from apps.py)."""
+    return AgentTool(
+        name=GET_CHICKEN_STATS,
+        description=_GET_CHICKEN_STATS_DESCRIPTION,
+        input_schema=_GET_CHICKEN_STATS_SCHEMA,
+        handler=_get_chicken_stats_handler,
+    )

--- a/apps/chickens/alerts.py
+++ b/apps/chickens/alerts.py
@@ -1,0 +1,109 @@
+"""
+Egg-drop alert evaluation (parcours 14, Lot 6.3) — single source of truth.
+
+``evaluate_egg_drop_alert`` is **pure**: it reads the household's egg logs +
+flock journal + (optionally) the weather forecast, and returns a structured
+alert or ``None``. It writes nothing — same contract as ``weather/alerts.py``.
+
+The pivot of the module applies here too: a day **without** an ``EggLog`` is
+*unknown*, never a zero. Both windows average over *logged* days only, and a
+coverage guard blocks the alert when there simply isn't enough data — a few
+un-logged days must not read as a laying collapse.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from django.db.models import Avg, Count
+from django.utils import timezone
+
+from .models import ChickenEvent, EggLog
+
+# --- Fixed thresholds (V1). Tunable in one place; per-household config is later. -
+RECENT_WINDOW_DAYS = 7          # [today-6 .. today]
+BASELINE_WINDOW_DAYS = 30       # 30 days ending one week before today
+BASELINE_GAP_DAYS = 7           # the recent window is excluded from the baseline
+DROP_THRESHOLD = 0.4            # recent <= baseline * (1 - 0.4) → drop (-40%)
+CRITICAL_DROP = 0.6             # >= -60% → critical
+MIN_BASELINE_DAYS = 10          # need this many logged baseline days to judge
+MIN_RECENT_DAYS = 3             # …and this many logged recent days
+MOLT_LOOKBACK_DAYS = 45         # a molt event this recent explains a drop
+
+CAUSE_MOLT = "molt"
+CAUSE_WEATHER = "weather"
+CAUSE_UNKNOWN = "unknown"
+
+# Weather kinds that plausibly depress laying (cold snap / heat stress).
+_LAYING_WEATHER_KINDS = {"frost", "heatwave"}
+
+
+def _logged_avg(household, start: date, end: date) -> tuple[float | None, int]:
+    """Mean eggs over *logged* days in ``[start, end]`` and how many were logged."""
+    agg = EggLog.objects.filter(
+        household=household, date__gte=start, date__lte=end
+    ).aggregate(avg=Avg("count"), n=Count("id"))
+    return (agg["avg"], agg["n"] or 0)
+
+
+def _drop_cause(household, today: date) -> str:
+    """Best explanation for a drop: an active molt, then extreme weather, else unknown."""
+    molt_since = today - timedelta(days=MOLT_LOOKBACK_DAYS)
+    if ChickenEvent.objects.filter(
+        household=household, type=ChickenEvent.Type.MOLT, occurred_on__gte=molt_since
+    ).exists():
+        return CAUSE_MOLT
+
+    if "weather" not in (getattr(household, "disabled_modules", None) or []):
+        try:
+            from weather.alerts import evaluate_weather_alerts
+
+            kinds = {a["kind"] for a in evaluate_weather_alerts(household)}
+            if kinds & _LAYING_WEATHER_KINDS:
+                return CAUSE_WEATHER
+        except Exception:  # weather is a soft dependency — never break the alert
+            pass
+
+    return CAUSE_UNKNOWN
+
+
+def evaluate_egg_drop_alert(household, today: date | None = None) -> dict | None:
+    """Return the active egg-drop alert for ``household`` or ``None``.
+
+    Alert shape::
+
+        {kind:'egg_drop', severity, drop_pct, baseline_avg, recent_avg,
+         cause, entity_url}
+
+    Pure read — no writes. Returns ``None`` when coverage is too thin to judge or
+    the drop is below threshold.
+    """
+    if household is None:
+        return None
+    today = today or timezone.localdate()
+
+    recent_start = today - timedelta(days=RECENT_WINDOW_DAYS - 1)
+    baseline_end = today - timedelta(days=BASELINE_GAP_DAYS)
+    baseline_start = baseline_end - timedelta(days=BASELINE_WINDOW_DAYS - 1)
+
+    baseline_avg, baseline_n = _logged_avg(household, baseline_start, baseline_end)
+    recent_avg, recent_n = _logged_avg(household, recent_start, today)
+
+    # Coverage guard — not enough data on either side to call a collapse.
+    if baseline_n < MIN_BASELINE_DAYS or recent_n < MIN_RECENT_DAYS:
+        return None
+    if not baseline_avg or baseline_avg <= 0:
+        return None
+
+    drop_pct = 1 - (recent_avg / baseline_avg)
+    if drop_pct < DROP_THRESHOLD:
+        return None
+
+    return {
+        "kind": "egg_drop",
+        "severity": "critical" if drop_pct >= CRITICAL_DROP else "warning",
+        "drop_pct": round(drop_pct * 100),
+        "baseline_avg": round(baseline_avg, 2),
+        "recent_avg": round(recent_avg, 2),
+        "cause": _drop_cause(household, today),
+        "entity_url": "/app/chickens",
+    }

--- a/apps/chickens/apps.py
+++ b/apps/chickens/apps.py
@@ -92,6 +92,15 @@ class ChickensConfig(AppConfig):
             default_send_at=dt_time(19, 0),
         ))
 
+        # Parcours 14 Lot 6.4 — read-only agent tool for flock/laying stats.
+        # Aggregates, not listable rows → dedicated tool (like weather's
+        # get_weather). Declared here, never touching apps/agent/.
+        from agent.tools import register as register_tool
+
+        from .agent import build_get_chicken_stats_tool
+
+        register_tool(build_get_chicken_stats_tool())
+
 
 def _chicken_related(chicken):
     """A hen's recent journal entries — injected in the anchored assistant context."""

--- a/apps/chickens/services.py
+++ b/apps/chickens/services.py
@@ -196,19 +196,32 @@ def get_settings(household) -> ChickenSettings:
 # --- Aggregates ---------------------------------------------------------------
 
 
-def egg_stats(household, *, today: date | None = None) -> dict:
-    """Egg-laying stats for the page header (US-4).
+# Laying-curve periods offered by the UI (days). Anything else falls back to 30.
+EGG_STATS_PERIODS = (7, 30, 90, 365)
 
-    Days without a log are treated as missing (excluded from averages), not as
-    zero — an unlogged day says nothing about the hens.
+
+def egg_stats(household, *, period: int = 30, today: date | None = None) -> dict:
+    """Egg-laying stats + laying curve for a period (Lot 6.1).
+
+    The pivot of this module: a day **without** an ``EggLog`` is *unknown*, never
+    a zero. So the ``series`` carries ``count=null`` for unlogged days (the chart
+    breaks the line there), and every average divides by the number of *logged*
+    days — not calendar days. ``coverage`` exposes that honesty numerically
+    (``logged_days`` / ``total_days``); the drop alert reuses the same idea as a
+    guard against false positives.
     """
     today = today or timezone.localdate()
+    if period not in EGG_STATS_PERIODS:
+        period = 30
+    start = today - timedelta(days=period - 1)
     start_30 = today - timedelta(days=29)
     start_7 = today - timedelta(days=6)
     month_start = today.replace(day=1)
 
+    # One query wide enough for both the period window and the 7/30-day headers.
+    window_start = min(start, start_30)
     logs = list(
-        EggLog.objects.filter(household=household, date__gte=start_30, date__lte=today)
+        EggLog.objects.filter(household=household, date__gte=window_start, date__lte=today)
         .order_by('date')
         .values('date', 'count')
     )
@@ -218,6 +231,22 @@ def egg_stats(household, *, today: date | None = None) -> dict:
         counts = [c for d, c in by_date.items() if d >= since]
         return round(sum(counts) / len(counts), 2) if counts else None
 
+    series = [
+        {
+            'date': (start + timedelta(days=i)).isoformat(),
+            'count': by_date.get(start + timedelta(days=i)),
+        }
+        for i in range(period)
+    ]
+    period_counts = [c for d, c in by_date.items() if start <= d <= today]
+    logged_days = len(period_counts)
+    period_total = sum(period_counts)
+    best = max(
+        ((d, c) for d, c in by_date.items() if start <= d <= today),
+        key=lambda pair: pair[1],
+        default=None,
+    )
+
     month_total = (
         EggLog.objects.filter(household=household, date__gte=month_start, date__lte=today)
         .aggregate(total=Sum('count'))['total']
@@ -226,32 +255,41 @@ def egg_stats(household, *, today: date | None = None) -> dict:
         total=Sum('count')
     )['total']
 
-    series = [
-        {
-            'date': (start_30 + timedelta(days=i)).isoformat(),
-            'count': by_date.get(start_30 + timedelta(days=i)),
-        }
-        for i in range(30)
-    ]
-
     return {
+        'period': period,
         'today': by_date.get(today),
         'avg_7d': _avg(start_7),
         'avg_30d': _avg(start_30),
         'month_total': month_total or 0,
         'total': total_all or 0,
+        'period_total': period_total,
+        'period_avg': round(period_total / logged_days, 2) if logged_days else None,
+        'best_day': {'date': best[0].isoformat(), 'count': best[1]} if best else None,
+        'coverage': {
+            'logged_days': logged_days,
+            'total_days': period,
+            'rate': round(logged_days / period, 3) if period else 0,
+        },
         'series': series,
     }
 
 
 def _cost_totals(household, *, today: date, feed_stock_item=None) -> dict:
-    """Cumulated module expenses + cost per egg.
+    """Cumulated flock expenses + cost per egg, with a feed/flock breakdown.
 
-    Counts the module's own purchases (metadata.kind == 'chickens_purchase')
-    plus, when a feed stock item is linked, the stock purchases of that item
-    (kind == 'stock_purchase' whose polymorphic source is the item). Accepted
-    limit: re-linking to another item stops attributing the old item's
-    purchases.
+    Product decision (Lot 6.2): cost per egg = **feed + care**, durable gear
+    excluded. That maps onto the existing data with no new field:
+
+    - **feed** = purchases of the linked feed StockItem
+      (``kind='stock_purchase'`` whose polymorphic source is that item);
+    - **flock** = per-hen purchases (``kind='chickens_purchase'`` — vet, wormer,
+      hen acquisition).
+
+    Durable gear (feeder, coop) lives in its own module, is never a
+    ``chickens_purchase``, and is therefore naturally out. The breakdown
+    (``feed_total`` / ``flock_total``) is returned so the UI can show what counts.
+    Accepted limit: re-linking to another feed item stops attributing the old
+    item's purchases.
     """
     from django.contrib.contenttypes.models import ContentType
     from django.db.models import Q
@@ -261,16 +299,21 @@ def _cost_totals(household, *, today: date, feed_stock_item=None) -> dict:
     year_start = today.replace(month=1, day=1)
     total = Decimal('0')
     year = Decimal('0')
+    feed_total = Decimal('0')
+    flock_total = Decimal('0')
     kinds = Q(metadata__kind='chickens_purchase')
+    feed_ct = None
     if feed_stock_item is not None:
+        feed_ct = ContentType.objects.get_for_model(type(feed_stock_item))
         kinds |= Q(
             metadata__kind='stock_purchase',
-            source_content_type=ContentType.objects.get_for_model(type(feed_stock_item)),
+            source_content_type=feed_ct,
             source_object_id=feed_stock_item.pk,
         )
     qs = Interaction.objects.filter(
         kinds, household=household, type='expense'
-    ).values('occurred_at', 'metadata')
+    ).values('occurred_at', 'metadata', 'source_content_type_id', 'source_object_id')
+    feed_ct_id = feed_ct.id if feed_ct is not None else None
     for row in qs:
         raw = (row['metadata'] or {}).get('amount')
         if raw in (None, ''):
@@ -280,6 +323,14 @@ def _cost_totals(household, *, today: date, feed_stock_item=None) -> dict:
         except (InvalidOperation, ValueError):
             continue
         total += amount
+        if (
+            feed_ct_id is not None
+            and row['source_content_type_id'] == feed_ct_id
+            and str(row['source_object_id']) == str(feed_stock_item.pk)
+        ):
+            feed_total += amount
+        else:
+            flock_total += amount
         occurred = row['occurred_at']
         if occurred is not None and occurred.date() >= year_start:
             year += amount
@@ -293,6 +344,8 @@ def _cost_totals(household, *, today: date, feed_stock_item=None) -> dict:
     return {
         'total': str(total),
         'year': str(year),
+        'feed_total': str(feed_total),
+        'flock_total': str(flock_total),
         'per_egg': str(per_egg) if per_egg is not None else None,
         'eggs_total': eggs_total,
     }

--- a/apps/chickens/tests/test_stats_health.py
+++ b/apps/chickens/tests/test_stats_health.py
@@ -1,0 +1,272 @@
+"""
+Tests for parcours 14 Lot 6 — stats & health (curve, coverage, cost, drop alert).
+
+The pivot under test everywhere: an unlogged day is *unknown*, never a zero.
+"""
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from chickens import services
+from chickens.alerts import evaluate_egg_drop_alert
+from chickens.models import ChickenEvent, EggLog
+from interactions.services import create_expense_interaction
+
+from .factories import (
+    ChickenFactory,
+    EggLogFactory,
+    HouseholdFactory,
+    UserFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def hh():
+    return HouseholdFactory()
+
+
+@pytest.fixture
+def user():
+    return UserFactory()
+
+
+def _log(hh, user, d, count):
+    return EggLogFactory(household=hh, created_by=user, date=d, count=count)
+
+
+# --- Lot 6.1 : egg_stats period + coverage -----------------------------------
+
+
+class TestEggStatsCoverage:
+    def test_unlogged_days_are_null_not_zero(self, hh, user):
+        today = date(2024, 6, 30)
+        _log(hh, user, today, 4)
+        _log(hh, user, today - timedelta(days=2), 3)
+
+        stats = services.egg_stats(hh, period=7, today=today)
+
+        by_date = {p["date"]: p["count"] for p in stats["series"]}
+        assert by_date[today.isoformat()] == 4
+        # a day never logged stays null in the series (the chart breaks the line)
+        assert by_date[(today - timedelta(days=1)).isoformat()] is None
+        assert len(stats["series"]) == 7
+
+    def test_coverage_counts_only_logged_days(self, hh, user):
+        today = date(2024, 6, 30)
+        for i in range(3):
+            _log(hh, user, today - timedelta(days=i), 2)
+
+        stats = services.egg_stats(hh, period=30, today=today)
+
+        assert stats["coverage"] == {"logged_days": 3, "total_days": 30, "rate": round(3 / 30, 3)}
+
+    def test_period_avg_divides_by_logged_days_not_calendar(self, hh, user):
+        today = date(2024, 6, 30)
+        _log(hh, user, today, 6)
+        _log(hh, user, today - timedelta(days=1), 4)
+        # 10 eggs over 2 *logged* days = 5.0, not 10/30
+        stats = services.egg_stats(hh, period=30, today=today)
+        assert stats["period_avg"] == 5.0
+        assert stats["period_total"] == 10
+
+    def test_real_zero_counts_in_average(self, hh, user):
+        today = date(2024, 6, 30)
+        _log(hh, user, today, 0)  # a real "no eggs" day
+        _log(hh, user, today - timedelta(days=1), 4)
+        stats = services.egg_stats(hh, period=30, today=today)
+        # (0 + 4) / 2 logged days = 2.0 — the real zero pulls the average down
+        assert stats["period_avg"] == 2.0
+        assert stats["coverage"]["logged_days"] == 2
+
+    def test_best_day(self, hh, user):
+        today = date(2024, 6, 30)
+        _log(hh, user, today, 3)
+        _log(hh, user, today - timedelta(days=1), 7)
+        stats = services.egg_stats(hh, period=7, today=today)
+        assert stats["best_day"] == {"date": (today - timedelta(days=1)).isoformat(), "count": 7}
+
+    def test_invalid_period_falls_back_to_30(self, hh, user):
+        stats = services.egg_stats(hh, period=999, today=date(2024, 6, 30))
+        assert stats["period"] == 30
+        assert len(stats["series"]) == 30
+
+    def test_empty_household(self, hh):
+        stats = services.egg_stats(hh, period=30, today=date(2024, 6, 30))
+        assert stats["period_avg"] is None
+        assert stats["best_day"] is None
+        assert stats["coverage"]["logged_days"] == 0
+        assert all(p["count"] is None for p in stats["series"])
+
+
+# --- Lot 6.2 : cost breakdown -------------------------------------------------
+
+
+class TestCostBreakdown:
+    def test_flock_purchase_counts_and_splits(self, hh, user):
+        today = timezone.localdate()
+        hen = ChickenFactory(household=hh, created_by=user)
+        create_expense_interaction(
+            source=hen, user=user, amount=Decimal("20.00"),
+            supplier="Vet", occurred_at=timezone.now(), kind="chickens_purchase",
+        )
+        EggLogFactory(household=hh, created_by=user, date=today, count=10)
+
+        cost = services._cost_totals(hh, today=today, feed_stock_item=None)
+
+        assert cost["flock_total"] == "20.00"
+        assert cost["feed_total"] == "0"
+        assert cost["total"] == "20.00"
+        # 20 / 10 eggs
+        assert cost["per_egg"] == "2.00"
+
+    def test_no_eggs_gives_null_per_egg(self, hh, user):
+        today = timezone.localdate()
+        hen = ChickenFactory(household=hh, created_by=user)
+        create_expense_interaction(
+            source=hen, user=user, amount=Decimal("20.00"),
+            supplier="Vet", occurred_at=timezone.now(), kind="chickens_purchase",
+        )
+        cost = services._cost_totals(hh, today=today, feed_stock_item=None)
+        assert cost["per_egg"] is None
+
+    def test_no_expense_gives_null_per_egg(self, hh, user):
+        today = timezone.localdate()
+        EggLogFactory(household=hh, created_by=user, date=today, count=5)
+        cost = services._cost_totals(hh, today=today, feed_stock_item=None)
+        assert cost["per_egg"] is None
+
+
+# --- Lot 6.3 : egg-drop alert -------------------------------------------------
+
+
+def _baseline_and_recent(hh, user, today, baseline_count, recent_count):
+    """Fill 30 baseline days (ending 7d ago) and 7 recent days with fixed counts."""
+    baseline_end = today - timedelta(days=7)
+    for i in range(30):
+        _log(hh, user, baseline_end - timedelta(days=i), baseline_count)
+    for i in range(7):
+        _log(hh, user, today - timedelta(days=i), recent_count)
+
+
+class TestEggDropAlert:
+    def test_no_alert_without_enough_baseline(self, hh, user):
+        today = date(2024, 6, 30)
+        # only a few recent days, no baseline
+        for i in range(5):
+            _log(hh, user, today - timedelta(days=i), 1)
+        assert evaluate_egg_drop_alert(hh, today) is None
+
+    def test_no_alert_when_laying_stable(self, hh, user):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=5, recent_count=5)
+        assert evaluate_egg_drop_alert(hh, today) is None
+
+    def test_alert_on_significant_drop_unknown_cause(self, hh, user):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=5, recent_count=2)  # -60%
+        alert = evaluate_egg_drop_alert(hh, today)
+        assert alert is not None
+        assert alert["kind"] == "egg_drop"
+        assert alert["cause"] == "unknown"
+        assert alert["drop_pct"] == 60
+        assert alert["severity"] == "critical"
+
+    def test_moderate_drop_is_warning(self, hh, user):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=10, recent_count=5)  # -50%
+        alert = evaluate_egg_drop_alert(hh, today)
+        assert alert is not None
+        assert alert["severity"] == "warning"
+
+    def test_molt_event_explains_drop(self, hh, user):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=2)
+        ChickenEvent.objects.create(
+            household=hh, created_by=user, type=ChickenEvent.Type.MOLT,
+            occurred_on=today - timedelta(days=10), title="Mue",
+        )
+        alert = evaluate_egg_drop_alert(hh, today)
+        assert alert["cause"] == "molt"
+
+    def test_old_molt_does_not_explain(self, hh, user):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=2)
+        ChickenEvent.objects.create(
+            household=hh, created_by=user, type=ChickenEvent.Type.MOLT,
+            occurred_on=today - timedelta(days=90), title="Vieille mue",
+        )
+        alert = evaluate_egg_drop_alert(hh, today)
+        assert alert["cause"] == "unknown"
+
+    def test_weather_cause(self, hh, user, monkeypatch):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=2)
+        monkeypatch.setattr(
+            "weather.alerts.evaluate_weather_alerts",
+            lambda household: [{"kind": "frost"}],
+        )
+        alert = evaluate_egg_drop_alert(hh, today)
+        assert alert["cause"] == "weather"
+
+    def test_molt_takes_priority_over_weather(self, hh, user, monkeypatch):
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=2)
+        ChickenEvent.objects.create(
+            household=hh, created_by=user, type=ChickenEvent.Type.MOLT,
+            occurred_on=today - timedelta(days=5), title="Mue",
+        )
+        monkeypatch.setattr(
+            "weather.alerts.evaluate_weather_alerts",
+            lambda household: [{"kind": "frost"}],
+        )
+        assert evaluate_egg_drop_alert(hh, today)["cause"] == "molt"
+
+
+class TestAlertsSummaryIntegration:
+    def test_egg_drop_surfaces_in_summary(self, hh, user):
+        from alerts.services import build_alerts_summary
+
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=1)
+        summary = build_alerts_summary(hh, today)
+        assert len(summary["egg_drop_alerts"]) == 1
+        assert summary["total"] >= 1
+
+    def test_disabled_module_hides_alert(self, hh, user):
+        from alerts.services import build_alerts_summary
+
+        today = date(2024, 6, 30)
+        _baseline_and_recent(hh, user, today, baseline_count=6, recent_count=1)
+        hh.disabled_modules = ["chickens"]
+        hh.save(update_fields=["disabled_modules"])
+        summary = build_alerts_summary(hh, today)
+        assert summary["egg_drop_alerts"] == []
+
+
+# --- Lot 6.4 : agent tool -----------------------------------------------------
+
+
+class TestAgentStatsTool:
+    def test_tool_reports_stats(self, hh, user):
+        from chickens.agent import build_get_chicken_stats_tool
+
+        ChickenFactory(household=hh, created_by=user)
+        EggLogFactory(household=hh, created_by=user, date=timezone.localdate(), count=4)
+
+        tool = build_get_chicken_stats_tool()
+        result = tool.handler(household=hh, user=user, tool_input={})
+        assert "Flock stats" in result.rendered
+        assert "Hens in flock: 1" in result.rendered
+
+    def test_tool_notes_disabled_module(self, hh, user):
+        from chickens.agent import build_get_chicken_stats_tool
+
+        hh.disabled_modules = ["chickens"]
+        hh.save(update_fields=["disabled_modules"])
+        tool = build_get_chicken_stats_tool()
+        result = tool.handler(household=hh, user=user, tool_input={})
+        assert "not enabled" in result.rendered

--- a/apps/chickens/views.py
+++ b/apps/chickens/views.py
@@ -140,8 +140,12 @@ class EggLogViewSet(viewsets.ModelViewSet):
 
     @action(detail=False, methods=['get'], url_path='stats')
     def stats(self, request):
-        """Egg-laying stats: today, 7/30-day averages, month total, 30-day series."""
-        return Response(services.egg_stats(request.household))
+        """Laying stats + curve. ``?period=`` (7/30/90/365) drives the series."""
+        try:
+            period = int(request.query_params.get('period', 30))
+        except (TypeError, ValueError):
+            period = 30
+        return Response(services.egg_stats(request.household, period=period))
 
 
 class ChickenEventViewSet(viewsets.ModelViewSet):

--- a/docs/MODULES/chickens.md
+++ b/docs/MODULES/chickens.md
@@ -5,7 +5,7 @@
 ## État synthétique
 
 - **Backend** : `apps/chickens/` — modèles (`Chicken`, `EggLog`, `ChickenEvent`, `ChickenSettings`), services (point d'entrée unique des écritures), serializers, viewsets DRF + vues settings/summary, câblage agent complet dans `apps.py::ready()`.
-- **Frontend** : `ui/src/features/chickens/` — `ChickensPage` (bandeau de ponte, stats, cards poules, journal), `ChickenDetailPage` (fiche + timeline + achat + assistant ancré), `ChickenDialog`, `ChickenEventDialog`, `ChickenPurchaseDialog` (wrap `PurchaseForm`), `EggLogBanner`, `EggStatsSection`, `EventTimeline`, `FeedCard`. Widget dashboard `ui/src/features/dashboard/ChickensCard.tsx` (masqué sans données).
+- **Frontend** : `ui/src/features/chickens/` — `ChickensPage` (bandeau de ponte, stats, cards poules, journal), `ChickenDetailPage` (fiche + timeline + achat + assistant ancré), `ChickenDialog`, `ChickenEventDialog`, `ChickenPurchaseDialog` (wrap `PurchaseForm`), `EggLogBanner`, `EggStatsSection` + `EggChart` (courbe SVG), `EventTimeline`, `FeedCard`. Widget dashboard `ui/src/features/dashboard/ChickensCard.tsx` (masqué sans données).
 - **Locales (en/fr/de/es)** : namespace `chickens` + `dashboard.metrics.chickens`.
 - **Tests** : `apps/chickens/tests/` — `test_api_chickens.py`, `test_agent_integration.py` (111 tests, dont le verrou de non-duplication agent/REST).
 
@@ -22,18 +22,24 @@
 
 - **`update_chicken`** : une transition vers `deceased`/`gone` **auto-crée le `ChickenEvent`** correspondant (death/departure) daté du jour — l'historique du troupeau reste complet quel que soit le canal (REST ou agent).
 - **`create_event`** : si `reminder_due_date` est fourni (option « Me le rappeler » d'un soin), une **Task** est créée via `tasks.services.create_task` (jamais l'ORM) — le rappel bénéficie ensuite des alertes de retard existantes, aucune mécanique nouvelle.
-- **`egg_stats`** : today, moyennes 7/30 j, total du mois, série de 30 points. Les jours sans relevé sont **absents (null), pas 0** — ils sont exclus des moyennes.
-- **`flock_summary`** : effectif actif, œufs du jour/7 j, snapshot de l'article de stock nourriture (quantité, unité, statut, seuil bas — pas de runway), coûts (`total`, `year`, `per_egg`), `has_data` (pilote l'affichage du widget dashboard).
+- **`egg_stats(period=30)`** : today, moyennes 7/30 j, total du mois, + (lot 6.1) `period` ∈ {7,30,90,365}, `series` (un point/jour, `count=null` si non relevé), `coverage {logged_days,total_days,rate}`, `period_total`, `period_avg`, `best_day`. Les jours sans relevé sont **absents (null), pas 0** — exclus des moyennes ; le **taux de relevé** rend cette honnêteté chiffrée.
+- **`flock_summary`** : effectif actif, œufs du jour/7 j, snapshot de l'article de stock nourriture (quantité, unité, statut, seuil bas — pas de runway), coûts (`total`, `year`, `feed_total`, `flock_total`, `per_egg`), `has_data` (pilote l'affichage du widget dashboard).
 
 ## Dépenses & coût par œuf
 
 - POST `/api/chickens/{id}/purchase/` (payload compatible `PurchaseForm` : `amount`, `supplier`, `occurred_at`, `notes`) → `interactions.services.create_expense_interaction(kind='chickens_purchase')`, zone de la poule héritée. Template enregistré dans `AUTO_SUBJECT_TEMPLATES` (même msgid « Purchase — {name} » que stock/equipment → déjà traduit dans les .po).
 - Coût cumulé = somme des Interactions `metadata.kind == 'chickens_purchase'` **plus** les `stock_purchase` dont la source polymorphe est l'article de stock lié (lot 7 — la nourriture achetée via Stock est attribuée au poulailler) ; coût par œuf = total ÷ œufs loggés. Limite acceptée : changer d'article lié désattribue les achats de l'ancien.
+- **Décision produit (lot 6.2) : coût = alimentation + soins**, hors équipement durable. Traduit sans nouveau champ : `feed_total` = achats de l'article nourriture ; `flock_total` = `chickens_purchase` (véto, vermifuge, acquisition). L'équipement durable vit dans son module, n'est jamais un `chickens_purchase` → naturellement exclu. La répartition `{feed_total, flock_total}` est renvoyée pour l'afficher (transparence).
+
+## Stats, santé & alerte de chute (lot 6)
+
+- **Courbe de ponte** (`EggStatsSection` + `EggChart`) : sélecteur 7/30/90/365 j, taux de relevé affiché, courbe SVG sans dépendance. Le pivot rendu visible : jour relevé = point (un vrai 0 = point sur l'axe), jour non relevé = ligne interrompue, bande « couverture » (une case/jour) dessous.
+- **Alerte de chute anormale** (`chickens/alerts.py::evaluate_egg_drop_alert`, fonction **pure** sur le modèle de `weather/alerts.py`) : baseline `[J-37..J-8]` vs récent `[J-6..J]` (moyennes sur jours relevés only) ; garde-fous couverture `MIN_BASELINE_DAYS=10` / `MIN_RECENT_DAYS=3` (anti-faux-positif) ; seuil −40 % (`critical` à −60 %) ; **cause** qualifiée : `molt` (ChickenEvent mue < 45 j) > `weather` (`evaluate_weather_alerts` frost/heatwave) > `unknown`. Câblée on-read dans `alerts.services.build_alerts_summary` (`egg_drop_alerts`, gaté `chickens` in `disabled_modules`), rendue client-side dans `AlertsPage`. Pas de ping en V1.
 
 ## API — `/api/chickens/`
 
 - CRUD `''` (poules) — filtres `?status=`, `?in_flock=true` ; action `purchase`.
-- CRUD `egg-logs/` — POST upsert (201 créé / 200 remplacé), filtres `?date_from=&date_to=`, action GET `stats/`.
+- CRUD `egg-logs/` — POST upsert (201 créé / 200 remplacé), filtres `?date_from=&date_to=`, action GET `stats/?period=` (7/30/90/365).
 - CRUD `events/` — filtres `?type=`, `?chicken=` ; `reminder_due_date` write-only à la création.
 - GET/PUT `settings/` — `feed_stock_item` (validation : article du foyer) + snapshot `feed_stock_item_detail`.
 - GET `summary/` — le payload du widget dashboard et de l'en-tête de page.
@@ -44,6 +50,7 @@
 - `WritableSpec('chicken')` — create/update/delete ; anchor zone → pré-remplit la zone ; « Roussette est morte » → update status=deceased (+ event auto).
 - `WritableSpec('egg_log')` — create = **upsert du jour** via `log_eggs` ; undo = hard delete de la row du jour (limite assumée : si l'agent a remplacé un compte existant, l'undo supprime la journée entière).
 - `ListableSpec('chicken')` (status, in_flock) + `ListableSpec('egg_log')` (date_from/date_to) — « combien d'œufs cette semaine ? » passe par `list_entities`.
+- **Tool agent `get_chicken_stats`** (lot 6.4, `chickens/agent.py`, enregistré depuis `apps.py`) : agrégats (effectif, ponte jour/7 j/30 j, taux de relevé, coût au œuf, état de l'alerte de chute + cause) — comme `get_weather`, un tool dédié plutôt qu'un searchable, **zéro modif de `apps/agent/`**.
 - Descriptions des tools étendues dans `apps/agent/tools.py` (create/update/list) — seule retouche dans `apps/agent/`.
 - Front : entrées `chicken`/`egg_log` dans `UNDO_HANDLERS` + `chicken` dans `UPDATE_UNDO_HANDLERS` (`ui/src/features/agent/hooks.ts`).
 

--- a/docs/parcours/PARCOURS_14_GERER_LE_POULAILLER_FAMILIAL.md
+++ b/docs/parcours/PARCOURS_14_GERER_LE_POULAILLER_FAMILIAL.md
@@ -2,9 +2,11 @@
 
 > **État** — cadrage + implémentation V1 livrés le 2026-07-11 (branche
 > `feat/chickens-module`). US-1 à US-13 couvertes, sauf : photo de poule (US-1,
-> reporté), et le coût par œuf (US-9) ne compte que les dépenses déclarées via le
-> module (`kind='chickens_purchase'`), pas les achats de nourriture faits dans
-> Stock — limite documentée dans `docs/MODULES/chickens.md`.
+> reporté). Le coût par œuf compte désormais aussi la nourriture achetée dans
+> Stock (lot 7). **Lot 6 — Stats & santé** (2026-07-16) ajoute : courbe de ponte
+> (période + taux de relevé), coût au œuf transparent (alimentation + soins),
+> alerte de chute anormale croisée météo/mue, tool agent `get_chicken_stats`.
+> Cadrage : `docs/parcours/PARCOURS_14_LOT6_STATS_SANTE_TROUPEAU.md`.
 
 ## Résumé
 

--- a/docs/parcours/PARCOURS_14_LOT6_STATS_SANTE_TROUPEAU.md
+++ b/docs/parcours/PARCOURS_14_LOT6_STATS_SANTE_TROUPEAU.md
@@ -1,0 +1,159 @@
+# Parcours 14 — Lot 6 : Stats & santé du troupeau
+
+> **État** — cadrage (2026-07-16). Fait suite au module poulailler V1
+> (parcours 14, lots 1-5) et à la refonte trackers/stock (parcours 11 lot 7 :
+> la nourriture est un `StockItem`, plus un tracker CONSUMPTION).
+
+## Résumé
+
+Le module poulailler enregistre déjà le troupeau (`Chicken`), la ponte
+quotidienne (`EggLog`, upsert `unique(household, date)`) et le journal
+(`ChickenEvent`, dont les types `molt`/mue). Ce lot exploite ces données pour
+**trois lectures** à forte valeur, sans nouveau modèle :
+
+1. **Courbe de ponte** — évolution dans le temps, avec sélecteur de période et
+   **taux de relevé** honnête (les jours non relevés ne comptent pas comme 0).
+2. **Alerte de chute de ponte anormale** — détectée sur la baseline, **qualifiée**
+   par la cause probable (mue en cours / météo extrême / inconnue), remontée dans
+   le module alertes existant.
+3. **Coût au œuf** — déjà calculé en V1 ; ce lot le rend **transparent**
+   (répartition alimentation / soins) et cohérent avec la décision produit.
+
+## Décision produit clé — le « zéro » n'existe pas sans relevé
+
+C'est le pivot du lot. Il faut distinguer **trois états**, pas deux :
+
+| État | Sémantique | Traitement |
+|---|---|---|
+| `EggLog` avec `count > 0` | fait réel | point plein sur la courbe |
+| `EggLog` avec `count = 0` | fait réel (froid, mue…) | point posé sur l'axe (creux visible) |
+| Pas de `EggLog` ce jour | **inconnu** | trou dans la courbe, exclu des agrégats |
+
+Le modèle sépare déjà nativement ces cas : **ligne présente = fait (y compris 0),
+ligne absente = inconnu** (grâce à l'upsert `unique(household, date)`). Aucune
+migration.
+
+**Conséquences directes :**
+
+- **Agrégats calculés sur les jours *relevés* uniquement** — moyenne =
+  `somme œufs ÷ nombre de jours relevés`, jamais ÷ jours calendaires. C'est déjà
+  ce que fait `egg_stats` en V1 (`_avg` ignore les jours absents).
+- **Taux de relevé (couverture)** exposé partout : `{logged_days, total_days,
+  rate}`. Nouvelle primitive partagée par la courbe (affichage), le coût
+  (transparence) et l'alerte (garde-fou anti-faux-positif).
+- **Pas d'imputation dans les chiffres.** Combler les trous par une moyenne
+  glissante fabriquerait des œufs → fausse le coût au œuf et *masque* la chute
+  qu'on veut détecter. L'estimation reste, si un jour on la veut, un pur confort
+  visuel cloisonné (hors périmètre de ce lot).
+- **Visuel :** trou = ligne interrompue/grisée ; vrai 0 = point sur l'axe ; une
+  bande « couverture » sous la courbe (une case/jour, pleine = relevé) rend les
+  trous lisibles d'un coup d'œil.
+
+## Lot 6.1 — Courbe de ponte
+
+**Backend** — `egg_stats(household, *, period=30, today=None)` :
+- `period` ∈ {7, 30, 90, 365} (jours). Défaut 30 (rétrocompat).
+- Renvoie, en plus de l'existant (`today`, `avg_7d`, `avg_30d`, `month_total`,
+  `total`) : `series` (un point/jour sur la période, `count=null` si non relevé),
+  `coverage: {logged_days, total_days, rate}`, `period_total`, `period_avg`
+  (sur jours relevés), `best_day: {date, count}`, `period` (echo).
+- Endpoint : `GET /api/chickens/egg-logs/stats/?period=90`.
+
+**Frontend** — `EggStatsSection` :
+- `FilterPill` 7 / 30 / 90 / 365 j (persisté via `useSessionState`).
+- Ligne couverture : « 24/30 jours relevés ».
+- Composant `EggChart` (SVG sans dépendance, style `Sparkline`) : points relevés
+  reliés, trous = segment interrompu, vrai 0 = point sur l'axe, bande couverture
+  dessous.
+
+## Lot 6.2 — Coût au œuf (transparence)
+
+Décision produit : **coût au œuf = alimentation + soins**, hors équipement
+durable amorti.
+
+Traduction concrète sur l'existant (aucun champ « catégorie » à ajouter) :
+- **Alimentation** = achats du `StockItem` nourriture lié (`kind='stock_purchase'`
+  sur l'item), déjà compté.
+- **Soins / troupeau** = achats déclarés sur une poule
+  (`kind='chickens_purchase'` : vétérinaire, vermifuge, acquisition), déjà comptés.
+- **Équipement durable** (mangeoire, poulailler) vit dans son propre module et
+  **n'est pas** un `chickens_purchase` → naturellement exclu.
+
+`_cost_totals` renvoie en plus une **répartition** `{feed_total, flock_total}`
+pour que la card affiche ce qui est compté (transparence). Le coût au œuf reste
+`dépenses ÷ œufs total`. Cas limites conservés : 0 œuf → `per_egg=null` (pas de
+division par zéro) ; 0 dépense → `per_egg=null`.
+
+## Lot 6.3 — Alerte de chute de ponte anormale (croisée météo / mue)
+
+**Backend** — `chickens/alerts.py::evaluate_egg_drop_alert(household, today=None)`,
+fonction **pure** (aucune écriture), sur le modèle de `weather/alerts.py` :
+
+- **Baseline** : moyenne des œufs/jour-relevé sur les jours `[today-37 .. today-8]`
+  (≈ 30 j finissant une semaine avant).
+- **Récent** : moyenne sur `[today-6 .. today]`.
+- **Garde-fou couverture** : pas d'alerte si baseline < `MIN_BASELINE_DAYS`
+  (10 jours relevés) ou récent < `MIN_RECENT_DAYS` (3 jours relevés). Évite de
+  crier « effondrement » sur quelques jours non saisis.
+- **Déclenchement** : `recent_avg <= baseline_avg × (1 − DROP_THRESHOLD)`
+  (`DROP_THRESHOLD = 0.4`, soit −40 %). Sévérité `critical` si chute ≥ 60 %.
+- **Cause probable** (ordre de priorité) :
+  - `molt` — un `ChickenEvent` type `molt` daté dans les ~45 derniers jours ;
+  - `weather` — `weather.alerts.evaluate_weather_alerts` renvoie frost/heatwave ;
+  - `unknown` — sinon (« à surveiller »).
+- Renvoie `{kind:'egg_drop', severity, drop_pct, baseline_avg, recent_avg, cause,
+  entity_url:'/app/chickens'}` ou `None`.
+
+**Câblage alertes** — `alerts.services.build_alerts_summary` gagne
+`egg_drop_alerts` (liste 0/1), gaté par `'chickens' in disabled_modules`
+(comme `_weather_alerts` pour la météo). Même pattern : import direct de la
+fonction pure de l'app propriétaire, rendu client-side depuis les champs
+structurés.
+
+**Frontend** — type `EggDropAlert` + section dédiée dans `AlertsPage`, message
+selon la cause (`alerts.eggDrop.molt` / `.weather` / `.unknown`).
+
+**V1 : canal on-read uniquement** (dashboard/page alertes). Pas de ping Telegram
+dédié — le garde-fou couverture et la fenêtre glissante suffisent ; un ping
+pourra s'ajouter plus tard via `PingSpec` (comme `weather_alert`).
+
+## Lot 6.4 — Tool agent `get_chicken_stats`
+
+Comme la météo (`get_weather`), les stats sont des **agrégats**, pas des lignes
+listables → tool de lecture dédié plutôt qu'un `SearchableSpec`.
+
+`chickens/agent.py::get_chicken_stats` (enregistré depuis `chickens/apps.py`,
+zéro modification de `apps/agent/`) : renvoie effectif, ponte du jour / 7 j / 30 j,
+taux de relevé, coût au œuf, et l'état de l'alerte de chute (avec cause). Permet
+« combien d'œufs cette semaine ? », « la ponte a-t-elle baissé ? », « combien me
+coûte un œuf ? ».
+
+## Carte d'intégration
+
+| Brique existante | Connexion |
+|---|---|
+| `EggLog` | Source des stats + baseline de l'alerte (jours relevés only) |
+| `ChickenEvent` (molt) | Qualifie la cause « mue » de l'alerte |
+| `weather.alerts` | Qualifie la cause « météo » (lecture seule, gaté module) |
+| `interactions` | Coût au œuf (feed stock_purchase + chickens_purchase) |
+| `alerts` | Nouvelle catégorie `egg_drop` dans le résumé |
+| `agent` | Tool `get_chicken_stats` déclaré depuis `chickens/apps.py` |
+
+## Découpage en lots / issues
+
+- **Lot 6.1 — Courbe de ponte** : `egg_stats` période + couverture, `EggChart` (feat, app:chickens, i18n)
+- **Lot 6.2 — Coût au œuf** : répartition + transparence (feat, app:chickens, i18n)
+- **Lot 6.3 — Alerte de chute** : `chickens/alerts.py` + câblage `alerts` + météo/mue (feat, app:chickens, app:alerts, app:weather, i18n)
+- **Lot 6.4 — Tool agent** : `get_chicken_stats` (feat, app:chickens, app:agent)
+
+Issues GitHub : « Parcours 14 — Lot 6.N : … ».
+
+## Limites acceptées (V1 de ce lot)
+
+- Coût au œuf sur **tout l'historique** (pas ramené à la période) — chiffre
+  « depuis toujours », stable ; la répartition feed/flock donne le détail.
+- Alerte de chute **on-read** seulement (pas de push).
+- Estimation visuelle des jours manquants : **hors périmètre** (décision : ne
+  jamais imputer dans les chiffres ; l'estimation resterait un toggle purement
+  cosmétique).
+- Seuils de l'alerte figés en constantes (pas d'UI de réglage).

--- a/e2e/chickens.spec.ts
+++ b/e2e/chickens.spec.ts
@@ -225,6 +225,30 @@ test.describe('Poulailler', () => {
     await expect(page.getByText('Décès')).toBeVisible();
   });
 
+  // ── 5b. Stats de ponte — sélecteur de période + taux de relevé ────────────
+
+  test('affiche la courbe de ponte avec période et taux de relevé', async ({ page }) => {
+    const token = await getAccessToken(page);
+    // A hen + one logged day today → the stats card shows real data.
+    await page.request.post('/api/chickens/', {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { name: `Poule Stats ${Date.now()}`, breed: '' },
+    });
+    await page.request.post('/api/chickens/egg-logs/', {
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      data: { date: new Date().toISOString().slice(0, 10), count: 4 },
+    });
+    await page.reload();
+
+    // Stats card title + coverage over the default 30-day window (1 logged day).
+    await expect(page.getByText('🥚 Ponte', { exact: true })).toBeVisible();
+    await expect(page.getByText('1/30 jours relevés')).toBeVisible();
+
+    // Switch to the 7-day period → coverage denominator updates.
+    await page.getByRole('button', { name: '7 j', exact: true }).click();
+    await expect(page.getByText('1/7 jours relevés')).toBeVisible();
+  });
+
   // ── 5. Suppression d'un événement avec undo ───────────────────────────────
 
   test('supprime un événement et peut annuler (undo)', async ({ page }) => {

--- a/ui/src/features/alerts/AlertsPage.tsx
+++ b/ui/src/features/alerts/AlertsPage.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation } from 'react-router-dom';
-import { AlertTriangle, Bell, Clock, CloudSun, Package, ShieldCheck, Wrench } from 'lucide-react';
+import { AlertTriangle, Bell, Clock, CloudSun, Egg, Package, ShieldCheck, Wrench } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { pushBack } from '@/lib/backNavigation';
 import EmptyState from '@/components/EmptyState';
@@ -11,6 +11,7 @@ import { cn } from '@/lib/utils';
 import {
   type AlertSeverity,
   type DueMaintenanceAlert,
+  type EggDropAlert,
   type ExpiringWarrantyAlert,
   type LowStockAlert,
   type OverdueTaskAlert,
@@ -81,6 +82,7 @@ export default function AlertsPage() {
     due_maintenances: [],
     low_stock: [],
     weather_alerts: [],
+    egg_drop_alerts: [],
     total: 0,
   };
 
@@ -212,6 +214,31 @@ export default function AlertsPage() {
                     weekday: 'long',
                     day: 'numeric',
                     month: 'short',
+                  })}
+                  severityLabel={t(`alerts.severity.${item.severity}`)}
+                  severity={item.severity}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {summary.egg_drop_alerts.length > 0 ? (
+          <section>
+            <h2 className="mb-2 flex items-center gap-2 text-sm font-semibold text-foreground">
+              <Egg className="h-4 w-4 text-amber-500" aria-hidden />
+              {t('alerts.sections.eggDrop')}
+              <span className="text-muted-foreground">({summary.egg_drop_alerts.length})</span>
+            </h2>
+            <div className="space-y-2">
+              {summary.egg_drop_alerts.map((item: EggDropAlert, index: number) => (
+                <AlertCard
+                  key={`egg-drop-${index}`}
+                  to={item.entity_url}
+                  title={t('alerts.eggDrop.title', { percent: item.drop_pct })}
+                  meta={t(`alerts.eggDrop.cause.${item.cause}`, {
+                    recent: item.recent_avg,
+                    baseline: item.baseline_avg,
                   })}
                   severityLabel={t(`alerts.severity.${item.severity}`)}
                   severity={item.severity}

--- a/ui/src/features/chickens/ChickensPage.tsx
+++ b/ui/src/features/chickens/ChickensPage.tsx
@@ -127,6 +127,9 @@ export default function ChickensPage() {
               <p className="mt-0.5 text-xs text-muted-foreground">
                 {t('chickens.cost.totals', { total: cost.total, year: cost.year })}
               </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {t('chickens.cost.breakdown', { feed: cost.feed_total, flock: cost.flock_total })}
+              </p>
             </Card>
           ) : null}
         </div>

--- a/ui/src/features/chickens/EggChart.tsx
+++ b/ui/src/features/chickens/EggChart.tsx
@@ -1,0 +1,100 @@
+import { useTranslation } from 'react-i18next';
+import type { EggStatsPoint } from '@/lib/api/chickens';
+
+interface EggChartProps {
+  series: EggStatsPoint[];
+  height?: number;
+  className?: string;
+}
+
+/**
+ * Laying curve — dependency-free SVG. The module's pivot made visible:
+ * - a **logged** day (incl. count 0) is a dot; consecutive logged days are lined;
+ * - a **gap** (count === null, day never logged) breaks the line — never a zero;
+ * - a real **0** sits as a dot on the baseline (a visible dip, distinct from a gap);
+ * - a **coverage strip** underneath shows one cell per day (filled = logged),
+ *   so missing days are readable at a glance.
+ */
+export default function EggChart({ series, height = 96, className }: EggChartProps) {
+  const { t } = useTranslation();
+  const width = 320;
+  const stripH = 10;
+  const gap = 6;
+  const pad = 4;
+  const chartH = height - stripH - gap;
+
+  const n = series.length;
+  if (n === 0) return null;
+
+  const maxCount = Math.max(1, ...series.map((p) => p.count ?? 0));
+  const x = (i: number) => (n === 1 ? width / 2 : pad + (i * (width - 2 * pad)) / (n - 1));
+  const y = (v: number) => pad + (chartH - 2 * pad) * (1 - v / maxCount);
+
+  // Split into segments of consecutive logged days so gaps break the line.
+  const segments: { i: number; v: number }[][] = [];
+  let current: { i: number; v: number }[] = [];
+  series.forEach((point, i) => {
+    if (point.count == null) {
+      if (current.length) segments.push(current);
+      current = [];
+    } else {
+      current.push({ i, v: point.count });
+    }
+  });
+  if (current.length) segments.push(current);
+
+  const dots = segments.flat();
+
+  return (
+    <svg
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      role="img"
+      aria-label={t('chickens.eggs.chart_aria')}
+      preserveAspectRatio="none"
+    >
+      {/* baseline */}
+      <line
+        x1={pad}
+        y1={y(0)}
+        x2={width - pad}
+        y2={y(0)}
+        className="stroke-border"
+        strokeWidth={1}
+      />
+      {/* lines between consecutive logged days */}
+      {segments.map((seg, si) =>
+        seg.length >= 2 ? (
+          <polyline
+            key={`seg-${si}`}
+            fill="none"
+            className="stroke-primary"
+            strokeWidth={2}
+            strokeLinejoin="round"
+            strokeLinecap="round"
+            points={seg.map((d) => `${x(d.i)},${y(d.v)}`).join(' ')}
+          />
+        ) : null,
+      )}
+      {/* dots on every logged day (a real 0 lands on the baseline) */}
+      {dots.map((d) => (
+        <circle key={`dot-${d.i}`} cx={x(d.i)} cy={y(d.v)} r={2.5} className="fill-primary" />
+      ))}
+      {/* coverage strip: one cell per day, filled = logged */}
+      {series.map((point, i) => {
+        const cellW = (width - 2 * pad) / n;
+        return (
+          <rect
+            key={`cov-${i}`}
+            x={pad + i * cellW + 0.5}
+            y={height - stripH}
+            width={Math.max(1, cellW - 1)}
+            height={stripH}
+            rx={1}
+            className={point.count == null ? 'fill-muted' : 'fill-primary/60'}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/ui/src/features/chickens/EggStatsSection.tsx
+++ b/ui/src/features/chickens/EggStatsSection.tsx
@@ -1,43 +1,64 @@
 import { useTranslation } from 'react-i18next';
 import { Card, CardTitle } from '@/design-system/card';
-import Sparkline from '@/components/Sparkline';
+import { FilterPill } from '@/design-system/filter-pill';
+import { useSessionState } from '@/lib/useSessionState';
+import { EGG_STATS_PERIODS, type EggStatsPeriod } from '@/lib/api/chickens';
+import EggChart from './EggChart';
 import { useEggStats } from './hooks';
 
 /**
- * Laying trends (US-4): today, 7/30-day averages, month total + 30-day sparkline.
- * Days without a log are missing (null), not zero — they are skipped in the line.
+ * Laying trends + curve (Lot 6.1). A day without a log is unknown, never zero:
+ * averages divide by logged days only, the coverage line shows how many days
+ * were recorded, and the chart breaks the line at gaps.
  */
 export default function EggStatsSection() {
   const { t } = useTranslation();
-  const { data: stats } = useEggStats();
+  const [period, setPeriod] = useSessionState<EggStatsPeriod>('chickens.eggStats.period', 30);
+  const { data: stats } = useEggStats(period);
 
   if (!stats) return null;
   const hasAny = stats.total > 0;
-
-  const points = stats.series
-    .filter((point) => point.count != null)
-    .map((point) => ({ t: `${point.date}T12:00:00`, v: point.count as number }));
+  const { coverage } = stats;
 
   return (
     <Card className="p-4">
-      <CardTitle className="text-sm text-muted-foreground">
-        {`🥚 ${t('chickens.eggs.stats_title')}`}
-      </CardTitle>
+      <div className="flex items-center justify-between gap-2">
+        <CardTitle className="text-sm text-muted-foreground">
+          {`🥚 ${t('chickens.eggs.stats_title')}`}
+        </CardTitle>
+        <div className="flex gap-1">
+          {EGG_STATS_PERIODS.map((p) => (
+            <FilterPill key={p} active={period === p} onClick={() => setPeriod(p)}>
+              {t(`chickens.eggs.period.${p}`)}
+            </FilterPill>
+          ))}
+        </div>
+      </div>
+
       {!hasAny ? (
         <p className="mt-2 text-sm text-muted-foreground">{t('chickens.eggs.stats_empty')}</p>
       ) : (
         <>
           <div className="mt-3 grid grid-cols-2 gap-3 sm:grid-cols-4">
             <Stat label={t('chickens.eggs.stat_today')} value={stats.today ?? '—'} />
-            <Stat label={t('chickens.eggs.stat_avg7')} value={stats.avg_7d ?? '—'} />
-            <Stat label={t('chickens.eggs.stat_avg30')} value={stats.avg_30d ?? '—'} />
-            <Stat label={t('chickens.eggs.stat_month')} value={stats.month_total} />
+            <Stat label={t('chickens.eggs.stat_period_total')} value={stats.period_total} />
+            <Stat label={t('chickens.eggs.stat_period_avg')} value={stats.period_avg ?? '—'} />
+            <Stat
+              label={t('chickens.eggs.stat_best')}
+              value={stats.best_day ? stats.best_day.count : '—'}
+            />
           </div>
-          {points.length >= 2 ? (
-            <div className="mt-3 text-primary">
-              <Sparkline points={points} width={280} height={40} className="w-full" />
-            </div>
-          ) : null}
+
+          <div className="mt-3">
+            <EggChart series={stats.series} className="h-24 w-full" />
+          </div>
+
+          <p className="mt-2 text-xs text-muted-foreground">
+            {t('chickens.eggs.coverage', {
+              logged: coverage.logged_days,
+              total: coverage.total_days,
+            })}
+          </p>
         </>
       )}
     </Card>

--- a/ui/src/features/chickens/hooks.ts
+++ b/ui/src/features/chickens/hooks.ts
@@ -23,6 +23,7 @@ import {
   type ChickenEventPayload,
   type ChickenPayload,
   type ChickenPurchasePayload,
+  type EggStatsPeriod,
 } from '@/lib/api/chickens';
 import { toast } from '@/lib/toast';
 
@@ -32,7 +33,7 @@ export const chickenKeys = {
     [...chickenKeys.all, 'list', filters] as const,
   detail: (id: string) => [...chickenKeys.all, 'detail', id] as const,
   eggLogs: () => [...chickenKeys.all, 'egg-logs'] as const,
-  eggStats: () => [...chickenKeys.all, 'egg-stats'] as const,
+  eggStats: (period: EggStatsPeriod = 30) => [...chickenKeys.all, 'egg-stats', period] as const,
   events: (filters?: { chicken?: string }) => [...chickenKeys.all, 'events', filters] as const,
   settings: () => [...chickenKeys.all, 'settings'] as const,
   summary: () => [...chickenKeys.all, 'summary'] as const,
@@ -60,10 +61,10 @@ export function useEggLogs(filters: { date_from?: string; date_to?: string } = {
   });
 }
 
-export function useEggStats() {
+export function useEggStats(period: EggStatsPeriod = 30) {
   return useQuery({
-    queryKey: chickenKeys.eggStats(),
-    queryFn: fetchEggStats,
+    queryKey: chickenKeys.eggStats(period),
+    queryFn: () => fetchEggStats(period),
   });
 }
 

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -63,7 +63,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'water', moduleKey: 'water', to: '/app/water', stepIds: ['readings', 'charts'] },
   { key: 'weather', moduleKey: 'weather', to: '/app/weather', stepIds: ['location', 'forecast', 'dashboard', 'alerts'] },
   { key: 'stock', moduleKey: 'stock', to: '/app/stock', stepIds: ['add', 'quantities', 'expiry'] },
-  { key: 'chickens', moduleKey: 'chickens', to: '/app/chickens', stepIds: ['flock', 'eggs', 'events'] },
+  { key: 'chickens', moduleKey: 'chickens', to: '/app/chickens', stepIds: ['flock', 'eggs', 'events', 'stats'] },
   { key: 'insurance', moduleKey: 'insurance', to: '/app/insurance', stepIds: ['contracts', 'documents'] },
   { key: 'tasks', moduleKey: 'tasks', to: '/app/tasks', stepIds: ['create', 'organize', 'weather', 'complete'] },
   { key: 'projects', moduleKey: 'projects', to: '/app/projects', stepIds: ['create', 'plan', 'budget'] },

--- a/ui/src/lib/api/alerts.ts
+++ b/ui/src/lib/api/alerts.ts
@@ -40,12 +40,25 @@ export interface LowStockAlert {
   severity: AlertSeverity;
 }
 
+export type EggDropCause = 'molt' | 'weather' | 'unknown';
+
+export interface EggDropAlert {
+  kind: 'egg_drop';
+  severity: AlertSeverity;
+  drop_pct: number;
+  baseline_avg: number;
+  recent_avg: number;
+  cause: EggDropCause;
+  entity_url: string;
+}
+
 export interface AlertsSummary {
   overdue_tasks: OverdueTaskAlert[];
   expiring_warranties: ExpiringWarrantyAlert[];
   due_maintenances: DueMaintenanceAlert[];
   low_stock: LowStockAlert[];
   weather_alerts: WeatherAlert[];
+  egg_drop_alerts: EggDropAlert[];
   total: number;
 }
 

--- a/ui/src/lib/api/chickens.ts
+++ b/ui/src/lib/api/chickens.ts
@@ -59,15 +59,30 @@ export interface EggLog {
 
 export interface EggStatsPoint {
   date: string;
+  /** null = the day was never logged (unknown, not zero) — the chart breaks the line. */
   count: number | null;
 }
 
+export type EggStatsPeriod = 7 | 30 | 90 | 365;
+export const EGG_STATS_PERIODS: EggStatsPeriod[] = [7, 30, 90, 365];
+
+export interface EggStatsCoverage {
+  logged_days: number;
+  total_days: number;
+  rate: number;
+}
+
 export interface EggStats {
+  period: EggStatsPeriod;
   today: number | null;
   avg_7d: number | null;
   avg_30d: number | null;
   month_total: number;
   total: number;
+  period_total: number;
+  period_avg: number | null;
+  best_day: { date: string; count: number } | null;
+  coverage: EggStatsCoverage;
   series: EggStatsPoint[];
 }
 
@@ -125,6 +140,8 @@ export interface FlockSummary {
   cost: {
     total: string;
     year: string;
+    feed_total: string;
+    flock_total: string;
     per_egg: string | null;
     eggs_total: number;
   };
@@ -213,8 +230,8 @@ export async function deleteEggLog(id: string): Promise<void> {
   await api.delete(`/chickens/egg-logs/${id}/`);
 }
 
-export async function fetchEggStats(): Promise<EggStats> {
-  const { data } = await api.get('/chickens/egg-logs/stats/');
+export async function fetchEggStats(period: EggStatsPeriod = 30): Promise<EggStats> {
+  const { data } = await api.get('/chickens/egg-logs/stats/', { params: { period } });
   return data as EggStats;
 }
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1119,6 +1119,10 @@
           "events": {
             "title": "Ereignisse festhalten",
             "body": "Pflege, Brut, Mauser, Tod: der Eintrag jeder Henne behält ihre Chronik."
+          },
+          "stats": {
+            "title": "Legeleistung und Kosten verfolgen",
+            "body": "Wählen Sie einen Zeitraum für die Legekurve: nicht erfasste Tage erscheinen nie als 0, und die Erfassungsquote bleibt sichtbar. Kosten pro Ei (Futter + Pflege) und eine Warnung bei Rückgang (Mauser, Wetter) ergänzen das Bild."
           }
         }
       },
@@ -2298,7 +2302,18 @@
       "stat_today": "Heute",
       "stat_avg7": "Ø 7 T",
       "stat_avg30": "Ø 30 T",
-      "stat_month": "Diesen Monat"
+      "stat_month": "Diesen Monat",
+      "period": {
+        "7": "7 T",
+        "30": "30 T",
+        "90": "90 T",
+        "365": "1 J"
+      },
+      "stat_period_total": "Zeitraum gesamt",
+      "stat_period_avg": "Ø / Tag",
+      "stat_best": "Bester Tag",
+      "coverage": "{{logged}}/{{total}} Tage erfasst",
+      "chart_aria": "Legekurve"
     },
     "events": {
       "title": "Journal",
@@ -2354,7 +2369,8 @@
     "cost": {
       "title": "Kosten",
       "per_egg": "{{amount}} € / Ei",
-      "totals": "{{total}} € gesamt · {{year}} € dieses Jahr"
+      "totals": "{{total}} € gesamt · {{year}} € dieses Jahr",
+      "breakdown": "Futter {{feed}} € · Herde {{flock}} €"
     },
     "tabs": {
       "info": "Info",
@@ -2379,7 +2395,8 @@
       "warranties": "Auslaufende Garantien",
       "maintenances": "Anstehende Wartungen",
       "stock": "Vorrat auffüllen",
-      "weather": "Wetter"
+      "weather": "Wetter",
+      "eggDrop": "Rückgang der Legeleistung"
     },
     "severity": {
       "critical": "Dringend",
@@ -2403,6 +2420,14 @@
       "wind": "Starker Wind: Böen bis zu {{value}} km/h",
       "storm": "Gewitter erwartet",
       "ahead": "Kommende Tage"
+    },
+    "eggDrop": {
+      "title": "Legeleistung {{percent}} % niedriger",
+      "cause": {
+        "molt": "Wahrscheinlich Mauser · {{recent}} statt {{baseline}} Eier/Tag",
+        "weather": "Kürzlich extremes Wetter · {{recent}} statt {{baseline}} Eier/Tag",
+        "unknown": "Unklare Ursache, beobachten · {{recent}} statt {{baseline}} Eier/Tag"
+      }
     }
   },
   "agent": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1119,6 +1119,10 @@
           "events": {
             "title": "Record events",
             "body": "Care, brooding, moulting, death: each hen's record keeps its timeline."
+          },
+          "stats": {
+            "title": "Track laying and cost",
+            "body": "Pick a period for the laying curve: un-logged days never show as 0, and the coverage rate stays visible. Cost per egg (feed + care) and an abnormal-drop alert (molt, weather) round it out."
           }
         }
       },
@@ -2298,7 +2302,18 @@
       "stat_today": "Today",
       "stat_avg7": "Avg 7 d",
       "stat_avg30": "Avg 30 d",
-      "stat_month": "This month"
+      "stat_month": "This month",
+      "period": {
+        "7": "7d",
+        "30": "30d",
+        "90": "90d",
+        "365": "1y"
+      },
+      "stat_period_total": "Period total",
+      "stat_period_avg": "Avg / day",
+      "stat_best": "Best day",
+      "coverage": "{{logged}}/{{total}} days logged",
+      "chart_aria": "Laying curve"
     },
     "events": {
       "title": "Journal",
@@ -2354,7 +2369,8 @@
     "cost": {
       "title": "Cost",
       "per_egg": "{{amount}} € / egg",
-      "totals": "{{total}} € total · {{year}} € this year"
+      "totals": "{{total}} € total · {{year}} € this year",
+      "breakdown": "Feed {{feed}} € · flock {{flock}} €"
     },
     "tabs": {
       "info": "Info",
@@ -2379,7 +2395,8 @@
       "warranties": "Warranties to watch",
       "maintenances": "Upcoming maintenances",
       "stock": "Stock to restock",
-      "weather": "Weather"
+      "weather": "Weather",
+      "eggDrop": "Egg-laying drop"
     },
     "severity": {
       "critical": "Urgent",
@@ -2403,6 +2420,14 @@
       "wind": "Strong wind: gusts up to {{value}} km/h",
       "storm": "Thunderstorm expected",
       "ahead": "Coming days"
+    },
+    "eggDrop": {
+      "title": "Laying down {{percent}}%",
+      "cause": {
+        "molt": "Likely molt · {{recent}} vs {{baseline}} eggs/day",
+        "weather": "Recent extreme weather · {{recent}} vs {{baseline}} eggs/day",
+        "unknown": "Unknown cause, keep an eye · {{recent}} vs {{baseline}} eggs/day"
+      }
     }
   },
   "agent": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1119,6 +1119,10 @@
           "events": {
             "title": "Registrar los eventos",
             "body": "Cuidados, incubación, muda, muerte: la ficha de cada gallina guarda su cronología."
+          },
+          "stats": {
+            "title": "Seguir la puesta y el coste",
+            "body": "Elige un periodo para la curva de puesta: los días sin registrar nunca aparecen como 0 y la tasa de registro queda visible. El coste por huevo (pienso + cuidados) y una alerta de caída (muda, clima) lo completan."
           }
         }
       },
@@ -2298,7 +2302,18 @@
       "stat_today": "Hoy",
       "stat_avg7": "Prom. 7 d",
       "stat_avg30": "Prom. 30 d",
-      "stat_month": "Este mes"
+      "stat_month": "Este mes",
+      "period": {
+        "7": "7 d",
+        "30": "30 d",
+        "90": "90 d",
+        "365": "1 año"
+      },
+      "stat_period_total": "Total periodo",
+      "stat_period_avg": "Prom. / día",
+      "stat_best": "Mejor día",
+      "coverage": "{{logged}}/{{total}} días registrados",
+      "chart_aria": "Curva de puesta"
     },
     "events": {
       "title": "Diario",
@@ -2354,7 +2369,8 @@
     "cost": {
       "title": "Coste",
       "per_egg": "{{amount}} € / huevo",
-      "totals": "{{total}} € en total · {{year}} € este año"
+      "totals": "{{total}} € en total · {{year}} € este año",
+      "breakdown": "Pienso {{feed}} € · gallinas {{flock}} €"
     },
     "tabs": {
       "info": "Info",
@@ -2379,7 +2395,8 @@
       "warranties": "Garantías a vigilar",
       "maintenances": "Mantenimientos a planificar",
       "stock": "Stock por reponer",
-      "weather": "Tiempo"
+      "weather": "Tiempo",
+      "eggDrop": "Caída de puesta"
     },
     "severity": {
       "critical": "Urgente",
@@ -2403,6 +2420,14 @@
       "wind": "Viento fuerte: rachas de hasta {{value}} km/h",
       "storm": "Tormenta prevista",
       "ahead": "Próximos días"
+    },
+    "eggDrop": {
+      "title": "Puesta baja un {{percent}} %",
+      "cause": {
+        "molt": "Probablemente muda · {{recent}} vs {{baseline}} huevos/día",
+        "weather": "Clima extremo reciente · {{recent}} vs {{baseline}} huevos/día",
+        "unknown": "Causa desconocida, vigilar · {{recent}} vs {{baseline}} huevos/día"
+      }
     }
   },
   "agent": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1119,6 +1119,10 @@
           "events": {
             "title": "Consigner les événements",
             "body": "Soins, couvaison, mue, décès : la fiche de chaque poule garde sa chronologie."
+          },
+          "stats": {
+            "title": "Suivre la ponte et le coût",
+            "body": "Choisissez une période pour la courbe de ponte : les jours non relevés n'apparaissent pas comme des 0 et le taux de relevé reste visible. Le coût au œuf (alimentation + soins) et une alerte de chute de ponte (mue, météo) complètent le tableau."
           }
         }
       },
@@ -2298,7 +2302,18 @@
       "stat_today": "Aujourd'hui",
       "stat_avg7": "Moy. 7 j",
       "stat_avg30": "Moy. 30 j",
-      "stat_month": "Ce mois-ci"
+      "stat_month": "Ce mois-ci",
+      "period": {
+        "7": "7 j",
+        "30": "30 j",
+        "90": "90 j",
+        "365": "1 an"
+      },
+      "stat_period_total": "Total période",
+      "stat_period_avg": "Moy. / jour",
+      "stat_best": "Meilleur jour",
+      "coverage": "{{logged}}/{{total}} jours relevés",
+      "chart_aria": "Courbe de ponte"
     },
     "events": {
       "title": "Journal",
@@ -2354,7 +2369,8 @@
     "cost": {
       "title": "Coût",
       "per_egg": "{{amount}} € / œuf",
-      "totals": "{{total}} € au total · {{year}} € cette année"
+      "totals": "{{total}} € au total · {{year}} € cette année",
+      "breakdown": "Aliment {{feed}} € · troupeau {{flock}} €"
     },
     "tabs": {
       "info": "Infos",
@@ -2379,7 +2395,8 @@
       "warranties": "Garanties à surveiller",
       "maintenances": "Maintenances à planifier",
       "stock": "Stock à réapprovisionner",
-      "weather": "Météo"
+      "weather": "Météo",
+      "eggDrop": "Chute de ponte"
     },
     "severity": {
       "critical": "Urgent",
@@ -2403,6 +2420,14 @@
       "wind": "Vent fort : rafales jusqu'à {{value}} km/h",
       "storm": "Orage prévu",
       "ahead": "Jours à venir"
+    },
+    "eggDrop": {
+      "title": "Ponte en baisse de {{percent}} %",
+      "cause": {
+        "molt": "Probablement la mue · {{recent}} vs {{baseline}} œufs/jour",
+        "weather": "Météo extrême récente · {{recent}} vs {{baseline}} œufs/jour",
+        "unknown": "Cause inconnue, à surveiller · {{recent}} vs {{baseline}} œufs/jour"
+      }
     }
   },
   "agent": {


### PR DESCRIPTION
Closes #303
Closes #304
Closes #305
Closes #306

## Quoi

Lot 6 du module poulailler — exploite `EggLog` + `ChickenEvent` (déjà là) pour trois lectures à forte valeur, **sans nouveau modèle**.

**Décision produit pivot** : un jour sans `EggLog` est *inconnu*, jamais un 0. Les moyennes divisent par les jours **relevés**, un **taux de relevé** est exposé partout, et rien n'est imputé dans les chiffres. Cadrage : `docs/parcours/PARCOURS_14_LOT6_STATS_SANTE_TROUPEAU.md`.

- **Courbe de ponte** (6.1) : `egg_stats(period)` (7/30/90/365 j) → `series` (`count=null` si non relevé), `coverage`, `period_total/avg`, `best_day`. Nouveau `EggChart` SVG : trous = ligne interrompue, vrai 0 = point sur l'axe, bande couverture dessous.
- **Coût au œuf transparent** (6.2) : `_cost_totals` renvoie la répartition `{feed_total, flock_total}` = alimentation + soins, hors équipement durable (naturellement exclu).
- **Alerte de chute anormale** (6.3) : `chickens/alerts.py::evaluate_egg_drop_alert`, fonction **pure** (modèle `weather/alerts.py`). Baseline vs récent sur jours relevés, garde-fous couverture, cause qualifiée **mue > météo > inconnue**. Câblée on-read dans `alerts.services.build_alerts_summary` (gaté `chickens` in `disabled_modules`), rendue dans `AlertsPage`.
- **Tool agent** (6.4) : `get_chicken_stats` enregistré depuis `chickens/apps.py` — **zéro modif de `apps/agent/`**.

## Critères des issues

- [x] `egg_stats` période + couverture, agrégats sur jours relevés, endpoint `?period=`
- [x] `EggChart` : trous ≠ 0, vrai 0 sur l'axe, bande couverture, sélecteur persisté
- [x] Coût = feed + flock, répartition affichée, cas limites (0 œuf / 0 dépense → `per_egg=null`)
- [x] Alerte pure, garde-fous MIN_BASELINE/RECENT, seuils −40/−60 %, cause mue/météo/inconnue
- [x] Câblage alerts gaté module + rendu client-side
- [x] `get_chicken_stats` (effectif, ponte, couverture, coût, état alerte)
- [x] i18n 4 langues, tutoriel, docs (parcours + fiche module), tests backend (22 nouveaux, 2025 verts)

## Hors scope (assumé)

Estimation visuelle des jours manquants (décision : ne jamais imputer dans les chiffres), ping Telegram de l'alerte (on-read only en V1), seuils configurables via UI.

## Note de test

E2E : test ajouté (`e2e/chickens.spec.ts`, sélecteur période + couverture) et validé en parsing ; non exécuté en local (worktree sans venv, CI ne lance pas Playwright).
