### PR TITLE
Parcours 21 — eval_retrieval --auto (golden auto-généré)

### DIFF
--- a/apps/agent/management/commands/eval_retrieval.py
+++ b/apps/agent/management/commands/eval_retrieval.py
@@ -2,16 +2,25 @@
 
 Runs a golden set of questions through the lexical, semantic and hybrid legs and
 reports recall@k + MRR per mode, so the hybrid gain (and any regression on
-exact-keyword queries) is measured on the real corpus rather than guessed. Also
-the arbiter for turning `AGENT_HYBRID_RETRIEVAL_ENABLED` on by default.
+exact-keyword queries) is measured on the real corpus rather than guessed. The
+arbiter for turning `AGENT_HYBRID_RETRIEVAL_ENABLED` on by default.
 
-Golden file: JSON list of ``{"question": str, "expected": ["entity_type:id", ...]}``.
+Two ways to supply the golden set:
+
+- **`--queries golden.json`** — a hand-written JSON list of
+  ``{"question": str, "expected": ["entity_type:id", ...]}``.
+- **`--auto N`** — build it automatically: sample N real entities, have the LLM
+  write a natural question each answers (expected = that entity). No manual
+  labelling; a "self-retrieval" proxy, fair because the three modes run on the
+  exact same questions. Save it with ``--auto-out`` to inspect/reuse.
 
     python manage.py eval_retrieval --household <uuid> --queries golden.json --mode all
+    python manage.py eval_retrieval --household <uuid> --auto 15 --auto-out golden.json
 """
 from __future__ import annotations
 
 import json
+import random
 
 from django.core.management.base import BaseCommand, CommandError
 from django.test import override_settings
@@ -21,6 +30,13 @@ from agent.eval.metrics import evaluate
 
 _MODES = ("fulltext", "vector", "hybrid")
 
+_QUESTION_SYSTEM = (
+    "Tu génères UNE question courte et naturelle, en français, qu'un membre du "
+    "foyer pourrait poser à son assistant et à laquelle le document fourni répond. "
+    "Écris comme une vraie personne (tu peux reformuler, ne recopie pas le texte "
+    "mot pour mot). Réponds UNIQUEMENT par la question, sans guillemets ni préambule."
+)
+
 
 class Command(BaseCommand):
     help = "Evaluate retrieval (recall@k, MRR) for fulltext / vector / hybrid."
@@ -28,8 +44,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--household", required=True, help="Household id to evaluate against.")
         parser.add_argument(
-            "--queries", required=True, help='JSON [{"question": ..., "expected": [...]}].'
+            "--queries", default=None, help='JSON [{"question": ..., "expected": [...]}].'
         )
+        parser.add_argument(
+            "--auto", type=int, default=None, help="Auto-build the golden from N sampled entities."
+        )
+        parser.add_argument("--auto-out", default=None, help="Save the auto-built golden to this path.")
         parser.add_argument("--mode", choices=(*_MODES, "all"), default="all")
         parser.add_argument("--k", type=int, default=10)
 
@@ -38,13 +58,23 @@ class Command(BaseCommand):
         k = options["k"]
         modes = _MODES if options["mode"] == "all" else (options["mode"],)
 
-        try:
-            with open(options["queries"], encoding="utf-8") as fh:
-                golden = json.load(fh)
-        except (OSError, ValueError) as exc:
-            raise CommandError(f"Could not read --queries: {exc}") from exc
-        if not isinstance(golden, list) or not golden:
-            raise CommandError("--queries must be a non-empty JSON list.")
+        if bool(options["queries"]) == bool(options["auto"]):
+            raise CommandError("Provide exactly one of --queries <path> or --auto <N>.")
+
+        if options["auto"]:
+            golden = self._build_auto_golden(household_id, options["auto"])
+            if options["auto_out"]:
+                with open(options["auto_out"], "w", encoding="utf-8") as fh:
+                    json.dump(golden, fh, ensure_ascii=False, indent=2)
+                self.stdout.write(f"Auto-golden ({len(golden)}) saved to {options['auto_out']}")
+        else:
+            try:
+                with open(options["queries"], encoding="utf-8") as fh:
+                    golden = json.load(fh)
+            except (OSError, ValueError) as exc:
+                raise CommandError(f"Could not read --queries: {exc}") from exc
+            if not isinstance(golden, list) or not golden:
+                raise CommandError("--queries must be a non-empty JSON list.")
 
         self.stdout.write(f"Evaluating {len(golden)} question(s), k={k}\n")
         self.stdout.write(f"{'mode':<10} {'queries':>8} {'recall@k':>10} {'mrr':>8}")
@@ -59,6 +89,50 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"{mode:<10} {m['queries']:>8} {m['recall_at_k']:>10.3f} {m['mrr']:>8.3f}"
             )
+
+    def _build_auto_golden(self, household_id, n) -> list[dict]:
+        """Sample N entities and let the LLM write a question each answers."""
+        from agent.llm import LLMError, get_llm_client
+        from agent.searchables import REGISTRY
+
+        candidates = []
+        for spec in REGISTRY:
+            if not spec.embed:
+                continue
+            for instance in spec.model.objects.filter(household_id=household_id):
+                text = retrieval._full_content(instance, spec.search_fields).strip()
+                if text:
+                    candidates.append((spec, instance, text))
+        if not candidates:
+            raise CommandError("No embeddable entities with text in this household — index some first.")
+
+        random.shuffle(candidates)
+        client = get_llm_client()
+        golden: list[dict] = []
+        last_error: Exception | None = None
+        for spec, instance, text in candidates[:n]:
+            try:
+                resp = client.complete(
+                    system=_QUESTION_SYSTEM,
+                    user=text[:800],
+                    feature="eval_autogolden",
+                    household_id=household_id,
+                    max_tokens=60,
+                )
+            except LLMError as exc:
+                last_error = exc
+                continue
+            question = resp.text.strip().strip('"').strip()
+            if question:
+                golden.append(
+                    {"question": question, "expected": [f"{spec.entity_type}:{instance.pk}"]}
+                )
+        if not golden:
+            raise CommandError(
+                "Could not generate any question via the LLM — check the LLM provider "
+                f"(ANTHROPIC_API_KEY / LLM_PROVIDER). Last error: {last_error}"
+            )
+        return golden
 
     def _retrieve(self, mode, household_id, question, k) -> list[str]:
         if mode == "vector":

--- a/apps/agent/tests/test_eval.py
+++ b/apps/agent/tests/test_eval.py
@@ -99,6 +99,45 @@ class TestEvalRetrievalCommand:
         assert "1.000" in output  # the exact-keyword match is recalled
 
 
+class _FakeLLM:
+    provider = "anthropic"
+    model = "fake"
+
+    def complete(self, *, system, user, feature, household_id, max_tokens=1024, metadata=None):
+        from agent.llm import LLMResponse
+
+        return LLMResponse(
+            text="Où est ma facture Engie ?",
+            input_tokens=1,
+            output_tokens=1,
+            duration_ms=1,
+            model=self.model,
+        )
+
+
+class TestAutoGolden:
+    def test_builds_golden_from_entities(self, household, make_document, tmp_path, monkeypatch):
+        from agent import llm as llm_module
+
+        doc = make_document(household, name="Engie", ocr_text="facture engie electricite")
+        monkeypatch.setattr(llm_module, "get_llm_client", lambda *a, **k: _FakeLLM())
+
+        path = tmp_path / "auto.json"
+        out = StringIO()
+        call_command(
+            "eval_retrieval",
+            household=str(household.id),
+            auto=10,  # >= entity count so the document gets a question too
+            mode="fulltext",
+            auto_out=str(path),
+            stdout=out,
+        )
+
+        golden = json.loads(path.read_text(encoding="utf-8"))
+        assert any(entry["expected"] == [f"document:{doc.pk}"] for entry in golden)
+        assert all("question" in entry and entry["question"] for entry in golden)
+
+
 class TestEmbeddingsStatusCommand:
     def test_reports_coverage(self, household, make_document):
         doc = make_document(household, name="Indexé", ocr_text="texte")

--- a/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md
@@ -355,11 +355,14 @@ trancher le fournisseur d'embeddings sur des chiffres, pas au feeling.
   couverture d'index** (combien d'entités searchables ont des chunks, combien
   sont obsolètes vs `EMBEDDING_MODEL` courant) — command `embeddings_status` ou
   intégration à la page `/app/admin/ai-usage/` (à trancher, léger) ;
-- **harnais d'éval** : un jeu de questions figé (`fixtures/eval_queries.json` :
-  `{question, expected_entity_ids}`) + une command `eval_retrieval` qui calcule
-  **recall@k** et **MRR** pour 3 modes (full-text seul / vecteur seul / hybride)
-  sur un foyer donné. Sortie tableau comparatif. Pas de réseau IA en CI (l'éval
-  se lance à la main sur données réelles) ;
+- **harnais d'éval** : command `eval_retrieval` qui calcule **recall@k** et **MRR**
+  pour 3 modes (full-text seul / vecteur seul / hybride) sur un foyer donné, en
+  tableau comparatif. Deux sources de golden : `--queries golden.json` (écrit à la
+  main : `{question, expected}`) **ou `--auto N`** qui **fabrique le golden depuis
+  les vraies entités** (l'IA génère une question par entité échantillonnée, réponse
+  attendue = cette entité ; proxy « self-retrieval », zéro étiquetage manuel,
+  `--auto-out` pour sauvegarder). Pas de réseau IA en CI (l'éval se lance à la main
+  sur données réelles ; le mode `--auto` est testé avec un LLM mocké) ;
 - le fournisseur prod est tranché (Voyage `voyage-3`) ; l'éval **valide la qualité
   de retrieval** sur le corpus réel et arbitre la valeur par défaut du flag
   `AGENT_HYBRID_RETRIEVAL_ENABLED`. Elle sert aussi de **garde-fou pour la bascule


### PR DESCRIPTION
Ajoute un mode qui **fabrique le golden set tout seul** depuis les vraies entités du foyer, pour lancer l'éval sans étiquetage manuel.

## Quoi
- **`eval_retrieval --auto N`** (+ `--auto-out golden.json`) en plus de `--queries` : échantillonne N entités searchables, l'IA génère **une question naturelle** à laquelle chacune répond (réponse attendue = cette entité). Proxy « self-retrieval », fair car les 3 modes tournent sur les mêmes questions.
- Message d'erreur honnête : distingue « aucune entité indexable » de « génération LLM échouée » (clé/provider).
- Test unitaire avec **LLM mocké** (réseau-free).

## Usage prod (une seule commande)
```bash
docker compose -f docker-compose.prod.yml exec web \
  python manage.py eval_retrieval --household <id> --auto 15 --auto-out golden.json --mode all
```

## Validation
- `pytest apps/agent/tests/test_eval.py` → 7 passed ; suite agent **560 passed**.
- Chaîne live (backfill + eval `--queries`) déjà validée en local sur OpenAI réel (fulltext 0.43 → hybrid 1.00 sur corpus synthétique).

Refs #331