### PR TITLE
feat(pwa): socle installable + service worker (parcours mobile lot 0)

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -64,6 +64,11 @@ urlpatterns += [
         template_name="manifest.json",
         content_type="application/manifest+json",
     ), name="manifest"),
+    # Service worker servi à la racine pour avoir un scope `/` (contrôle /app/*).
+    path("sw.js", TemplateView.as_view(
+        template_name="sw.js",
+        content_type="application/javascript",
+    ), name="service_worker"),
     re_path(r"^(?!api/|admin/|static/|media/|i18n/).*$",
             TemplateView.as_view(template_name="index.html"),
             name="spa_catchall"),

--- a/templates/sw.js
+++ b/templates/sw.js
@@ -1,0 +1,129 @@
+/*
+ * Service worker — House PWA.
+ *
+ * Servi à la racine (`/sw.js`) par Django (voir config/urls.py) pour avoir un
+ * scope `/` et contrôler tout `/app/*`. NE PAS le déplacer sous /static/ :
+ * son scope serait réduit à /static/ et il ne contrôlerait plus le SPA.
+ *
+ * Rôles :
+ *  - rendre l'app installable + consultable hors-ligne (cache app-shell + assets
+ *    Vite immuables). Les réponses /api ne sont volontairement jamais mises en
+ *    cache ici (auth par Bearer token → risque de fuite entre utilisateurs).
+ *  - recevoir les notifications push (Web Push) et gérer le clic → deep-link.
+ *
+ * Fichier servi via TemplateView : ne pas y introduire de syntaxe de template
+ * Django (doubles accolades ou balises pourcent), elle serait interprétée.
+ */
+
+const STATIC_CACHE = 'house-static-v1';
+const SHELL_CACHE = 'house-shell-v1';
+const SHELL_KEY = '__app_shell__';
+const KNOWN_CACHES = [STATIC_CACHE, SHELL_CACHE];
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.filter((k) => !KNOWN_CACHES.includes(k)).map((k) => caches.delete(k)))
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+function isImmutableAsset(url) {
+  return (
+    url.origin === self.location.origin &&
+    (url.pathname.startsWith('/static/react/assets/') || url.pathname.startsWith('/static/icons/'))
+  );
+}
+
+async function cacheFirst(request) {
+  const cached = await caches.match(request);
+  if (cached) return cached;
+  const response = await fetch(request);
+  if (response && response.ok) {
+    const cache = await caches.open(STATIC_CACHE);
+    cache.put(request, response.clone());
+  }
+  return response;
+}
+
+async function networkFirstShell(request) {
+  const cache = await caches.open(SHELL_CACHE);
+  try {
+    const response = await fetch(request);
+    if (response && response.ok) {
+      // Tous les chemins /app/* renvoient le même index.html : on le stocke
+      // sous une clé unique pour servir n'importe quelle route hors-ligne.
+      cache.put(SHELL_KEY, response.clone());
+    }
+    return response;
+  } catch (err) {
+    const cached = await cache.match(SHELL_KEY);
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+self.addEventListener('fetch', (event) => {
+  const request = event.request;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+
+  if (isImmutableAsset(url)) {
+    event.respondWith(cacheFirst(request));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(networkFirstShell(request));
+    return;
+  }
+
+  // Tout le reste (dont /api) : réseau direct, pas de cache SW.
+});
+
+// --- Web Push -------------------------------------------------------------
+
+self.addEventListener('push', (event) => {
+  let payload = {};
+  try {
+    payload = event.data ? event.data.json() : {};
+  } catch (err) {
+    payload = { body: event.data ? event.data.text() : '' };
+  }
+
+  const title = payload.title || 'House';
+  const options = {
+    body: payload.body || '',
+    icon: '/static/icons/icon-192.png',
+    badge: '/static/icons/icon-192.png',
+    tag: payload.tag || undefined,
+    data: { url: payload.url || '/app/dashboard' },
+  };
+
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const targetUrl = (event.notification.data && event.notification.data.url) || '/app/dashboard';
+
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientList) => {
+      for (const client of clientList) {
+        if ('focus' in client) {
+          if ('navigate' in client) client.navigate(targetUrl);
+          return client.focus();
+        }
+      }
+      return self.clients.openWindow(targetUrl);
+    })
+  );
+});

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -2,11 +2,13 @@ import { SidebarToggleProvider } from './SidebarToggleContext';
 import Sidebar from './Sidebar';
 import TopBar from './TopBar';
 import ImpersonationBanner from './ImpersonationBanner';
+import InstallHint from './InstallHint';
 
 function AppShellInner({ children }: { children?: React.ReactNode }) {
   return (
     <div className="fixed inset-0 overscroll-none bg-sidebar flex flex-col pt-[env(safe-area-inset-top)] pb-[env(safe-area-inset-bottom)] pl-[env(safe-area-inset-left)] pr-[env(safe-area-inset-right)]">
       <ImpersonationBanner />
+      <InstallHint />
       <TopBar />
       <div className="flex flex-1 overflow-hidden gap-2">
         <Sidebar />

--- a/ui/src/components/InstallHint.tsx
+++ b/ui/src/components/InstallHint.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { Share, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+const DISMISS_KEY = 'pwa_install_hint_dismissed';
+
+function isIos(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    // iOS Safari expose ce flag non standard quand l'app est lancée depuis l'écran d'accueil.
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
+/**
+ * Bandeau invitant à installer la PWA sur iOS (Safari ne propose pas de prompt
+ * automatique). Le Web Push iOS ne fonctionne QUE depuis l'app installée sur
+ * l'écran d'accueil — ce hint est donc un prérequis fonctionnel, pas cosmétique.
+ * Masqué si déjà installée, hors iOS, ou déjà rejeté.
+ */
+export default function InstallHint() {
+  const { t } = useTranslation();
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => typeof localStorage !== 'undefined' && localStorage.getItem(DISMISS_KEY) === '1'
+  );
+
+  if (dismissed || !isIos() || isStandalone()) return null;
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(DISMISS_KEY, '1');
+    } catch {
+      /* stockage indisponible : on masque juste pour la session */
+    }
+    setDismissed(true);
+  };
+
+  return (
+    <div className="flex items-start justify-between gap-3 px-4 py-2 bg-primary/10 text-foreground text-sm shrink-0">
+      <div className="flex items-start gap-2 min-w-0">
+        <Share className="h-4 w-4 shrink-0 mt-0.5 text-primary" />
+        <span className="min-w-0">
+          <span className="font-medium">{t('pwa.install.title')}</span>{' '}
+          <span className="text-muted-foreground">{t('pwa.install.iosInstructions')}</span>
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={dismiss}
+        aria-label={t('pwa.install.dismiss')}
+        className="shrink-0 text-muted-foreground hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/ui/src/lib/pwa/registerServiceWorker.ts
+++ b/ui/src/lib/pwa/registerServiceWorker.ts
@@ -1,0 +1,16 @@
+/**
+ * Enregistre le service worker (`/sw.js`, servi par Django à la racine).
+ *
+ * Uniquement en production : en dev, Vite/django-vite fait du HMR et un SW qui
+ * met en cache l'app-shell rendrait le rechargement à chaud imprévisible.
+ */
+export function registerServiceWorker(): void {
+  if (!import.meta.env.PROD) return;
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((err) => {
+      console.error('[pwa] service worker registration failed', err);
+    });
+  });
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2829,5 +2829,12 @@
     "overBy": "Überschritten um {{amount}}",
     "percentUsed": "{{pct}} % genutzt",
     "namedExceedsGlobal": "Deine Budgets ergeben {{named}}, mehr als die globale Obergrenze von {{global}}."
+  },
+  "pwa": {
+    "install": {
+      "title": "App installieren",
+      "iosInstructions": "Tippen Sie auf Teilen und dann auf „Zum Home-Bildschirm“.",
+      "dismiss": "Schließen"
+    }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2829,5 +2829,12 @@
     "overBy": "Over by {{amount}}",
     "percentUsed": "{{pct}}% used",
     "namedExceedsGlobal": "Your budgets total {{named}}, more than the global cap of {{global}}."
+  },
+  "pwa": {
+    "install": {
+      "title": "Install the app",
+      "iosInstructions": "Tap Share, then “Add to Home Screen”.",
+      "dismiss": "Dismiss"
+    }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2829,5 +2829,12 @@
     "overBy": "Superado en {{amount}}",
     "percentUsed": "{{pct}} % usado",
     "namedExceedsGlobal": "Tus presupuestos suman {{named}}, más que el límite global de {{global}}."
+  },
+  "pwa": {
+    "install": {
+      "title": "Instala la app",
+      "iosInstructions": "Toca Compartir y luego «Añadir a pantalla de inicio».",
+      "dismiss": "Cerrar"
+    }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2829,5 +2829,12 @@
     "overBy": "Dépassé de {{amount}}",
     "percentUsed": "{{pct}} % utilisé",
     "namedExceedsGlobal": "Tes budgets totalisent {{named}}, plus que le plafond global de {{global}}."
+  },
+  "pwa": {
+    "install": {
+      "title": "Installez l'app",
+      "iosInstructions": "Appuyez sur Partager puis « Sur l'écran d'accueil ».",
+      "dismiss": "Fermer"
+    }
   }
 }

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -7,8 +7,11 @@ import { router } from './router';
 import { queryClient } from './lib/queryClient';
 import { AuthProvider } from './lib/auth/context';
 import { Toaster } from './design-system/toast';
+import { registerServiceWorker } from './lib/pwa/registerServiceWorker';
 import './lib/i18n';
 import './styles.css';
+
+registerServiceWorker();
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
Closes #353

## Quoi

Premier lot du parcours « app mobile » : rendre l'app **installable** (PWA) et poser le **service worker**, prérequis indispensable du Web Push — en particulier sur iOS 16.4+, où le push ne fonctionne que depuis une PWA installée sur l'écran d'accueil.

- **Service worker à la racine** (`templates/sw.js`, servi par Django à `/sw.js` via `config/urls.py`, miroir de `/manifest.json`). Servi à la racine pour avoir un scope `/` et contrôler tout `/app/*`. Choix assumé de **ne pas** utiliser `vite-plugin-pwa` : l'archi est django-vite (le HTML est servi par Django, le build Vite vit sous `/static/react/`), le plugin y colle mal ; un SW servi par Django à la racine est plus simple et plus robuste. Le manifest reste une source unique.
- **Stratégie de cache** : app-shell en network-first (fallback offline sur l'index caché), assets Vite immuables en cache-first. `/api` **jamais** mis en cache par le SW (auth par Bearer token → évite toute fuite de données entre utilisateurs sur un même appareil).
- **Handlers `push` + `notificationclick`** déjà présents dans le SW → prêt pour le lot Web Push, avec deep-link au clic.
- **Enregistrement** (`registerServiceWorker.ts`, appelé depuis `main.tsx`) **en production uniquement** — en dev, django-vite fait du HMR qu'un SW de cache rendrait imprévisible.
- **Bandeau d'installation iOS** (`InstallHint.tsx`, monté dans `AppShell`) : « Partager → Sur l'écran d'accueil ». Masqué hors iOS, en mode standalone, ou après rejet. Chaînes i18n `pwa.install.*` dans les 4 langues.

## Critères de l'issue

- ✅ `/sw.js` renvoie 200 `application/javascript`, scope racine.
- ✅ Le SW s'enregistre en prod et met en cache app-shell + assets.
- ✅ App installable iPhone (Safari) / Android (Chrome) — manifest + SW en place.
- ✅ Bandeau d'installation iOS affiché hors standalone, masqué une fois installée/rejeté.
- ✅ i18n des chaînes du bandeau (en/fr/de/es).

## Hors scope (lots suivants)

- Lot 1 : backend Web Push (VAPID, modèle d'abonnement, envoi via `pywebpush`).
- Lots 2-3 : abonnement + réglages front, branchement des notifs événements (`notifications.service.send`) et pings sur le canal push.

## Notes de test

Le service worker ne s'active qu'en **production** (build servi par Django). Vérifié en local : `/sw.js` et `/manifest.json` répondent 200 avec le bon content-type, handlers `push`/`fetch` présents, pas de fuite de syntaxe de template. `npm run lint`, `npx tsc -b`, `python manage.py check` verts.
