### PR TITLE
fix(webpush): la notif de test pose une pastille de démo (unreadCount=1)

### DIFF
--- a/apps/webpush/tests/test_webpush.py
+++ b/apps/webpush/tests/test_webpush.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -181,3 +182,6 @@ def test_test_endpoint_reports_sent_count(user, auth_client, vapid):
     assert response.status_code == status.HTTP_200_OK
     assert response.data["sent"] == 1
     mock_push.assert_called_once()
+    # The test push carries a demo badge so it also exercises the Badging API.
+    payload = json.loads(mock_push.call_args.kwargs["data"])
+    assert payload["unreadCount"] == 1

--- a/apps/webpush/views.py
+++ b/apps/webpush/views.py
@@ -67,5 +67,8 @@ class TestPushView(APIView):
             "🔔 Notification de test",
             url="/app/dashboard",
             tag="webpush-test",
+            # Demo badge so the test also exercises the app-icon Badging API. It
+            # resyncs to the real unread count as soon as the SPA reopens.
+            data={"unreadCount": 1},
         )
         return Response({"sent": sent})


### PR DESCRIPTION
## Quoi

`WebPushSection` → bouton **Tester** : le push de test ne portait pas de `unreadCount`, or le service worker ne pose la pastille d'icône que si ce champ est présent. Résultat : le test n'allumait jamais la pastille, ce qui donnait l'impression qu'elle ne marchait pas.

Le test embarque désormais `data={"unreadCount": 1}` (démo) → il exerce le pipeline complet, pastille comprise. La pastille se resynchronise au vrai compteur de non-lues dès que la SPA reprend le focus (`useUnreadCount` → `syncAppBadge`), donc pas de « 1 » fantôme persistant.

## Vérifs

- `apps/webpush/tests/test_webpush.py` : le test du endpoint vérifie maintenant `data.unreadCount == 1`. 10 tests verts.

## Note

Comportement iOS : la pastille n'apparaît que depuis la PWA installée (iOS 16.4+) avec le service worker à jour — fermer/rouvrir l'app une fois pour récupérer le SW livré en #368.
