### PR TITLE
fix(agent): eval_retrieval — baseline full-text juste (query_expansion)

### DIFF
--- a/apps/agent/management/commands/eval_retrieval.py
+++ b/apps/agent/management/commands/eval_retrieval.py
@@ -52,6 +52,13 @@ class Command(BaseCommand):
         parser.add_argument("--auto-out", default=None, help="Save the auto-built golden to this path.")
         parser.add_argument("--mode", choices=(*_MODES, "all"), default="all")
         parser.add_argument("--k", type=int, default=10)
+        parser.add_argument(
+            "--no-expand",
+            action="store_true",
+            help="Feed raw questions to the lexical/hybrid legs instead of query-expanded "
+            "keywords. Off by default: expansion mirrors what the live agent does "
+            "(query_expansion → search_multi), so full-text gets a fair shot.",
+        )
 
     def handle(self, *args, **options):
         household_id = options["household"]
@@ -76,15 +83,32 @@ class Command(BaseCommand):
             if not isinstance(golden, list) or not golden:
                 raise CommandError("--queries must be a non-empty JSON list.")
 
-        self.stdout.write(f"Evaluating {len(golden)} question(s), k={k}\n")
+        # Expand once per question (reused by the fulltext + hybrid legs), mirroring
+        # the agent's search_household → query_expansion → search_multi path.
+        expand = not options["no_expand"]
+        need_terms = expand and any(m in ("fulltext", "hybrid") for m in modes)
+        terms_by_q: dict[str, list[str]] = {}
+        if need_terms:
+            from agent.llm import get_llm_client
+            from agent.query_expansion import expand as expand_query
+
+            client = get_llm_client()
+            for entry in golden:
+                q = entry.get("question", "")
+                terms_by_q[q] = expand_query(q, client=client, household_id=household_id)
+
+        header_suffix = "" if expand else " (raw, no expansion)"
+        self.stdout.write(f"Evaluating {len(golden)} question(s), k={k}{header_suffix}\n")
         self.stdout.write(f"{'mode':<10} {'queries':>8} {'recall@k':>10} {'mrr':>8}")
         self.stdout.write("-" * 40)
         for mode in modes:
-            runs = [
-                (self._retrieve(mode, household_id, entry.get("question", ""), k),
-                 entry.get("expected", []))
-                for entry in golden
-            ]
+            runs = []
+            for entry in golden:
+                q = entry.get("question", "")
+                terms = terms_by_q.get(q, [q]) if expand else [q]
+                runs.append(
+                    (self._retrieve(mode, household_id, q, terms, k), entry.get("expected", []))
+                )
             m = evaluate(runs, k)
             self.stdout.write(
                 f"{mode:<10} {m['queries']:>8} {m['recall_at_k']:>10.3f} {m['mrr']:>8.3f}"
@@ -134,10 +158,13 @@ class Command(BaseCommand):
             )
         return golden
 
-    def _retrieve(self, mode, household_id, question, k) -> list[str]:
+    def _retrieve(self, mode, household_id, question, terms, k) -> list[str]:
+        # Vector leg embeds the full natural question (best for semantics). The
+        # lexical/hybrid legs run search_multi over the (expanded) terms, exactly
+        # like the agent's search_household tool.
         if mode == "vector":
             hits = retrieval._vector_search(household_id, question, k)
         else:
             with override_settings(AGENT_HYBRID_RETRIEVAL_ENABLED=(mode == "hybrid")):
-                hits = retrieval.search(household_id, question, limit=k)
+                hits = retrieval.search_multi(household_id, terms, limit=k)
         return [f"{h.entity_type}:{h.id}" for h in hits]

--- a/apps/agent/tests/test_eval.py
+++ b/apps/agent/tests/test_eval.py
@@ -92,6 +92,7 @@ class TestEvalRetrievalCommand:
             queries=str(path),
             mode="fulltext",
             k=10,
+            no_expand=True,
             stdout=out,
         )
         output = out.getvalue()
@@ -130,12 +131,46 @@ class TestAutoGolden:
             auto=10,  # >= entity count so the document gets a question too
             mode="fulltext",
             auto_out=str(path),
+            no_expand=True,
             stdout=out,
         )
 
         golden = json.loads(path.read_text(encoding="utf-8"))
         assert any(entry["expected"] == [f"document:{doc.pk}"] for entry in golden)
         assert all("question" in entry and entry["question"] for entry in golden)
+
+
+class _TermsLLM:
+    provider = "anthropic"
+    model = "fake"
+
+    def complete(self, *, system, user, feature, household_id, user_id=None, max_tokens=1024, metadata=None):
+        from agent.llm import LLMResponse
+
+        return LLMResponse(
+            text="Engie, facture", input_tokens=1, output_tokens=1, duration_ms=1, model=self.model
+        )
+
+
+class TestExpansionPath:
+    def test_expansion_makes_fulltext_find_keywordless_question(
+        self, household, make_document, tmp_path, monkeypatch
+    ):
+        from agent import llm as llm_module
+
+        # Question shares NO word with the doc → raw full-text misses it; expansion
+        # (mocked → "Engie, facture") turns it into keywords that DO match.
+        doc = make_document(household, name="Engie", ocr_text="facture electricite du mois")
+        golden = [{"question": "chez qui je paie le courant ?", "expected": [f"document:{doc.pk}"]}]
+        path = tmp_path / "g.json"
+        path.write_text(json.dumps(golden), encoding="utf-8")
+        monkeypatch.setattr(llm_module, "get_llm_client", lambda *a, **k: _TermsLLM())
+
+        out = StringIO()
+        call_command(
+            "eval_retrieval", household=str(household.id), queries=str(path), mode="fulltext", k=10, stdout=out
+        )
+        assert "1.000" in out.getvalue()
 
 
 class TestEmbeddingsStatusCommand:


### PR DESCRIPTION
Corrige un **biais de méthodologie** de `eval_retrieval` révélé en lançant l'éval sur le corpus réel : le full-text tombait à `0.000` (artefact), pas parce qu'il est mauvais mais parce que le harnais lui envoyait la **question brute** (`retrieval.search()` fait un ET sans stopwords → rien ne matche sur du langage naturel). Le vrai agent passe par `query_expansion → search_multi`.

## Fix
- Jambes **fulltext/hybride** : `query_expansion.expand()` puis `search_multi()` sur les termes — exactement le chemin de `search_household`.
- Jambe **vector** : question brute (optimal pour l'embedding).
- `--no-expand` conserve l'ancien comportement (question brute).
- Expansion calculée une fois par question, réutilisée par les 2 jambes.

## Tests
- Nouveau : chemin d'expansion (LLM mocké) — une question sans mot commun avec le doc est retrouvée via les mots-clés générés.
- `pytest apps/agent/` → **561 passed**.

## Suite
Une fois mergé/déployé, je relance l'éval prod (expansion active par défaut) → baseline full-text honnête + comparaison apples-to-apples pour décider de l'activation.

Refs #331