### PR TITLE
docs(webpush): concept PWA/Web Push + fiche module

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -360,6 +360,25 @@ docker compose -f docker-compose.prod.yml exec web python manage.py createsuperu
 
 Ouvrir `https://house.tondomaine.com` — Traefik doit avoir obtenu le certificat Let's Encrypt automatiquement (peut prendre 30 secondes au premier accès).
 
+### Étape 9 — (Optionnel) Activer les notifications push
+
+La PWA peut envoyer des notifications push (Web Push / VAPID). Sans clés, tout marche
+mais l'envoi est un no-op. Pour activer :
+
+```bash
+# Générer une paire de clés VAPID
+docker compose -f docker-compose.prod.yml exec web python manage.py generate_vapid_keys
+# Copier VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY dans .env, ajouter VAPID_ADMIN_EMAIL=<contact>
+nano .env
+# Recréer les conteneurs qui envoient (web = événements/test, scheduler = pings)
+docker compose -f docker-compose.prod.yml up -d --force-recreate web scheduler
+# Vérifier
+docker compose -f docker-compose.prod.yml exec web \
+  python manage.py shell -c "from webpush.service import is_configured; print(is_configured())"
+```
+
+Concepts + architecture : [docs/fiches/PWA_PUSH.md](docs/fiches/PWA_PUSH.md) · module : [docs/MODULES/webpush.md](docs/MODULES/webpush.md).
+
 ---
 
 ## 6. Mises à jour

--- a/docs/MODULES/README.md
+++ b/docs/MODULES/README.md
@@ -35,6 +35,7 @@ Lecture recommandée pour reprendre un module après pause — pour les bugs et 
 - [pings](./pings.md) — questions proactives templatées (Telegram)
 - [digest](./digest.md) — résumé quotidien proactif (agrège les signaux du foyer)
 - [telegram](./telegram.md) — canal Telegram entrant/sortant
+- [webpush](./webpush.md) — canal notifications push PWA (Web Push / VAPID)
 
 ## Apps frontend / utilitaires
 

--- a/docs/MODULES/webpush.md
+++ b/docs/MODULES/webpush.md
@@ -1,0 +1,77 @@
+# Module — webpush
+
+> Rôle : **canal de notifications push** vers la PWA (Web Push / VAPID). Stocke les
+> abonnements des navigateurs des utilisateurs et sait leur envoyer une notification
+> système, même app fermée. Couche de **transport** pure : le *contenu* des notifs
+> vient des sources existantes (`notifications.service.send`, `pings`) — cf. lot 3.
+>
+> Parcours : « app mobile » (lot 0 socle PWA, lot 1 backend). Concepts + décisions :
+> [../fiches/PWA_PUSH.md](../fiches/PWA_PUSH.md). Sources de notifs :
+> [notifications.md](./notifications.md), [pings.md](./pings.md).
+
+## État synthétique
+
+- **Backend** : `apps/webpush/`
+  - `models.py` — `WebPushSubscription` (user-scoped, 1 ligne par endpoint navigateur : `endpoint` unique, `p256dh`, `auth`, `user_agent`, `last_success_at`).
+  - `service.py` — `send_web_push(user, title, body, *, url, tag, data)` : signe (VAPID) et POST via `pywebpush`. **Best-effort** (ne lève jamais), **prune auto** des abonnements morts (HTTP 404/410), **no-op** si VAPID non configuré (`is_configured()`).
+  - `views.py` / `urls.py` — 4 endpoints DRF (voir plus bas).
+  - `serializers.py` — `SubscribeSerializer` (shape `PushSubscription.toJSON()` : `endpoint` + `keys{p256dh, auth}`).
+  - `management/commands/generate_vapid_keys.py` — génère une paire VAPID (formats prêts pour le navigateur + pywebpush).
+  - `admin.py` — lecture des abonnements (clés en readonly).
+- **Service worker** (socle PWA, lot 0) : `templates/sw.js`, servi à la racine `/sw.js` par une route Django (`config/urls.py`) pour avoir un scope `/`. Porte les handlers `push` + `notificationclick`. Enregistré en prod par `ui/src/lib/pwa/registerServiceWorker.ts`.
+- **Frontend abonnement** : lot 2 (à venir) — le SW sait déjà recevoir.
+- **Config** : `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_ADMIN_EMAIL` (env ; défauts vides ⇒ push désactivé proprement).
+- **Dépendance** : `pywebpush==2.3.0` (tire `cryptography`, `py-vapid`, `http-ece`).
+- **Tests** : `apps/webpush/tests/test_webpush.py` — subscribe/unsubscribe/scoping, no-op sans clés, prune 410, garde sur erreur transitoire, endpoint de test.
+
+## Modèles & API
+
+`WebPushSubscription` — **user-scoped** (comme `Notification`) : un abonnement appartient
+à un navigateur d'un user, pas à un foyer. Un push part vers tous les appareils du user.
+
+| Endpoint | Méthode | Rôle |
+|---|---|---|
+| `/api/webpush/vapid-public-key/` | GET | Clé publique (application server key) dont le navigateur a besoin pour s'abonner. |
+| `/api/webpush/subscribe/` | POST | Upsert **par `endpoint`** (idempotent) l'abonnement du user courant. |
+| `/api/webpush/unsubscribe/` | POST | Supprime l'abonnement (`endpoint`) du user courant. |
+| `/api/webpush/test/` | POST | Envoie une notif de test au user courant → `{ "sent": <n> }`. |
+
+Toutes protégées par `IsAuthenticated`.
+
+## Flux d'un envoi
+
+```
+source de notif (stock bas, invitation, ping…)   ← lot 3
+   ▼
+webpush.service.send_web_push(user, title, body, url=…)
+   │  is_configured() ? sinon return 0 (no-op)
+   ▼  pour chaque WebPushSubscription du user
+pywebpush.webpush(subscription_info, data=JSON, vapid_private_key, vapid_claims)
+   │   ├─ 201/2xx → last_success_at = now()
+   │   ├─ 404/410 → DELETE la sub (endpoint mort)
+   │   └─ autre erreur → log, sub conservée (transitoire)
+   ▼
+push service (FCM/Apple/Mozilla) → SW du navigateur → sw.js `push` → showNotification
+   ▼ clic → sw.js `notificationclick` → focus/ouvre data.url (deep-link)
+```
+
+## Sécurité & robustesse
+
+- **VAPID** : la clé privée signe chaque envoi, prouvant au push service l'identité du serveur. Vide ⇒ `is_configured()` False ⇒ aucun envoi (pas de crash). La clé privée ne vit que dans le `.env` (jamais commitée ; `generate_vapid_keys` ne l'imprime qu'au terminal).
+- **Scope user** : `subscribe`/`unsubscribe` opèrent sur `request.user` ; un user ne peut pas supprimer l'abonnement d'un autre.
+- **Auto-nettoyage** : les endpoints révoqués par le navigateur (désabonnement, désinstallation) renvoient 404/410 au premier envoi → la ligne est supprimée. Pas d'accumulation de subs mortes.
+- **Best-effort** : `send_web_push` avale toutes les exceptions — un push raté ne casse jamais l'action métier qui l'a déclenché.
+- **Contenu non mis en cache** : le SW ne met jamais `/api` en cache (auth Bearer → risque de fuite entre users) ; seul l'app-shell + les assets immuables le sont.
+
+## Activer en production
+
+1. `docker compose -f docker-compose.prod.yml exec web python manage.py generate_vapid_keys`
+2. Copier `VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY` dans le `.env`, ajouter `VAPID_ADMIN_EMAIL=<contact>`.
+3. Recréer les conteneurs qui envoient : `docker compose -f docker-compose.prod.yml up -d --force-recreate web scheduler`.
+4. Vérifier : `... exec web python manage.py shell -c "from webpush.service import is_configured; print(is_configured())"` → `True`.
+
+## Notes / décisions
+
+- **Pas de `enabled` sur le modèle** : subscribe = create, unsubscribe = delete, prune = delete. Un seul état, pas de flag à synchroniser.
+- **`web` ET `scheduler` doivent avoir les clés** : le `web` envoie les notifs événementielles + le test ; le `scheduler` enverra les pings (lot 3). Les deux lisent `env_file: .env`.
+- **iOS** : le push n'arrive que si la PWA est **installée** sur l'écran d'accueil (iOS 16.4+) — d'où le bandeau d'installation du lot 0. Cf. fiche PWA_PUSH.

--- a/docs/fiches/PWA_PUSH.md
+++ b/docs/fiches/PWA_PUSH.md
@@ -1,0 +1,116 @@
+# PWA & Web Push — app installable + notifications système
+
+> Comment `house` est devenu une app installable sur téléphone, capable d'envoyer
+> des notifications push même fermée — sans app native, sans store, sans compte Apple.
+> Parcours « app mobile » (lot 0 socle PWA, lot 1 backend). Module : [../MODULES/webpush.md](../MODULES/webpush.md).
+
+## 1. Le problème
+
+`house` est un SPA React servi par Django. On voulait le recevoir **comme une app**
+sur le téléphone (surtout iPhone) et surtout : **recevoir des notifications** (stock
+bas, rappels, digest…) sans avoir l'app ouverte. Deux options classiques :
+
+- **App native** (Swift/Kotlin) ou **React Native** : vraie app store, push fiable,
+  mais un 2ᵉ codebase à maintenir + compte Apple Developer (99 €/an) + build iOS.
+- **PWA (Progressive Web App)** : on emballe le site web existant pour qu'il soit
+  installable et qu'il reçoive du push. Un seul codebase, gratuit.
+
+Vu qu'on est solo et que le front est déjà responsive, on a choisi la **PWA**.
+
+## 2. Les concepts en deux phrases (chacun)
+
+- **PWA** : un site web qui, grâce à un **manifest** (métadonnées : nom, icône, mode
+  plein écran) et un **service worker**, peut être « installé » sur l'écran d'accueil
+  et fonctionner comme une app.
+- **Service worker (SW)** : un script JS qui tourne **en arrière-plan**, séparé de la
+  page, même quand l'app est fermée. Il intercepte les requêtes réseau (cache/offline)
+  et reçoit les **événements push** du système.
+- **Web Push** : le protocole standard qui permet à un serveur d'envoyer un message à
+  un navigateur via un **push service** tiers (Google FCM, Apple, Mozilla). Le
+  navigateur réveille le SW, qui affiche la notification.
+- **VAPID** : une paire de clés (publique/privée) qui **identifie ton serveur** auprès
+  des push services. La clé privée signe chaque envoi ; la clé publique est donnée au
+  navigateur au moment de l'abonnement. Sans VAPID, les push services refusent l'envoi.
+
+### Le trajet complet d'une notification
+
+```
+1. (navigateur) l'utilisateur autorise + s'abonne avec la clé publique VAPID
+        → obtient un "endpoint" (URL unique chez FCM/Apple/Mozilla) + 2 clés de chiffrement
+2. (front → serveur) POST /api/webpush/subscribe/  { endpoint, keys }   → stocké en DB
+        ...plus tard...
+3. (serveur) send_web_push(user, titre, corps)  → signe VAPID + POST vers l'endpoint
+4. (push service)  route le message vers l'appareil, réveille le service worker
+5. (sw.js) event "push" → showNotification(titre, corps, icône, url)
+6. (sw.js) clic → event "notificationclick" → ouvre l'app sur la bonne page (deep-link)
+```
+
+## 3. Comment on l'a appliqué dans house
+
+### Lot 0 — rendre l'app installable (le socle)
+
+- **Manifest** : déjà présent (`templates/manifest.json`, servi par Django) — nom,
+  icônes 192/512, `display: standalone`, `start_url: /app/dashboard`.
+- **Service worker** : `templates/sw.js`. Point subtil de l'archi **django-vite** : le
+  HTML est servi par **Django**, pas par Vite, et le build vit sous `/static/react/`.
+  Un SW ne contrôle que les URLs **sous son propre chemin** ; servi depuis
+  `/static/react/` il ne verrait pas `/app/*`. On le sert donc **à la racine `/sw.js`**
+  via une route Django (miroir de `/manifest.json`) → scope `/` → il contrôle tout.
+  C'est pour ça qu'on **n'a pas utilisé `vite-plugin-pwa`** (il suppose que Vite
+  possède le HTML).
+- Le SW met en cache l'app-shell (offline lecture) mais **jamais `/api`** (auth par
+  Bearer token → une réponse mise en cache pourrait fuiter vers un autre user du même
+  appareil). Il embarque déjà les handlers `push` / `notificationclick`.
+- **Installation iOS** : Safari ne propose pas de bouton « installer » automatique, et
+  surtout le push iOS **n'existe que depuis une PWA installée** sur l'écran d'accueil
+  (iOS 16.4+). D'où `ui/src/components/InstallHint.tsx` : un bandeau « Partager → Sur
+  l'écran d'accueil », affiché seulement sur iOS hors mode standalone.
+
+### Lot 1 — le backend d'envoi (VAPID)
+
+- App `apps/webpush/` : modèle `WebPushSubscription` (les abonnements) + service
+  `send_web_push` (signature + envoi via `pywebpush`) + endpoints subscribe / unsubscribe
+  / vapid-public-key / test. Détails : [../MODULES/webpush.md](../MODULES/webpush.md).
+- Clés VAPID générées par `manage.py generate_vapid_keys`, stockées en `.env`.
+  Vides ⇒ tout marche mais l'envoi est un **no-op** (dégradation propre).
+
+### Lots 2-3 (à venir)
+
+- **Lot 2** : l'abonnement côté front (le SW sait déjà recevoir) + un toggle
+  « Notifications push » dans les réglages + le bouton « notif de test ».
+- **Lot 3** : brancher le push sur les sources existantes — un point central
+  (`notifications.service.send`) pour les événements, et une abstraction canal pour
+  les `pings` (Web Push **à côté** de Telegram, qui reste en filet).
+
+## 4. Pourquoi cette implémentation
+
+- **PWA plutôt que natif** : 1 codebase, 0 € de store, réutilise 100 % du front. Le
+  coût assumé est la contrainte iOS (installation manuelle obligatoire).
+- **SW servi par Django à la racine** : seule façon simple d'obtenir un scope `/` dans
+  une archi où Django possède le HTML. Plus robuste que de forcer un plugin Vite.
+- **Transport séparé du contenu** : `webpush` ne sait qu'*envoyer*. Le *quoi* et le
+  *quand* restent dans les sources de notifs existantes → on ne duplique aucune logique
+  métier, et brancher une nouvelle source = un appel de plus à `send_web_push`.
+- **No-op sans clés + best-effort** : la feature n'a jamais le droit de casser un
+  déploiement (clés absentes) ni une action métier (push raté).
+
+## 5. Ce qu'on a écarté et pourquoi
+
+- **Capacitor / React Native** : reportés. Pertinents si un jour on veut un push iOS
+  ultra-fiable ou une présence App Store. Le backend `webpush` et le front resteraient
+  largement réutilisables. Pour un usage foyer, la PWA suffit.
+- **`vite-plugin-pwa`** : mauvais fit avec django-vite (HTML côté Django, assets sous
+  `/static/react/`). SW écrit à la main = plus simple à raisonner et à servir en scope `/`.
+- **Mettre `/api` en cache offline** : écarté pour le lot 0 (risque de fuite entre
+  users, auth Bearer). Un offline « données » viendra via une persistance react-query
+  ciblée si besoin.
+- **Un flag `enabled` sur l'abonnement** : inutile — subscribe crée, unsubscribe et
+  prune suppriment. Un seul état.
+
+## 6. Pour aller plus loin
+
+- [Web Push (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Push_API)
+- [Service Worker API (MDN)](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
+- [VAPID — RFC 8292](https://datatracker.ietf.org/doc/html/rfc8292)
+- [PWA sur iOS / Web Push (WebKit, iOS 16.4+)](https://webkit.org/blog/13878/web-push-for-web-apps-on-ios-and-ipados/)
+- [pywebpush](https://github.com/web-push-libs/pywebpush)

--- a/docs/fiches/README.md
+++ b/docs/fiches/README.md
@@ -21,6 +21,7 @@ Chaque fiche suit le même squelette :
 
 - [RAG.md](RAG.md) — Retrieval-Augmented Generation : comment l'agent conversationnel répond à partir de la mémoire du foyer (parcours 07)
 - [EMBEDDINGS.md](EMBEDDINGS.md) — Embeddings & recherche sémantique hybride : ajouter une jambe vectorielle (pgvector + fusion RRF) au retrieval full-text (parcours 21)
+- [PWA_PUSH.md](PWA_PUSH.md) — PWA & Web Push : app installable + notifications système sans app native (VAPID, service worker, django-vite) (parcours app mobile)
 
 ## Quand créer une fiche ?
 


### PR DESCRIPTION
## Quoi

Documentation de l'ajout Web Push / PWA (lots 0-1 du parcours mobile), suite à la demande de « mentionner cet ajout » + un guide des concepts.

- **`docs/fiches/PWA_PUSH.md`** (nouveau) — guide conceptuel suivant le squelette des fiches : le problème, les concepts (PWA, service worker, Web Push, VAPID) avec le trajet complet d'une notification, comment c'est implémenté dans house (SW à la racine via django-vite, app webpush), pourquoi ces choix, ce qui a été écarté (Capacitor, vite-plugin-pwa, cache /api).
- **`docs/MODULES/webpush.md`** (nouveau) — fiche module au format standard : modèle, endpoints, flux d'un envoi, sécurité, procédure d'activation prod.
- **Index** `docs/MODULES/README.md` + `docs/fiches/README.md` mis à jour.
- **`DEPLOYMENT.md`** — étape optionnelle « Activer les notifications push » (génération VAPID + recréation web/scheduler + vérif).

Docs-only, aucun changement de code.

## Note

Les clés VAPID ont déjà été posées en prod (`is_configured: True`) — cette PR documente l'ajout et la procédure pour reproduire.