### PR TITLE
Parcours 21 — Lot 2 : backfill_embeddings (indexation de l'existant)

### DIFF
--- a/apps/agent/indexing.py
+++ b/apps/agent/indexing.py
@@ -89,12 +89,16 @@ def _delete_chunks(entity_type: str, object_id: str) -> int:
     return deleted
 
 
-def reindex_instance(instance: Model, *, client: EmbeddingClient | None = None) -> int:
+def reindex_instance(
+    instance: Model, *, client: EmbeddingClient | None = None, force: bool = False
+) -> int:
     """(Re)build the vector index for one searchable instance. Returns #chunks written.
 
     Idempotent: returns 0 without embedding when the content hash and model are
-    unchanged. Unregistered / non-embeddable / empty-text instances are cleaned
-    of any stale chunks and return 0.
+    unchanged, unless ``force`` (used by the backfill after a model/provider
+    switch, where the vectors must be recomputed even though the text is the same).
+    Unregistered / non-embeddable / empty-text instances are cleaned of any stale
+    chunks and return 0.
     """
     spec = find_spec_for_instance(instance)
     if spec is None:
@@ -121,7 +125,12 @@ def reindex_instance(instance: Model, *, client: EmbeddingClient | None = None) 
     existing = list(
         EmbeddingChunk.objects.filter(entity_type=entity_type, object_id=object_id)[:1]
     )
-    if existing and existing[0].content_hash == new_hash and existing[0].model == model_name:
+    if (
+        not force
+        and existing
+        and existing[0].content_hash == new_hash
+        and existing[0].model == model_name
+    ):
         return 0  # nothing changed — skip the embedding call entirely
 
     chunks = chunk_text(text)

--- a/apps/agent/management/commands/backfill_embeddings.py
+++ b/apps/agent/management/commands/backfill_embeddings.py
@@ -1,0 +1,134 @@
+"""Backfill the vector index (``EmbeddingChunk``) for existing searchable entities.
+
+Write-time indexing (parcours 21 lot 1) only covers entities saved *after* it was
+enabled. This command indexes the **existing** corpus, and re-indexes everything
+after an embedding model/provider switch (``--force``). Mirror of
+``documents.extract_documents_text`` (the OCR backfill).
+
+Usage:
+
+    python manage.py backfill_embeddings --dry-run              # count + cost, write nothing
+    python manage.py backfill_embeddings --limit 50             # first 50 entities
+    python manage.py backfill_embeddings --household <uuid>     # one household
+    python manage.py backfill_embeddings --entity-type document # one entity type
+    python manage.py backfill_embeddings --force                # re-embed all (model switch)
+"""
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from agent import indexing
+from agent.embeddings import get_embedding_client
+from agent.searchables import REGISTRY, find_spec
+
+# Rough estimate only: ~4 chars/token, Voyage voyage-3 input ≈ $0.06 / 1M tokens.
+# Used solely for the --dry-run cost hint, never for billing.
+_CHARS_PER_TOKEN = 4
+_USD_PER_1M_TOKENS = {"voyage": 0.06, "openai": 0.02}
+
+
+class Command(BaseCommand):
+    help = "Backfill the EmbeddingChunk vector index for existing searchable entities."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--household", type=str, default=None, help="Restrict to one household id.")
+        parser.add_argument(
+            "--entity-type", type=str, default=None, help="Restrict to one registry entity_type."
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Re-embed even when content is unchanged (use after a model/provider switch).",
+        )
+        parser.add_argument("--limit", type=int, default=None, help="Max number of entities to process.")
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Count entities and estimate cost; embed nothing, write nothing.",
+        )
+
+    def handle(self, *args, **options):
+        entity_type = options["entity_type"]
+        household = options["household"]
+        force = options["force"]
+        limit = options["limit"]
+        dry_run = options["dry_run"]
+
+        specs = [spec for spec in REGISTRY if spec.embed]
+        if entity_type:
+            spec = find_spec(entity_type)
+            if spec is None:
+                raise CommandError(f"Unknown entity_type: {entity_type!r}")
+            if not spec.embed:
+                raise CommandError(f"entity_type {entity_type!r} is not embeddable (embed=False).")
+            specs = [spec]
+
+        total = sum(self._queryset(spec, household).count() for spec in specs)
+        if total == 0:
+            self.stdout.write("Nothing to index.")
+            return
+
+        client = None if dry_run else get_embedding_client()
+        processed = indexed = skipped = failed = 0
+        total_chunks = total_chars = 0
+
+        for spec in specs:
+            for instance in self._queryset(spec, household).iterator():
+                if limit is not None and processed >= limit:
+                    break
+                processed += 1
+
+                text = indexing._full_content(instance, spec.search_fields)
+                chunks = indexing.chunk_text(text)
+                total_chunks += len(chunks)
+                total_chars += sum(len(c) for c in chunks)
+
+                if dry_run:
+                    continue
+
+                try:
+                    written = indexing.reindex_instance(instance, client=client, force=force)
+                    if written:
+                        indexed += 1
+                    else:
+                        skipped += 1
+                except Exception as exc:  # one bad entity must not abort the batch
+                    failed += 1
+                    self.stderr.write(f"  ! {spec.entity_type}:{instance.pk} failed: {exc}")
+
+                if processed % 25 == 0 or processed == total:
+                    self.stdout.write(f"  [{processed}/{total}] processed")
+            if limit is not None and processed >= limit:
+                break
+
+        self._report(dry_run, processed, indexed, skipped, failed, total_chunks, total_chars)
+
+    def _queryset(self, spec, household):
+        qs = spec.model.objects.all()
+        if household:
+            qs = qs.filter(household_id=household)
+        return qs
+
+    def _report(self, dry_run, processed, indexed, skipped, failed, total_chunks, total_chars):
+        est_tokens = total_chars // _CHARS_PER_TOKEN
+        provider = getattr(settings, "EMBEDDING_PROVIDER", "voyage")
+        rate = _USD_PER_1M_TOKENS.get(provider)
+        if rate is None:
+            cost = "0 $ (local)"
+        else:
+            cost = f"~${est_tokens / 1_000_000 * rate:.4f} ({provider})"
+
+        if dry_run:
+            self.stdout.write(
+                f"[dry-run] {processed} entit(ies) → ~{total_chunks} chunk(s), "
+                f"~{est_tokens} tokens, estimated cost {cost}. Nothing written."
+            )
+            return
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Done: {processed} processed — {indexed} indexed, {skipped} skipped, "
+                f"{failed} failed. {total_chunks} chunk(s), estimated cost {cost}."
+            )
+        )

--- a/apps/agent/tests/test_backfill_embeddings.py
+++ b/apps/agent/tests/test_backfill_embeddings.py
@@ -1,0 +1,157 @@
+"""Tests for the `backfill_embeddings` management command (parcours 21 lot 2).
+
+Network-free: a fake embedding client is injected via monkeypatch. Covers
+dry-run (no writes), real indexing, --limit, --household, --entity-type, --force,
+and resilience (one failing entity doesn't abort the batch).
+"""
+from __future__ import annotations
+
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from agent.embeddings import EmbeddingResponse
+from agent.management.commands import backfill_embeddings as cmd_module
+from agent.models import EmbeddingChunk
+
+
+class _FakeEmbeddingClient:
+    model = "fake-embed"
+
+    def embed(self, texts, *, household_id, feature="embed", user_id=None, metadata=None):
+        if any("BOOM" in t for t in texts):
+            raise ValueError("simulated provider failure")
+        dim = 1024
+        return EmbeddingResponse(
+            vectors=[[0.1] * dim for _ in texts],
+            model=self.model,
+            dimensions=dim,
+            duration_ms=1,
+        )
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="backfill-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    h = Household.objects.create(name="Backfill House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    return h
+
+
+@pytest.fixture
+def other_household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    h = Household.objects.create(name="Other Backfill House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    return h
+
+
+@pytest.fixture
+def make_document(owner):
+    from documents.models import Document
+
+    def _make(household, **overrides):
+        payload = dict(
+            household=household,
+            created_by=owner,
+            file_path="documents/x.pdf",
+            name="Doc",
+            mime_type="application/pdf",
+            type="document",
+            ocr_text="contenu à indexer",
+            notes="",
+        )
+        payload.update(overrides)
+        return Document.objects.create(**payload)
+
+    return _make
+
+
+@pytest.fixture(autouse=True)
+def _fake_client(monkeypatch):
+    monkeypatch.setattr(cmd_module, "get_embedding_client", lambda *a, **k: _FakeEmbeddingClient())
+
+
+def _run(**kwargs):
+    out = StringIO()
+    call_command("backfill_embeddings", stdout=out, stderr=out, **kwargs)
+    return out.getvalue()
+
+
+def _object_ids(household):
+    """Distinct source ids indexed for a household (scoped so a --reuse-db test
+    database with leftover rows from other households can't leak in)."""
+    return set(
+        EmbeddingChunk.objects.filter(household=household).values_list("object_id", flat=True)
+    )
+
+
+class TestBackfillEmbeddings:
+    def test_dry_run_writes_nothing(self, make_document, household):
+        make_document(household, ocr_text="facture engie mars")
+        output = _run(dry_run=True)
+        assert "[dry-run]" in output
+        assert EmbeddingChunk.objects.count() == 0
+
+    def test_indexes_entities(self, make_document, household):
+        # entity_type=document: a household auto-creates a root Zone (also
+        # searchable), so scope to documents to keep the count deterministic.
+        make_document(household, ocr_text="pompe à chaleur")
+        make_document(household, ocr_text="chaudière gaz")
+        _run(household=str(household.id), entity_type="document")
+        assert len(_object_ids(household)) == 2
+
+    def test_limit_caps_processing(self, make_document, household):
+        for i in range(4):
+            make_document(household, ocr_text=f"doc numero {i}")
+        _run(household=str(household.id), entity_type="document", limit=2)
+        assert len(_object_ids(household)) == 2
+
+    def test_household_filter(self, make_document, household, other_household):
+        mine = make_document(household, ocr_text="chez moi")
+        theirs = make_document(other_household, ocr_text="chez eux")
+        _run(household=str(household.id))
+        assert str(mine.pk) in _object_ids(household)
+        assert str(theirs.pk) not in _object_ids(household)
+        assert str(theirs.pk) not in _object_ids(other_household)  # not touched at all
+
+    def test_entity_type_filter_unknown_raises(self):
+        with pytest.raises(CommandError):
+            _run(entity_type="does_not_exist")
+
+    def test_force_reembeds(self, make_document, household):
+        make_document(household, ocr_text="texte stable")
+        _run(household=str(household.id), entity_type="document")
+        before = EmbeddingChunk.objects.filter(household=household, entity_type="document").count()
+        # Idempotent second run without --force: no change.
+        _run(household=str(household.id), entity_type="document")
+        assert (
+            EmbeddingChunk.objects.filter(household=household, entity_type="document").count()
+            == before
+        )
+        # --force rebuilds regardless.
+        output = _run(household=str(household.id), entity_type="document", force=True)
+        assert "indexed" in output
+        assert (
+            EmbeddingChunk.objects.filter(household=household, entity_type="document").count()
+            == before
+        )
+
+    def test_one_failure_does_not_abort(self, make_document, household):
+        make_document(household, ocr_text="bon document")
+        make_document(household, ocr_text="document BOOM cassé")
+        output = _run(household=str(household.id), entity_type="document")
+        # The good one is indexed, the batch reports one failure, run completes.
+        assert "1 failed" in output
+        assert len(_object_ids(household)) == 1

--- a/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
@@ -13,8 +13,8 @@ Socle dont on hérite : [PARCOURS_07_BACKLOG_TECHNIQUE.md](./PARCOURS_07_BACKLOG
 | Lot | Sujet | Statut | Issue |
 |---|---|---|---|
 | 0 | Socle pgvector + abstraction `EmbeddingClient` (Voyage `voyage-3`) | ✅ Livré (PR #333) | #327 |
-| 1 | Modèle `EmbeddingChunk` + chunking + indexation write-time | 🚧 En PR | #328 |
-| 2 | Backfill par management command (`backfill_embeddings`) | ⬜ À faire | #329 |
+| 1 | Modèle `EmbeddingChunk` + chunking + indexation write-time | ✅ Livré (PR #334) | #328 |
+| 2 | Backfill par management command (`backfill_embeddings`) | 🚧 En PR | #329 |
 | 3 | Retrieval hybride (full-text + vecteur, fusion RRF) + flag | ⬜ À faire | #330 |
 | 4 | Observabilité (`AIUsageLog` feature `embed`) + harnais d'évaluation | ⬜ À faire | #331 |
 | 5 | Idées V2 (reranking, index HNSW, chunking sémantique) | 💡 Idée | #332 |


### PR DESCRIPTION
Closes #329

Troisième lot. Management command pour indexer le corpus **existant** (le write-time du lot 1 ne couvre que les écritures futures) et le ré-indexer après un changement de modèle/provider.

## Quoi
- **`manage.py backfill_embeddings`** : `--household`, `--entity-type`, `--force`, `--limit`, `--dry-run`. Itère le registry `searchables` (specs `embed=True`), réutilise `reindex_instance` — zéro logique dupliquée.
- **`--dry-run`** : compte les entités + estime chunks/tokens/coût (voyage ≈ $0.06/1M, « 0 $ (local) » si ollama), n'écrit rien, n'appelle pas l'embedding.
- **Progression** `[N/total]` ; une entité en erreur est loguée et **n'arrête pas** le batch.
- **`reindex_instance(..., force=True)`** : ré-embed même si `content_hash`+`model` inchangés (cas changement de modèle).

## Critères de l'issue
- ✅ `--dry-run` liste volume + coût sans rien écrire
- ✅ `--limit N` traite N entités
- ✅ relance sans `--force` → idempotent (rien de réécrit)
- ✅ `--force` ré-embed
- ✅ `--household` / `--entity-type` filtrent ; entity_type inconnu → erreur
- ✅ une entité en erreur n'arrête pas le batch

## Validation
- `pytest apps/agent/tests/test_backfill_embeddings.py` → 7 passed ; suite agent **545 passed**.

## Note
Command **manuelle** (aucun cron). Sans effet tant que `VOYAGE_API_KEY` n'est pas configuré en prod. Prochain lot (#330) : le retrieval hybride RRF — le gain visible.