### PR TITLE
feat(webpush): branche le push sur événements + pings et pastille d'icône (#367)

### DIFF
--- a/apps/notifications/service.py
+++ b/apps/notifications/service.py
@@ -2,13 +2,26 @@
 Notification service — single entry point for creating and managing notifications.
 Transport-agnostic: swap polling for WebSocket later by editing only this file.
 """
+import logging
+
 from django.utils import timezone
 
 from .models import Notification
 
+logger = logging.getLogger(__name__)
+
 # HTMX event name broadcast on the body to refresh the bell widget.
 # Used in both Django views (HX-Trigger header) and React (dispatchEvent).
 BELL_REFRESH_EVENT = "bellRefresh"
+
+# Deep-link a push notification opens when tapped, per notification type. The
+# service worker falls back to /app/dashboard for anything unmapped, so this map
+# only needs the types that have a more specific landing page.
+_DEEP_LINKS = {
+    Notification.Type.STOCK_LOW: "/app/stock",
+    Notification.Type.STOCK_OUT: "/app/stock",
+    Notification.Type.HOUSEHOLD_INVITATION: "/app/dashboard",
+}
 
 
 def send(
@@ -21,6 +34,10 @@ def send(
     """
     Create and persist a notification for a user.
     All callers (households, projects, etc.) go through here.
+
+    Also mirrors the notification to Web Push (best-effort): a user with a push
+    subscription gets it on their device even when the SPA is closed. The push
+    carries the current unread count so the PWA can set its app-icon badge.
     """
     notif = Notification.objects.create(
         user=user,
@@ -29,8 +46,29 @@ def send(
         body=body,
         payload=payload or {},
     )
+    _mirror_to_web_push(notif)
     # Future: channel_layer.group_send(f"user_{user.id}", {...}) here for WS
     return notif
+
+
+def _mirror_to_web_push(notif: Notification) -> None:
+    """Fire the notification to the user's push subscriptions. Never raises."""
+    try:
+        from webpush.service import send_web_push
+
+        unread = Notification.objects.filter(
+            user=notif.user, is_read=False, deleted_at__isnull=True
+        ).count()
+        send_web_push(
+            notif.user,
+            notif.title,
+            notif.body,
+            url=_DEEP_LINKS.get(notif.type, "/app/dashboard"),
+            tag=notif.type,
+            data={"unreadCount": unread},
+        )
+    except Exception:  # noqa: BLE001 — push must never break notification creation
+        logger.exception("web push mirror failed for notification %s", notif.id)
 
 
 # Keep legacy alias so existing callers don't break

--- a/apps/notifications/tests/test_notifications.py
+++ b/apps/notifications/tests/test_notifications.py
@@ -1,10 +1,12 @@
+from unittest.mock import patch
+
 import pytest
 from rest_framework.test import APIClient
 from rest_framework import status
 
 from households.models import Household, HouseholdMember
 from notifications.models import Notification
-from notifications.service import create_notification
+from notifications.service import create_notification, send
 
 
 @pytest.fixture
@@ -42,6 +44,34 @@ class TestCreateNotification:
     def test_payload_stored(self, db, user):
         notif = create_notification(user, "household_invitation", "T", payload={"household_id": "abc"})
         assert notif.payload["household_id"] == "abc"
+
+
+class TestWebPushMirror:
+    def test_send_mirrors_to_web_push_with_deep_link_and_unread_count(self, db, user):
+        with patch("webpush.service.send_web_push") as push:
+            send(user, "stock_low", "Low: sugar", "Restock it")
+
+        push.assert_called_once()
+        assert push.call_args.args == (user, "Low: sugar", "Restock it")
+        assert push.call_args.kwargs["url"] == "/app/stock"
+        assert push.call_args.kwargs["tag"] == "stock_low"
+        assert push.call_args.kwargs["data"] == {"unreadCount": 1}
+
+    def test_unread_count_reflects_prior_unread(self, db, user):
+        send(user, "household_invitation", "First")  # unread #1
+        with patch("webpush.service.send_web_push") as push:
+            send(user, "household_invitation", "Second")  # unread #2
+        assert push.call_args.kwargs["data"]["unreadCount"] == 2
+
+    def test_default_deep_link_for_unmapped_type(self, db, user):
+        with patch("webpush.service.send_web_push") as push:
+            send(user, "household_invitation", "You're invited")
+        assert push.call_args.kwargs["url"] == "/app/dashboard"
+
+    def test_push_failure_never_breaks_notification_creation(self, db, user):
+        with patch("webpush.service.send_web_push", side_effect=RuntimeError("boom")):
+            notif = send(user, "household_invitation", "Still created")
+        assert Notification.objects.filter(pk=notif.pk).exists()
 
 
 class TestNotificationAPI:

--- a/apps/pings/services.py
+++ b/apps/pings/services.py
@@ -111,9 +111,14 @@ def send_due_pings(now: datetime | None = None) -> dict:
 
 
 def _send_one(pref: PingPreference, now: datetime) -> bool:
-    """Evaluate one preference; send if due. True = a message went out."""
-    from telegram.outbound import send_agent_message
+    """Evaluate one preference; send if due. True = a message went out.
 
+    A due ping fans out to every channel the user can receive on: Telegram (the
+    original channel, which also persists the question as an agent turn so a
+    reply keeps context) and Web Push. The ping counts as sent as soon as *one*
+    channel delivers; if none do, the claimed ``PingLog`` slot is released so a
+    later tick retries.
+    """
     spec = registry.find_spec(pref.ping_type)
     if spec is None:
         return False  # stale row for an unregistered type
@@ -131,20 +136,14 @@ def _send_one(pref: PingPreference, now: datetime) -> bool:
     ).exists():
         return False  # already sent today
 
-    account = (
-        TelegramAccount.objects.filter(user=pref.user).select_related("user").first()
-    )
-    if account is None:
-        return False  # nowhere to send — silent skip, the UI nudges to link
-
     with translation.override(_recipient_language(pref)):
         text = spec.build_message(household, pref.user, today=today)
         if not text:
             return False  # nothing worth asking today (data already entered…)
 
         # Claim the (day, ping) slot BEFORE sending: overlapping ticks race on
-        # the unique constraint, not on Telegram. A failed delivery releases
-        # the claim so the next tick retries.
+        # the unique constraint, not on a channel. A total delivery failure
+        # releases the claim so the next tick retries.
         log, created = PingLog.objects.get_or_create(
             household=household,
             user=pref.user,
@@ -155,10 +154,33 @@ def _send_one(pref: PingPreference, now: datetime) -> bool:
         if not created:
             return False
 
-        if not send_agent_message(account, household, text):
+        if not _deliver(pref.user, household, text):
             log.delete()
             return False
     return True
+
+
+def _deliver(user, household, text: str) -> bool:
+    """Fan a ping out to every available channel. True if any delivered."""
+    delivered = False
+
+    account = (
+        TelegramAccount.objects.filter(user=user).select_related("user").first()
+    )
+    if account is not None:
+        from telegram.outbound import send_agent_message
+
+        # Telegram also persists the question as an agent turn (reply pipeline).
+        if send_agent_message(account, household, text):
+            delivered = True
+
+    from webpush.service import send_web_push
+
+    # Best-effort, never raises; no-op (0) if the user has no subscription.
+    if send_web_push(user, str(household), text, url="/app/dashboard") > 0:
+        delivered = True
+
+    return delivered
 
 
 def _household_tz(household) -> ZoneInfo:

--- a/apps/pings/tests/test_services.py
+++ b/apps/pings/tests/test_services.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time, timezone as dt_timezone
+from unittest import mock
 
 import pytest
 
@@ -68,6 +69,43 @@ class TestTick:
     def test_no_telegram_account_skips(self, preference, outbound_client):
         assert send_due_pings(now=_utc(17, 5))["sent"] == 0
         outbound_client.send_message.assert_not_called()
+
+
+class TestChannelFanout:
+    """A due ping fans out to Telegram + Web Push; one success = delivered."""
+
+    def test_delivers_via_web_push_without_telegram(self, preference, outbound_client):
+        with mock.patch("webpush.service.send_web_push", return_value=1) as push:
+            summary = send_due_pings(now=_utc(17, 5))
+
+        assert summary["sent"] == 1
+        push.assert_called_once()
+        assert push.call_args.args[0] == preference.user
+        assert push.call_args.kwargs["url"] == "/app/dashboard"
+        assert PingLog.objects.count() == 1
+        outbound_client.send_message.assert_not_called()
+
+    def test_fans_out_to_both_channels(self, preference, linked_account, outbound_client):
+        with mock.patch("webpush.service.send_web_push", return_value=1) as push:
+            assert send_due_pings(now=_utc(17, 5))["sent"] == 1
+
+        outbound_client.send_message.assert_called_once()
+        push.assert_called_once()
+        assert PingLog.objects.count() == 1
+
+    def test_no_channel_delivers_releases_log(self, preference, outbound_client):
+        # No Telegram account and web push delivers to nobody → nothing sent,
+        # log released so a later tick retries.
+        with mock.patch("webpush.service.send_web_push", return_value=0):
+            assert send_due_pings(now=_utc(17, 5))["sent"] == 0
+        assert not PingLog.objects.exists()
+
+    def test_telegram_success_counts_even_if_push_empty(
+        self, preference, linked_account, outbound_client
+    ):
+        with mock.patch("webpush.service.send_web_push", return_value=0):
+            assert send_due_pings(now=_utc(17, 5))["sent"] == 1
+        assert PingLog.objects.count() == 1
 
     def test_module_disabled_since_optin_skips(self, household, user,
                                                 linked_account, outbound_client):

--- a/docs/MODULES/webpush.md
+++ b/docs/MODULES/webpush.md
@@ -3,9 +3,9 @@
 > Rôle : **canal de notifications push** vers la PWA (Web Push / VAPID). Stocke les
 > abonnements des navigateurs des utilisateurs et sait leur envoyer une notification
 > système, même app fermée. Couche de **transport** pure : le *contenu* des notifs
-> vient des sources existantes (`notifications.service.send`, `pings`) — cf. lot 3.
+> vient des sources existantes (`notifications.service.send`, `pings`) — branché au lot 3.
 >
-> Parcours : « app mobile » (lot 0 socle PWA, lot 1 backend). Concepts + décisions :
+> Parcours : « app mobile » (lot 0 socle PWA, lot 1 backend, lot 2 front, lot 3 branchement sources + pastille). Concepts + décisions :
 > [../fiches/PWA_PUSH.md](../fiches/PWA_PUSH.md). Sources de notifs :
 > [notifications.md](./notifications.md), [pings.md](./pings.md).
 
@@ -19,7 +19,11 @@
   - `management/commands/generate_vapid_keys.py` — génère une paire VAPID (formats prêts pour le navigateur + pywebpush).
   - `admin.py` — lecture des abonnements (clés en readonly).
 - **Service worker** (socle PWA, lot 0) : `templates/sw.js`, servi à la racine `/sw.js` par une route Django (`config/urls.py`) pour avoir un scope `/`. Porte les handlers `push` + `notificationclick`. Enregistré en prod par `ui/src/lib/pwa/registerServiceWorker.ts`.
-- **Frontend abonnement** : lot 2 (à venir) — le SW sait déjà recevoir.
+- **Frontend abonnement** (lot 2) : `ui/src/features/settings/components/WebPushSection.tsx` (activer/désactiver + test), `ui/src/lib/api/webpush.ts`, `ui/src/lib/pwa/platform.ts`.
+- **Branchement des sources** (lot 3) :
+  - **Événements** — `notifications.service.send()` mirroir best-effort vers `send_web_push` (deep-link par type, `tag=type`, `data.unreadCount`). Couvre stock/invitation/météo d'un coup (point d'entrée unique).
+  - **Pings** — `pings.services._deliver()` fan-out Telegram + Web Push ; le ping compte comme envoyé dès qu'**un** canal délivre (un user sans Telegram mais abonné push le reçoit). `PingLog` réclamé avant envoi, relâché si aucun canal ne délivre.
+  - **Pastille d'icône** (Badging API) : le `push` du SW pose `self.navigator.setAppBadge(data.unreadCount)` (app fermée) ; `useUnreadCount` synchronise la pastille tant que l'app tourne (`syncAppBadge`) et l'efface à la lecture. Guardé (API optionnelle, iOS 16.4+ PWA installée).
 - **Config** : `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY`, `VAPID_ADMIN_EMAIL` (env ; défauts vides ⇒ push désactivé proprement).
 - **Dépendance** : `pywebpush==2.3.0` (tire `cryptography`, `py-vapid`, `http-ece`).
 - **Tests** : `apps/webpush/tests/test_webpush.py` — subscribe/unsubscribe/scoping, no-op sans clés, prune 410, garde sur erreur transitoire, endpoint de test.
@@ -41,7 +45,7 @@ Toutes protégées par `IsAuthenticated`.
 ## Flux d'un envoi
 
 ```
-source de notif (stock bas, invitation, ping…)   ← lot 3
+source de notif (stock bas, invitation, ping…)   ← notifications.service.send / pings._deliver
    ▼
 webpush.service.send_web_push(user, title, body, url=…)
    │  is_configured() ? sinon return 0 (no-op)
@@ -73,5 +77,5 @@ push service (FCM/Apple/Mozilla) → SW du navigateur → sw.js `push` → showN
 ## Notes / décisions
 
 - **Pas de `enabled` sur le modèle** : subscribe = create, unsubscribe = delete, prune = delete. Un seul état, pas de flag à synchroniser.
-- **`web` ET `scheduler` doivent avoir les clés** : le `web` envoie les notifs événementielles + le test ; le `scheduler` enverra les pings (lot 3). Les deux lisent `env_file: .env`.
+- **`web` ET `scheduler` doivent avoir les clés** : le `web` envoie les notifs événementielles + le test ; le `scheduler` envoie les pings. Les deux lisent `env_file: .env`.
 - **iOS** : le push n'arrive que si la PWA est **installée** sur l'écran d'accueil (iOS 16.4+) — d'où le bandeau d'installation du lot 0. Cf. fiche PWA_PUSH.

--- a/templates/sw.js
+++ b/templates/sw.js
@@ -108,7 +108,18 @@ self.addEventListener('push', (event) => {
     data: { url: payload.url || '/app/dashboard' },
   };
 
-  event.waitUntil(self.registration.showNotification(title, options));
+  // App-icon badge (Badging API): the count rides in the payload so the badge
+  // stays right even when the SPA is closed. Guarded — not every UA/OS exposes
+  // it, and it only surfaces on an installed PWA (iOS 16.4+).
+  const tasks = [self.registration.showNotification(title, options)];
+  if (typeof payload.unreadCount === 'number' && self.navigator.setAppBadge) {
+    tasks.push(
+      payload.unreadCount > 0
+        ? self.navigator.setAppBadge(payload.unreadCount)
+        : self.navigator.clearAppBadge()
+    );
+  }
+  event.waitUntil(Promise.all(tasks).catch(() => {}));
 });
 
 self.addEventListener('notificationclick', (event) => {

--- a/ui/src/features/notifications/hooks.ts
+++ b/ui/src/features/notifications/hooks.ts
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '@/lib/toast';
+import { syncAppBadge } from '@/lib/pwa/platform';
 import {
   fetchNotifications,
   fetchUnreadCount,
@@ -22,13 +24,23 @@ export function useNotifications() {
 }
 
 export function useUnreadCount() {
-  return useQuery({
+  const query = useQuery({
     queryKey: notificationKeys.unreadCount(),
     queryFn: fetchUnreadCount,
     staleTime: 30_000,
     refetchInterval: 60_000,
     refetchOnWindowFocus: true,
   });
+
+  // Keep the PWA app-icon badge in sync while the SPA is open: this polls every
+  // 60s and refetches on focus, and mark-read invalidates it → the badge clears
+  // on read. Push handles the closed-app case (service worker sets the badge).
+  const count = query.data;
+  useEffect(() => {
+    if (typeof count === 'number') syncAppBadge(count);
+  }, [count]);
+
+  return query;
 }
 
 export function useMarkRead() {

--- a/ui/src/lib/pwa/platform.ts
+++ b/ui/src/lib/pwa/platform.ts
@@ -27,6 +27,28 @@ export function isPushSupported(): boolean {
 }
 
 /**
+ * Reflète le nombre de notifications non lues sur l'icône de l'app (Badging API).
+ * No-op silencieux si l'API n'est pas exposée (navigateur/OS non compatible, ou
+ * PWA non installée). `count <= 0` efface la pastille.
+ */
+export function syncAppBadge(count: number): void {
+  if (typeof navigator === 'undefined') return;
+  const nav = navigator as Navigator & {
+    setAppBadge?: (n?: number) => Promise<void>;
+    clearAppBadge?: () => Promise<void>;
+  };
+  try {
+    if (count > 0) {
+      void nav.setAppBadge?.(count);
+    } else {
+      void nav.clearAppBadge?.();
+    }
+  } catch {
+    // Badging API absent or refused — ignore.
+  }
+}
+
+/**
  * Convertit une clé publique VAPID (base64url) en Uint8Array, format attendu par
  * `pushManager.subscribe({ applicationServerKey })`.
  */


### PR DESCRIPTION
Closes #367

## Quoi

Dernier lot du parcours « app mobile ». Le transport Web Push (VAPID) existait depuis les lots 1-2 mais rien ne l'alimentait — seul le bouton « Tester » envoyait quelque chose. Ce lot branche les **vraies** notifs du foyer sur le push et ajoute la **pastille chiffrée** sur l'icône.

- **Événements** — `notifications.service.send()` miroite chaque notif vers `webpush.service.send_web_push` en best-effort (jamais bloquant). Comme c'est le point d'entrée unique, ça couvre **stock bas/rupture, invitations et alertes météo** d'un coup. Deep-link par type (stock → `/app/stock`, défaut → `/app/dashboard`), `tag` = type, et `unreadCount` embarqué pour la pastille.
- **Pings** — `pings.services` gagne une abstraction canal (`_deliver`) : fan-out **Telegram + Web Push**. Le ping compte comme envoyé dès qu'**un** canal délivre (un user sans Telegram mais abonné push le reçoit désormais) ; le `PingLog` réclamé est relâché seulement si aucun canal ne passe. Telegram garde sa persistance de tour de conversation (pipeline de réponse).
- **Pastille (Badging API)** — `sw.js` pose `setAppBadge(unreadCount)` à la réception d'un push (app fermée) ; `useUnreadCount` + helper `syncAppBadge` synchronisent la pastille tant que l'app tourne et l'effacent à la lecture (mark-read → refetch → badge 0). Gardé partout (API optionnelle, iOS 16.4+ en PWA installée).

## Critères de l'issue

- [x] Une notif stock/invitation/météo déclenche un push best-effort (jamais bloquant).
- [x] Un ping dû part sur tous les canaux disponibles ; `PingLog` relâché si aucun ne délivre.
- [x] La pastille reflète le nombre de non-lues et s'efface à la lecture.
- [x] Tests backend (mirror events, fan-out pings) verts.

## Tests

- 8 nouveaux tests : miroir événement (deep-link, tag, unreadCount, résilience à l'exception), fan-out pings (web-push-only, 2 canaux, relâche du log, succès Telegram seul).
- Suite complète : 2711 passed. ESLint 0 erreur, `tsc -b` OK.

## Hors scope

- Pastille par ping (les pings n'ont pas de notion « non lu » → ils déclenchent une bannière mais n'incrémentent pas le chiffre).
