### PR TITLE
Parcours 21 — Lot 4 : harnais d'évaluation + statut d'index

### DIFF
--- a/apps/agent/eval/metrics.py
+++ b/apps/agent/eval/metrics.py
@@ -1,0 +1,56 @@
+"""Retrieval quality metrics (parcours 21 lot 4) — pure, network-free.
+
+Ids are opaque strings (``"entity_type:id"``) so lexical, semantic and hybrid
+runs are comparable and a golden set can pin the exact expected entities.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def recall_at_k(retrieved: list[str], relevant: Iterable[str], k: int) -> float:
+    """Fraction of the relevant ids found in the top-``k`` retrieved ids.
+
+    Returns 0.0 when there are no relevant ids (an empty golden entry can't be
+    "recalled") — the caller decides whether to skip such entries.
+    """
+    relevant_set = set(relevant)
+    if not relevant_set:
+        return 0.0
+    top = set(retrieved[:k])
+    return len(top & relevant_set) / len(relevant_set)
+
+
+def reciprocal_rank(retrieved: list[str], relevant: Iterable[str]) -> float:
+    """Reciprocal rank of the first relevant id (0.0 if none present)."""
+    relevant_set = set(relevant)
+    for index, rid in enumerate(retrieved):
+        if rid in relevant_set:
+            return 1.0 / (index + 1)
+    return 0.0
+
+
+def mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def evaluate(
+    runs: list[tuple[list[str], Iterable[str]]], k: int
+) -> dict[str, float]:
+    """Aggregate recall@k and MRR over ``(retrieved, relevant)`` pairs.
+
+    Skips entries with no relevant ids (nothing to score against).
+    """
+    recalls: list[float] = []
+    rrs: list[float] = []
+    for retrieved, relevant in runs:
+        relevant_set = set(relevant)
+        if not relevant_set:
+            continue
+        recalls.append(recall_at_k(retrieved, relevant_set, k))
+        rrs.append(reciprocal_rank(retrieved, relevant_set))
+    return {
+        "queries": len(recalls),
+        "recall_at_k": mean(recalls),
+        "mrr": mean(rrs),
+    }

--- a/apps/agent/management/commands/embeddings_status.py
+++ b/apps/agent/management/commands/embeddings_status.py
@@ -1,0 +1,55 @@
+"""Report vector-index coverage per searchable entity (parcours 21 lot 4).
+
+Shows, for each embeddable entity type, how many source entities exist, how many
+are indexed, and how many are stale (embedded by a model other than the current
+``EMBEDDING_MODEL`` — a signal that a `backfill_embeddings --force` is due after a
+model/provider switch).
+
+    python manage.py embeddings_status [--household <uuid>]
+"""
+from __future__ import annotations
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from agent.models import EmbeddingChunk
+from agent.searchables import REGISTRY
+
+
+class Command(BaseCommand):
+    help = "Report EmbeddingChunk index coverage per searchable entity type."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--household", default=None, help="Restrict to one household id.")
+
+    def handle(self, *args, **options):
+        household = options["household"]
+        current_model = getattr(settings, "EMBEDDING_MODEL", "")
+        self.stdout.write(f"Current embedding model: {current_model or '(unset)'}")
+        self.stdout.write(f"{'entity_type':<20} {'total':>7} {'indexed':>8} {'stale':>7}")
+        self.stdout.write("-" * 46)
+
+        totals = {"total": 0, "indexed": 0, "stale": 0}
+        for spec in REGISTRY:
+            if not spec.embed:
+                continue
+            source_qs = spec.model.objects.all()
+            chunk_qs = EmbeddingChunk.objects.filter(entity_type=spec.entity_type)
+            if household:
+                source_qs = source_qs.filter(household_id=household)
+                chunk_qs = chunk_qs.filter(household_id=household)
+
+            total = source_qs.count()
+            indexed = chunk_qs.values("object_id").distinct().count()
+            stale = (
+                chunk_qs.exclude(model=current_model).values("object_id").distinct().count()
+            )
+            totals["total"] += total
+            totals["indexed"] += indexed
+            totals["stale"] += stale
+            self.stdout.write(f"{spec.entity_type:<20} {total:>7} {indexed:>8} {stale:>7}")
+
+        self.stdout.write("-" * 46)
+        self.stdout.write(
+            f"{'TOTAL':<20} {totals['total']:>7} {totals['indexed']:>8} {totals['stale']:>7}"
+        )

--- a/apps/agent/management/commands/eval_retrieval.py
+++ b/apps/agent/management/commands/eval_retrieval.py
@@ -1,0 +1,69 @@
+"""Evaluate retrieval quality across modes (parcours 21 lot 4).
+
+Runs a golden set of questions through the lexical, semantic and hybrid legs and
+reports recall@k + MRR per mode, so the hybrid gain (and any regression on
+exact-keyword queries) is measured on the real corpus rather than guessed. Also
+the arbiter for turning `AGENT_HYBRID_RETRIEVAL_ENABLED` on by default.
+
+Golden file: JSON list of ``{"question": str, "expected": ["entity_type:id", ...]}``.
+
+    python manage.py eval_retrieval --household <uuid> --queries golden.json --mode all
+"""
+from __future__ import annotations
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+from django.test import override_settings
+
+from agent import retrieval
+from agent.eval.metrics import evaluate
+
+_MODES = ("fulltext", "vector", "hybrid")
+
+
+class Command(BaseCommand):
+    help = "Evaluate retrieval (recall@k, MRR) for fulltext / vector / hybrid."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--household", required=True, help="Household id to evaluate against.")
+        parser.add_argument(
+            "--queries", required=True, help='JSON [{"question": ..., "expected": [...]}].'
+        )
+        parser.add_argument("--mode", choices=(*_MODES, "all"), default="all")
+        parser.add_argument("--k", type=int, default=10)
+
+    def handle(self, *args, **options):
+        household_id = options["household"]
+        k = options["k"]
+        modes = _MODES if options["mode"] == "all" else (options["mode"],)
+
+        try:
+            with open(options["queries"], encoding="utf-8") as fh:
+                golden = json.load(fh)
+        except (OSError, ValueError) as exc:
+            raise CommandError(f"Could not read --queries: {exc}") from exc
+        if not isinstance(golden, list) or not golden:
+            raise CommandError("--queries must be a non-empty JSON list.")
+
+        self.stdout.write(f"Evaluating {len(golden)} question(s), k={k}\n")
+        self.stdout.write(f"{'mode':<10} {'queries':>8} {'recall@k':>10} {'mrr':>8}")
+        self.stdout.write("-" * 40)
+        for mode in modes:
+            runs = [
+                (self._retrieve(mode, household_id, entry.get("question", ""), k),
+                 entry.get("expected", []))
+                for entry in golden
+            ]
+            m = evaluate(runs, k)
+            self.stdout.write(
+                f"{mode:<10} {m['queries']:>8} {m['recall_at_k']:>10.3f} {m['mrr']:>8.3f}"
+            )
+
+    def _retrieve(self, mode, household_id, question, k) -> list[str]:
+        if mode == "vector":
+            hits = retrieval._vector_search(household_id, question, k)
+        else:
+            with override_settings(AGENT_HYBRID_RETRIEVAL_ENABLED=(mode == "hybrid")):
+                hits = retrieval.search(household_id, question, limit=k)
+        return [f"{h.entity_type}:{h.id}" for h in hits]

--- a/apps/agent/tests/test_eval.py
+++ b/apps/agent/tests/test_eval.py
@@ -1,0 +1,119 @@
+"""Tests for the retrieval eval harness + index status (parcours 21 lot 4).
+
+Metrics are pure (no DB, no network). The command smoke tests use full-text mode
+(no embeddings) and direct chunk rows, so nothing hits a provider.
+"""
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+import pytest
+from django.core.management import call_command
+
+from agent.eval.metrics import evaluate, mean, recall_at_k, reciprocal_rank
+from agent.models import EmbeddingChunk
+
+
+class TestMetrics:
+    def test_recall_at_k(self):
+        assert recall_at_k(["a", "b", "c"], {"a", "c"}, k=3) == 1.0
+        assert recall_at_k(["a", "b", "c"], {"a", "z"}, k=3) == 0.5
+        assert recall_at_k(["x", "a"], {"a"}, k=1) == 0.0  # a is below k
+        assert recall_at_k(["a"], set(), k=3) == 0.0  # nothing relevant
+
+    def test_reciprocal_rank(self):
+        assert reciprocal_rank(["a", "b"], {"a"}) == 1.0
+        assert reciprocal_rank(["a", "b"], {"b"}) == 0.5
+        assert reciprocal_rank(["a", "b"], {"z"}) == 0.0
+
+    def test_mean(self):
+        assert mean([1.0, 0.0]) == 0.5
+        assert mean([]) == 0.0
+
+    def test_evaluate_skips_empty_relevant(self):
+        runs = [
+            (["doc:1", "doc:2"], ["doc:1"]),  # recall 1.0, rr 1.0
+            (["doc:9"], []),  # skipped (no relevant)
+            (["doc:5", "doc:3"], ["doc:3"]),  # recall 1.0, rr 0.5
+        ]
+        result = evaluate(runs, k=10)
+        assert result["queries"] == 2
+        assert result["recall_at_k"] == 1.0
+        assert result["mrr"] == 0.75
+
+
+@pytest.fixture
+def owner(db):
+    from accounts.tests.factories import UserFactory
+
+    return UserFactory(email="eval-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    from households.models import Household, HouseholdMember
+
+    h = Household.objects.create(name="Eval House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    return h
+
+
+@pytest.fixture
+def make_document(owner):
+    from documents.models import Document
+
+    def _make(household, name="Doc", ocr_text=""):
+        return Document.objects.create(
+            household=household,
+            created_by=owner,
+            file_path="documents/x.pdf",
+            name=name,
+            mime_type="application/pdf",
+            type="document",
+            ocr_text=ocr_text,
+            notes="",
+        )
+
+    return _make
+
+
+class TestEvalRetrievalCommand:
+    def test_fulltext_mode_scores_a_match(self, household, make_document, tmp_path):
+        doc = make_document(household, name="Facture Engie", ocr_text="montant")
+        golden = [{"question": "Engie", "expected": [f"document:{doc.pk}"]}]
+        path = tmp_path / "golden.json"
+        path.write_text(json.dumps(golden), encoding="utf-8")
+
+        out = StringIO()
+        call_command(
+            "eval_retrieval",
+            household=str(household.id),
+            queries=str(path),
+            mode="fulltext",
+            k=10,
+            stdout=out,
+        )
+        output = out.getvalue()
+        assert "fulltext" in output
+        assert "1.000" in output  # the exact-keyword match is recalled
+
+
+class TestEmbeddingsStatusCommand:
+    def test_reports_coverage(self, household, make_document):
+        doc = make_document(household, name="Indexé", ocr_text="texte")
+        EmbeddingChunk.objects.create(
+            household=household,
+            entity_type="document",
+            object_id=str(doc.pk),
+            chunk_index=0,
+            content="texte",
+            embedding=[0.1] * 1024,
+            model="some-old-model",  # != current EMBEDDING_MODEL → counts as stale
+            content_hash="h",
+        )
+        out = StringIO()
+        call_command("embeddings_status", household=str(household.id), stdout=out)
+        output = out.getvalue()
+        assert "document" in output
+        assert "TOTAL" in output

--- a/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
@@ -15,8 +15,8 @@ Socle dont on hérite : [PARCOURS_07_BACKLOG_TECHNIQUE.md](./PARCOURS_07_BACKLOG
 | 0 | Socle pgvector + abstraction `EmbeddingClient` (Voyage `voyage-3`) | ✅ Livré (PR #333) | #327 |
 | 1 | Modèle `EmbeddingChunk` + chunking + indexation write-time | ✅ Livré (PR #334) | #328 |
 | 2 | Backfill par management command (`backfill_embeddings`) | ✅ Livré (PR #335) | #329 |
-| 3 | Retrieval hybride (full-text + vecteur, fusion RRF) + flag | 🚧 En PR | #330 |
-| 4 | Observabilité (`AIUsageLog` feature `embed`) + harnais d'évaluation | ⬜ À faire | #331 |
+| 3 | Retrieval hybride (full-text + vecteur, fusion RRF) + flag | ✅ Livré (PR #336) | #330 |
+| 4 | Observabilité (`AIUsageLog` feature `embed`) + harnais d'évaluation | 🚧 En PR | #331 |
 | 5 | Idées V2 (reranking, index HNSW, chunking sémantique) | 💡 Idée | #332 |
 
 ## Philosophie d'implémentation


### PR DESCRIPTION
Closes #331

Dernier lot : de quoi **mesurer** que l'hybride gagne sans régresser, et décider sur des chiffres l'activation du flag.

## Quoi
- **`apps/agent/eval/metrics.py`** : `recall_at_k`, `reciprocal_rank`, `evaluate` — fonctions pures (ids opaques `"entity_type:id"`), testées sans réseau.
- **`manage.py eval_retrieval --household --queries golden.json --mode {fulltext,vector,hybrid,all} --k`** : recall@k + MRR par mode sur un jeu de questions figé. L'arbitre pour activer `AGENT_HYBRID_RETRIEVAL_ENABLED` par défaut (et comparer un futur provider).
- **`manage.py embeddings_status [--household]`** : couverture d'index par entity_type (total / indexed / **stale** vs `EMBEDDING_MODEL` courant → signale un `backfill --force` dû après un switch de modèle).
- Observabilité : les embeddings loguent déjà `AIUsageLog(feature=embed_index|embed_query)` (posé aux lots 0/1/3).

## Critères de l'issue
- ✅ `eval_retrieval --mode all` compare les 3 modes sur recall@k + MRR
- ✅ `embeddings_status` indique la couverture
- ✅ métriques testées sans réseau

## Validation
- `pytest apps/agent/tests/test_eval.py` → 6 passed ; suite agent **557 passed**.

## Chantier complet
Lot 4 clôt le parcours 21. Séquence d'activation prod (manuelle, quand tu veux) : `VOYAGE_API_KEY` → `EMBEDDING_INDEXING_ENABLED=true` + `backfill_embeddings` → `eval_retrieval` pour valider → `AGENT_HYBRID_RETRIEVAL_ENABLED=true`.