### PR TITLE
docs(tutorials): guide « Installer l'app & notifications push »

### DIFF
--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -1,5 +1,5 @@
 import {
-  AlertCircle, LayoutDashboard, Newspaper, Sparkles, User,
+  AlertCircle, LayoutDashboard, Newspaper, Smartphone, Sparkles, User,
   type LucideIcon,
 } from 'lucide-react';
 import { MODULES } from '@/lib/modules';
@@ -58,6 +58,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'dashboard', Icon: LayoutDashboard, to: '/app/dashboard', stepIds: ['overview', 'activity', 'alerts'] },
   { key: 'agent', Icon: Sparkles, to: '/app/agent', stepIds: ['ask', 'citations', 'web', 'context', 'create', 'memory'] },
   { key: 'digest', Icon: Newspaper, to: '/app/digest', stepIds: ['preview', 'enable', 'sections'] },
+  { key: 'install', Icon: Smartphone, to: '/app/settings', stepIds: ['install', 'enable', 'badge'] },
   { key: 'zones', moduleKey: 'zones', to: '/app/zones', stepIds: ['create', 'hierarchy', 'navigate'] },
   { key: 'equipment', moduleKey: 'equipment', to: '/app/equipment', stepIds: ['add', 'purchase', 'history'] },
   { key: 'electricity', moduleKey: 'electricity', to: '/app/electricity', stepIds: ['board', 'readings', 'analyze'] },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1499,6 +1499,24 @@
           }
         }
       },
+      "install": {
+        "title": "App installieren & Benachrichtigungen aktivieren",
+        "intro": "Fügen Sie den Haushalt zum Startbildschirm Ihres Handys hinzu und erhalten Sie seine Benachrichtigungen als Push – auch bei geschlossener App.",
+        "steps": {
+          "install": {
+            "title": "Zum Startbildschirm hinzufügen",
+            "body": "Auf dem iPhone (Safari): auf Teilen tippen, dann „Zum Home-Bildschirm\". Auf Android oder Desktop: die Installationsschaltfläche des Browsers verwenden. Öffnen Sie die App danach über dieses Symbol."
+          },
+          "enable": {
+            "title": "Push-Benachrichtigungen einschalten",
+            "body": "Öffnen Sie in den Einstellungen „Push-Benachrichtigungen\", tippen Sie auf Aktivieren und erlauben Sie die Berechtigung. Mit Testen prüfen Sie, ob eine Benachrichtigung Ihr Gerät erreicht."
+          },
+          "badge": {
+            "title": "Zähler auf dem Symbol",
+            "body": "Ungelesene Benachrichtigungen erscheinen als Zähler auf dem App-Symbol und werden beim Lesen gelöscht. Auf dem iPhone funktioniert das nur in der installierten App (iOS 16.4+)."
+          }
+        }
+      },
       "budget": {
         "title": "Budgets",
         "intro": "Lege monatliche Obergrenzen fest und sieh auf einen Blick, ob deine Ausgaben darin bleiben.",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1499,6 +1499,24 @@
           }
         }
       },
+      "install": {
+        "title": "Install the app & get notifications",
+        "intro": "Add the house to your phone's home screen and receive its notifications as push, even when the app is closed.",
+        "steps": {
+          "install": {
+            "title": "Add to your home screen",
+            "body": "On iPhone (Safari): tap Share, then \"Add to Home Screen\". On Android or desktop: use the browser's install button. Then open the app from that icon."
+          },
+          "enable": {
+            "title": "Turn on push notifications",
+            "body": "In Settings, open \"Push notifications\", tap Enable and allow the permission. Use Test to check a notification reaches your device."
+          },
+          "badge": {
+            "title": "Badge on the icon",
+            "body": "Unread notifications show as a count on the app icon, cleared when you read them. On iPhone this works only from the installed app (iOS 16.4+)."
+          }
+        }
+      },
       "budget": {
         "title": "Budgets",
         "intro": "Set monthly ceilings and see at a glance whether your spending stays within them.",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1499,6 +1499,24 @@
           }
         }
       },
+      "install": {
+        "title": "Instalar la app y activar las notificaciones",
+        "intro": "Añade el hogar a la pantalla de inicio de tu teléfono y recibe sus notificaciones como push, incluso con la app cerrada.",
+        "steps": {
+          "install": {
+            "title": "Añadir a la pantalla de inicio",
+            "body": "En iPhone (Safari): toca Compartir y luego «Añadir a pantalla de inicio». En Android u ordenador: usa el botón de instalación del navegador. Después abre la app desde ese icono."
+          },
+          "enable": {
+            "title": "Activar las notificaciones push",
+            "body": "En Ajustes, abre «Notificaciones push», toca Activar y concede el permiso. Usa Probar para comprobar que llega una notificación a tu dispositivo."
+          },
+          "badge": {
+            "title": "Insignia en el icono",
+            "body": "Las notificaciones sin leer aparecen como contador en el icono de la app y se borran al leerlas. En iPhone solo funciona desde la app instalada (iOS 16.4+)."
+          }
+        }
+      },
       "budget": {
         "title": "Presupuestos",
         "intro": "Fija límites mensuales y comprueba de un vistazo si tus gastos se mantienen dentro.",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1499,6 +1499,24 @@
           }
         }
       },
+      "install": {
+        "title": "Installer l'app & activer les notifications",
+        "intro": "Ajoutez le foyer à l'écran d'accueil de votre téléphone et recevez ses notifications en push, même l'app fermée.",
+        "steps": {
+          "install": {
+            "title": "Ajouter à l'écran d'accueil",
+            "body": "Sur iPhone (Safari) : bouton Partager, puis « Sur l'écran d'accueil ». Sur Android ou ordinateur : bouton d'installation du navigateur. Rouvrez ensuite l'app depuis cette icône."
+          },
+          "enable": {
+            "title": "Activer les notifications push",
+            "body": "Dans Réglages, ouvrez « Notifications push », touchez Activer et autorisez la permission. Utilisez Tester pour vérifier qu'une notif arrive sur votre appareil."
+          },
+          "badge": {
+            "title": "Pastille sur l'icône",
+            "body": "Les notifications non lues s'affichent en compteur sur l'icône de l'app, effacé à la lecture. Sur iPhone, cela ne marche que depuis l'app installée (iOS 16.4+)."
+          }
+        }
+      },
       "budget": {
         "title": "Budgets",
         "intro": "Fixe des plafonds mensuels et vois d'un coup d'œil si tes dépenses tiennent dedans.",


### PR DESCRIPTION
## Quoi

Comble le trou tutoriel du parcours « app mobile » : les lots 2-3 (abonnement push + branchement) n'avaient pas mis à jour `/app/tutorial`, alors que la règle projet l'impose pour toute feature user-facing.

Nouveau guide transverse **« Installer l'app & notifications push »** (icône `Smartphone`, deep-link `/app/settings`), 3 étapes :
- **install** — ajouter à l'écran d'accueil (iPhone Safari : Partager → Sur l'écran d'accueil ; Android/desktop : bouton d'installation), puis rouvrir depuis l'icône.
- **enable** — activer « Notifications push » dans Réglages + bouton Tester.
- **badge** — la pastille chiffrée sur l'icône (non-lues, effacée à la lecture), gating iOS 16.4+ / app installée.

Prose ajoutée dans les **4 locales** (en/fr/de/es), aucune touche backend (progression = clé opaque `guide.install`).

## Vérifs

- Script de cohérence registre ↔ 4 locales : OK.
- `npm run lint` : 0 erreur. `npm run build` : OK.

## Hors scope

- Pas d'item dans la checklist « Bien démarrer » (déjà à 6 items ; l'install reste optionnelle, pas une première action indispensable).
