### PR TITLE
feat(briefings): génération du contenu par l'agent + aperçu et envoi manuel (parcours 23 lot 2)

### DIFF
--- a/apps/briefings/generation.py
+++ b/apps/briefings/generation.py
@@ -1,0 +1,134 @@
+"""Briefing content generation + manual delivery.
+
+A briefing's content is produced by the **agent** itself: the user's free-text
+``prompt`` is run through ``agent.service.ask`` so the message benefits from the
+whole toolbox (household RAG, weather, web search) with zero briefing-specific
+retrieval code. The answer is stripped of ``<cite/>`` markers and HTML-escaped
+before it reaches Telegram (which parses HTML).
+
+Two entry points, both reused later by the scheduled tick (lot 3):
+
+- ``generate_briefing_text`` — one agent run, scoped to a recipient's
+  permissions (private data filtering follows the user passed to ``ask``);
+- ``send_briefing_now`` — generate per recipient and push via Telegram, with a
+  ``{sent, skipped_no_telegram, errors, total_recipients}`` summary. Recipients
+  are the creator (private) or every household member (shared); a member without
+  a linked Telegram account is skipped, never an error.
+"""
+from __future__ import annotations
+
+import html
+import logging
+import re
+
+from django.utils import translation
+
+logger = logging.getLogger(__name__)
+
+# Strip the agent's citation markers (<cite id="…"/>) — meaningless in a pushed
+# briefing. Both quote styles, self-closing or not (mirrors agent.service._CITE_RE).
+_CITE_RE = re.compile(r"""<cite\s+[^>]*?/?>""", re.IGNORECASE)
+
+# Frames the user's prompt so the model returns a ready-to-send message rather
+# than a Q&A answer with citations/preamble.
+_GEN_INSTRUCTION = (
+    "You are composing a short, natural personal briefing that will be pushed to "
+    "the user on Telegram. Reply with the message only — no preamble, no heading, "
+    "no citations, no markdown. Answer in the user's language. Here is what the "
+    "user wants in this briefing:\n\n"
+)
+
+
+def generate_briefing_text(briefing, *, recipient) -> str:
+    """Generate the briefing message for ``recipient`` (one agent run).
+
+    Runs inside the recipient's language so any localized tool output aligns.
+    Never raises for an empty/IDK answer — returns whatever the agent produced
+    (possibly the agent's own "nothing found" message). LLM transport errors
+    (timeout, API) propagate so the caller can surface them.
+    """
+    from agent.service import ask
+
+    with translation.override(_recipient_language(recipient, briefing.household)):
+        result = ask(
+            _GEN_INSTRUCTION + briefing.prompt,
+            briefing.household,
+            user=recipient,
+        )
+    return _cleanup(_CITE_RE.sub("", result.answer or ""))
+
+
+def send_briefing_now(briefing, *, triggered_by) -> dict:
+    """Generate + push the briefing to its recipients right now (manual trigger).
+
+    Per-recipient generation keeps each message scoped to that user's
+    permissions. Fault-isolated: one recipient failing (LLM or Telegram) never
+    blocks the others. Returns a summary for the caller's toast.
+    """
+    from telegram.models import TelegramAccount
+    from telegram.outbound import send_agent_message
+
+    recipients = _recipients(briefing)
+    sent = skipped_no_telegram = errors = 0
+
+    for user in recipients:
+        account = TelegramAccount.objects.filter(user=user).first()
+        if account is None:
+            skipped_no_telegram += 1
+            continue
+        try:
+            with translation.override(_recipient_language(user, briefing.household)):
+                text = generate_briefing_text(briefing, recipient=user)
+                payload = _render_telegram(briefing, text)
+            if send_agent_message(account, briefing.household, payload):
+                sent += 1
+            else:
+                errors += 1
+        except Exception:  # noqa: BLE001 — isolate failures per recipient
+            errors += 1
+            logger.exception(
+                "briefings.send_now failed for briefing=%s user=%s",
+                briefing.pk,
+                user.pk,
+            )
+
+    return {
+        "total_recipients": len(recipients),
+        "sent": sent,
+        "skipped_no_telegram": skipped_no_telegram,
+        "errors": errors,
+    }
+
+
+def _recipients(briefing) -> list:
+    """Users who should receive this briefing: creator (private) or all members."""
+    if briefing.is_private:
+        return [briefing.created_by] if briefing.created_by_id else []
+
+    from households.models import HouseholdMember
+
+    members = HouseholdMember.objects.filter(
+        household_id=briefing.household_id
+    ).select_related("user")
+    return [m.user for m in members if m.user_id]
+
+
+def _render_telegram(briefing, text: str) -> str:
+    """Bold title + escaped body — safe for Telegram's HTML parser."""
+    title = html.escape(briefing.title)
+    body = html.escape(text)
+    return f"<b>{title}</b>\n\n{body}"
+
+
+def _recipient_language(user, household) -> str:
+    """User locale, falling back to the household language (same as pings)."""
+    if getattr(user, "locale", None):
+        return user.locale
+    return household.preferred_language or "en"
+
+
+def _cleanup(text: str) -> str:
+    """Trim and collapse whitespace left by stripped markers."""
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()

--- a/apps/briefings/tests/test_api_generation.py
+++ b/apps/briefings/tests/test_api_generation.py
@@ -1,0 +1,612 @@
+"""Tests for Briefings Lot 2: content generation + manual send.
+
+Coverage:
+1. generate_briefing_text — strips <cite/> markers, cleans whitespace.
+2. _render_telegram — HTML-escapes title & body, wraps title in <b>.
+3. send_briefing_now PRIVATE — only creator is recipient; with/without TelegramAccount.
+4. send_briefing_now SHARED — all members; send_agent_message False → errors++;
+   per-recipient fault isolation (one ask() raises → errors++, others still sent).
+5. preview endpoint — creator 200, other member on shared 200, member on private 404,
+   LLM error → 503.
+6. send-now endpoint permissions — creator 200, non-creator member on shared 403,
+   household owner (non-creator) on shared 200, anonymous 401.
+"""
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from briefings.models import Briefing
+from briefings.tests.factories import BriefingFactory
+from households.models import Household, HouseholdMember
+from telegram.models import TelegramAccount
+
+
+# ── Shared helpers (mirror existing test_api_briefings.py) ───────────────────
+
+def _make_user(email: str):
+    return UserFactory(email=email)
+
+
+def _make_household(name: str = "Gen House") -> Household:
+    return Household.objects.create(name=name)
+
+
+def _add_member(user, household, role=HouseholdMember.Role.OWNER) -> HouseholdMember:
+    membership = HouseholdMember.objects.create(user=user, household=household, role=role)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return membership
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _anon_client() -> APIClient:
+    return APIClient()
+
+
+def _make_briefing(household, user, **kwargs) -> Briefing:
+    defaults = {
+        "title": "Test briefing",
+        "prompt": "Give me a daily summary.",
+        "is_private": False,
+        "is_active": True,
+    }
+    defaults.update(kwargs)
+    return Briefing.objects.create(household=household, created_by=user, **defaults)
+
+
+def _make_telegram_account(user, chat_id: int) -> TelegramAccount:
+    return TelegramAccount.objects.create(user=user, chat_id=chat_id)
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def owner(db):
+    return _make_user("gen-owner@test.dev")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = _make_household("Gen House")
+    _add_member(owner, hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+@pytest.fixture
+def member(db, household):
+    user = _make_user("gen-member@test.dev")
+    _add_member(user, household, role=HouseholdMember.Role.MEMBER)
+    return user
+
+
+@pytest.fixture
+def other_owner(db):
+    return _make_user("gen-other@test.dev")
+
+
+@pytest.fixture
+def other_household(db, other_owner):
+    hh = _make_household("Other Gen House")
+    _add_member(other_owner, hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+# ── Fake agent result ─────────────────────────────────────────────────────────
+
+class _FakeResult:
+    """Minimal stand-in for agent.service.AnswerResult."""
+
+    def __init__(self, answer: str):
+        self.answer = answer
+        self.citations = []
+
+
+# ── TestGenerateBriefingText ──────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestGenerateBriefingText:
+    """Unit tests for generate_briefing_text — mocks agent.service.ask."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Daily brief", "prompt": "What's new?", **overrides}
+
+    def test_cite_markers_stripped_from_answer(self, owner, household, monkeypatch):
+        """<cite id="..."/> tags must not appear in the returned text."""
+        from briefings import generation
+
+        raw = 'Voici ton briefing <cite id="task:1"/> et aussi <cite id="zone:2"/> ok'
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult(raw))
+        briefing = self._create_briefing(household, owner)
+
+        result = generation.generate_briefing_text(briefing, recipient=owner)
+
+        assert "<cite" not in result
+        assert "Voici ton briefing" in result
+        assert "ok" in result
+
+    def test_cleaned_text_has_no_extra_whitespace(self, owner, household, monkeypatch):
+        """Whitespace left by stripped markers is collapsed."""
+        from briefings import generation
+
+        # Two adjacent cite markers produce a double space after stripping.
+        raw = "Hello <cite id=\"a:1\"/>  <cite id=\"b:2\"/> world"
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult(raw))
+        briefing = self._create_briefing(household, owner)
+
+        result = generation.generate_briefing_text(briefing, recipient=owner)
+
+        assert "  " not in result  # no double spaces
+        assert "Hello" in result
+        assert "world" in result
+
+    def test_returns_plain_text_when_no_markers(self, owner, household, monkeypatch):
+        """Clean agent answer is returned unchanged (except whitespace trim)."""
+        from briefings import generation
+
+        plain = "No tasks due today. Have a great day!"
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult(plain))
+        briefing = self._create_briefing(household, owner)
+
+        result = generation.generate_briefing_text(briefing, recipient=owner)
+
+        assert result == plain
+
+    def test_multiple_cite_styles_stripped(self, owner, household, monkeypatch):
+        """Both self-closing variants are stripped."""
+        from briefings import generation
+
+        raw = 'A<cite id="x:1"/> B<cite id="y:2" /> C'
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult(raw))
+        briefing = self._create_briefing(household, owner)
+
+        result = generation.generate_briefing_text(briefing, recipient=owner)
+
+        assert "<cite" not in result
+        assert "A" in result
+        assert "B" in result
+        assert "C" in result
+
+
+# ── TestRenderTelegram ────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestRenderTelegram:
+    """Unit tests for _render_telegram — HTML escaping and formatting."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Brief", "prompt": "Summary.", **overrides}
+
+    def test_title_wrapped_in_bold_tag(self, owner, household):
+        """Title must appear inside <b>...</b>."""
+        from briefings.generation import _render_telegram
+
+        briefing = self._create_briefing(household, owner, title="My brief")
+        result = _render_telegram(briefing, "Some body text.")
+
+        assert result.startswith("<b>My brief</b>")
+
+    def test_title_html_escaped(self, owner, household):
+        """Special chars in the title must be HTML-escaped."""
+        from briefings.generation import _render_telegram
+
+        briefing = self._create_briefing(household, owner, title="Recap <Today> & More")
+        result = _render_telegram(briefing, "body")
+
+        assert "<Today>" not in result
+        assert "&lt;Today&gt;" in result
+        assert "&amp;" in result
+        # Still wrapped in bold
+        assert result.startswith("<b>")
+
+    def test_body_html_escaped(self, owner, household):
+        """Special chars in the body must be HTML-escaped."""
+        from briefings.generation import _render_telegram
+
+        briefing = self._create_briefing(household, owner, title="Brief")
+        body = "Temp: 5 < 10 & it's 'cold'"
+        result = _render_telegram(briefing, body)
+
+        assert "<" not in result.split("</b>", 1)[1].lstrip("\n")  # no raw < in body
+        assert "&lt;" in result
+        assert "&amp;" in result
+
+    def test_title_and_body_separated_by_blank_line(self, owner, household):
+        """Title block and body must be separated by a blank line (\\n\\n)."""
+        from briefings.generation import _render_telegram
+
+        briefing = self._create_briefing(household, owner, title="T")
+        result = _render_telegram(briefing, "B")
+
+        assert "</b>\n\n" in result
+
+
+# ── TestSendBriefingNowPrivate ────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestSendBriefingNowPrivate:
+    """send_briefing_now with a private briefing — only the creator is a recipient."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, is_private=True, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Private", "prompt": "My own summary.", **overrides}
+
+    def test_creator_with_telegram_account_is_sent(self, owner, household, monkeypatch):
+        """Private briefing: creator has TelegramAccount → sent=1."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=100001)
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Your summary."))
+        send_spy = []
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: send_spy.append((account, payload)) or True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 1
+        assert result["sent"] == 1
+        assert result["skipped_no_telegram"] == 0
+        assert result["errors"] == 0
+        assert len(send_spy) == 1
+
+    def test_creator_without_telegram_account_is_skipped(self, owner, household, monkeypatch):
+        """Private briefing: no TelegramAccount → skipped_no_telegram=1, sent=0."""
+        from briefings.generation import send_briefing_now
+
+        # No TelegramAccount created for owner
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Summary."))
+        send_spy = []
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: send_spy.append(True) or True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 1
+        assert result["sent"] == 0
+        assert result["skipped_no_telegram"] == 1
+        assert result["errors"] == 0
+        assert len(send_spy) == 0
+
+    def test_only_creator_receives_not_other_members(self, owner, household, member, monkeypatch):
+        """Private briefing: member with TelegramAccount is NOT a recipient."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=100002)
+        _make_telegram_account(member, chat_id=100003)
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Summary."))
+        sent_accounts = []
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: sent_accounts.append(account.user_id) or True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        # Only owner (creator) should appear in sent accounts
+        assert result["total_recipients"] == 1
+        assert result["sent"] == 1
+        assert owner.id in sent_accounts
+        assert member.id not in sent_accounts
+
+
+# ── TestSendBriefingNowShared ─────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestSendBriefingNowShared:
+    """send_briefing_now with a shared briefing — all household members are recipients."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, is_private=False, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Shared", "prompt": "All of us.", **overrides}
+
+    def test_all_members_with_accounts_are_sent(self, owner, household, member, monkeypatch):
+        """Shared briefing: both members have Telegram accounts → sent=2."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=200001)
+        _make_telegram_account(member, chat_id=200002)
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("All good."))
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 2
+        assert result["sent"] == 2
+        assert result["skipped_no_telegram"] == 0
+        assert result["errors"] == 0
+
+    def test_member_without_account_is_skipped(self, owner, household, member, monkeypatch):
+        """Shared briefing: owner has account, member does not → skipped=1."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=200003)
+        # No account for member
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Summary."))
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 2
+        assert result["sent"] == 1
+        assert result["skipped_no_telegram"] == 1
+        assert result["errors"] == 0
+
+    def test_send_agent_message_returning_false_counts_as_error(
+        self, owner, household, member, monkeypatch
+    ):
+        """send_agent_message returning False → errors++ (not sent++)."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=200004)
+        _make_telegram_account(member, chat_id=200005)
+        briefing = self._create_briefing(household, owner)
+
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Text."))
+        # Always returns False
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: False,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 2
+        assert result["sent"] == 0
+        assert result["errors"] == 2
+
+    def test_one_recipient_ask_raises_is_isolated(self, owner, household, member, monkeypatch):
+        """If ask() raises for one user, errors++ but the other recipient still gets sent."""
+        from briefings.generation import send_briefing_now
+
+        _make_telegram_account(owner, chat_id=200006)
+        _make_telegram_account(member, chat_id=200007)
+        briefing = self._create_briefing(household, owner)
+
+        sent_accounts = []
+
+        # Raise for member, succeed for owner
+        def _ask_sometimes_fails(*args, user=None, **kwargs):
+            if user is not None and user.id == member.id:
+                raise RuntimeError("LLM kaboom")
+            return _FakeResult("Good summary.")
+
+        monkeypatch.setattr("agent.service.ask", _ask_sometimes_fails)
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: sent_accounts.append(account.user_id) or True,
+        )
+
+        result = send_briefing_now(briefing, triggered_by=owner)
+
+        assert result["total_recipients"] == 2
+        assert result["errors"] == 1
+        assert result["sent"] == 1
+        assert owner.id in sent_accounts
+        assert member.id not in sent_accounts
+
+
+# ── TestPreviewEndpoint ───────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestPreviewEndpoint:
+    """POST /api/briefings/briefings/<id>/preview/ — generate text, no side effects."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Preview brief", "prompt": "Preview content.", **overrides}
+
+    def test_creator_gets_200_with_text(self, owner, household, monkeypatch):
+        """Creator previewing their own briefing → 200 {text: ...}."""
+        raw = "Your briefing text <cite id=\"x:1\"/> here."
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult(raw))
+        briefing = self._create_briefing(household, owner)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-preview", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "text" in response.data
+        assert "<cite" not in response.data["text"]
+
+    def test_other_member_can_preview_shared_briefing(self, owner, household, member, monkeypatch):
+        """A non-creator member may preview a shared briefing → 200."""
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("The answer."))
+        briefing = self._create_briefing(household, owner, is_private=False)
+        client = _client_for(member)
+
+        response = client.post(reverse("briefing-preview", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "text" in response.data
+
+    def test_member_cannot_preview_other_members_private_briefing(
+        self, owner, household, member, monkeypatch
+    ):
+        """Private briefing not owned by the requesting member → 404 (queryset exclusion)."""
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Secret."))
+        briefing = self._create_briefing(household, owner, is_private=True)
+        client = _client_for(member)
+
+        response = client.post(reverse("briefing-preview", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_llm_timeout_error_returns_503(self, owner, household, monkeypatch):
+        """LLMTimeoutError propagates out of generate_briefing_text → 503."""
+        from agent.llm import LLMTimeoutError
+
+        def _raise(*a, **kw):
+            raise LLMTimeoutError("Timeout")
+
+        monkeypatch.setattr("agent.service.ask", _raise)
+        briefing = self._create_briefing(household, owner)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-preview", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.data.get("detail") == "generation_failed"
+
+    def test_llm_error_returns_503(self, owner, household, monkeypatch):
+        """LLMError (non-timeout) also returns 503."""
+        from agent.llm import LLMError
+
+        def _raise(*a, **kw):
+            raise LLMError("API error")
+
+        monkeypatch.setattr("agent.service.ask", _raise)
+        briefing = self._create_briefing(household, owner)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-preview", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert response.data.get("detail") == "generation_failed"
+
+    def test_anonymous_gets_401(self, owner, household):
+        """Unauthenticated request to preview → 401."""
+        briefing = self._create_briefing(household, owner)
+        response = _anon_client().post(reverse("briefing-preview", args=[str(briefing.pk)]))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_cross_household_preview_returns_404(
+        self, owner, household, other_owner, other_household, monkeypatch
+    ):
+        """A briefing from another household is invisible → 404."""
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("X"))
+        foreign = _make_briefing(other_household, other_owner, is_private=False)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-preview", args=[str(foreign.pk)]))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── TestSendNowEndpoint ───────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestSendNowEndpoint:
+    """POST /api/briefings/briefings/<id>/send-now/ — permission matrix."""
+
+    def _create_briefing(self, household, user, **kwargs):
+        return _make_briefing(household, user, **kwargs)
+
+    def _briefing_payload(self, **overrides):
+        return {"title": "Send now", "prompt": "Push it.", **overrides}
+
+    def _patch_send(self, monkeypatch):
+        """Suppress real agent + Telegram calls; return empty summary."""
+        monkeypatch.setattr("agent.service.ask", lambda *a, **kw: _FakeResult("Text."))
+        monkeypatch.setattr(
+            "telegram.outbound.send_agent_message",
+            lambda account, household, payload: True,
+        )
+
+    def test_creator_can_send_now(self, owner, household, monkeypatch):
+        """Creator triggering send-now → 200 with summary dict."""
+        self._patch_send(monkeypatch)
+        briefing = self._create_briefing(household, owner, is_private=False)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-send-now", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "sent" in response.data
+        assert "total_recipients" in response.data
+        assert "skipped_no_telegram" in response.data
+        assert "errors" in response.data
+
+    def test_non_creator_member_on_shared_briefing_gets_403(
+        self, owner, household, member, monkeypatch
+    ):
+        """Non-creator, non-owner member cannot trigger send-now → 403."""
+        self._patch_send(monkeypatch)
+        briefing = self._create_briefing(household, owner, is_private=False)
+        client = _client_for(member)
+
+        response = client.post(reverse("briefing-send-now", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_household_owner_non_creator_can_send_shared_briefing(
+        self, owner, household, monkeypatch
+    ):
+        """Household owner (non-creator) CAN send a shared briefing → 200."""
+        self._patch_send(monkeypatch)
+        co_creator = _make_user("gen-cocreator@test.dev")
+        _add_member(co_creator, household, role=HouseholdMember.Role.MEMBER)
+        briefing = self._create_briefing(household, co_creator, is_private=False)
+
+        # owner is an OWNER role in the household but did not create the briefing
+        client = _client_for(owner)
+        response = client.post(reverse("briefing-send-now", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_anonymous_gets_401(self, owner, household):
+        """Unauthenticated send-now → 401."""
+        briefing = self._create_briefing(household, owner)
+        response = _anon_client().post(reverse("briefing-send-now", args=[str(briefing.pk)]))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_member_cannot_send_private_briefing_by_another_user(
+        self, owner, household, member, monkeypatch
+    ):
+        """Private briefing owned by someone else → 404 (queryset exclusion)."""
+        self._patch_send(monkeypatch)
+        briefing = self._create_briefing(household, owner, is_private=True)
+        client = _client_for(member)
+
+        response = client.post(reverse("briefing-send-now", args=[str(briefing.pk)]))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_cross_household_send_now_returns_404(
+        self, owner, household, other_owner, other_household, monkeypatch
+    ):
+        """Briefing from another household → 404."""
+        self._patch_send(monkeypatch)
+        foreign = _make_briefing(other_household, other_owner, is_private=False)
+        client = _client_for(owner)
+
+        response = client.post(reverse("briefing-send-now", args=[str(foreign.pk)]))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/apps/briefings/views.py
+++ b/apps/briefings/views.py
@@ -1,13 +1,21 @@
 """Briefings REST API."""
-from django.db.models import Q
-from rest_framework import filters, viewsets
+import logging
 
+from django.db.models import Q
+from rest_framework import filters, status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+
+from agent.llm import LLMError, LLMTimeoutError
 from core.permissions import IsHouseholdMember
 
+from .generation import generate_briefing_text, send_briefing_now
 from .models import Briefing
 from .permissions import CanManageBriefing
 from .serializers import BriefingSerializer
 from .services import create_briefing, update_briefing
+
+logger = logging.getLogger(__name__)
 
 
 class BriefingViewSet(viewsets.ModelViewSet):
@@ -55,3 +63,32 @@ class BriefingViewSet(viewsets.ModelViewSet):
             serializer.instance,
             fields=serializer.validated_data,
         )
+
+    def get_permissions(self):
+        # Preview is a read-grade action (generate, no side effect): any member
+        # who can *see* the briefing may preview it — the queryset already hides
+        # others' private briefings (404). Sending is a manage action.
+        if self.action == "preview":
+            return [IsHouseholdMember()]
+        return [IsHouseholdMember(), CanManageBriefing()]
+
+    @action(detail=True, methods=["post"])
+    def preview(self, request, pk=None):
+        """Generate the briefing content for the requesting user — no Telegram send."""
+        briefing = self.get_object()
+        try:
+            text = generate_briefing_text(briefing, recipient=request.user)
+        except (LLMTimeoutError, LLMError):
+            logger.warning("briefings.preview: LLM error for briefing=%s", briefing.pk)
+            return Response(
+                {"detail": "generation_failed"},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        return Response({"text": text})
+
+    @action(detail=True, methods=["post"], url_path="send-now")
+    def send_now(self, request, pk=None):
+        """Generate + push the briefing to its recipients right now (manual)."""
+        briefing = self.get_object()
+        summary = send_briefing_now(briefing, triggered_by=request.user)
+        return Response(summary)

--- a/ui/src/features/briefings/BriefingCard.tsx
+++ b/ui/src/features/briefings/BriefingCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Lock, Pencil, Power, Trash2, Users } from 'lucide-react';
+import { Eye, Lock, Pencil, Power, Trash2, Users } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
@@ -12,12 +12,14 @@ interface Props {
   onEdit: (briefing: Briefing) => void;
   onDelete: (briefing: Briefing) => void;
   onToggleActive: (briefing: Briefing) => void;
+  onPreview: (briefing: Briefing) => void;
 }
 
-export default function BriefingCard({ briefing, onEdit, onDelete, onToggleActive }: Props) {
+export default function BriefingCard({ briefing, onEdit, onDelete, onToggleActive, onPreview }: Props) {
   const { t } = useTranslation();
 
   const actions: CardAction[] = [
+    { label: t('briefings.preview.action'), icon: Eye, onClick: () => onPreview(briefing) },
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(briefing) },
     { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(briefing), variant: 'danger' },
   ];

--- a/ui/src/features/briefings/BriefingPreviewDialog.tsx
+++ b/ui/src/features/briefings/BriefingPreviewDialog.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { AlertCircle, Send } from 'lucide-react';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Button } from '@/design-system/button';
+import { useTelegramStatus } from '@/features/settings/hooks';
+import type { Briefing } from '@/lib/api/briefings';
+import { usePreviewBriefing, useSendBriefingNow } from './hooks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  briefing?: Briefing;
+}
+
+export default function BriefingPreviewDialog({ open, onOpenChange, briefing }: Props) {
+  const { t } = useTranslation();
+  const preview = usePreviewBriefing();
+  const send = useSendBriefingNow();
+  const { data: telegram } = useTelegramStatus();
+
+  const { reset: resetPreview, mutate: runPreview } = preview;
+
+  // Generate the content once each time the dialog opens for a briefing.
+  React.useEffect(() => {
+    if (!open || !briefing) return;
+    resetPreview();
+    runPreview(briefing.id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, briefing?.id]);
+
+  async function handleSend() {
+    if (!briefing) return;
+    await send.mutateAsync(briefing.id);
+    onOpenChange(false);
+  }
+
+  const text = preview.data?.text ?? '';
+  const telegramLinked = telegram?.linked ?? true; // don't nag before status loads
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('briefings.preview.title')}>
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">{t('briefings.preview.description')}</p>
+
+        {preview.isPending ? (
+          <div className="space-y-2" aria-live="polite">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-4 animate-pulse rounded bg-muted" />
+            ))}
+          </div>
+        ) : preview.isError ? (
+          <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <div className="flex-1">
+              <p>{t('briefings.preview.failed')}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-2"
+                onClick={() => briefing && preview.mutate(briefing.id)}
+              >
+                {t('common.retry')}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="whitespace-pre-wrap rounded-md border border-border bg-muted/40 p-3 text-sm text-foreground">
+            {text || t('briefings.preview.empty')}
+          </div>
+        )}
+
+        {!telegramLinked ? (
+          <div className="flex items-start gap-2 rounded-md border border-border bg-card p-3 text-sm text-muted-foreground">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+            <p>
+              {t('briefings.preview.linkFirst')}{' '}
+              <Link to="/app/settings" className="text-primary underline">
+                {t('briefings.preview.linkCta')}
+              </Link>
+            </p>
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.close')}
+          </Button>
+          <Button
+            type="button"
+            className="gap-1"
+            disabled={preview.isPending || send.isPending || !telegramLinked}
+            onClick={handleSend}
+          >
+            <Send className="h-4 w-4" />
+            {t('briefings.send.button')}
+          </Button>
+        </div>
+      </div>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/briefings/BriefingsPage.tsx
+++ b/ui/src/features/briefings/BriefingsPage.tsx
@@ -18,6 +18,7 @@ import {
 } from './hooks';
 import BriefingCard from './BriefingCard';
 import BriefingDialog from './BriefingDialog';
+import BriefingPreviewDialog from './BriefingPreviewDialog';
 
 type FilterKey = 'all' | 'active' | 'inactive';
 
@@ -39,6 +40,8 @@ export default function BriefingsPage() {
   const [filter, setFilter] = useSessionState<FilterKey>('briefings.filter', 'all');
   const [editing, setEditing] = React.useState<Briefing | undefined>();
   const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [previewing, setPreviewing] = React.useState<Briefing | undefined>();
+  const [previewOpen, setPreviewOpen] = React.useState(false);
 
   const showSkeleton = useDelayedLoading(isLoading);
 
@@ -61,6 +64,11 @@ export default function BriefingsPage() {
   function openEdit(briefing: Briefing) {
     setEditing(briefing);
     setDialogOpen(true);
+  }
+
+  function openPreview(briefing: Briefing) {
+    setPreviewing(briefing);
+    setPreviewOpen(true);
   }
 
   function toggleActive(briefing: Briefing) {
@@ -124,12 +132,14 @@ export default function BriefingsPage() {
               onEdit={openEdit}
               onDelete={remove}
               onToggleActive={toggleActive}
+              onPreview={openPreview}
             />
           ))}
         </div>
       )}
 
       <BriefingDialog open={dialogOpen} onOpenChange={setDialogOpen} existing={editing} />
+      <BriefingPreviewDialog open={previewOpen} onOpenChange={setPreviewOpen} briefing={previewing} />
     </div>
   );
 }

--- a/ui/src/features/briefings/hooks.ts
+++ b/ui/src/features/briefings/hooks.ts
@@ -4,6 +4,8 @@ import {
   createBriefing,
   deleteBriefing,
   fetchBriefings,
+  previewBriefing,
+  sendBriefingNow,
   updateBriefing,
   type Briefing,
   type BriefingPayload,
@@ -53,5 +55,30 @@ export function useDeleteBriefing() {
   return useMutation({
     mutationFn: (id: string) => deleteBriefing(id),
     onSuccess: () => void qc.invalidateQueries({ queryKey: briefingKeys.list() }),
+  });
+}
+
+export function usePreviewBriefing() {
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (id: string) => previewBriefing(id),
+    onError: () => toast({ description: t('briefings.preview.failed'), variant: 'destructive' }),
+  });
+}
+
+export function useSendBriefingNow() {
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (id: string) => sendBriefingNow(id),
+    onSuccess: (summary) => {
+      if (summary.sent > 0) {
+        toast({ description: t('briefings.send.sent', { count: summary.sent }), variant: 'success' });
+      } else if (summary.skipped_no_telegram > 0) {
+        toast({ description: t('briefings.send.noTelegram'), variant: 'destructive' });
+      } else {
+        toast({ description: t('briefings.send.failed'), variant: 'destructive' });
+      }
+    },
+    onError: () => toast({ description: t('briefings.send.failed'), variant: 'destructive' }),
   });
 }

--- a/ui/src/lib/api/briefings.ts
+++ b/ui/src/lib/api/briefings.ts
@@ -69,3 +69,22 @@ export async function updateBriefing(
 export async function deleteBriefing(id: string): Promise<void> {
   await api.delete(`/briefings/briefings/${id}/`);
 }
+
+/** Generate the briefing content for the current user, without sending (Lot 2). */
+export async function previewBriefing(id: string): Promise<{ text: string }> {
+  const { data } = await api.post(`/briefings/briefings/${id}/preview/`);
+  return data as { text: string };
+}
+
+export interface BriefingSendSummary {
+  total_recipients: number;
+  sent: number;
+  skipped_no_telegram: number;
+  errors: number;
+}
+
+/** Generate + push the briefing to its recipients right now (Lot 2). */
+export async function sendBriefingNow(id: string): Promise<BriefingSendSummary> {
+  const { data } = await api.post(`/briefings/briefings/${id}/send-now/`);
+  return data as BriefingSendSummary;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -38,6 +38,21 @@
       "conditionHint": "Optional. Der Assistent sendet das Briefing nur, wenn dies zutrifft — z. B. „wenn es heute regnet\".",
       "conditionPlaceholder": "Wenn es heute regnet",
       "visibility": "Sichtbarkeit"
+    },
+    "preview": {
+      "action": "Vorschau",
+      "title": "Vorschau & senden",
+      "description": "Dein Assistent erstellt die Nachricht jetzt — prüfe sie vor dem Senden.",
+      "failed": "Briefing konnte nicht erstellt werden. Versuche es erneut.",
+      "empty": "Der Assistent hat für dieses Briefing nichts zurückgegeben.",
+      "linkFirst": "Verknüpfe dein Telegram-Konto, um Briefings zu erhalten.",
+      "linkCta": "Telegram verknüpfen"
+    },
+    "send": {
+      "button": "Jetzt senden",
+      "sent": "An {{count}} Empfänger gesendet",
+      "noTelegram": "Nichts gesendet — kein Empfänger hat Telegram verknüpft.",
+      "failed": "Senden fehlgeschlagen."
     }
   },
   "shoppingList": {
@@ -99,7 +114,8 @@
     "loading": "Wird geladen…",
     "add": "Hinzufügen",
     "create": "Erstellen",
-    "showMore": "Mehr anzeigen"
+    "showMore": "Mehr anzeigen",
+    "close": "Schließen"
   },
   "errors": {
     "notFoundTitle": "Seite nicht gefunden",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -38,6 +38,21 @@
       "conditionHint": "Optional. The assistant only sends the briefing when this is true — e.g. \"if it rains today\".",
       "conditionPlaceholder": "If it rains today",
       "visibility": "Visibility"
+    },
+    "preview": {
+      "action": "Preview",
+      "title": "Preview & send",
+      "description": "Your assistant generates the message now — review it before sending.",
+      "failed": "Couldn't generate the briefing. Try again.",
+      "empty": "The assistant returned nothing for this briefing.",
+      "linkFirst": "Link your Telegram account to receive briefings.",
+      "linkCta": "Link Telegram"
+    },
+    "send": {
+      "button": "Send now",
+      "sent": "Sent to {{count}} recipient(s)",
+      "noTelegram": "Nothing sent — no recipient has Telegram linked.",
+      "failed": "Sending failed."
     }
   },
   "shoppingList": {
@@ -99,7 +114,8 @@
     "loading": "Loading…",
     "add": "Add",
     "create": "Create",
-    "showMore": "Show more"
+    "showMore": "Show more",
+    "close": "Close"
   },
   "errors": {
     "notFoundTitle": "Page not found",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -38,6 +38,21 @@
       "conditionHint": "Opcional. El asistente solo envía el briefing cuando esto es cierto, p. ej. «si llueve hoy».",
       "conditionPlaceholder": "Si llueve hoy",
       "visibility": "Visibilidad"
+    },
+    "preview": {
+      "action": "Vista previa",
+      "title": "Vista previa y envío",
+      "description": "Tu asistente genera el mensaje ahora — revísalo antes de enviarlo.",
+      "failed": "No se pudo generar el briefing. Inténtalo de nuevo.",
+      "empty": "El asistente no devolvió nada para este briefing.",
+      "linkFirst": "Vincula tu cuenta de Telegram para recibir briefings.",
+      "linkCta": "Vincular Telegram"
+    },
+    "send": {
+      "button": "Enviar ahora",
+      "sent": "Enviado a {{count}} destinatario(s)",
+      "noTelegram": "No se envió nada: ningún destinatario tiene Telegram vinculado.",
+      "failed": "Error al enviar."
     }
   },
   "shoppingList": {
@@ -99,7 +114,8 @@
     "loading": "Cargando…",
     "add": "Añadir",
     "create": "Crear",
-    "showMore": "Mostrar más"
+    "showMore": "Mostrar más",
+    "close": "Cerrar"
   },
   "errors": {
     "notFoundTitle": "Página no encontrada",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -38,6 +38,21 @@
       "conditionHint": "Optionnel. L'assistant n'envoie le briefing que si c'est vrai — ex. « s'il pleut aujourd'hui ».",
       "conditionPlaceholder": "S'il pleut aujourd'hui",
       "visibility": "Visibilité"
+    },
+    "preview": {
+      "action": "Aperçu",
+      "title": "Aperçu et envoi",
+      "description": "Votre assistant génère le message maintenant — relisez-le avant de l'envoyer.",
+      "failed": "Impossible de générer le briefing. Réessayez.",
+      "empty": "L'assistant n'a rien renvoyé pour ce briefing.",
+      "linkFirst": "Liez votre compte Telegram pour recevoir les briefings.",
+      "linkCta": "Lier Telegram"
+    },
+    "send": {
+      "button": "Envoyer maintenant",
+      "sent": "Envoyé à {{count}} destinataire(s)",
+      "noTelegram": "Rien envoyé — aucun destinataire n'a lié Telegram.",
+      "failed": "Échec de l'envoi."
     }
   },
   "shoppingList": {
@@ -99,7 +114,8 @@
     "loading": "Chargement…",
     "add": "Ajouter",
     "create": "Créer",
-    "showMore": "Afficher plus"
+    "showMore": "Afficher plus",
+    "close": "Fermer"
   },
   "errors": {
     "notFoundTitle": "Page introuvable",


### PR DESCRIPTION
Closes #341

## Quoi

Lot 2 du **parcours 23 — Briefings personnalisés**. Le Lot 1 posait le modèle + CRUD ; ce lot rend le briefing **vivant** : l'agent génère son contenu, l'utilisateur peut le prévisualiser et l'envoyer sur Telegram à la demande. (La planification automatique = Lot 3 ; l'évaluation de conditions = Lot 4.)

**Backend** — `apps/briefings/generation.py`
- `generate_briefing_text(briefing, recipient)` : exécute le `prompt` de l'utilisateur via `agent.service.ask` → bénéficie de toute la boîte à outils de l'agent (RAG foyer + météo + web search) sans code de récupération dédié. Les marqueurs `<cite/>` sont retirés et le texte est **HTML-échappé** (Telegram parse en HTML).
- `send_briefing_now(briefing, triggered_by)` : génération **par destinataire** (donc scoping des permissions par destinataire), envoi Telegram, résumé `{total_recipients, sent, skipped_no_telegram, errors}`. Destinataires = créateur (privé) ou tous les membres du foyer (partagé). Fault-isolé : un destinataire en échec (LLM ou Telegram) ne bloque pas les autres ; un membre sans Telegram lié est *skippé*, pas une erreur.
- Endpoints `POST /preview/` (grade lecture — tout membre qui *voit* le briefing peut prévisualiser ; 503 si le LLM échoue) et `POST /send-now/` (grade manage — créateur ou owner).

**Frontend**
- `BriefingPreviewDialog` : génère l'aperçu à l'ouverture (skeleton de chargement, état d'erreur avec « Réessayer »), bouton **Envoyer maintenant**, garde-fou **Telegram non lié** (message + lien vers les réglages, envoi bloqué).
- Action « Aperçu » sur la `BriefingCard`.
- Hooks `usePreviewBriefing` / `useSendBriefingNow` (toasts : envoyé à N destinataires / Telegram non lié / échec).
- i18n `briefings.preview.*` + `briefings.send.*` + `common.close` (4 langues).

## Critères de l'issue #341

- [x] 2.1 Génération via l'agent (RAG + météo + web), rendu lisible Telegram, scopé aux permissions du destinataire (génération par destinataire)
- [x] 2.2 Aperçu (sans envoi) + Envoyer maintenant, état de chargement + erreurs
- [x] 2.3 Telegram non lié → CTA vers la liaison, aucun envoi tenté

## Notes / hors scope

- **Tests** : 28 nouveaux (`test_api_generation.py`) — stripping `<cite>`, rendu HTML échappé, résolution des destinataires privé/partagé, isolation des pannes, permissions preview/send-now. Suite briefings **98 passés** en local (env pgvector désormais OK). lint + tsc verts.
- **Condition** (champ déjà présent) : pas encore évaluée avant l'envoi — c'est le Lot 4. Ici « Envoyer maintenant » génère et envoie sans filtre de condition.
- **Coût** : la génération par destinataire d'un briefing partagé = 1 run agent par membre. Acceptable pour une action manuelle ; les garde-fous globaux (planification, ≥1h, etc.) arrivent au Lot 3.
