### PR TITLE
feat(webpush): abonnement front + réglage Notifications push (parcours mobile lot 2)

### DIFF
--- a/ui/src/components/InstallHint.tsx
+++ b/ui/src/components/InstallHint.tsx
@@ -2,21 +2,9 @@ import { useState } from 'react';
 import { Share, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { isIos, isStandalone } from '@/lib/pwa/platform';
+
 const DISMISS_KEY = 'pwa_install_hint_dismissed';
-
-function isIos(): boolean {
-  if (typeof navigator === 'undefined') return false;
-  return /iphone|ipad|ipod/i.test(navigator.userAgent);
-}
-
-function isStandalone(): boolean {
-  if (typeof window === 'undefined') return false;
-  return (
-    window.matchMedia('(display-mode: standalone)').matches ||
-    // iOS Safari expose ce flag non standard quand l'app est lancée depuis l'écran d'accueil.
-    (window.navigator as unknown as { standalone?: boolean }).standalone === true
-  );
-}
 
 /**
  * Bandeau invitant à installer la PWA sur iOS (Safari ne propose pas de prompt

--- a/ui/src/features/settings/SettingsPage.tsx
+++ b/ui/src/features/settings/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { useCurrentUser } from './hooks';
 import { ProactiveSection } from './components/ProactiveSection';
 import { ProfileSection } from './components/ProfileSection';
 import { TelegramSection } from './components/TelegramSection';
+import { WebPushSection } from './components/WebPushSection';
 import { ThemeSection } from './components/ThemeSection';
 import { AgentMemorySection } from './components/AgentMemorySection';
 import { ChangePasswordSection } from './components/ChangePasswordSection';
@@ -40,6 +41,7 @@ export default function SettingsPage() {
       <ModulesSection />
       <ProfileSection />
       <TelegramSection />
+      <WebPushSection />
       <ProactiveSection />
       <ThemeSection />
       <AgentMemorySection />

--- a/ui/src/features/settings/components/WebPushSection.tsx
+++ b/ui/src/features/settings/components/WebPushSection.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/design-system/button';
+import { useToast } from '@/lib/toast';
+import {
+  fetchVapidPublicKey,
+  sendTestWebPush,
+  subscribeWebPush,
+  unsubscribeWebPush,
+} from '@/lib/api/webpush';
+import { isIos, isPushSupported, isStandalone, urlBase64ToUint8Array } from '@/lib/pwa/platform';
+import { SettingsSection } from './SettingsSection';
+
+/**
+ * Browser-side push subscription state + actions. The "subscribed" flag is read
+ * from the service worker (not the server), since it reflects *this* device.
+ */
+function useWebPush(vapidKey: string | undefined) {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  const [subscribed, setSubscribed] = useState<boolean | null>(null);
+  const [permission, setPermission] = useState<NotificationPermission>(
+    typeof Notification !== 'undefined' ? Notification.permission : 'default'
+  );
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!isPushSupported()) {
+      setSubscribed(false);
+      return;
+    }
+    let cancelled = false;
+    // getRegistration() (not .ready) resolves to undefined when no SW is present,
+    // avoiding a hang in dev where the SW is registered in prod only.
+    navigator.serviceWorker
+      .getRegistration()
+      .then((reg) => (reg ? reg.pushManager.getSubscription() : null))
+      .then((sub) => {
+        if (!cancelled) setSubscribed(Boolean(sub));
+      })
+      .catch(() => {
+        if (!cancelled) setSubscribed(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function subscribe() {
+    if (!vapidKey) return;
+    setBusy(true);
+    try {
+      const perm = await Notification.requestPermission();
+      setPermission(perm);
+      if (perm !== 'granted') return;
+      const reg = await navigator.serviceWorker.ready;
+      const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(vapidKey),
+      });
+      await subscribeWebPush(sub);
+      setSubscribed(true);
+      toast({ description: t('settings.push.enabledToast'), variant: 'success' });
+    } catch {
+      toast({ description: t('settings.requestFailed'), variant: 'destructive' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function unsubscribe() {
+    setBusy(true);
+    try {
+      const reg = await navigator.serviceWorker.getRegistration();
+      const sub = reg ? await reg.pushManager.getSubscription() : null;
+      if (sub) {
+        await unsubscribeWebPush(sub.endpoint);
+        await sub.unsubscribe();
+      }
+      setSubscribed(false);
+      toast({ description: t('settings.push.disabledToast'), variant: 'success' });
+    } catch {
+      toast({ description: t('settings.requestFailed'), variant: 'destructive' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function sendTest() {
+    setBusy(true);
+    try {
+      const sent = await sendTestWebPush();
+      toast({
+        description: sent > 0 ? t('settings.push.testSent') : t('settings.push.testNoDevice'),
+        variant: sent > 0 ? 'success' : 'default',
+      });
+    } catch {
+      toast({ description: t('settings.requestFailed'), variant: 'destructive' });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return { subscribed, permission, busy, subscribe, unsubscribe, sendTest };
+}
+
+/**
+ * Réglage « Notifications push » — active/désactive le Web Push pour cet appareil.
+ * Masqué si le push n'est pas configuré côté serveur (clé VAPID vide) ou non
+ * supporté par le navigateur. Sur iOS hors app installée, invite à installer
+ * l'app d'abord (le push iOS n'existe que depuis l'écran d'accueil).
+ */
+export function WebPushSection() {
+  const { t } = useTranslation();
+  const { data: vapidKey, isLoading } = useQuery({
+    queryKey: ['settings', 'webpush', 'vapid'],
+    queryFn: fetchVapidPublicKey,
+    staleTime: Infinity,
+    enabled: isPushSupported(),
+  });
+
+  const configured = Boolean(vapidKey);
+  const { subscribed, permission, busy, subscribe, unsubscribe, sendTest } = useWebPush(vapidKey);
+
+  // Push non supporté par le navigateur, ou non configuré côté serveur → rien.
+  if (isLoading || !isPushSupported() || !configured) return null;
+
+  // iOS : le push n'existe que depuis la PWA installée sur l'écran d'accueil.
+  if (isIos() && !isStandalone()) {
+    return (
+      <SettingsSection
+        title={t('settings.push.title')}
+        description={t('settings.push.description')}
+      >
+        <p className="text-sm text-muted-foreground">{t('settings.push.iosHint')}</p>
+      </SettingsSection>
+    );
+  }
+
+  if (permission === 'denied') {
+    return (
+      <SettingsSection
+        title={t('settings.push.title')}
+        description={t('settings.push.description')}
+      >
+        <p className="text-sm text-muted-foreground">{t('settings.push.permissionDenied')}</p>
+      </SettingsSection>
+    );
+  }
+
+  return (
+    <SettingsSection title={t('settings.push.title')} description={t('settings.push.description')}>
+      {subscribed ? (
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <p className="text-sm text-muted-foreground">{t('settings.push.enabled')}</p>
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" onClick={() => void sendTest()} disabled={busy}>
+              {t('settings.push.test')}
+            </Button>
+            <Button variant="outline" size="sm" onClick={() => void unsubscribe()} disabled={busy}>
+              {t('settings.push.disable')}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm text-muted-foreground">{t('settings.push.enableHint')}</p>
+          <Button onClick={() => void subscribe()} disabled={busy || subscribed === null}>
+            {t('settings.push.enable')}
+          </Button>
+        </div>
+      )}
+    </SettingsSection>
+  );
+}

--- a/ui/src/lib/api/webpush.ts
+++ b/ui/src/lib/api/webpush.ts
@@ -1,0 +1,32 @@
+import { api } from '@/lib/axios';
+
+export interface VapidPublicKey {
+  publicKey: string;
+}
+
+/** Clé publique VAPID (vide = push non configuré côté serveur → feature masquée). */
+export async function fetchVapidPublicKey(): Promise<string> {
+  const { data } = await api.get<VapidPublicKey>('/webpush/vapid-public-key/');
+  return data.publicKey;
+}
+
+/**
+ * Enregistre l'abonnement du navigateur. `PushSubscription.toJSON()` produit
+ * exactement la forme attendue par le backend : { endpoint, keys: { p256dh, auth } }.
+ */
+export async function subscribeWebPush(subscription: PushSubscription): Promise<void> {
+  const json = subscription.toJSON();
+  await api.post('/webpush/subscribe/', {
+    endpoint: json.endpoint,
+    keys: json.keys,
+  });
+}
+
+export async function unsubscribeWebPush(endpoint: string): Promise<void> {
+  await api.post('/webpush/unsubscribe/', { endpoint });
+}
+
+export async function sendTestWebPush(): Promise<number> {
+  const { data } = await api.post<{ sent: number }>('/webpush/test/', {});
+  return data.sent;
+}

--- a/ui/src/lib/pwa/platform.ts
+++ b/ui/src/lib/pwa/platform.ts
@@ -1,0 +1,45 @@
+/** Détection de plateforme / capacités PWA, partagée (InstallHint, Web Push). */
+
+export function isIos(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /iphone|ipad|ipod/i.test(navigator.userAgent);
+}
+
+/** True quand l'app tourne installée (écran d'accueil / fenêtre standalone). */
+export function isStandalone(): boolean {
+  if (typeof window === 'undefined') return false;
+  return (
+    window.matchMedia('(display-mode: standalone)').matches ||
+    // iOS Safari expose ce flag non standard quand lancée depuis l'écran d'accueil.
+    (window.navigator as unknown as { standalone?: boolean }).standalone === true
+  );
+}
+
+/** True si le navigateur supporte le Web Push (service worker + PushManager + Notification). */
+export function isPushSupported(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    'serviceWorker' in navigator &&
+    typeof window !== 'undefined' &&
+    'PushManager' in window &&
+    'Notification' in window
+  );
+}
+
+/**
+ * Convertit une clé publique VAPID (base64url) en Uint8Array, format attendu par
+ * `pushManager.subscribe({ applicationServerKey })`.
+ */
+export function urlBase64ToUint8Array(base64String: string): Uint8Array<ArrayBuffer> {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = window.atob(base64);
+  // Back it by a concrete ArrayBuffer so the result satisfies BufferSource
+  // (applicationServerKey) under the generic Uint8Array typings.
+  const buffer = new ArrayBuffer(raw.length);
+  const output = new Uint8Array(buffer);
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1015,6 +1015,21 @@
       "description": "Wähle aus, welche Module für diesen Haushalt aktiv sind.",
       "hint": "Deaktivierte Module werden für alle Mitglieder ausgeblendet (Seitenleiste, Dashboard, Assistent). Es werden keine Daten gelöscht — beim Reaktivieren ist alles wieder da.",
       "saved": "Module aktualisiert"
+    },
+    "push": {
+      "title": "Push-Benachrichtigungen",
+      "description": "Erhalte Haushalts-Benachrichtigungen, auch wenn die App geschlossen ist.",
+      "enable": "Benachrichtigungen aktivieren",
+      "enableHint": "Erlaube Benachrichtigungen, um auf diesem Gerät informiert zu werden.",
+      "enabled": "Benachrichtigungen auf diesem Gerät aktiviert.",
+      "disable": "Deaktivieren",
+      "disabledToast": "Benachrichtigungen deaktiviert",
+      "enabledToast": "Benachrichtigungen aktiviert",
+      "test": "Testen",
+      "testSent": "Test-Benachrichtigung gesendet",
+      "testNoDevice": "Kein abonniertes Gerät",
+      "permissionDenied": "Benachrichtigungen sind blockiert. Aktiviere sie in den Browsereinstellungen.",
+      "iosHint": "Füge die App auf dem iPhone zuerst zum Startbildschirm hinzu (Teilen → Zum Home-Bildschirm), um Benachrichtigungen zu aktivieren."
     }
   },
   "tutorials": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1015,6 +1015,21 @@
       "description": "Choose which modules are active for this household.",
       "hint": "Disabled modules are hidden for every member (sidebar, dashboard, assistant). No data is deleted — re-enable a module to get everything back.",
       "saved": "Modules updated"
+    },
+    "push": {
+      "title": "Push notifications",
+      "description": "Get household notifications even when the app is closed.",
+      "enable": "Enable notifications",
+      "enableHint": "Allow notifications to be alerted on this device.",
+      "enabled": "Notifications enabled on this device.",
+      "disable": "Disable",
+      "disabledToast": "Notifications disabled",
+      "enabledToast": "Notifications enabled",
+      "test": "Test",
+      "testSent": "Test notification sent",
+      "testNoDevice": "No subscribed device",
+      "permissionDenied": "Notifications are blocked. Re-enable them in your browser settings.",
+      "iosHint": "On iPhone, first add the app to your home screen (Share → Add to Home Screen) to enable notifications."
     }
   },
   "tutorials": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1015,6 +1015,21 @@
       "description": "Elige qué módulos están activos para este hogar.",
       "hint": "Los módulos desactivados se ocultan para todos los miembros (barra lateral, panel, asistente). No se elimina ningún dato: reactiva un módulo para recuperarlo todo.",
       "saved": "Módulos actualizados"
+    },
+    "push": {
+      "title": "Notificaciones push",
+      "description": "Recibe las notificaciones del hogar aunque la app esté cerrada.",
+      "enable": "Activar notificaciones",
+      "enableHint": "Permite las notificaciones para recibir avisos en este dispositivo.",
+      "enabled": "Notificaciones activadas en este dispositivo.",
+      "disable": "Desactivar",
+      "disabledToast": "Notificaciones desactivadas",
+      "enabledToast": "Notificaciones activadas",
+      "test": "Probar",
+      "testSent": "Notificación de prueba enviada",
+      "testNoDevice": "Ningún dispositivo suscrito",
+      "permissionDenied": "Las notificaciones están bloqueadas. Reactívalas en los ajustes del navegador.",
+      "iosHint": "En iPhone, primero añade la app a la pantalla de inicio (Compartir → Añadir a pantalla de inicio) para activar las notificaciones."
     }
   },
   "tutorials": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1015,6 +1015,21 @@
       "description": "Choisissez les modules actifs pour ce foyer.",
       "hint": "Les modules désactivés sont masqués pour tous les membres (sidebar, dashboard, assistant). Aucune donnée n’est supprimée — réactivez un module pour tout retrouver.",
       "saved": "Modules mis à jour"
+    },
+    "push": {
+      "title": "Notifications push",
+      "description": "Recevez les notifications du foyer même l'app fermée.",
+      "enable": "Activer les notifications",
+      "enableHint": "Autorisez les notifications pour être prévenu sur cet appareil.",
+      "enabled": "Notifications activées sur cet appareil.",
+      "disable": "Désactiver",
+      "disabledToast": "Notifications désactivées",
+      "enabledToast": "Notifications activées",
+      "test": "Tester",
+      "testSent": "Notification de test envoyée",
+      "testNoDevice": "Aucun appareil abonné",
+      "permissionDenied": "Les notifications sont bloquées. Réactivez-les dans les réglages de votre navigateur.",
+      "iosHint": "Sur iPhone, installez d'abord l'app sur l'écran d'accueil (Partager → Sur l'écran d'accueil) pour activer les notifications."
     }
   },
   "tutorials": {


### PR DESCRIPTION
Closes #365

## Quoi

Lot 2 du parcours « app mobile ». Après le socle PWA (#353) et le backend VAPID (#360), ce lot ajoute **l'interface d'abonnement** — c'est ce qui rend le push utilisable : l'utilisateur active les notifications sur son appareil et peut recevoir une notif de test.

- **Section « Notifications push »** dans les réglages (`WebPushSection.tsx`, placée après Telegram) : activer / désactiver + bouton « Tester ».
- **Abonnement navigateur** : récupère la clé publique VAPID (`GET /webpush/vapid-public-key/`) → `pushManager.subscribe({ userVisibleOnly, applicationServerKey })` → `POST /webpush/subscribe/` (`PushSubscription.toJSON()` = shape backend). Désabonnement symétrique (`/unsubscribe/` + `sub.unsubscribe()`).
- **État « abonné » lu côté service worker** (`getSubscription()`), pas côté serveur : il reflète *cet* appareil.
- **Gating & garde-fous** : sur iOS hors app installée → invite à installer d'abord (le push iOS n'existe que depuis l'écran d'accueil) ; section masquée si push non configuré côté serveur (clé VAPID vide) ou navigateur non compatible ; message si permission bloquée.
- **Détection plateforme** extraite dans `ui/src/lib/pwa/platform.ts` (`isIos`/`isStandalone`/`isPushSupported`/`urlBase64ToUint8Array`), réutilisée par `InstallHint` (dédup).
- **API client** `ui/src/lib/api/webpush.ts` (pattern manuel, comme `telegram.ts`).
- **i18n** `settings.push.*` (en/fr/de/es).

## Critères de l'issue

- ✅ Toggle activer/désactiver (permission + subscribe/unsubscribe).
- ✅ Bouton « Tester » → `POST /webpush/test/`.
- ✅ Section masquée si non configuré / non supporté ; gating iOS ; message si permission bloquée.
- ✅ i18n en/fr/de/es.

## Vérifs

`npm run lint` (0 erreur), `npx tsc -b`, `npm run build` verts. Frontend uniquement — aucun changement backend.

## Note de test réel

Le flux complet (permission → subscribe → notif) ne se teste que sur une PWA **installée** avec des clés VAPID configurées (déjà fait en prod, `is_configured: True`). En dev local sans clés VAPID, la section est simplement masquée (comportement voulu).

## Hors scope

- Lot 3 : brancher les notifs existantes (événements `notifications.service.send` + pings) sur le canal push.