### PR TITLE
Parcours 21 — Lot 0 : socle embeddings (pgvector + EmbeddingClient)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-alpine
+        # postgres:16 + pgvector extension (parcours 21). The migration
+        # apps/agent/0008 runs CREATE EXTENSION vector during test DB setup.
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_DB: house_test
           POSTGRES_USER: house_user

--- a/apps/agent/embeddings.py
+++ b/apps/agent/embeddings.py
@@ -1,0 +1,334 @@
+"""
+Embedding client abstraction — the vector counterpart of ``apps/agent/llm.py``.
+
+Anthropic provides **no** embeddings API: Claude stays the generation engine, but
+the vectors used by the hybrid retrieval (parcours 21) come from a separate
+provider. That provider is a settings decision (``EMBEDDING_PROVIDER``), never a
+caller decision — exactly like ``LLMClient`` hides Anthropic/Ollama for generation.
+
+- **Voyage AI** (``voyage``, default) — hosted API, called over REST via ``httpx``
+  (no heavy SDK). Chosen for prod because the 4 GB VPS can't hold a local model
+  next to the app. See docs/fiches/EMBEDDINGS.md §6.
+- **Ollama** (``ollama``) — local model over HTTP (``/api/embed``). The target once
+  the machine has ≥ 8 GB RAM; flip ``EMBEDDING_PROVIDER=ollama``, no refactor.
+- **OpenAI** (``openai``) — optional stub, not wired.
+
+``get_embedding_client(provider=…)`` is the single entry point. Every call is
+logged into ``AIUsageLog`` (feature defaults to ``embed``) so embedding usage
+stays observable across providers, just like generation.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, NoReturn, Protocol
+from uuid import UUID
+
+from django.conf import settings
+
+from ai_usage.services import log_ai_usage
+
+logger = logging.getLogger(__name__)
+
+# Default AIUsageLog feature tag for embedding calls. Indexing/query callers may
+# override it (e.g. "embed_index", "embed_query") to split usage in the logs.
+DEFAULT_EMBED_FEATURE = "embed"
+
+# Voyage asymmetric embeddings: documents and queries are embedded with a
+# different `input_type` for better retrieval. Providers that ignore it (Ollama)
+# simply drop the hint.
+INPUT_TYPE_DOCUMENT = "document"
+INPUT_TYPE_QUERY = "query"
+
+
+class EmbeddingError(Exception):
+    """Raised on any embedding provider failure (auth, rate-limit, 5xx, config…)."""
+
+
+class EmbeddingTimeoutError(EmbeddingError):
+    """Raised when an embedding provider call exceeds the configured timeout."""
+
+
+@dataclass
+class EmbeddingResponse:
+    """Result of one embedding call — one vector per input text, in order."""
+
+    vectors: list[list[float]]
+    model: str
+    dimensions: int
+    duration_ms: int
+    # Total tokens billed, when the provider reports it (Voyage does, Ollama may).
+    total_tokens: int | None = None
+
+
+class EmbeddingClient(Protocol):
+    """Provider-neutral embedding contract consumed by the retrieval/indexing layer."""
+
+    provider: str
+
+    def embed(
+        self,
+        texts: list[str],
+        *,
+        household_id: UUID | str,
+        feature: str = DEFAULT_EMBED_FEATURE,
+        user_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> EmbeddingResponse:
+        """Embed a batch of documents (``input_type=document``)."""
+        ...
+
+    def embed_query(
+        self,
+        text: str,
+        *,
+        household_id: UUID | str,
+        feature: str = DEFAULT_EMBED_FEATURE,
+        user_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[float]:
+        """Embed a single search query (``input_type=query``) and return its vector."""
+        ...
+
+
+class _BaseEmbeddingClient:
+    """Shared timing + logging + error handling. Providers implement ``_embed_raw``.
+
+    Mirrors the logging discipline of ``AnthropicClient`` in ``llm.py``: every
+    call — success or failure — writes one ``AIUsageLog`` row, and failures never
+    leak the provider's native exception (always ``EmbeddingError`` subclasses).
+    """
+
+    provider = "base"
+    model = ""
+
+    def _embed_raw(
+        self, texts: list[str], *, input_type: str
+    ) -> tuple[list[list[float]], int | None]:
+        """Provider-specific call. Return ``(vectors, total_tokens)``."""
+        raise NotImplementedError
+
+    def _run(
+        self,
+        texts: list[str],
+        *,
+        input_type: str,
+        household_id: UUID | str,
+        feature: str,
+        user_id: int | None,
+        metadata: dict[str, Any] | None,
+    ) -> EmbeddingResponse:
+        started = time.monotonic()
+        try:
+            vectors, total_tokens = self._embed_raw(texts, input_type=input_type)
+        except Exception as exc:
+            self._log_and_raise_failure(
+                exc,
+                started=started,
+                feature=feature,
+                household_id=household_id,
+                user_id=user_id,
+                metadata=metadata,
+            )
+
+        duration_ms = int((time.monotonic() - started) * 1000)
+        dimensions = len(vectors[0]) if vectors and vectors[0] else 0
+        log_ai_usage(
+            household_id=household_id,
+            user_id=user_id,
+            feature=feature,
+            provider=self.provider,
+            model=self.model,
+            duration_ms=duration_ms,
+            input_tokens=total_tokens,
+            success=True,
+            metadata={**(metadata or {}), "count": len(vectors), "dimensions": dimensions},
+        )
+        return EmbeddingResponse(
+            vectors=vectors,
+            model=self.model,
+            dimensions=dimensions,
+            duration_ms=duration_ms,
+            total_tokens=total_tokens,
+        )
+
+    def embed(
+        self,
+        texts: list[str],
+        *,
+        household_id: UUID | str,
+        feature: str = DEFAULT_EMBED_FEATURE,
+        user_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> EmbeddingResponse:
+        if not texts:
+            return EmbeddingResponse(vectors=[], model=self.model, dimensions=0, duration_ms=0)
+        return self._run(
+            list(texts),
+            input_type=INPUT_TYPE_DOCUMENT,
+            household_id=household_id,
+            feature=feature,
+            user_id=user_id,
+            metadata=metadata,
+        )
+
+    def embed_query(
+        self,
+        text: str,
+        *,
+        household_id: UUID | str,
+        feature: str = DEFAULT_EMBED_FEATURE,
+        user_id: int | None = None,
+        metadata: dict[str, Any] | None = None,
+    ) -> list[float]:
+        response = self._run(
+            [text],
+            input_type=INPUT_TYPE_QUERY,
+            household_id=household_id,
+            feature=feature,
+            user_id=user_id,
+            metadata=metadata,
+        )
+        return response.vectors[0] if response.vectors else []
+
+    def _log_and_raise_failure(
+        self,
+        exc: Exception,
+        *,
+        started: float,
+        feature: str,
+        household_id: UUID | str,
+        user_id: int | None,
+        metadata: dict[str, Any] | None,
+    ) -> NoReturn:
+        """Log a failed embedding call and re-raise as the right EmbeddingError."""
+        duration_ms = int((time.monotonic() - started) * 1000)
+        error_type = _classify_error(exc)
+        log_ai_usage(
+            household_id=household_id,
+            user_id=user_id,
+            feature=feature,
+            provider=self.provider,
+            model=self.model,
+            duration_ms=duration_ms,
+            success=False,
+            error_type=error_type,
+            metadata=metadata,
+        )
+        if error_type == "timeout":
+            raise EmbeddingTimeoutError(str(exc)) from exc
+        raise EmbeddingError(str(exc)) from exc
+
+
+class VoyageEmbeddingClient(_BaseEmbeddingClient):
+    """Voyage AI over its REST endpoint (no SDK — httpx, like the Ollama path).
+
+    The ``voyageai`` SDK pulls a heavy tree (langchain/numpy/tokenizers); the REST
+    call is a single POST, so we keep the prod image lean.
+    """
+
+    provider = "voyage"
+    API_URL = "https://api.voyageai.com/v1/embeddings"
+
+    def __init__(self, *, model: str | None = None, timeout: float | None = None):
+        self.model = model or getattr(settings, "EMBEDDING_MODEL", "voyage-3")
+        self.timeout = timeout or float(getattr(settings, "EMBEDDING_REQUEST_TIMEOUT_SECONDS", 30))
+
+    def _embed_raw(self, texts, *, input_type):
+        api_key = getattr(settings, "VOYAGE_API_KEY", "") or ""
+        if not api_key:
+            raise EmbeddingError("VOYAGE_API_KEY is not configured")
+        import httpx
+
+        response = httpx.post(
+            self.API_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={"model": self.model, "input": texts, "input_type": input_type},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        # Voyage returns data sorted by index, but sort defensively to preserve order.
+        rows = sorted(payload.get("data", []), key=lambda row: row.get("index", 0))
+        vectors = [row["embedding"] for row in rows]
+        total_tokens = (payload.get("usage") or {}).get("total_tokens")
+        return vectors, total_tokens
+
+
+class OllamaEmbeddingClient(_BaseEmbeddingClient):
+    """Local Ollama over HTTP (`/api/embed` batch endpoint). Target for RAM ≥ 8 GB."""
+
+    provider = "ollama"
+
+    def __init__(
+        self,
+        *,
+        model: str | None = None,
+        base_url: str | None = None,
+        timeout: float | None = None,
+    ):
+        self.model = model or getattr(settings, "EMBEDDING_MODEL", "bge-m3")
+        base = base_url or getattr(settings, "EMBEDDING_BASE_URL", "http://localhost:11434")
+        self.base_url = base.rstrip("/")
+        self.timeout = timeout or float(getattr(settings, "EMBEDDING_REQUEST_TIMEOUT_SECONDS", 60))
+
+    def _embed_raw(self, texts, *, input_type):
+        # Ollama's embedding models are symmetric — input_type carries no meaning
+        # here, so it is intentionally ignored.
+        import httpx
+
+        response = httpx.post(
+            f"{self.base_url}/api/embed",
+            json={"model": self.model, "input": texts},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        vectors = payload.get("embeddings") or []
+        total_tokens = payload.get("prompt_eval_count")
+        return vectors, total_tokens
+
+
+class OpenAIEmbeddingClient(_BaseEmbeddingClient):
+    """Optional stub — branchable porte de sortie, not implemented (see EMBEDDINGS.md)."""
+
+    provider = "openai"
+
+    def __init__(self, *, model: str | None = None, timeout: float | None = None):
+        self.model = model or getattr(settings, "EMBEDDING_MODEL", "text-embedding-3-small")
+
+    def _embed_raw(self, texts, *, input_type):
+        raise EmbeddingError(
+            "OpenAIEmbeddingClient is not implemented — set EMBEDDING_PROVIDER=voyage or ollama"
+        )
+
+
+def _classify_error(exc: Exception) -> str:
+    """Map provider exceptions to a short error_type tag for ``AIUsageLog``."""
+    name = type(exc).__name__.lower()
+    if "timeout" in name:
+        return "timeout"
+    if "rate" in name and "limit" in name:
+        return "rate_limit"
+    if "auth" in name or "unauthorized" in name:
+        return "auth"
+    if "connect" in name:
+        return "connection"
+    return name or "unknown"
+
+
+_CLIENTS: dict[str, type[_BaseEmbeddingClient]] = {
+    "voyage": VoyageEmbeddingClient,
+    "ollama": OllamaEmbeddingClient,
+    "openai": OpenAIEmbeddingClient,
+}
+
+
+def get_embedding_client(provider: str | None = None) -> EmbeddingClient:
+    """Return the configured embedding client. Override the provider for tests/scripts."""
+    chosen = (provider or getattr(settings, "EMBEDDING_PROVIDER", "voyage")).lower()
+    try:
+        return _CLIENTS[chosen]()
+    except KeyError:
+        raise EmbeddingError(f"Unknown embedding provider: {chosen!r}") from None

--- a/apps/agent/migrations/0008_pgvector_extension.py
+++ b/apps/agent/migrations/0008_pgvector_extension.py
@@ -1,0 +1,21 @@
+"""Enable the pgvector extension used by the hybrid semantic retrieval (parcours 21).
+
+`CREATE EXTENSION vector` — the vector column type + k-NN operators. Mirrors the
+`UnaccentExtension` bootstrap in 0001_initial.py. Requires the extension to be
+available on the Postgres server (image `pgvector/pgvector:pg16` in CI/prod; built
+from source for local Homebrew — see docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md).
+"""
+from pgvector.django import VectorExtension
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("agent", "0007_agentconversation_web_search_enabled"),
+    ]
+
+    operations = [
+        VectorExtension(),
+    ]

--- a/apps/agent/tests/test_embeddings.py
+++ b/apps/agent/tests/test_embeddings.py
@@ -1,0 +1,194 @@
+"""Tests for the embedding client abstraction.
+
+Never hits a real provider — every call patches ``httpx.post`` so CI stays
+network-free. Exercises Voyage + Ollama happy paths, the factory, logging into
+``AIUsageLog``, and the error/timeout classification.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from accounts.tests.factories import UserFactory
+from agent.embeddings import (
+    EmbeddingError,
+    EmbeddingTimeoutError,
+    OllamaEmbeddingClient,
+    OpenAIEmbeddingClient,
+    VoyageEmbeddingClient,
+    get_embedding_client,
+)
+from ai_usage.models import AIUsageLog
+from households.models import Household
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Embedding test household")
+
+
+@pytest.fixture
+def user(db):
+    return UserFactory(email="embed-test@example.com")
+
+
+@pytest.fixture
+def with_voyage_key(settings):
+    settings.VOYAGE_API_KEY = "pa-test-fake"
+    return settings
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakePost:
+    """Records the last httpx.post call and returns a canned payload (or raises)."""
+
+    def __init__(self, payload=None, raises: Exception | None = None):
+        self.payload = payload
+        self.raises = raises
+        self.calls: list[dict] = []
+
+    def __call__(self, url, **kwargs):
+        self.calls.append({"url": url, **kwargs})
+        if self.raises:
+            raise self.raises
+        return _FakeResponse(self.payload)
+
+
+def _voyage_payload(*vectors):
+    return {
+        "data": [{"index": i, "embedding": list(v)} for i, v in enumerate(vectors)],
+        "usage": {"total_tokens": 42},
+    }
+
+
+class TestVoyageClient:
+    def test_embed_returns_vectors_and_logs(self, with_voyage_key, monkeypatch, household, user):
+        fake = _FakePost(payload=_voyage_payload([0.1, 0.2, 0.3], [0.4, 0.5, 0.6]))
+        monkeypatch.setattr(httpx, "post", fake)
+
+        client = VoyageEmbeddingClient(model="voyage-3")
+        result = client.embed(
+            ["facture engie", "pompe à chaleur"],
+            household_id=household.id,
+            user_id=user.id,
+        )
+
+        assert result.vectors == [[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]
+        assert result.dimensions == 3
+        assert result.total_tokens == 42
+        assert result.model == "voyage-3"
+
+        # Request shape: bearer auth, document input_type, both texts.
+        call = fake.calls[0]
+        assert call["url"] == VoyageEmbeddingClient.API_URL
+        assert call["headers"]["Authorization"] == "Bearer pa-test-fake"
+        assert call["json"]["input"] == ["facture engie", "pompe à chaleur"]
+        assert call["json"]["input_type"] == "document"
+
+        log = AIUsageLog.objects.get()
+        assert log.feature == "embed"
+        assert log.provider == "voyage"
+        assert log.model == "voyage-3"
+        assert log.success is True
+        assert log.input_tokens == 42
+        assert log.metadata["count"] == 2
+        assert log.metadata["dimensions"] == 3
+        assert log.household_id == household.id
+        assert log.user_id == user.id
+
+    def test_embed_query_uses_query_input_type(self, with_voyage_key, monkeypatch, household):
+        fake = _FakePost(payload=_voyage_payload([0.7, 0.8]))
+        monkeypatch.setattr(httpx, "post", fake)
+
+        vector = VoyageEmbeddingClient().embed_query("le chauffage", household_id=household.id)
+
+        assert vector == [0.7, 0.8]
+        assert fake.calls[0]["json"]["input_type"] == "query"
+
+    def test_missing_key_raises_and_logs_failure(self, settings, monkeypatch, household):
+        settings.VOYAGE_API_KEY = ""
+        # Should fail before any network call — but guard anyway.
+        monkeypatch.setattr(httpx, "post", _FakePost(payload=_voyage_payload([0.1])))
+
+        with pytest.raises(EmbeddingError):
+            VoyageEmbeddingClient().embed(["x"], household_id=household.id)
+
+        log = AIUsageLog.objects.get()
+        assert log.success is False
+        assert log.provider == "voyage"
+
+    def test_timeout_raises_timeout_error(self, with_voyage_key, monkeypatch, household):
+        fake = _FakePost(raises=httpx.TimeoutException("timed out"))
+        monkeypatch.setattr(httpx, "post", fake)
+
+        with pytest.raises(EmbeddingTimeoutError):
+            VoyageEmbeddingClient().embed(["x"], household_id=household.id)
+
+        log = AIUsageLog.objects.get()
+        assert log.success is False
+        assert log.error_type == "timeout"
+
+    def test_empty_input_short_circuits(self, with_voyage_key, monkeypatch, household):
+        fake = _FakePost(payload=_voyage_payload())
+        monkeypatch.setattr(httpx, "post", fake)
+
+        result = VoyageEmbeddingClient().embed([], household_id=household.id)
+
+        assert result.vectors == []
+        assert fake.calls == []  # no network
+        assert AIUsageLog.objects.count() == 0  # nothing logged
+
+
+class TestOllamaClient:
+    def test_embed_hits_batch_endpoint(self, monkeypatch, household):
+        fake = _FakePost(payload={"embeddings": [[1.0, 2.0], [3.0, 4.0]], "prompt_eval_count": 8})
+        monkeypatch.setattr(httpx, "post", fake)
+
+        client = OllamaEmbeddingClient(model="bge-m3", base_url="http://ollama:11434/")
+        result = client.embed(["a", "b"], household_id=household.id)
+
+        assert result.vectors == [[1.0, 2.0], [3.0, 4.0]]
+        assert result.total_tokens == 8
+        assert fake.calls[0]["url"] == "http://ollama:11434/api/embed"
+        assert fake.calls[0]["json"] == {"model": "bge-m3", "input": ["a", "b"]}
+
+        log = AIUsageLog.objects.get()
+        assert log.provider == "ollama"
+        assert log.model == "bge-m3"
+
+
+class TestFactory:
+    def test_returns_provider_from_settings(self, settings):
+        settings.EMBEDDING_PROVIDER = "voyage"
+        assert isinstance(get_embedding_client(), VoyageEmbeddingClient)
+        settings.EMBEDDING_PROVIDER = "ollama"
+        assert isinstance(get_embedding_client(), OllamaEmbeddingClient)
+
+    def test_explicit_override_wins(self, settings):
+        settings.EMBEDDING_PROVIDER = "voyage"
+        assert isinstance(get_embedding_client("ollama"), OllamaEmbeddingClient)
+        assert isinstance(get_embedding_client("openai"), OpenAIEmbeddingClient)
+
+    def test_unknown_provider_raises(self, settings):
+        with pytest.raises(EmbeddingError):
+            get_embedding_client("pinecone")
+
+    def test_openai_stub_raises_and_logs(self, monkeypatch, household):
+        with pytest.raises(EmbeddingError):
+            OpenAIEmbeddingClient().embed(["x"], household_id=household.id)
+
+        log = AIUsageLog.objects.get()
+        assert log.provider == "openai"
+        assert log.success is False

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -214,6 +214,21 @@ LLM_REQUEST_TIMEOUT_SECONDS = 30
 # Vision OCR (full-page images) is slower than chat round-trips.
 LLM_VISION_TIMEOUT_SECONDS = 60
 
+# Embedding provider (hybrid semantic retrieval, parcours 21). Anthropic has no
+# embeddings API, so vectors come from a separate provider behind
+# `apps.agent.embeddings.get_embedding_client()`, keyed on `EMBEDDING_PROVIDER`.
+# Prod default: Voyage AI (hosted, 0 GB RAM on the VPS). Ollama local (bge-m3) is
+# the target once the machine has >= 8 GB RAM — flip EMBEDDING_PROVIDER=ollama,
+# no refactor. See docs/fiches/EMBEDDINGS.md.
+EMBEDDING_PROVIDER = "voyage"
+EMBEDDING_MODEL = "voyage-3"
+EMBEDDING_DIMENSIONS = 1024
+EMBEDDING_REQUEST_TIMEOUT_SECONDS = 30
+# Ollama endpoint, only used when EMBEDDING_PROVIDER=ollama.
+EMBEDDING_BASE_URL = "http://localhost:11434"
+# Voyage API key — empty by default; set per environment / in .env.
+VOYAGE_API_KEY = ""
+
 # Agent tool-use loop: max LLM round-trips per question. Each iteration is one
 # LLM call; the tools are dropped on the last pass to force a final answer.
 # Bounds latency and cost of the function-calling loop. 4 leaves room to chain

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -65,6 +65,14 @@ LLM_PROVIDER = env("LLM_PROVIDER", default="anthropic")
 LLM_TEXT_MODEL = env("LLM_TEXT_MODEL", default="claude-haiku-4-5-20251001")
 LLM_VISION_MODEL = env("LLM_VISION_MODEL", default="claude-haiku-4-5-20251001")
 
+# Embedding provider (parcours 21). Locally you can run Ollama (bge-m3) for free
+# by setting EMBEDDING_PROVIDER=ollama; otherwise Voyage needs VOYAGE_API_KEY.
+EMBEDDING_PROVIDER = env("EMBEDDING_PROVIDER", default="voyage")
+EMBEDDING_MODEL = env("EMBEDDING_MODEL", default="voyage-3")
+EMBEDDING_DIMENSIONS = env.int("EMBEDDING_DIMENSIONS", default=1024)
+EMBEDDING_BASE_URL = env("EMBEDDING_BASE_URL", default="http://localhost:11434")
+VOYAGE_API_KEY = env("VOYAGE_API_KEY", default="")
+
 # Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
 AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -80,6 +80,14 @@ LLM_PROVIDER = env("LLM_PROVIDER", default="anthropic")
 LLM_TEXT_MODEL = env("LLM_TEXT_MODEL", default="claude-haiku-4-5-20251001")
 LLM_VISION_MODEL = env("LLM_VISION_MODEL", default="claude-haiku-4-5-20251001")
 
+# Embedding provider (parcours 21). Prod default: Voyage AI (VOYAGE_API_KEY
+# required). Switch to local Ollama (bge-m3) only once the host has >= 8 GB RAM.
+EMBEDDING_PROVIDER = env("EMBEDDING_PROVIDER", default="voyage")
+EMBEDDING_MODEL = env("EMBEDDING_MODEL", default="voyage-3")
+EMBEDDING_DIMENSIONS = env.int("EMBEDDING_DIMENSIONS", default=1024)
+EMBEDDING_BASE_URL = env("EMBEDDING_BASE_URL", default="http://ollama:11434")
+VOYAGE_API_KEY = env("VOYAGE_API_KEY", default="")
+
 # Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
 AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,6 +1,11 @@
 services:
   db:
-    image: postgres:16-alpine
+    # pgvector/pgvector:pg16 = official postgres:16 (Debian) + the `vector`
+    # extension preinstalled (parcours 21, hybrid semantic retrieval). Same PG
+    # major as before, so the postgres-data volume is compatible; a REINDEX after
+    # the alpine(musl)->debian(glibc) switch is prudent if text-index collation
+    # ever looks off. See docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md.
+    image: pgvector/pgvector:pg16
     restart: always
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ jsonschema==4.26.0
 jsonschema-specifications==2025.9.1
 openpyxl==3.1.5
 packaging==26.0
+pgvector==0.5.0  # Django VectorField + pgvector k-NN (parcours 21). Server extension installed via migration.
 pillow==12.1.1
 pillow-heif==0.18.0
 psycopg==3.3.2


### PR DESCRIPTION
Socle de la recherche sémantique hybride (parcours 21). **Aucun effet utilisateur** : rien n'indexe ni ne cherche encore — on pose les fondations.

## Contenu
- **Migration** `agent/0008_pgvector_extension` : `CREATE EXTENSION vector`.
- **Images Postgres CI + prod** basculées `postgres:16-alpine` → `pgvector/pgvector:pg16`.
- **`apps/agent/embeddings.py`** : `EmbeddingClient` Protocol (miroir de `llm.py`) + `VoyageEmbeddingClient` (REST via `httpx`, actif) + `OllamaEmbeddingClient` (cible local RAM ≥ 8 Go) + `OpenAIEmbeddingClient` (stub) + factory `get_embedding_client()`. Chaque appel logue dans `AIUsageLog` (feature `embed`).
- **Settings** `EMBEDDING_*` (défaut `voyage` / `voyage-3` / 1024 dims) + `VOYAGE_API_KEY`.
- **requirements** : `pgvector` (pas de SDK Voyage — REST httpx, footprint minimal).
- **Tests** : Voyage/Ollama happy path, factory, logging, timeout/erreur (mock `httpx`, zéro réseau).

## Validation
- `pytest apps/agent/` → **524 passed** (base fraîche).
- Migration appliquée en local (pgvector 0.8.0 compilé pour PG16).

## ⚠️ Implication prod au merge
L'auto-deploy recrée le conteneur `db` avec l'image pgvector. Même PG16 → volume compatible ; un `REINDEX` est prudent si une collation de texte semble anormale après le passage alpine(musl)→debian(glibc). **Prérequis prod** : poser `VOYAGE_API_KEY` dans le `.env` avant que le lot 3 (retrieval hybride) n'active la recherche vectorielle.

Refs #327