### PR TITLE
feat(documents): onglets Documents/Photos génériques + onglet poule

### DIFF
--- a/apps/chickens/models.py
+++ b/apps/chickens/models.py
@@ -8,6 +8,7 @@ ChickenSettings only references the household's feed stock item.
 """
 import uuid
 
+from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 
 from core.managers import HouseholdScopedManager
@@ -48,6 +49,9 @@ class Chicken(HouseholdScopedModel):
         related_name='chickens',
         db_column='zone_id',
     )
+    # Polymorphic document/photo links (renovation-style before/after photos,
+    # vet papers…) — mirrors Project/Zone/Equipment. No schema change.
+    document_links = GenericRelation('documents.DocumentLink')
 
     objects = HouseholdScopedManager()
 

--- a/apps/chickens/serializers.py
+++ b/apps/chickens/serializers.py
@@ -13,6 +13,10 @@ class ChickenSerializer(serializers.ModelSerializer):
 
     zone_name = serializers.SerializerMethodField()
     zone_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    # Items behind each detail tab (events/documents/photos). Filled ONLY on the
+    # retrieve (detail) — null in list, to avoid paying the counts per hen. The
+    # frontend hides tabs at 0. Mirrors ProjectSerializer.tab_counts.
+    tab_counts = serializers.SerializerMethodField()
 
     class Meta:
         model = Chicken
@@ -21,12 +25,21 @@ class ChickenSerializer(serializers.ModelSerializer):
             'name', 'breed', 'color', 'hatched_on', 'acquired_on',
             'status', 'notes',
             'zone', 'zone_id', 'zone_name',
+            'tab_counts',
             'created_at', 'updated_at', 'created_by',
         ]
         read_only_fields = ['id', 'household', 'zone', 'created_at', 'updated_at', 'created_by']
 
     def get_zone_name(self, obj):
         return obj.zone.name if obj.zone_id and obj.zone else None
+
+    def get_tab_counts(self, obj):
+        view = self.context.get('view')
+        if view is not None and getattr(view, 'action', None) != 'retrieve':
+            return None
+        from .services import chicken_tab_counts
+
+        return chicken_tab_counts(obj)
 
     def validate_name(self, value):
         if not value or not value.strip():

--- a/apps/chickens/services.py
+++ b/apps/chickens/services.py
@@ -394,3 +394,24 @@ def flock_summary(household, *, today: date | None = None) -> dict:
         'cost': _cost_totals(household, today=today, feed_stock_item=item),
         'has_data': has_data,
     }
+
+
+def chicken_tab_counts(chicken: Chicken) -> dict[str, int]:
+    """Number of items behind each tab of the chicken detail page.
+
+    Consumed by ``ChickenSerializer`` (detail only) so the frontend can hide
+    empty tabs. A couple of aggregate queries — fine for a single object, NOT
+    on a list (would N+1). Mirrors ``projects.services.project_tab_counts``.
+    """
+    from django.contrib.contenttypes.models import ContentType
+
+    from documents.models import DocumentLink
+
+    chicken_ct = ContentType.objects.get_for_model(Chicken)
+    links = DocumentLink.objects.filter(content_type=chicken_ct, object_id=chicken.id)
+
+    return {
+        'events': ChickenEvent.objects.filter(chicken=chicken).count(),
+        'documents': links.exclude(document__type='photo').count(),
+        'photos': links.filter(document__type='photo').count(),
+    }

--- a/apps/chickens/tests/test_document_links.py
+++ b/apps/chickens/tests/test_document_links.py
@@ -1,0 +1,166 @@
+# chickens/tests/test_document_links.py
+"""
+Document/photo linking on the chicken detail (harmonisation onglets docs/photos).
+
+Coverage:
+  1. chicken_tab_counts() — events/documents/photos split by document type.
+  2. ChickenSerializer.tab_counts — populated on retrieve, null on list.
+  3. DocumentLinkActionsMixin on ChickenViewSet — attach/detach/set_phase.
+  4. GET /api/documents/documents/?chicken=<id> filters via DocumentLink.
+"""
+from __future__ import annotations
+
+import pytest
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from chickens.models import Chicken, ChickenEvent
+from chickens.services import chicken_tab_counts
+from documents.models import Document, DocumentLink
+from households.models import HouseholdMember
+
+from .factories import (
+    ChickenEventFactory,
+    ChickenFactory,
+    HouseholdFactory,
+    HouseholdMemberFactory,
+    UserFactory,
+)
+
+
+def _owner(household):
+    user = UserFactory()
+    HouseholdMemberFactory(household=household, user=user, role=HouseholdMember.Role.OWNER)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return user
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _document(household, user, *, name="Doc", doc_type="invoice") -> Document:
+    return Document.objects.create(
+        household=household,
+        created_by=user,
+        file_path=f"documents/{name.lower()}.bin",
+        name=name,
+        mime_type="application/octet-stream",
+        type=doc_type,
+    )
+
+
+@pytest.fixture
+def household():
+    return HouseholdFactory()
+
+
+@pytest.fixture
+def owner(household):
+    return _owner(household)
+
+
+@pytest.fixture
+def chicken(household, owner):
+    return ChickenFactory(household=household, created_by=owner)
+
+
+# ---------------------------------------------------------------------------
+# 1. chicken_tab_counts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_tab_counts_splits_documents_photos_and_events(household, owner, chicken):
+    ChickenEventFactory(chicken=chicken, household=household, created_by=owner)
+    ChickenEventFactory(chicken=chicken, household=household, created_by=owner)
+
+    doc = _document(household, owner, name="Vet", doc_type="invoice")
+    photo = _document(household, owner, name="Hen", doc_type="photo")
+    ct = ContentType.objects.get_for_model(Chicken)
+    DocumentLink.objects.create(content_type=ct, object_id=chicken.id, document=doc)
+    DocumentLink.objects.create(content_type=ct, object_id=chicken.id, document=photo)
+
+    counts = chicken_tab_counts(chicken)
+    assert counts == {"events": 2, "documents": 1, "photos": 1}
+
+
+# ---------------------------------------------------------------------------
+# 2. Serializer tab_counts — retrieve vs list
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_retrieve_exposes_tab_counts(owner, chicken):
+    resp = _client_for(owner).get(reverse("chicken-detail", args=[chicken.id]))
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.data["tab_counts"] == {"events": 0, "documents": 0, "photos": 0}
+
+
+@pytest.mark.django_db
+def test_list_does_not_compute_tab_counts(owner, chicken):
+    resp = _client_for(owner).get(reverse("chicken-list"))
+    assert resp.status_code == status.HTTP_200_OK
+    row = next(r for r in resp.data if str(r["id"]) == str(chicken.id))
+    assert row["tab_counts"] is None
+
+
+# ---------------------------------------------------------------------------
+# 3. attach / detach / set_phase actions
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_attach_detach_document(household, owner, chicken):
+    client = _client_for(owner)
+    photo = _document(household, owner, name="Hen", doc_type="photo")
+
+    attach = client.post(
+        reverse("chicken-attach-document", args=[chicken.id]),
+        {"document_id": str(photo.id), "phase": "before"},
+        format="json",
+    )
+    assert attach.status_code == status.HTTP_201_CREATED
+    ct = ContentType.objects.get_for_model(Chicken)
+    link = DocumentLink.objects.get(content_type=ct, object_id=chicken.id, document=photo)
+    assert link.phase == "before"
+
+    set_phase = client.post(
+        reverse("chicken-set-document-phase", args=[chicken.id]),
+        {"document_id": str(photo.id), "phase": "after"},
+        format="json",
+    )
+    assert set_phase.status_code == status.HTTP_200_OK
+    link.refresh_from_db()
+    assert link.phase == "after"
+
+    detach = client.post(
+        reverse("chicken-detach-document", args=[chicken.id]),
+        {"document_id": str(photo.id)},
+        format="json",
+    )
+    assert detach.status_code == status.HTTP_204_NO_CONTENT
+    assert not DocumentLink.objects.filter(
+        content_type=ct, object_id=chicken.id, document=photo
+    ).exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. document list filter ?chicken=<id>
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_documents_filtered_by_chicken(household, owner, chicken):
+    client = _client_for(owner)
+    linked = _document(household, owner, name="Linked", doc_type="invoice")
+    _document(household, owner, name="Unrelated", doc_type="invoice")
+    ct = ContentType.objects.get_for_model(Chicken)
+    DocumentLink.objects.create(content_type=ct, object_id=chicken.id, document=linked)
+
+    resp = client.get("/api/documents/documents/", {"chicken": str(chicken.id)})
+    assert resp.status_code == status.HTTP_200_OK
+    rows = resp.data["results"] if isinstance(resp.data, dict) else resp.data
+    names = {r["name"] for r in rows}
+    assert names == {"Linked"}

--- a/apps/chickens/views.py
+++ b/apps/chickens/views.py
@@ -12,6 +12,7 @@ from rest_framework.views import APIView
 from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsHouseholdMember
+from documents.mixins import DocumentLinkActionsMixin
 from interactions.services import create_expense_interaction
 
 from . import services
@@ -25,8 +26,8 @@ from .serializers import (
 )
 
 
-class ChickenViewSet(viewsets.ModelViewSet):
-    """Flock register CRUD + per-hen purchase declaration."""
+class ChickenViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
+    """Flock register CRUD + per-hen purchase declaration + document/photo links."""
 
     permission_classes = [IsHouseholdMember]
     serializer_class = ChickenSerializer

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -84,7 +84,7 @@ def get_documents_queryset_for_request(request):
     from agent import searchables
 
     entity_filters = []
-    for param in ('zone', 'project', 'equipment'):
+    for param in ('zone', 'project', 'equipment', 'task', 'chicken'):
         value = (query_params.get(param) or '').strip()
         if value:
             entity_filters.append((param, value))

--- a/apps/tasks/views.py
+++ b/apps/tasks/views.py
@@ -13,6 +13,7 @@ from rest_framework.response import Response
 from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsHouseholdMember
+from documents.mixins import DocumentLinkActionsMixin
 from documents.models import Document, DocumentLink
 from interactions.models import Interaction
 from zones.models import Zone
@@ -24,7 +25,7 @@ from .serializers import (
 )
 
 
-class TaskViewSet(viewsets.ModelViewSet):
+class TaskViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
     """
     Task CRUD with filtering by status, priority, zone, assigned_to, overdue.
     completed_by and completed_at are auto-managed on status transitions.

--- a/apps/zones/views.py
+++ b/apps/zones/views.py
@@ -15,19 +15,21 @@ from .models import Zone
 from .serializers import ZoneSerializer, ZoneTreeSerializer, ZoneDocumentSerializer
 from core.permissions import IsHouseholdMember
 from documents.models import Document, DocumentLink
+from documents.mixins import DocumentLinkActionsMixin
 from documents.services import link_document
 
 
-class ZoneViewSet(viewsets.ModelViewSet):
+class ZoneViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
     """
     ViewSet for zone CRUD operations.
-    
+
     List: Returns zones for user's households (flat or tree)
     Create: Creates new zone
     Retrieve: Gets zone details
     Update: Updates zone
     Delete: Deletes zone (cascades to children)
     """
+    document_link_role = 'document'
     permission_classes = [IsAuthenticated, IsHouseholdMember]
     serializer_class = ZoneSerializer
 

--- a/ui/src/features/chickens/ChickenDetailPage.tsx
+++ b/ui/src/features/chickens/ChickenDetailPage.tsx
@@ -4,12 +4,14 @@ import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import PageHeader from '@/components/PageHeader';
 import BackLink from '@/components/BackLink';
-import { TabShell } from '@/components/TabShell';
+import { TabShell, type TabConfig } from '@/components/TabShell';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useNavigateBack } from '@/lib/backNavigation';
+import EntityDocumentsTab from '@/features/documents/EntityDocumentsTab';
+import EntityPhotosTab from '@/features/photos/EntityPhotosTab';
 import type { ChickenEvent } from '@/lib/api/chickens';
 import {
   chickenKeys,
@@ -24,8 +26,9 @@ import ChickenEventDialog from './ChickenEventDialog';
 import ChickenPurchaseDialog from './ChickenPurchaseDialog';
 import EventTimeline from './EventTimeline';
 
-type Tab = 'info' | 'events';
-const TABS: Tab[] = ['info', 'events'];
+type Tab = 'info' | 'events' | 'documents' | 'photos';
+// Counted tabs — hidden when empty, revealed when populated or reachable via « + ».
+const COUNTED_TABS: Exclude<Tab, 'info'>[] = ['events', 'documents', 'photos'];
 
 export default function ChickenDetailPage() {
   const { id = '' } = useParams();
@@ -40,6 +43,7 @@ export default function ChickenDetailPage() {
   const [eventDialogOpen, setEventDialogOpen] = React.useState(false);
   const [editingEvent, setEditingEvent] = React.useState<ChickenEvent | null>(null);
   const [purchaseOpen, setPurchaseOpen] = React.useState(false);
+  const [activeTab, setActiveTab] = React.useState<Tab>('info');
 
   const deleteChickenMutation = useDeleteChicken();
   const deleteEventMutation = useDeleteChickenEvent();
@@ -90,6 +94,24 @@ export default function ChickenDetailPage() {
     );
   }
 
+  const counts = chicken.tab_counts ?? null;
+  // Visible tabs: info always, others when they have content OR are currently
+  // active (so the active tab doesn't vanish when it empties).
+  const isVisible = (tab: Exclude<Tab, 'info'>) =>
+    (counts ? counts[tab] > 0 : true) || tab === activeTab;
+  const visibleTabs: TabConfig<Tab>[] = [
+    { key: 'info', label: t('chickens.tabs.info') },
+    ...COUNTED_TABS.filter(isVisible).map((tab) => ({
+      key: tab,
+      label: t(`chickens.tabs.${tab}`),
+      badge: counts?.[tab],
+    })),
+  ];
+  // Empty tabs, reachable via the « + » menu so the first item can still be added.
+  const moreTabs: TabConfig<Tab>[] = COUNTED_TABS.filter((tab) => !isVisible(tab)).map(
+    (tab) => ({ key: tab, label: t(`chickens.tabs.${tab}`) }),
+  );
+
   const facts: Array<{ label: string; value: string | null }> = [
     { label: t('chickens.fields.breed'), value: chicken.breed || null },
     { label: t('chickens.fields.color'), value: chicken.color || null },
@@ -117,9 +139,11 @@ export default function ChickenDetailPage() {
       </PageHeader>
 
       <TabShell<Tab>
-        tabs={TABS.map((tab) => ({ key: tab, label: t(`chickens.tabs.${tab}`) }))}
+        tabs={visibleTabs}
+        moreTabs={moreTabs}
         sessionKey={`chicken-detail.${chicken.id}.tab`}
         defaultTab="info"
+        onTabChange={setActiveTab}
       >
         {(tab) => (
           <>
@@ -173,6 +197,14 @@ export default function ChickenDetailPage() {
                   />
                 )}
               </div>
+            ) : null}
+
+            {tab === 'documents' ? (
+              <EntityDocumentsTab entityType="chicken" objectId={chicken.id} />
+            ) : null}
+
+            {tab === 'photos' ? (
+              <EntityPhotosTab entityType="chicken" objectId={chicken.id} />
             ) : null}
           </>
         )}

--- a/ui/src/features/documents/EntityAttachDocumentDialog.tsx
+++ b/ui/src/features/documents/EntityAttachDocumentDialog.tsx
@@ -1,11 +1,18 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
 import { Button } from '@/design-system/button';
-import { useDocuments, documentKeys, useAttachEntityDocument } from './hooks';
-import type { DocumentItem } from '@/lib/api/documents';
+import { documentKeys } from './hooks';
+import {
+  fetchDocuments,
+  fetchPhotoDocuments,
+  attachEntityDocument,
+  entityDetailQueryKey,
+  type DocumentItem,
+  type PhotoPhase,
+} from '@/lib/api/documents';
 
 interface Props {
   open: boolean;
@@ -13,6 +20,14 @@ interface Props {
   entityType: string;
   objectId: string;
   attachedIds: Set<string>;
+  /** Restrict the candidate pool to a document type (e.g. 'photo'). */
+  documentType?: string;
+  /** Phase to store on the link when attaching (photos only). */
+  phase?: PhotoPhase | '';
+  /** Extra invalidation after a successful attach (e.g. the photos entity key). */
+  onAttached?: () => void;
+  /** Dialog title override (defaults to the documents wording). */
+  title?: string;
 }
 
 export default function EntityAttachDocumentDialog({
@@ -21,16 +36,27 @@ export default function EntityAttachDocumentDialog({
   entityType,
   objectId,
   attachedIds,
+  documentType,
+  phase,
+  onAttached,
+  title,
 }: Props) {
   const { t } = useTranslation();
   const qc = useQueryClient();
   const [search, setSearch] = React.useState('');
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [error, setError] = React.useState<string | null>(null);
+  const [isAttaching, setIsAttaching] = React.useState(false);
 
-  const filters = React.useMemo(() => (search ? { search } : {}), [search]);
-  const { data: documents = [], isLoading } = useDocuments(filters);
-  const attachMutation = useAttachEntityDocument(entityType, objectId);
+  const isPhoto = documentType === 'photo';
+  const { data: documents = [], isLoading } = useQuery({
+    queryKey: [...documentKeys.all, 'attach-pool', documentType ?? 'any', search] as const,
+    queryFn: () =>
+      isPhoto
+        ? fetchPhotoDocuments(search ? { search } : {})
+        : fetchDocuments(search ? { search } : {}),
+    enabled: open,
+  });
 
   React.useEffect(() => {
     if (!open) {
@@ -57,14 +83,22 @@ export default function EntityAttachDocumentDialog({
   async function handleAttach() {
     if (selected.size === 0) return;
     setError(null);
+    setIsAttaching(true);
     try {
       await Promise.all(
-        Array.from(selected).map((id) => attachMutation.mutateAsync(id)),
+        Array.from(selected).map((id) =>
+          attachEntityDocument(entityType, objectId, id, phase),
+        ),
       );
       void qc.invalidateQueries({ queryKey: documentKeys.all });
+      const detailKey = entityDetailQueryKey(entityType);
+      if (detailKey) void qc.invalidateQueries({ queryKey: detailKey });
+      onAttached?.();
       onOpenChange(false);
     } catch {
       setError(t('common.saveFailed'));
+    } finally {
+      setIsAttaching(false);
     }
   }
 
@@ -72,7 +106,7 @@ export default function EntityAttachDocumentDialog({
     <SheetDialog
       open={open}
       onOpenChange={onOpenChange}
-      title={t('documents.link.attach_existing')}
+      title={title ?? t('documents.link.attach_existing')}
     >
       <div className="space-y-3">
         {error ? (
@@ -107,11 +141,19 @@ export default function EntityAttachDocumentDialog({
                         onChange={() => toggle(doc.id)}
                         className="h-4 w-4"
                       />
+                      {isPhoto && (doc.thumbnail_url || doc.file_url) ? (
+                        <img
+                          src={doc.thumbnail_url || doc.file_url || ''}
+                          alt={doc.name}
+                          loading="lazy"
+                          className="h-10 w-10 shrink-0 rounded object-cover"
+                        />
+                      ) : null}
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm text-foreground">{doc.name}</p>
-                        {doc.type ? (
+                        {!isPhoto && doc.type ? (
                           <p className="text-xs text-muted-foreground">
-                            {t(`documents.type.${doc.type}`, { defaultValue: doc.type })}
+                            {t(`documents.type.${doc.type}`)}
                           </p>
                         ) : null}
                       </div>
@@ -130,9 +172,9 @@ export default function EntityAttachDocumentDialog({
           <Button
             type="button"
             onClick={handleAttach}
-            disabled={selected.size === 0 || attachMutation.isPending}
+            disabled={selected.size === 0 || isAttaching}
           >
-            {attachMutation.isPending
+            {isAttaching
               ? t('common.saving')
               : t('documents.link.attach', { count: selected.size })}
           </Button>

--- a/ui/src/features/documents/EntityDocumentsTab.tsx
+++ b/ui/src/features/documents/EntityDocumentsTab.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { Plus, Upload } from 'lucide-react';
+import { Plus, Upload, FileText } from 'lucide-react';
 import { Button } from '@/design-system/button';
+import EmptyState from '@/components/EmptyState';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useDocuments, documentKeys, useAttachEntityDocument, useDetachEntityDocument } from './hooks';
@@ -112,9 +113,12 @@ export default function EntityDocumentsTab({ entityType, objectId }: Props) {
         ) : error ? (
           <p className="text-sm text-destructive">{t('common.error_loading')}</p>
         ) : documents.length === 0 ? (
-          <p className="text-sm italic text-muted-foreground">
-            {t('documents.link.empty')}
-          </p>
+          <EmptyState
+            icon={FileText}
+            title={t('documents.link.empty')}
+            description={t('documents.link.empty_hint')}
+            action={{ label: t('documents.link.upload'), onClick: () => setUploadOpen(true) }}
+          />
         ) : (
           <ul className="space-y-2">
             {documents.map((doc) => (

--- a/ui/src/features/documents/hooks.ts
+++ b/ui/src/features/documents/hooks.ts
@@ -8,9 +8,11 @@ import {
   reprocessDocumentOcr,
   attachEntityDocument,
   detachEntityDocument,
+  entityDetailQueryKey,
   type DocumentFilters,
   type UploadDocumentInput,
 } from '@/lib/api/documents';
+import type { QueryClient } from '@tanstack/react-query';
 
 export const documentKeys = {
   all: ['documents'] as const,
@@ -19,12 +21,19 @@ export const documentKeys = {
   detail: (id: string) => [...documentKeys.all, 'detail', id] as const,
 };
 
+/** Refresh the document lists + the linked entity's detail (its tab_counts). */
+function invalidateEntityDocuments(qc: QueryClient, entityType: string) {
+  void qc.invalidateQueries({ queryKey: documentKeys.all });
+  const detailKey = entityDetailQueryKey(entityType);
+  if (detailKey) void qc.invalidateQueries({ queryKey: detailKey });
+}
+
 /** Attach an existing document to any linkable entity (project, equipment, …). */
 export function useAttachEntityDocument(entityType: string, objectId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (documentId: string) => attachEntityDocument(entityType, objectId, documentId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
+    onSuccess: () => invalidateEntityDocuments(qc, entityType),
   });
 }
 
@@ -32,7 +41,7 @@ export function useDetachEntityDocument(entityType: string, objectId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (documentId: string) => detachEntityDocument(entityType, objectId, documentId),
-    onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
+    onSuccess: () => invalidateEntityDocuments(qc, entityType),
   });
 }
 

--- a/ui/src/features/equipment/EquipmentDetailPage.tsx
+++ b/ui/src/features/equipment/EquipmentDetailPage.tsx
@@ -25,10 +25,11 @@ import {
 import { statusVariant } from './format';
 import EquipmentDialog from './EquipmentDialog';
 import EntityDocumentsTab from '@/features/documents/EntityDocumentsTab';
+import EntityPhotosTab from '@/features/photos/EntityPhotosTab';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
-type Tab = 'info' | 'history' | 'documents';
-const TABS: Tab[] = ['info', 'history', 'documents'];
+type Tab = 'info' | 'history' | 'documents' | 'photos';
+const TABS: Tab[] = ['info', 'history', 'documents', 'photos'];
 
 export default function EquipmentDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -287,6 +288,10 @@ export default function EquipmentDetailPage() {
 
               {tab === 'documents' ? (
                 <EntityDocumentsTab entityType="equipment" objectId={equipment.id} />
+              ) : null}
+
+              {tab === 'photos' ? (
+                <EntityPhotosTab entityType="equipment" objectId={equipment.id} />
               ) : null}
             </>
           )}

--- a/ui/src/features/photos/EntityPhotosTab.tsx
+++ b/ui/src/features/photos/EntityPhotosTab.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { Camera, Upload, Trash2, ArrowRightLeft, GitCompareArrows } from 'lucide-react';
+import { Camera, Upload, Trash2, ArrowRightLeft, GitCompareArrows, Plus } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { Card, CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
+import EmptyState from '@/components/EmptyState';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import DocumentUploadDialog from '@/features/documents/DocumentUploadDialog';
+import EntityAttachDocumentDialog from '@/features/documents/EntityAttachDocumentDialog';
 import PhotoDetailPanel from './PhotoDetailPanel';
 import BeforeAfterCompare from './BeforeAfterCompare';
 import {
@@ -49,6 +51,7 @@ export default function EntityPhotosTab({ entityType, objectId }: Props) {
   const setPhaseMutation = useSetPhotoPhase(entityType, objectId);
 
   const [uploadPhase, setUploadPhase] = React.useState<PhotoPhase | '' | null>(null);
+  const [attachOpen, setAttachOpen] = React.useState(false);
   const [viewing, setViewing] = React.useState<DocumentItem | null>(null);
   const [comparing, setComparing] = React.useState(false);
 
@@ -56,6 +59,13 @@ export default function EntityPhotosTab({ entityType, objectId }: Props) {
     () => photoKeys.entity(entityType, objectId),
     [entityType, objectId],
   );
+
+  const attachedIds = React.useMemo(() => new Set(photos.map((p) => p.id)), [photos]);
+
+  const invalidatePhotos = React.useCallback(() => {
+    void qc.invalidateQueries({ queryKey });
+    void qc.invalidateQueries({ queryKey: photoKeys.all });
+  }, [qc, queryKey]);
 
   const { deleteWithUndo } = useDeleteWithUndo({
     label: t('photos.entity.removed'),
@@ -136,6 +146,16 @@ export default function EntityPhotosTab({ entityType, objectId }: Props) {
           <Button
             type="button"
             size="sm"
+            variant="outline"
+            onClick={() => setAttachOpen(true)}
+            className="gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t('photos.entity.attach_existing')}
+          </Button>
+          <Button
+            type="button"
+            size="sm"
             onClick={() => setUploadPhase('')}
             className="gap-1.5"
           >
@@ -145,7 +165,12 @@ export default function EntityPhotosTab({ entityType, objectId }: Props) {
         </div>
 
         {photos.length === 0 ? (
-          <p className="text-sm italic text-muted-foreground">{t('photos.entity.empty')}</p>
+          <EmptyState
+            icon={Camera}
+            title={t('photos.entity.empty')}
+            description={t('photos.entity.empty_hint')}
+            action={{ label: t('photos.entity.upload'), onClick: () => setUploadPhase('') }}
+          />
         ) : (
           PHASE_ORDER.map((phase) => {
             const items = grouped[phase];
@@ -196,6 +221,18 @@ export default function EntityPhotosTab({ entityType, objectId }: Props) {
         }}
         onSaved={handleUploaded}
         forcedType="photo"
+      />
+
+      <EntityAttachDocumentDialog
+        open={attachOpen}
+        onOpenChange={setAttachOpen}
+        entityType={entityType}
+        objectId={objectId}
+        attachedIds={attachedIds}
+        documentType="photo"
+        phase=""
+        onAttached={invalidatePhotos}
+        title={t('photos.entity.attach_existing')}
       />
 
       <PhotoDetailPanel

--- a/ui/src/features/photos/hooks.ts
+++ b/ui/src/features/photos/hooks.ts
@@ -5,6 +5,7 @@ import {
   attachEntityDocument,
   detachEntityDocument,
   setDocumentPhase,
+  entityDetailQueryKey,
   type PhotoPhase,
 } from '@/lib/api/documents';
 
@@ -48,14 +49,15 @@ export function useEntityPhotos(entityType: string, objectId: string) {
   });
 }
 
-/** Invalidate the entity photos list + the project detail (photos tab count). */
+/** Invalidate the entity photos list + the entity detail (its photos tab count). */
 function useEntityPhotoInvalidation(entityType: string, objectId: string) {
   const qc = useQueryClient();
   return () => {
     void qc.invalidateQueries({ queryKey: photoKeys.entity(entityType, objectId) });
     void qc.invalidateQueries({ queryKey: photoKeys.all });
-    // tab_counts.photos lives on the project detail (projectKeys.all === ['projects']).
-    void qc.invalidateQueries({ queryKey: ['projects'] });
+    // tab_counts.photos lives on the linked entity's detail (project, chicken…).
+    const detailKey = entityDetailQueryKey(entityType);
+    if (detailKey) void qc.invalidateQueries({ queryKey: detailKey });
   };
 }
 

--- a/ui/src/features/tasks/TaskDetailPage.tsx
+++ b/ui/src/features/tasks/TaskDetailPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useParams, Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
-import { Download, ExternalLink, FileText, Lock, Paperclip, Pencil, Trash2 } from 'lucide-react';
+import { ExternalLink, FileText, Lock, Pencil, Trash2 } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
 import ConfirmDialog from '@/components/ConfirmDialog';
@@ -28,8 +28,8 @@ import {
 import TaskStatusBadge from './TaskStatusBadge';
 import TaskAssigneeBadge from './TaskAssigneeBadge';
 import NewTaskDialog from './NewTaskDialog';
-import TaskAttachmentsDialog from './TaskAttachmentsDialog';
 import TaskWeatherHint from './TaskWeatherHint';
+import EntityDocumentsTab from '@/features/documents/EntityDocumentsTab';
 
 function priorityLabelKey(priority: Task['priority']): string {
   if (priority === 1) return 'tasks.priorityHigh_label';
@@ -54,7 +54,6 @@ export default function TaskDetailPage() {
 
   const [editOpen, setEditOpen] = React.useState(false);
   const [deleteOpen, setDeleteOpen] = React.useState(false);
-  const [attachmentsOpen, setAttachmentsOpen] = React.useState(false);
 
   const { data: task, isLoading, error } = useTask(id ?? '');
   const { data: householdMembers = [] } = useHouseholdMembersWithMe();
@@ -118,8 +117,6 @@ export default function TaskDetailPage() {
   const overdue = isTaskOverdue(task);
   const relativeDate = formatRelativeDate(task.due_date);
   const zoneName = task.zone_names?.[0];
-  const totalAttachments =
-    (task.linked_document_count ?? 0) + (task.linked_interaction_count ?? 0);
 
   return (
     <>
@@ -261,54 +258,7 @@ export default function TaskDetailPage() {
               ) : null}
 
               {tab === 'documents' ? (
-                <div className="space-y-2">
-                  {isCreator && (
-                    <div className="flex justify-end">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="h-8 px-3 text-sm"
-                        onClick={() => setAttachmentsOpen(true)}
-                      >
-                        <Paperclip className="mr-1.5 h-3.5 w-3.5" />
-                        {t('tasks.manageAttachments')}
-                        {totalAttachments > 0 ? ` (${totalAttachments})` : ''}
-                      </Button>
-                    </div>
-                  )}
-                  {task.linked_documents.length === 0 ? (
-                    <p className="text-sm italic text-muted-foreground">
-                      {t('tasks.noLinkedDocuments')}
-                    </p>
-                  ) : (
-                    <ul className="space-y-2">
-                      {task.linked_documents.map((doc) => (
-                        <li key={doc.id} className="rounded-md border border-border p-3 text-sm">
-                          <div className="flex items-start justify-between gap-2">
-                            <Link
-                              to={`/app/documents/${doc.document_id}`}
-                              state={pushBack(location)}
-                              className="min-w-0 flex-1 truncate font-medium text-foreground hover:text-primary hover:underline"
-                            >
-                              {doc.name || '—'}
-                            </Link>
-                            {doc.file_url && (
-                              <a
-                                href={doc.file_url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex shrink-0 items-center text-muted-foreground hover:text-foreground"
-                                aria-label={t('documents.detail.download')}
-                              >
-                                <Download className="h-3.5 w-3.5" />
-                              </a>
-                            )}
-                          </div>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
+                <EntityDocumentsTab entityType="task" objectId={task.id} />
               ) : null}
 
               {tab === 'activity' ? (
@@ -359,12 +309,6 @@ export default function TaskDetailPage() {
         existingTask={task}
         onUpdated={handleEdited}
         householdMembers={householdMembers}
-      />
-
-      <TaskAttachmentsDialog
-        task={attachmentsOpen ? task : null}
-        open={attachmentsOpen}
-        onOpenChange={setAttachmentsOpen}
       />
 
       <ConfirmDialog

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -64,7 +64,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'water', moduleKey: 'water', to: '/app/water', stepIds: ['readings', 'charts'] },
   { key: 'weather', moduleKey: 'weather', to: '/app/weather', stepIds: ['location', 'forecast', 'dashboard', 'alerts'] },
   { key: 'stock', moduleKey: 'stock', to: '/app/stock', stepIds: ['add', 'quantities', 'expiry'] },
-  { key: 'chickens', moduleKey: 'chickens', to: '/app/chickens', stepIds: ['flock', 'eggs', 'events', 'stats'] },
+  { key: 'chickens', moduleKey: 'chickens', to: '/app/chickens', stepIds: ['flock', 'eggs', 'events', 'stats', 'media'] },
   { key: 'insurance', moduleKey: 'insurance', to: '/app/insurance', stepIds: ['contracts', 'documents'] },
   { key: 'tasks', moduleKey: 'tasks', to: '/app/tasks', stepIds: ['create', 'organize', 'weather', 'complete'] },
   { key: 'projects', moduleKey: 'projects', to: '/app/projects', stepIds: ['create', 'plan', 'photos', 'budget'] },

--- a/ui/src/features/zones/ZoneDetailPage.tsx
+++ b/ui/src/features/zones/ZoneDetailPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Layers, NotebookText, FileText, ImageIcon } from 'lucide-react';
+import { Layers, NotebookText } from 'lucide-react';
 import { pushBack } from '@/lib/backNavigation';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
@@ -19,13 +19,13 @@ import {
   useZoneTasks,
   useZoneActivity,
   useZoneProjects,
-  useZoneDocuments,
-  useZonePhotos,
   zoneInteractionKeys,
 } from './hooks';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 import ZoneDialog from './ZoneDialog';
 import RenovationTab from '@/features/renovation/RenovationTab';
+import EntityDocumentsTab from '@/features/documents/EntityDocumentsTab';
+import EntityPhotosTab from '@/features/photos/EntityPhotosTab';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 
 // ── Tab types ──────────────────────────────────────────────
@@ -342,110 +342,6 @@ function TabProjects({ zoneId }: { zoneId: string }) {
   );
 }
 
-// ── Tab: Photos ────────────────────────────────────────────
-
-function TabPhotos({ zoneId }: { zoneId: string }) {
-  const { t } = useTranslation();
-  const location = useLocation();
-  const { data: photos = [], isLoading } = useZonePhotos(zoneId);
-
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-        {[1, 2, 3, 4].map((i) => (
-          <div key={i} className="aspect-square animate-pulse rounded-lg bg-muted" />
-        ))}
-      </div>
-    );
-  }
-
-  if (photos.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-3 py-8 text-center">
-        <ImageIcon className="h-10 w-10 text-muted-foreground/40" />
-        <p className="text-sm text-muted-foreground">{t('zones.photos.empty')}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-      {photos.map((photo) => (
-        <Link
-          key={photo.id}
-          to={`/app/documents/${photo.id}`}
-          state={pushBack(location)}
-          className="group relative aspect-square overflow-hidden rounded-lg border border-border bg-muted"
-        >
-          {photo.file_url ? (
-            <img
-              src={photo.file_url}
-              alt={photo.name}
-              className="h-full w-full object-cover transition-transform group-hover:scale-105"
-            />
-          ) : (
-            <div className="flex h-full items-center justify-center">
-              <ImageIcon className="h-8 w-8 text-muted-foreground/40" />
-            </div>
-          )}
-          <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/60 to-transparent p-2 opacity-0 transition-opacity group-hover:opacity-100">
-            <p className="truncate text-xs text-white">{photo.name}</p>
-          </div>
-        </Link>
-      ))}
-    </div>
-  );
-}
-
-// ── Tab: Documents ─────────────────────────────────────────
-
-function TabDocuments({ zoneId }: { zoneId: string }) {
-  const { t } = useTranslation();
-  const location = useLocation();
-  const { data: documents = [], isLoading } = useZoneDocuments(zoneId);
-
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        {[1, 2, 3].map((i) => <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />)}
-      </div>
-    );
-  }
-
-  if (documents.length === 0) {
-    return (
-      <div className="flex flex-col items-center gap-3 py-8 text-center">
-        <FileText className="h-10 w-10 text-muted-foreground/40" />
-        <p className="text-sm text-muted-foreground">{t('zones.detail.documents_empty')}</p>
-      </div>
-    );
-  }
-
-  return (
-    <ul className="space-y-1">
-      {documents.map((doc) => (
-        <li key={doc.id}>
-          <Link
-            to={`/app/documents/${doc.id}`}
-            state={pushBack(location)}
-            className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
-          >
-            <div className="flex min-w-0 items-center gap-2">
-              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="truncate">{doc.name || doc.file_path.split('/').pop()}</span>
-            </div>
-            {doc.type ? (
-              <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
-                {doc.type}
-              </span>
-            ) : null}
-          </Link>
-        </li>
-      ))}
-    </ul>
-  );
-}
-
 // ── Main page ──────────────────────────────────────────────
 
 export default function ZoneDetailPage() {
@@ -556,9 +452,11 @@ export default function ZoneDetailPage() {
 
                 {tab === 'projects' ? <TabProjects zoneId={id} /> : null}
 
-                {tab === 'photos' ? <TabPhotos zoneId={id} /> : null}
+                {tab === 'photos' ? <EntityPhotosTab entityType="zone" objectId={id} /> : null}
 
-                {tab === 'documents' ? <TabDocuments zoneId={id} /> : null}
+                {tab === 'documents' ? (
+                  <EntityDocumentsTab entityType="zone" objectId={id} />
+                ) : null}
               </CardContent>
             </Card>
           )}

--- a/ui/src/features/zones/hooks.ts
+++ b/ui/src/features/zones/hooks.ts
@@ -14,7 +14,6 @@ import { fetchEquipmentList } from '@/lib/api/equipment';
 import { fetchInteractions } from '@/lib/api/interactions';
 import { fetchTasks } from '@/lib/api/tasks';
 import { fetchProjects } from '@/lib/api/projects';
-import { fetchDocuments, fetchPhotoDocuments } from '@/lib/api/documents';
 
 export const zoneKeys = {
   all: ['zones'] as const,
@@ -122,22 +121,6 @@ export function useZoneProjects(zoneId: string) {
   return useQuery({
     queryKey: ['zones', zoneId, 'projects'],
     queryFn: () => fetchProjects({ zone: zoneId, status: 'active' }),
-    enabled: !!zoneId,
-  });
-}
-
-export function useZoneDocuments(zoneId: string) {
-  return useQuery({
-    queryKey: ['zones', zoneId, 'documents'],
-    queryFn: () => fetchDocuments({ zone: zoneId }),
-    enabled: !!zoneId,
-  });
-}
-
-export function useZonePhotos(zoneId: string) {
-  return useQuery({
-    queryKey: ['zones', zoneId, 'photos'],
-    queryFn: () => fetchPhotoDocuments({ zone: zoneId }),
     enabled: !!zoneId,
   });
 }

--- a/ui/src/lib/api/chickens.ts
+++ b/ui/src/lib/api/chickens.ts
@@ -20,6 +20,13 @@ export const CHICKEN_EVENT_TYPES: ChickenEventType[] = [
   'arrival', 'care', 'illness', 'broody', 'molt', 'predator', 'death', 'departure', 'other',
 ];
 
+/** Items behind each chicken-detail tab. Null in list responses (detail only). */
+export interface ChickenTabCounts {
+  events: number;
+  documents: number;
+  photos: number;
+}
+
 export interface Chicken {
   id: string;
   household: string;
@@ -32,6 +39,7 @@ export interface Chicken {
   notes: string;
   zone: string | null;
   zone_name: string | null;
+  tab_counts?: ChickenTabCounts | null;
   created_at: string;
   updated_at: string;
 }

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -93,12 +93,13 @@ function normalizeId(d: DocumentItem & { id: string | number }): DocumentItem {
 }
 
 export async function fetchDocuments(filters: DocumentFilters = {}): Promise<DocumentItem[]> {
+  // Forward every filter as a query param: `search`/`type` are reserved, any
+  // other key is an entity link filter (?zone= / ?project= / ?task= / ?chicken=…)
+  // resolved polymorphically by the backend via the searchables registry.
   const params: Record<string, string> = { ordering: '-created_at' };
-  if (filters.search) params.search = filters.search;
-  if (filters.type) params.type = filters.type;
-  if (filters.zone) params.zone = filters.zone;
-  if (filters.project) params.project = filters.project;
-  if (filters.equipment) params.equipment = filters.equipment;
+  for (const [key, value] of Object.entries(filters)) {
+    if (value) params[key] = value;
+  }
 
   const { data } = await api.get('/documents/documents/', { params });
   const list: Array<DocumentItem & { id: string | number }> = Array.isArray(data)
@@ -110,10 +111,10 @@ export async function fetchDocuments(filters: DocumentFilters = {}): Promise<Doc
 
 export async function fetchPhotoDocuments(filters: Omit<DocumentFilters, 'type'> = {}): Promise<DocumentItem[]> {
   const params: Record<string, string> = { ordering: '-created_at', type: 'photo' };
-  if (filters.search) params.search = filters.search;
-  if (filters.zone) params.zone = filters.zone;
-  if (filters.project) params.project = filters.project;
-  if (filters.equipment) params.equipment = filters.equipment;
+  for (const [key, value] of Object.entries(filters)) {
+    if (key === 'type') continue; // forced to 'photo'
+    if (value) params[key] = value;
+  }
 
   const { data } = await api.get('/documents/documents/', { params });
   const list: Array<DocumentItem & { id: string | number }> = Array.isArray(data)
@@ -169,10 +170,30 @@ export async function deleteDocument(id: string): Promise<void> {
 const DOCUMENT_LINK_ENDPOINTS: Record<string, (id: string) => string> = {
   project: (id) => `/projects/projects/${id}`,
   equipment: (id) => `/equipment/${id}`,
+  zone: (id) => `/zones/${id}`,
+  task: (id) => `/tasks/tasks/${id}`,
+  chicken: (id) => `/chickens/${id}`,
 };
 
 export function supportsDocumentLinking(entityType: string): boolean {
   return entityType in DOCUMENT_LINK_ENDPOINTS;
+}
+
+/**
+ * Root React Query key of an entity's detail cache, so attaching/detaching a
+ * document or photo can refresh its `tab_counts`. Pluralization is irregular
+ * (equipment stays singular) — keep this map explicit rather than guessing.
+ */
+const ENTITY_DETAIL_QUERY_KEYS: Record<string, readonly unknown[]> = {
+  project: ['projects'],
+  equipment: ['equipment'],
+  zone: ['zones'],
+  task: ['tasks'],
+  chicken: ['chickens'],
+};
+
+export function entityDetailQueryKey(entityType: string): readonly unknown[] | null {
+  return ENTITY_DETAIL_QUERY_KEYS[entityType] ?? null;
 }
 
 export async function attachEntityDocument(

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1125,6 +1125,10 @@
           "stats": {
             "title": "Legeleistung und Kosten verfolgen",
             "body": "Wählen Sie einen Zeitraum für die Legekurve: nicht erfasste Tage erscheinen nie als 0, und die Erfassungsquote bleibt sichtbar. Kosten pro Ei (Futter + Pflege) und eine Warnung bei Rückgang (Mauser, Wetter) ergänzen das Bild."
+          },
+          "media": {
+            "title": "Fotos & Dokumente",
+            "body": "Öffnen Sie den Tab Fotos oder Dokumente einer Henne, um Vorher/Nachher-Fotos oder Unterlagen (Tierarzt, Rechnung) anzuhängen. Laden Sie eine neue Datei hoch oder verknüpfen Sie eine vorhandene — der Tab erscheint über das Menü « + », solange er leer ist."
           }
         }
       },
@@ -1374,7 +1378,9 @@
       "addToPhase": "Hier hinzufügen",
       "moveTo": "Verschieben nach {{phase}}",
       "remove": "Entfernen",
-      "empty": "Noch keine Fotos. Laden Sie eines hoch, um das Vorher und Nachher des Projekts zu dokumentieren."
+      "empty": "Noch keine Fotos. Laden Sie eines hoch, um das Vorher und Nachher des Projekts zu dokumentieren.",
+      "attach_existing": "Vorhandenes wählen",
+      "empty_hint": "Laden Sie ein neues hoch oder verknüpfen Sie ein vorhandenes Foto."
     }
   },
   "directory": {
@@ -1558,7 +1564,8 @@
       "empty": "Noch keine Dokumente.",
       "attach": "Anhängen ({{count}})",
       "detach": "Entfernen",
-      "detached": "Dokument entfernt"
+      "detached": "Dokument entfernt",
+      "empty_hint": "Laden Sie ein Dokument hoch oder verknüpfen Sie ein vorhandenes."
     },
     "linked_to": {
       "title": "Verknüpft mit",
@@ -1730,7 +1737,8 @@
       "info": "Info",
       "history": "Verlauf",
       "assistant": "Assistent",
-      "documents": "Dokumente"
+      "documents": "Dokumente",
+      "photos": "Fotos"
     }
   },
   "dashboard": {
@@ -2417,7 +2425,9 @@
     "tabs": {
       "info": "Info",
       "events": "Journal",
-      "assistant": "Assistent"
+      "assistant": "Assistent",
+      "documents": "Dokumente",
+      "photos": "Fotos"
     }
   },
   "alerts": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1125,6 +1125,10 @@
           "stats": {
             "title": "Track laying and cost",
             "body": "Pick a period for the laying curve: un-logged days never show as 0, and the coverage rate stays visible. Cost per egg (feed + care) and an abnormal-drop alert (molt, weather) round it out."
+          },
+          "media": {
+            "title": "Photos & documents",
+            "body": "Open the Photos or Documents tab on a hen to attach before/after photos or papers (vet, invoice). Upload a new file or connect an existing one — the tab appears via the « + » menu until it holds something."
           }
         }
       },
@@ -1374,7 +1378,9 @@
       "addToPhase": "Add here",
       "moveTo": "Move to {{phase}}",
       "remove": "Remove",
-      "empty": "No photos yet. Upload one to document the project before and after."
+      "empty": "No photos yet. Upload one to document the project before and after.",
+      "attach_existing": "Choose existing",
+      "empty_hint": "Upload a new one or connect an existing photo."
     }
   },
   "directory": {
@@ -1558,7 +1564,8 @@
       "empty": "No documents yet.",
       "attach": "Attach ({{count}})",
       "detach": "Detach",
-      "detached": "Document detached"
+      "detached": "Document detached",
+      "empty_hint": "Upload a new document or connect an existing one."
     },
     "linked_to": {
       "title": "Attached to",
@@ -1730,7 +1737,8 @@
       "info": "Info",
       "history": "History",
       "assistant": "Assistant",
-      "documents": "Documents"
+      "documents": "Documents",
+      "photos": "Photos"
     }
   },
   "dashboard": {
@@ -2417,7 +2425,9 @@
     "tabs": {
       "info": "Info",
       "events": "Journal",
-      "assistant": "Assistant"
+      "assistant": "Assistant",
+      "documents": "Documents",
+      "photos": "Photos"
     }
   },
   "alerts": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1125,6 +1125,10 @@
           "stats": {
             "title": "Seguir la puesta y el coste",
             "body": "Elige un periodo para la curva de puesta: los días sin registrar nunca aparecen como 0 y la tasa de registro queda visible. El coste por huevo (pienso + cuidados) y una alerta de caída (muda, clima) lo completan."
+          },
+          "media": {
+            "title": "Fotos y documentos",
+            "body": "Abre la pestaña Fotos o Documentos de una gallina para adjuntar fotos antes/después o papeles (veterinario, factura). Sube un archivo nuevo o vincula uno existente — la pestaña aparece en el menú « + » mientras esté vacía."
           }
         }
       },
@@ -1374,7 +1378,9 @@
       "addToPhase": "Añadir aquí",
       "moveTo": "Mover a {{phase}}",
       "remove": "Quitar",
-      "empty": "Aún no hay fotos. Sube una para documentar el antes y el después del proyecto."
+      "empty": "Aún no hay fotos. Sube una para documentar el antes y el después del proyecto.",
+      "attach_existing": "Elegir existente",
+      "empty_hint": "Sube una nueva o vincula una foto existente."
     }
   },
   "directory": {
@@ -1558,7 +1564,8 @@
       "empty": "Aún no hay documentos.",
       "attach": "Adjuntar ({{count}})",
       "detach": "Quitar",
-      "detached": "Documento quitado"
+      "detached": "Documento quitado",
+      "empty_hint": "Sube un documento o vincula uno existente."
     },
     "linked_to": {
       "title": "Vinculado a",
@@ -1730,7 +1737,8 @@
       "info": "Info",
       "history": "Historial",
       "assistant": "Asistente",
-      "documents": "Documentos"
+      "documents": "Documentos",
+      "photos": "Fotos"
     }
   },
   "dashboard": {
@@ -2417,7 +2425,9 @@
     "tabs": {
       "info": "Info",
       "events": "Diario",
-      "assistant": "Asistente"
+      "assistant": "Asistente",
+      "documents": "Documentos",
+      "photos": "Fotos"
     }
   },
   "alerts": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1125,6 +1125,10 @@
           "stats": {
             "title": "Suivre la ponte et le coût",
             "body": "Choisissez une période pour la courbe de ponte : les jours non relevés n'apparaissent pas comme des 0 et le taux de relevé reste visible. Le coût au œuf (alimentation + soins) et une alerte de chute de ponte (mue, météo) complètent le tableau."
+          },
+          "media": {
+            "title": "Photos & documents",
+            "body": "Ouvrez l'onglet Photos ou Documents d'une poule pour y joindre des photos avant/après ou des papiers (véto, facture). Importez un nouveau fichier ou reliez-en un existant — l'onglet apparaît via le menu « + » tant qu'il est vide."
           }
         }
       },
@@ -1374,7 +1378,9 @@
       "addToPhase": "Ajouter ici",
       "moveTo": "Déplacer vers {{phase}}",
       "remove": "Retirer",
-      "empty": "Aucune photo. Ajoutez-en pour documenter l'avant et l'après du projet."
+      "empty": "Aucune photo. Ajoutez-en pour documenter l'avant et l'après du projet.",
+      "attach_existing": "Choisir une existante",
+      "empty_hint": "Ajoutez-en une ou reliez une photo existante."
     }
   },
   "directory": {
@@ -1558,7 +1564,8 @@
       "empty": "Aucun document pour le moment.",
       "attach": "Rattacher ({{count}})",
       "detach": "Détacher",
-      "detached": "Document détaché"
+      "detached": "Document détaché",
+      "empty_hint": "Importez un document ou reliez-en un existant."
     },
     "linked_to": {
       "title": "Rattaché à",
@@ -1730,7 +1737,8 @@
       "info": "Infos",
       "history": "Historique",
       "assistant": "Assistant",
-      "documents": "Documents"
+      "documents": "Documents",
+      "photos": "Photos"
     }
   },
   "dashboard": {
@@ -2417,7 +2425,9 @@
     "tabs": {
       "info": "Infos",
       "events": "Journal",
-      "assistant": "Assistant"
+      "assistant": "Assistant",
+      "documents": "Documents",
+      "photos": "Photos"
     }
   },
   "alerts": {


### PR DESCRIPTION
## Quoi

Harmonise les onglets **Documents** et **Photos** des pages de détail autour d'une seule paire de composants génériques (`EntityDocumentsTab` / `EntityPhotosTab`), et enrichit le détail Poule des mêmes onglets adaptatifs que le détail Projet. Objectif : supprimer la duplication (dette technique) et offrir partout le même parcours « connecter un existant **ou** importer un nouveau ».

### Socle générique
- `EntityPhotosTab` gagne **« connecter une photo existante »** (il n'avait que l'upload), via `EntityAttachDocumentDialog` généralisé (`documentType='photo'`, vignettes dans le picker).
- Les deux onglets utilisent désormais le composant `EmptyState` (icône + CTA) au lieu d'un texte italique.
- Lecture des documents rendue **polymorphe** : `fetchDocuments`/`fetchPhotoDocuments` forwardent toutes les clés de filtre ; l'allow-list backend accepte `task` et `chicken`.
- Invalidation des `tab_counts` généralisée (`entityDetailQueryKey`) — plus de `['projects']` codé en dur.

### Poule — onglets Documents + Photos adaptatifs
- Backend : `Chicken.document_links` (GenericRelation, pas de migration), `chicken_tab_counts()`, `tab_counts` sur le serializer (retrieve only), `DocumentLinkActionsMixin` sur le viewset.
- Front : `ChickenDetailPage` migré vers `TabShell` adaptatif (info + events/documents/photos via le menu « + »).

### Doublons migrés vers le socle
- **Zones** : `TabPhotos`/`TabDocuments` maison + hooks supprimés → composants génériques.
- **Tasks** : onglet Documents du détail → `EntityDocumentsTab`.
- **Équipement** : ajout de l'onglet Photos.

## Livré ✅
- [x] Composant générique docs/photos réutilisé sur project / equipment / zone / task / chicken
- [x] « Connecter un existant » **et** « importer » sur les deux onglets, avec empty state
- [x] Détail Poule : onglets Photos + Documents adaptatifs (comme Projet)
- [x] Tests backend (`apps/chickens/tests/test_document_links.py`) + suite verte
- [x] i18n en/fr/de/es + step tutoriel « Photos & documents » (poules)

## Hors scope (dette conservée volontairement)
- Surface **card-level** des tâches (`TaskAttachmentsDialog` dans TaskCard/TasksPanel + `TaskDocumentViewSet` + `linked_documents`/`linked_document_count`) : ce n'est pas de la duplication de page détail (permission creator-only, quick-action) — conservée.
- Actions legacy Zone (`photos`/`attach_photo`) : gardées (couvertes par des tests), simplement plus consommées par le front.
- `gen:api:refresh` non relancé (types Chicken écrits à la main, non consommés depuis le schéma OpenAPI).
