### PR TITLE
feat(shopping): l'agent liste la liste de courses (parcours 22 lot 5)

### DIFF
--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -625,7 +625,7 @@ _LIST_ENTITIES_SCHEMA = {
             "description": (
                 "What to list. Supported: 'task', 'interaction', 'consumption', "
                 "'meter_reading', 'water_reading', 'tracker', 'chicken', "
-                "'egg_log'."
+                "'egg_log', 'shopping_item'."
             ),
         },
         "filters": {
@@ -657,7 +657,12 @@ _LIST_ENTITIES_SCHEMA = {
                 "(comma-separated among active, broody, sick, deceased, gone), "
                 "in_flock ('true' = only hens currently in the flock). "
                 "For 'egg_log' (daily egg counts): date_from / date_to "
-                "(YYYY-MM-DD)."
+                "(YYYY-MM-DD). "
+                "For 'shopping_item' (the household shopping list — use it for "
+                "'qu'est-ce qu'il me manque ?' with checked='false'): checked "
+                "('false' = still to buy, 'true' = already picked up), linked "
+                "('true' = only lines tied to a stock item, 'false' = free-text "
+                "only)."
             ),
         },
         "limit": {
@@ -676,7 +681,8 @@ _LIST_ENTITIES_DESCRIPTION = (
     "items (citable ids), the total count, and — when items carry an amount "
     "(expenses in EUR, consumption in kWh) — the sum of amounts over the whole "
     "filtered set. Supported types: 'task', 'interaction', 'consumption', "
-    "'meter_reading', 'water_reading', 'tracker', 'chicken', 'egg_log'."
+    "'meter_reading', 'water_reading', 'tracker', 'chicken', 'egg_log', "
+    "'shopping_item'."
 )
 
 

--- a/apps/shopping/apps.py
+++ b/apps/shopping/apps.py
@@ -6,6 +6,7 @@ class ShoppingConfig(AppConfig):
     name = "shopping"
 
     def ready(self):
+        from agent.listables import ListableSpec, ListFilter, register as register_listable
         from agent.searchables import SearchableSpec, register
         from agent.writables import WritableSpec, register as register_writable
 
@@ -18,6 +19,20 @@ class ShoppingConfig(AppConfig):
             search_fields=('label', 'note'),
             label_attr='label',
             url_template='/app/shopping-list?item={id}',
+        ))
+
+        # Structured listing — answers "qu'est-ce qu'il me manque ?" (checked=false)
+        # where full-text search can't: nothing lexical to match, it's a state query.
+        register_listable(ListableSpec(
+            entity_type='shopping_item',
+            module='shopping',
+            model=ShoppingListItem,
+            filters=(
+                ListFilter('checked', "'true' = only picked-up lines, 'false' = only still-to-buy", _filter_checked),
+                ListFilter('linked', "'true' = only lines linked to a stock item, 'false' = only free-text lines", _filter_linked),
+            ),
+            order_by=('sort_order', 'created_at'),
+            describe=_describe_shopping_item,
         ))
 
         # Add an item to the shopping list. Reversible: the undo hard-deletes it.
@@ -87,3 +102,33 @@ def _delete_shopping_item_from_agent(household, user, object_id):
     if item is None:
         raise LookupError(f"no shopping list item {object_id} in this household")
     delete_list_item(item)
+
+
+# --- list_entities filters ---------------------------------------------------
+
+def _parse_bool(value):
+    """Parse a filter flag; raise ValueError on anything unrecognised."""
+    normalized = str(value).strip().lower()
+    if normalized in ('true', '1', 'yes'):
+        return True
+    if normalized in ('false', '0', 'no'):
+        return False
+    raise ValueError(f"expected true/false, got {value!r}")
+
+
+def _filter_checked(qs, value):
+    return qs.filter(checked_at__isnull=not _parse_bool(value))
+
+
+def _filter_linked(qs, value):
+    return qs.filter(stock_item__isnull=not _parse_bool(value))
+
+
+def _describe_shopping_item(item) -> str:
+    parts = ['picked' if item.checked else 'to buy']
+    if item.quantity:
+        qty = str(item.quantity.normalize()) if hasattr(item.quantity, 'normalize') else str(item.quantity)
+        parts.append(f"{qty} {item.unit}".strip())
+    if item.stock_item_id:
+        parts.append('stock-linked')
+    return ' | '.join(parts)

--- a/apps/shopping/tests/test_agent_shopping.py
+++ b/apps/shopping/tests/test_agent_shopping.py
@@ -303,3 +303,73 @@ class TestAgentDelete:
             _dispatch_delete(household, owner, foreign_item.id)
         # The item must still exist
         assert ShoppingListItem.objects.filter(id=foreign_item.id).exists()
+
+
+# ── list_entities (Lot 5 — "qu'est-ce qu'il me manque ?") ──────────────────────
+
+def _dispatch_list(household, filters=None):
+    return tools.dispatch(
+        "list_entities",
+        {"entity_type": "shopping_item", "filters": filters or {}},
+        household=household,
+    )
+
+
+@pytest.mark.django_db
+class TestAgentListShoppingItem:
+    def test_listablespec_registered(self):
+        from agent import listables
+
+        assert listables.find_spec("shopping_item") is not None
+        assert "shopping_item" in listables.supported_entity_types()
+
+    def _seed(self, household, owner):
+        """Café (to buy, stock-linked), Piles (to buy, free), Pain (picked)."""
+        from shopping import services
+
+        stock = _make_stock_item(household, owner, name="Café", unit="kg")
+        cafe, _ = services.add_stock_item_to_list(household, owner, stock)
+        piles = services.create_list_item(household, owner, label="Piles AA", quantity="4")
+        pain = services.create_list_item(household, owner, label="Pain")
+        services.update_list_item(household, owner, pain, fields={"checked": True})
+        return cafe, piles, pain
+
+    def test_to_buy_filter_excludes_picked(self, household, owner):
+        cafe, piles, pain = self._seed(household, owner)
+        result = _dispatch_list(household, {"checked": "false"})
+        assert str(cafe.id) in result.rendered
+        assert str(piles.id) in result.rendered
+        assert str(pain.id) not in result.rendered
+        assert "total=2" in result.rendered
+
+    def test_picked_filter_returns_only_checked(self, household, owner):
+        cafe, piles, pain = self._seed(household, owner)
+        result = _dispatch_list(household, {"checked": "true"})
+        assert str(pain.id) in result.rendered
+        assert str(cafe.id) not in result.rendered
+        assert "total=1" in result.rendered
+
+    def test_linked_filter_returns_only_stock_linked(self, household, owner):
+        cafe, piles, pain = self._seed(household, owner)
+        result = _dispatch_list(household, {"linked": "true"})
+        assert str(cafe.id) in result.rendered
+        assert str(piles.id) not in result.rendered
+
+    def test_no_filter_lists_all(self, household, owner):
+        self._seed(household, owner)
+        result = _dispatch_list(household)
+        assert "total=3" in result.rendered
+
+    def test_invalid_flag_is_recoverable(self, household, owner):
+        self._seed(household, owner)
+        # A bad flag must not 500 — the tool turns ValueError into a message.
+        result = _dispatch_list(household, {"checked": "maybe"})
+        assert "total=" not in result.rendered
+
+    def test_scoped_to_household(self, household, owner):
+        self._seed(household, owner)
+        other_owner = _make_user("other-list@test.dev")
+        other_hh = _make_household("Other House List")
+        _add_member(other_owner, other_hh)
+        result = _dispatch_list(other_hh, {"checked": "false"})
+        assert "total=0" in result.rendered

--- a/docs/MODULES/shopping.md
+++ b/docs/MODULES/shopping.md
@@ -26,10 +26,11 @@
 
 ## Agent
 
-- `SearchableSpec('shopping_item')` — l'agent liste/cite ce qu'il reste à acheter (`search_fields = label, note`).
+- `SearchableSpec('shopping_item')` — l'agent cite un item par recherche plein-texte (`search_fields = label, note`).
+- `ListableSpec('shopping_item')` (**Lot 5**) — répond à « qu'est-ce qu'il me manque ? » là où la recherche plein-texte échoue (rien de lexical à matcher, c'est une requête d'**état**). Filtres : `checked` (`false` = à acheter, `true` = pris) et `linked` (`true` = seulement les lignes liées au stock). `describe` rend « to buy | 2 kg | stock-linked ». Ordre = `sort_order, created_at`.
 - `WritableSpec('shopping_item')` — create/update/delete, tous adossés à `services.py`. Le create (`_create_shopping_item_from_agent`) est **intelligent** : « ajoute du café à la liste » lie la ligne au `StockItem` « Café » existant (et déduplique) via `resolve_stock_item_hint` ; un libellé inconnu crée une ligne texte libre. L'ancre de conversation `stock_item` pré-sélectionne aussi la cible.
 - Réversible : undo par hard-delete côté front (`UNDO_HANDLERS['shopping_item']` dans `ui/src/features/agent/hooks.ts`).
-- Descriptions du tool `create_entity` étendues dans `apps/agent/tools.py` (schéma + description).
+- Descriptions des tools `create_entity` **et** `list_entities` étendues dans `apps/agent/tools.py` (types supportés + filtres).
 
 ## Frontend
 
@@ -41,6 +42,6 @@
 
 ## Limites V1 / suites (parcours 22)
 
-- **Lot 3** (suggestions depuis le stock bas), **Lot 4** (enregistrer les cochés → stock, créer l'item si absent), **Lot 5** (agent — déjà partiellement là via le writable), **Lot 6** (planification de repas adossée au stock) restent à faire — issues #317/#318/#319/#320.
+- **Lot 5 (agent — lire/remplir la liste)** : ✅ livré — writable (create/update/delete lié au stock + dédup), searchable, et `ListableSpec` pour « qu'est-ce qu'il me manque ? ». Restent : **Lot 3** (suggestions depuis le stock bas), **Lot 4** (enregistrer les cochés → stock, créer l'item si absent), **Lot 6** (planification de repas adossée au stock) — issues #317/#318/#320.
 - Pas de page détail par ligne : le `url_template` des specs agent pointe la page liste avec l'id en query (`/app/shopping-list?item={id}`, `{id}` requis par le test de registry ; le param est inoffensif, la page peut l'ignorer).
 - Concurrence : dernier écrivain gagne (pas de merge), acceptable pour une liste de foyer.


### PR DESCRIPTION
Closes #319.

Parcours 22 — **Lot 5 : l'agent remplit et lit la liste**. L'essentiel du lot avait déjà atterri avec les Lots 1+2 (create/update/delete + searchable via les registres génériques). Cette PR ajoute le morceau manquant : le **listing structurel**, pour répondre à « qu'est-ce qu'il me manque ? ».

## Quoi
- **`ListableSpec('shopping_item')`** dans `apps/shopping/apps.py` : l'agent peut lister/filtrer la liste via le tool générique `list_entities` — là où la recherche plein-texte échoue (c'est une requête d'état, rien de lexical à matcher).
  - Filtre `checked` : `false` = ce qu'il reste à acheter, `true` = déjà pris.
  - Filtre `linked` : `true` = seulement les lignes liées à un article de stock.
  - `describe` : « to buy | 2 kg | stock-linked ». Ordre `sort_order, created_at`.
- Descriptions du tool `list_entities` étendues (`apps/agent/tools.py`) : `shopping_item` dans les types supportés + ses filtres, avec le hint explicite « pour "qu'est-ce qu'il me manque ?" utiliser checked='false' ».
- Doc `docs/MODULES/shopping.md` mise à jour (section Agent + statut du Lot 5).

## Critères de l'issue #319
- [x] Créer un item via `create_entity` — ✅ (Lots 1+2)
- [x] Ajout réversible (toast Annuler) — ✅ (Lots 1+2)
- [x] **Lister ce qu'il reste à acheter et le citer** — ✅ **cette PR** (`ListableSpec` + searchable pour la citation)
- [x] Lier à un stock connu plutôt qu'un doublon — ✅ (Lots 1+2)
- [x] Créer seulement sur demande explicite (garde-fou/tour) — ✅ (générique `service.ask`)
- [x] Description `create_entity` étendue — ✅ (Lots 1+2) ; `list_entities` étendue — ✅ cette PR

## Tests
- `apps/shopping/tests/test_agent_shopping.py` : nouvelle classe `TestAgentListShoppingItem` (6 tests) — listable enregistré, `checked=false` exclut les cochés, `checked=true` ne renvoie que les pris, filtre `linked`, listing complet, flag invalide récupérable, scoping foyer.
- Backend-only (aucun changement front) — `django check` OK, collection pytest OK. Suite complète validée par la CI (pgvector requis, indispo en local).

## Hors scope
Lots 3 (suggestions stock bas #317), 4 (enregistrer les cochés → stock #318), 6 (repas #320).