### PR TITLE
Parcours 21 — Lot 3 : retrieval hybride (full-text + sémantique, RRF)

### DIFF
--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -1,17 +1,25 @@
 """
-Naive full-text retrieval over household entities.
+Retrieval over household entities — lexical (full-text) + optional semantic.
 
-Iterates over the registry, runs a `SearchVector` query per model with
-`config='simple'` (multi-tenant safe — no stemming), merges hits, and ranks
-them globally by the Postgres `SearchRank`. Snippets are produced via
-`SearchHeadline`.
+Lexical: iterates the registry, runs a `SearchVector` query per model with
+`config='simple_unaccent'` (multi-tenant safe — no stemming), merges hits, ranks
+them by the Postgres `SearchRank`, snippets via `SearchHeadline`.
+
+Hybrid (parcours 21, behind `AGENT_HYBRID_RETRIEVAL_ENABLED`): a second semantic
+leg embeds the query and runs a pgvector k-NN over `EmbeddingChunk`, then the two
+rankings are merged by Reciprocal Rank Fusion. The public contract —
+`search(household_id, query) -> list[Hit]` — is unchanged, so the agent (tools,
+service, anchored context) is transparent to the change. Flag off = byte-identical
+to the pure full-text behaviour.
 """
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 from uuid import UUID
 
+from django.conf import settings
 from django.contrib.postgres.search import (
     SearchHeadline,
     SearchQuery,
@@ -19,9 +27,20 @@ from django.contrib.postgres.search import (
     SearchVector,
 )
 from django.db.models import F, Value
+from pgvector.django import CosineDistance
 
 from .modules import disabled_modules_for, spec_disabled
-from .searchables import REGISTRY, SearchableSpec, resolve_label
+from .searchables import REGISTRY, SearchableSpec, find_spec, resolve_label
+
+logger = logging.getLogger(__name__)
+
+# Reciprocal Rank Fusion damping constant (Cormack 2009 convention). Overridable
+# via settings.RRF_K. Higher = flatter contribution of top ranks.
+_RRF_K_DEFAULT = 60
+
+# Chunks fetched from the k-NN before deduping to entities. One entity can own
+# several chunks; over-fetching lets us still surface `limit` distinct entities.
+_VECTOR_CHUNK_FANOUT = 5
 
 SNIPPET_MAX_WORDS = 30
 SNIPPET_MIN_WORDS = 8
@@ -220,7 +239,109 @@ def search(
         all_hits.extend(_search_one(spec, household_id, query, limit))
 
     all_hits.sort(key=lambda h: h.rank, reverse=True)
-    return all_hits[:limit]
+    fulltext_hits = all_hits[:limit]
+
+    if not _hybrid_enabled():
+        return fulltext_hits
+
+    vector_hits = _vector_search(household_id, query, limit, disabled=disabled)
+    if not vector_hits:
+        # No semantic leg (embeddings disabled/unavailable/empty index) → behave
+        # exactly like pure full-text. Never worse than today.
+        return fulltext_hits
+
+    return _fuse_rrf([fulltext_hits, vector_hits])[:limit]
+
+
+def _hybrid_enabled() -> bool:
+    return bool(getattr(settings, "AGENT_HYBRID_RETRIEVAL_ENABLED", False))
+
+
+def _vector_search(
+    household_id: UUID,
+    query: str,
+    limit: int,
+    disabled: frozenset[str] | None = None,
+) -> list[Hit]:
+    """Semantic leg: embed the query, k-NN over `EmbeddingChunk`, dedupe to entities.
+
+    Best-effort — any embedding failure degrades to `[]` so `search()` falls back
+    to full-text. Chunks are resolved back to their source entity via the registry
+    and rendered as citable Hits (interface identical to the lexical leg).
+    """
+    from .embeddings import EmbeddingError, get_embedding_client
+    from .models import EmbeddingChunk
+
+    if disabled is None:
+        disabled = disabled_modules_for(household_id)
+
+    try:
+        vector = get_embedding_client().embed_query(
+            query, household_id=household_id, feature="embed_query"
+        )
+    except EmbeddingError:
+        logger.warning("hybrid retrieval: query embedding failed, falling back to full-text")
+        return []
+    if not vector:
+        return []
+
+    rows = (
+        EmbeddingChunk.objects.filter(household_id=household_id)
+        .annotate(distance=CosineDistance("embedding", vector))
+        .order_by("distance")[: limit * _VECTOR_CHUNK_FANOUT]
+    )
+
+    hits: list[Hit] = []
+    seen: set[tuple[str, str]] = set()
+    for chunk in rows:
+        key = (chunk.entity_type, chunk.object_id)
+        if key in seen:  # rows are distance-ordered → first per entity is its best chunk
+            continue
+        spec = find_spec(chunk.entity_type)
+        if spec is None or spec_disabled(spec, disabled):
+            continue
+        instance = spec.model.objects.filter(
+            household_id=household_id, pk=chunk.object_id
+        ).first()
+        if instance is None:  # stale chunk (source deleted) — skip
+            continue
+        seen.add(key)
+        hit = hit_from_instance(spec, instance, rank=1.0 - float(chunk.distance))
+        # Prefer the matched chunk as the snippet when the source has one.
+        if chunk.content:
+            hit.snippet = chunk.content[:200].strip()
+        hits.append(hit)
+        if len(hits) >= limit:
+            break
+    return hits
+
+
+def _fuse_rrf(rankings: list[list[Hit]], k: int | None = None) -> list[Hit]:
+    """Merge several ranked Hit lists by Reciprocal Rank Fusion.
+
+    Uses only each hit's *position* (scores from ts_rank and cosine distance are
+    not comparable). A hit present in several lists accumulates score, so an entity
+    surfaced by both the lexical and semantic legs rises to the top. The kept
+    representative is the first-seen hit (full-text list is passed first, so its
+    highlighted snippet wins); its `rank` is overwritten with the RRF score so
+    downstream `search_multi` ordering stays consistent.
+    """
+    if k is None:
+        k = int(getattr(settings, "RRF_K", _RRF_K_DEFAULT))
+
+    scores: dict[tuple[str, Any], float] = {}
+    representative: dict[tuple[str, Any], Hit] = {}
+    for hits in rankings:
+        for position, hit in enumerate(hits):
+            key = (hit.entity_type, hit.id)
+            scores[key] = scores.get(key, 0.0) + 1.0 / (k + position + 1)
+            representative.setdefault(key, hit)
+
+    fused = list(representative.values())
+    for hit in fused:
+        hit.rank = scores[(hit.entity_type, hit.id)]
+    fused.sort(key=lambda h: h.rank, reverse=True)
+    return fused
 
 
 def search_multi(household_id: UUID, queries: list[str], limit: int = 20) -> list[Hit]:

--- a/apps/agent/tests/test_retrieval_hybrid.py
+++ b/apps/agent/tests/test_retrieval_hybrid.py
@@ -1,0 +1,176 @@
+"""Tests for the hybrid (full-text + semantic) retrieval (parcours 21 lot 3).
+
+Network-free: a deterministic fake embedding client maps text to a one-hot
+"bucket" vector, so a query and a document land at cosine-distance 0 iff they
+share a bucket — letting us drive the k-NN without a real provider. Covers the
+flag-off non-regression, semantic recall (the win), exact-keyword non-regression,
+household scope, stale-chunk skipping, and RRF dual-presence ranking.
+"""
+from __future__ import annotations
+
+import pytest
+
+from agent import embeddings as embeddings_module
+from agent import indexing
+from agent.embeddings import EmbeddingResponse
+from agent.models import EmbeddingChunk
+from agent.retrieval import search
+
+_HEAT_WORDS = ("chauffage", "pompe", "chaleur", "pac", "daikin")
+
+
+class _FakeEmbeddingClient:
+    model = "fake-embed"
+
+    def _vec(self, text: str):
+        v = [0.0] * 1024
+        v[0 if any(w in text.lower() for w in _HEAT_WORDS) else 1] = 1.0
+        return v
+
+    def embed(self, texts, *, household_id, feature="embed", user_id=None, metadata=None):
+        return EmbeddingResponse(
+            vectors=[self._vec(t) for t in texts], model=self.model, dimensions=1024, duration_ms=1
+        )
+
+    def embed_query(self, text, *, household_id, feature="embed", user_id=None, metadata=None):
+        return self._vec(text)
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="hybrid-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    h = Household.objects.create(name="Hybrid House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    return h
+
+
+@pytest.fixture
+def make_document(owner):
+    from documents.models import Document
+
+    def _make(household, name="Doc", ocr_text=""):
+        return Document.objects.create(
+            household=household,
+            created_by=owner,
+            file_path="documents/x.pdf",
+            name=name,
+            mime_type="application/pdf",
+            type="document",
+            ocr_text=ocr_text,
+            notes="",
+        )
+
+    return _make
+
+
+@pytest.fixture
+def fake_embeddings(monkeypatch):
+    client = _FakeEmbeddingClient()
+    monkeypatch.setattr(embeddings_module, "get_embedding_client", lambda *a, **k: client)
+    return client
+
+
+def _index(instance, client):
+    indexing.reindex_instance(instance, client=client)
+
+
+def _ids(hits):
+    return {str(h.id) for h in hits}
+
+
+class TestFlagOff:
+    def test_pure_fulltext_no_embedding_call(self, settings, household, make_document, monkeypatch):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = False
+        doc = make_document(household, name="Pompe à chaleur", ocr_text="Daikin")
+
+        # If the vector leg were reached it would call this and blow up.
+        def _boom(*a, **k):
+            raise AssertionError("embedding client must not be called when hybrid is off")
+
+        monkeypatch.setattr(embeddings_module, "get_embedding_client", _boom)
+
+        hits = search(household.id, "pompe")
+        assert str(doc.pk) in _ids(hits)
+
+
+class TestSemanticRecall:
+    def test_paraphrase_surfaces_via_vector(self, settings, household, make_document, fake_embeddings):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        # Document never says "chauffage"; full-text alone would miss the query.
+        doc = make_document(household, name="Facture", ocr_text="pompe à chaleur Daikin")
+        _index(doc, fake_embeddings)
+
+        fulltext_only = {str(doc.pk)}
+        # Sanity: lexical "chauffage" doesn't match the doc's text.
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = False
+        assert str(doc.pk) not in _ids(search(household.id, "chauffage"))
+
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        assert fulltext_only <= _ids(search(household.id, "chauffage"))
+
+
+class TestNoRegressionOnExactMatch:
+    def test_exact_keyword_still_returned(self, settings, household, make_document, fake_embeddings):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        doc = make_document(household, name="Facture Engie", ocr_text="montant 142,67")
+        _index(doc, fake_embeddings)
+        assert str(doc.pk) in _ids(search(household.id, "Engie"))
+
+
+class TestScope:
+    def test_vector_leg_scoped_to_household(self, settings, make_document, fake_embeddings, owner):
+        from households.models import Household, HouseholdMember
+
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        mine = Household.objects.create(name="Mine")
+        HouseholdMember.objects.create(user=owner, household=mine, role=HouseholdMember.Role.OWNER)
+        theirs = Household.objects.create(name="Theirs")
+        HouseholdMember.objects.create(user=owner, household=theirs, role=HouseholdMember.Role.OWNER)
+
+        their_doc = make_document(theirs, name="Facture", ocr_text="pompe à chaleur")
+        _index(their_doc, fake_embeddings)
+
+        # Querying my (empty) household must not surface their doc semantically.
+        assert str(their_doc.pk) not in _ids(search(mine.id, "chauffage"))
+
+
+class TestStaleChunk:
+    def test_orphan_chunk_is_skipped(self, settings, household, fake_embeddings):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        # A chunk whose source no longer exists must never surface.
+        EmbeddingChunk.objects.create(
+            household=household,
+            entity_type="document",
+            object_id="999999",
+            chunk_index=0,
+            content="pompe à chaleur",
+            embedding=[1.0] + [0.0] * 1023,
+            model="fake-embed",
+            content_hash="x",
+        )
+        hits = search(household.id, "chauffage")
+        assert all(str(h.id) != "999999" for h in hits)
+
+
+class TestRRF:
+    def test_dual_presence_ranks_first(self, settings, household, make_document, fake_embeddings):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        # both: matched lexically ("pompe") AND semantically (heat bucket)
+        both = make_document(household, name="Pompe à chaleur", ocr_text="pompe à chaleur")
+        # semantic-only: heat bucket, but no lexical "pompe"
+        semantic_only = make_document(household, name="Radiateur", ocr_text="chaleur douce")
+        _index(both, fake_embeddings)
+        _index(semantic_only, fake_embeddings)
+
+        hits = search(household.id, "pompe")
+        ids = [str(h.id) for h in hits]
+        assert str(both.pk) in ids and str(semantic_only.pk) in ids
+        assert ids.index(str(both.pk)) < ids.index(str(semantic_only.pk))

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -235,6 +235,14 @@ VOYAGE_API_KEY = ""
 # The backfill command indexes regardless of this flag.
 EMBEDDING_INDEXING_ENABLED = False
 
+# Hybrid retrieval (parcours 21 lot 3): when True, `retrieval.search()` adds a
+# semantic (pgvector k-NN) leg alongside full-text and fuses both with Reciprocal
+# Rank Fusion. Off by default → byte-identical to pure full-text. Turn on only
+# once the index is populated (VOYAGE_API_KEY set + `backfill_embeddings` run).
+AGENT_HYBRID_RETRIEVAL_ENABLED = False
+# RRF damping constant (rank fusion). 60 is the standard default.
+RRF_K = 60
+
 # Agent tool-use loop: max LLM round-trips per question. Each iteration is one
 # LLM call; the tools are dropped on the last pass to force a final answer.
 # Bounds latency and cost of the function-calling loop. 4 leaves room to chain

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -73,6 +73,7 @@ EMBEDDING_DIMENSIONS = env.int("EMBEDDING_DIMENSIONS", default=1024)
 EMBEDDING_BASE_URL = env("EMBEDDING_BASE_URL", default="http://localhost:11434")
 VOYAGE_API_KEY = env("VOYAGE_API_KEY", default="")
 EMBEDDING_INDEXING_ENABLED = env.bool("EMBEDDING_INDEXING_ENABLED", default=False)
+AGENT_HYBRID_RETRIEVAL_ENABLED = env.bool("AGENT_HYBRID_RETRIEVAL_ENABLED", default=False)
 
 # Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
 AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -88,6 +88,7 @@ EMBEDDING_DIMENSIONS = env.int("EMBEDDING_DIMENSIONS", default=1024)
 EMBEDDING_BASE_URL = env("EMBEDDING_BASE_URL", default="http://ollama:11434")
 VOYAGE_API_KEY = env("VOYAGE_API_KEY", default="")
 EMBEDDING_INDEXING_ENABLED = env.bool("EMBEDDING_INDEXING_ENABLED", default=False)
+AGENT_HYBRID_RETRIEVAL_ENABLED = env.bool("AGENT_HYBRID_RETRIEVAL_ENABLED", default=False)
 
 # Agent web search — requires the agent on Sonnet 4.6+ (dynamic filtering).
 AGENT_WEB_SEARCH_ENABLED = env.bool("AGENT_WEB_SEARCH_ENABLED", default=False)

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -259,21 +259,30 @@ Sous `/api/agent/` :
   (`PrivacyNotice` + `privacyStorage`), partagée entre `AgentPage` et
   `EntityAssistant`.
 
-## À venir — retrieval hybride (parcours 21, cadré 2026-07-21)
+## Retrieval hybride (parcours 21) — full-text + sémantique
 
-Le retrieval est aujourd'hui **100 % full-text** (`retrieval.py`, `tsvector`). Un
-chantier cadré (non démarré) ajoute une **jambe sémantique** (embeddings
-`pgvector`) **à côté** du full-text, fusionnée par Reciprocal Rank Fusion — pour
-retrouver par le sens quand le vocabulaire de la question diverge des documents.
+Le retrieval combine deux jambes, fusionnées par **Reciprocal Rank Fusion** :
 
-Point d'architecture qui concerne ce module : **rien dans `apps/agent/` ne change
-sur le fond**. La fusion se fait **dans** `retrieval.search()`, dont la signature
-et le type de retour (`list[Hit]`) restent identiques ; les tools
-(`search_household`…), le service, la conversation ancrée, le digest et Telegram
-sont transparents au changement. Nouveaux artefacts prévus côté module :
-`embeddings.py` (abstraction `EmbeddingClient`, miroir de `llm.py`), modèle
-`EmbeddingChunk`, `indexing.py`, command `backfill_embeddings`, flag
-`AGENT_HYBRID_RETRIEVAL_ENABLED`.
+- **lexicale** — `tsvector` / `simple_unaccent` (comme avant) ;
+- **sémantique** — embeddings `pgvector`, pour retrouver par le sens quand le
+  vocabulaire de la question diverge des documents (« chauffage » → facture
+  « pompe à chaleur »).
+
+**`apps/agent/` reste transparent au changement** : la fusion vit **dans**
+`retrieval.search()`, dont la signature et le type de retour (`list[Hit]`) ne
+bougent pas ; tools (`search_household`…), service, conversation ancrée, digest et
+Telegram n'en savent rien.
+
+Artefacts : `embeddings.py` (`EmbeddingClient`, miroir de `llm.py` ; provider
+`voyage` par défaut, `ollama` en cible), modèle `EmbeddingChunk` (+ `indexing.py`
+write-time, gated par `EMBEDDING_INDEXING_ENABLED`), command `backfill_embeddings`,
+et les fonctions `_vector_search` / `_fuse_rrf` de `retrieval.py`.
+
+**Deux flags, off par défaut** (rollout maîtrisé) :
+- `EMBEDDING_INDEXING_ENABLED` — indexation write-time sur `post_save`/`post_delete` ;
+- `AGENT_HYBRID_RETRIEVAL_ENABLED` — jambe sémantique dans `search()` (off =
+  full-text à l'octet près). À activer une fois `VOYAGE_API_KEY` posé et le corpus
+  indexé (`manage.py backfill_embeddings`).
 
 Fiche concept (le cours) : [docs/fiches/EMBEDDINGS.md](../fiches/EMBEDDINGS.md).
 Backlog : [PARCOURS_21_BACKLOG_TECHNIQUE.md](../parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md).

--- a/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
@@ -14,8 +14,8 @@ Socle dont on hérite : [PARCOURS_07_BACKLOG_TECHNIQUE.md](./PARCOURS_07_BACKLOG
 |---|---|---|---|
 | 0 | Socle pgvector + abstraction `EmbeddingClient` (Voyage `voyage-3`) | ✅ Livré (PR #333) | #327 |
 | 1 | Modèle `EmbeddingChunk` + chunking + indexation write-time | ✅ Livré (PR #334) | #328 |
-| 2 | Backfill par management command (`backfill_embeddings`) | 🚧 En PR | #329 |
-| 3 | Retrieval hybride (full-text + vecteur, fusion RRF) + flag | ⬜ À faire | #330 |
+| 2 | Backfill par management command (`backfill_embeddings`) | ✅ Livré (PR #335) | #329 |
+| 3 | Retrieval hybride (full-text + vecteur, fusion RRF) + flag | 🚧 En PR | #330 |
 | 4 | Observabilité (`AIUsageLog` feature `embed`) + harnais d'évaluation | ⬜ À faire | #331 |
 | 5 | Idées V2 (reranking, index HNSW, chunking sémantique) | 💡 Idée | #332 |
 


### PR DESCRIPTION
Closes #330

Le lot qui apporte le gain : l'agent retrouve désormais **par le sens** autant que par les mots — sans rien perdre du lexical. Livré **flag off** (`AGENT_HYBRID_RETRIEVAL_ENABLED`), donc aucun changement de comportement tant qu'on ne l'active pas.

## Quoi
- **`_vector_search`** : embed la question (`embed_query`) + k-NN pgvector (`CosineDistance`) sur `EmbeddingChunk`, dédup chunk→entité, Hits citables via le registry. Best-effort : tout échec d'embedding → `[]` → `search()` retombe sur le full-text.
- **`_fuse_rrf`** : Reciprocal Rank Fusion — fusion par **rang** (les scores `ts_rank` et distance cosinus ne sont pas comparables). Une entité présente dans les deux jambes remonte en tête.
- **`search()`** : branche la fusion derrière `AGENT_HYBRID_RETRIEVAL_ENABLED`. **Off = chemin full-text à l'octet près.** Signature et contrat `Hit` inchangés → tout `apps/agent/` (tools, service, ancré, digest, Telegram) transparent.
- Snippet : headline full-text si dispo, sinon tête du meilleur chunk.
- Settings `AGENT_HYBRID_RETRIEVAL_ENABLED` (off) + `RRF_K` (60).

## Critères de l'issue
- ✅ « chauffage » retrouve la facture « pompe à chaleur » (impossible en full-text)
- ✅ « Engie » / mot-clé exact toujours présent (pas de régression)
- ✅ flag off → sortie identique au full-text (test de non-régression)
- ✅ scope foyer respecté ; chunk orphelin (source supprimée) ignoré
- ✅ RRF : entité présente dans les 2 jambes classée devant

## Validation
- `pytest apps/agent/tests/test_retrieval_hybrid.py` → 6 passed ; suite agent **551 passed**.

## Activation (post-merge, manuel)
Rien ne change en prod tant que : (1) `VOYAGE_API_KEY` posé, (2) `EMBEDDING_INDEXING_ENABLED=true` + `manage.py backfill_embeddings`, (3) `AGENT_HYBRID_RETRIEVAL_ENABLED=true`. Le lot 4 (éval) mesure le gain avant d'activer.