### PR TITLE
fix(stock): route les écritures de quantité du CRUD par la logique inventaire (#325)

### DIFF
--- a/apps/stock/services.py
+++ b/apps/stock/services.py
@@ -202,6 +202,26 @@ def record_inventory(
     return item
 
 
+def record_initial_level(*, item: StockItem, user, occurred_at: datetime | None = None) -> StockLevelReading | None:
+    """Write the origin ``inventory`` reading for a freshly created item.
+
+    Called from ``perform_create`` so an item created with an initial quantity
+    has a starting point on its consumption curve and satisfies the invariant
+    (last reading == quantity) from birth. No status recompute nor notification:
+    the create form owns the item's initial status. Returns ``None`` for an empty
+    item (nothing to plot yet).
+    """
+    if Decimal(item.quantity) <= 0:
+        return None
+    return _record_level(
+        item,
+        quantity=Decimal(item.quantity),
+        kind=StockLevelReading.Kind.INVENTORY,
+        reading_at=occurred_at or timezone.now(),
+        user=user,
+    )
+
+
 def resolve_category(household, raw: str):
     """Resolve a stock category by id or (case-insensitive) name within a household.
 

--- a/apps/stock/tests/test_stock_consumption.py
+++ b/apps/stock/tests/test_stock_consumption.py
@@ -243,3 +243,118 @@ def test_consumption_ignores_restock_jumps(client, user, feed, membership):
     # Consumed: 8 (day0→5) + 8 (day6→10) = 16 over 10 days = 1.6 kg/day.
     assert data["rate_per_day"] == pytest.approx(1.6, abs=0.01)
     assert data["points_count"] == 4
+
+
+# --- CRUD writes must go through the inventory path (regression #325) ---------
+
+
+@pytest.mark.django_db
+def test_create_item_with_quantity_records_initial_inventory_reading(client, user, category, membership):
+    """Creating an item with an initial quantity writes the origin level reading.
+
+    Without it the consumption curve has no starting point and the documented
+    invariant (last reading == item.quantity) is broken from creation.
+    """
+    client.force_login(user)
+    response = client.post(
+        reverse("stock-item-list"),
+        data={
+            "category": str(category.id),
+            "name": "Sugar",
+            "quantity": "10.000",
+            "unit": "kg",
+            "status": "in_stock",
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201
+    item = StockItem.objects.get(id=response.json()["id"])
+    readings = _readings(item)
+    assert len(readings) == 1
+    assert readings[0].kind == StockLevelReading.Kind.INVENTORY
+    assert readings[0].quantity == Decimal("10.000")
+    assert readings[-1].quantity == item.quantity
+
+
+@pytest.mark.django_db
+def test_create_item_with_zero_quantity_records_no_reading(client, user, category, membership):
+    """An item created empty has nothing to plot yet — no spurious reading."""
+    client.force_login(user)
+    response = client.post(
+        reverse("stock-item-list"),
+        data={
+            "category": str(category.id),
+            "name": "Flour",
+            "quantity": "0",
+            "unit": "kg",
+            "status": "out_of_stock",
+        },
+        content_type="application/json",
+    )
+
+    assert response.status_code == 201
+    item = StockItem.objects.get(id=response.json()["id"])
+    assert _readings(item) == []
+
+
+@pytest.mark.django_db
+def test_edit_quantity_records_inventory_and_recomputes_status(client, user, category, membership, household):
+    """Editing the quantity via the form is a de-facto inventory count.
+
+    It must persist a reading, recompute the status from the new level, and keep
+    the invariant (last reading == item.quantity).
+    """
+    item = StockItem.objects.create(
+        household=household,
+        category=category,
+        name="Beans",
+        quantity=Decimal("5.000"),
+        min_quantity=Decimal("2"),
+        unit="kg",
+        status="in_stock",
+        created_by=user,
+    )
+
+    client.force_login(user)
+    response = client.patch(
+        reverse("stock-item-detail", kwargs={"pk": item.id}),
+        data={"quantity": "1.000"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["quantity"] == "1.000"
+    assert payload["status"] == "low_stock"
+
+    item.refresh_from_db()
+    readings = _readings(item)
+    assert len(readings) == 1
+    assert readings[0].kind == StockLevelReading.Kind.INVENTORY
+    assert readings[0].quantity == Decimal("1.000")
+    assert readings[-1].quantity == item.quantity
+
+
+@pytest.mark.django_db
+def test_edit_without_quantity_change_records_no_reading(client, user, category, membership, household):
+    """Editing another field (not the quantity) must not fabricate a reading."""
+    item = StockItem.objects.create(
+        household=household,
+        category=category,
+        name="Rice",
+        quantity=Decimal("3.000"),
+        unit="kg",
+        status="in_stock",
+        created_by=user,
+    )
+
+    client.force_login(user)
+    response = client.patch(
+        reverse("stock-item-detail", kwargs={"pk": item.id}),
+        data={"name": "Basmati rice"},
+        content_type="application/json",
+    )
+
+    assert response.status_code == 200
+    assert _readings(item) == []

--- a/apps/stock/views.py
+++ b/apps/stock/views.py
@@ -26,6 +26,7 @@ from .services import (
     compute_consumption,
     purchase_stock_item,
     recompute_status,
+    record_initial_level,
     record_inventory,
     undo_purchase,
 )
@@ -90,9 +91,18 @@ class StockItemViewSet(viewsets.ModelViewSet):
         if item.status == StockItem.Status.ORDERED and item.quantity > 0:
             item.last_restocked_at = timezone.now()
             item.save(update_fields=["last_restocked_at", "updated_at"])
+        # Origin point for the consumption curve — keeps the invariant
+        # (last reading == quantity) true from creation. No-op when empty.
+        record_initial_level(item=item, user=self.request.user)
 
     def perform_update(self, serializer):
-        serializer.save(updated_by=self.request.user)
+        old_quantity = Decimal(serializer.instance.quantity)
+        item = serializer.save(updated_by=self.request.user)
+        # Editing the quantity via the form is a de-facto inventory count: route
+        # it through the same path (level reading + status recompute + notify)
+        # instead of a silent direct write. Untouched quantity → nothing.
+        if Decimal(item.quantity) != old_quantity:
+            record_inventory(item=item, user=self.request.user, quantity=Decimal(item.quantity))
 
     @action(detail=True, methods=["post"], url_path="adjust-quantity")
     def adjust_quantity(self, request, pk=None):


### PR DESCRIPTION
Closes #325

## Problème

Le chemin CRUD standard (`perform_create` / `perform_update`) mutait `StockItem.quantity` en direct via `serializer.save()`, **sans passer par `stock.services`**. Conséquences :

- Aucun `StockLevelReading` écrit → `compute_consumption` (qui ne lit que les readings) affiche une courbe sans point d'origine, et les corrections de stock via le form d'édition sont invisibles.
- `item.quantity` désynchronisé du dernier reading → viole l'invariant documenté en tête de `apps/stock/services.py` (« callers must never mutate StockItem.quantity directly / quantity always has a matching last reading »).
- À l'édition, pas de `recompute_status` ni de notification.

## Correctif (option validée)

Le champ quantité **reste éditable** dans le formulaire, mais les écritures de quantité du CRUD sont routées par la logique inventaire :

- **Création avec `quantity > 0`** → nouveau service `record_initial_level` écrit un `StockLevelReading(kind=INVENTORY)` d'origine. Pas de `recompute_status`/notify : le formulaire de création possède le statut initial (préserve le cas `ORDERED`).
- **Édition où `quantity` change** → `record_inventory` (reading + `recompute_status` + notify), comme l'action inventaire dédiée.
- **Quantité inchangée / création vide** → aucun reading fabriqué.

## Tests

4 tests de régression dans `apps/stock/tests/test_stock_consumption.py` (create avec/sans quantité, edit avec/sans changement de quantité). Rouges avant le fix, verts après. Suite stock complète : 41 passed.

## Hors scope (suite éventuelle)

Le chemin agent `services.update_stock_item` (via `update_entity`) mute aussi la quantité en direct et contourne cet invariant — non traité ici, à router de la même façon dans un correctif dédié si on veut fermer complètement le trou.