### PR TITLE
feat(briefings): historique & suivi des envois (parcours 23 lot 5)

### DIFF
--- a/apps/briefings/serializers.py
+++ b/apps/briefings/serializers.py
@@ -1,8 +1,36 @@
 """Briefing serializers — validation shared by the REST viewset and services."""
 from rest_framework import serializers
 
-from .models import Briefing
+from .models import Briefing, BriefingSendLog
 from .schedule import next_send_at, validate_schedule
+
+
+class BriefingSendLogSerializer(serializers.ModelSerializer):
+    """One line of a briefing's send history (lot 5).
+
+    ``content`` is dual-purpose by status: the sent message when ``sent``, the
+    skip reason when ``skipped_condition``, empty on ``error`` — the UI labels it
+    accordingly.
+    """
+
+    user_name = serializers.SerializerMethodField()
+
+    class Meta:
+        model = BriefingSendLog
+        fields = [
+            "id",
+            "status",
+            "content",
+            "slot_date",
+            "slot_time",
+            "user",
+            "user_name",
+            "created_at",
+        ]
+        read_only_fields = fields
+
+    def get_user_name(self, obj):
+        return obj.user.full_name if obj.user_id and obj.user else None
 
 
 class BriefingSerializer(serializers.ModelSerializer):
@@ -20,6 +48,7 @@ class BriefingSerializer(serializers.ModelSerializer):
         child=serializers.IntegerField(min_value=0, max_value=6), required=False
     )
     next_send_at = serializers.SerializerMethodField()
+    last_send = serializers.SerializerMethodField()
 
     class Meta:
         model = Briefing
@@ -36,6 +65,7 @@ class BriefingSerializer(serializers.ModelSerializer):
             "send_times",
             "weekdays",
             "next_send_at",
+            "last_send",
             "created_at",
             "updated_at",
             "created_by",
@@ -45,6 +75,7 @@ class BriefingSerializer(serializers.ModelSerializer):
             "id",
             "household",
             "next_send_at",
+            "last_send",
             "created_at",
             "updated_at",
             "created_by",
@@ -56,6 +87,17 @@ class BriefingSerializer(serializers.ModelSerializer):
     def get_next_send_at(self, obj):
         dt = next_send_at(obj)
         return dt.isoformat() if dt else None
+
+    def get_last_send(self, obj):
+        """Compact summary of the most recent send attempt, for the card glance."""
+        log = obj.send_logs.order_by("-created_at").first()
+        if log is None:
+            return None
+        return {
+            "status": log.status,
+            "content": log.content,
+            "created_at": log.created_at.isoformat(),
+        }
 
     def validate(self, attrs):
         """Cross-field checks: valid, spaced-out schedule; no activation without one."""

--- a/apps/briefings/tests/test_api_history_lot5.py
+++ b/apps/briefings/tests/test_api_history_lot5.py
@@ -1,0 +1,432 @@
+"""REST API tests for Briefing Lot 5: send history endpoint + last_send glance.
+
+Coverage:
+1. last_send on BriefingSerializer — null when no send_logs; reflects most recent
+   log's status/content/created_at when logs exist.
+2. history endpoint (GET /api/briefings/briefings/<id>/history/) — newest-first,
+   correct serializer fields, empty list on zero logs, ordering by -created_at.
+3. history cap at HISTORY_PAGE_SIZE (30) — create 35 logs, assert only 30 returned.
+4. Permissions on history:
+   - creator of a private briefing can GET history (200);
+   - a different member cannot GET history of a private briefing (404, hidden by queryset);
+   - any member can GET history of a shared briefing (200);
+   - anonymous → 401;
+   - cross-household briefing id → 404.
+5. Isolation: history only returns logs of THAT briefing (no cross-briefing leakage).
+"""
+import datetime
+import uuid
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from briefings.models import Briefing, BriefingSendLog
+from households.models import Household, HouseholdMember
+
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+
+def _make_user(email: str):
+    return UserFactory(email=email)
+
+
+def _make_household(name: str = "History House") -> Household:
+    return Household.objects.create(name=name)
+
+
+def _add_member(user, household, role=HouseholdMember.Role.OWNER) -> HouseholdMember:
+    """Add user to household and set it as their active household."""
+    membership = HouseholdMember.objects.create(user=user, household=household, role=role)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return membership
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _anon_client() -> APIClient:
+    return APIClient()
+
+
+# ── Module-level fixtures ─────────────────────────────────────────────────────
+
+@pytest.fixture
+def owner(db):
+    return _make_user("history-owner@test.dev")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = _make_household("History House")
+    _add_member(owner, hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+@pytest.fixture
+def member(db, household):
+    user = _make_user("history-member@test.dev")
+    _add_member(user, household, role=HouseholdMember.Role.MEMBER)
+    return user
+
+
+@pytest.fixture
+def other_owner(db):
+    return _make_user("history-other@test.dev")
+
+
+@pytest.fixture
+def other_household(db, other_owner):
+    hh = _make_household("Other History House")
+    _add_member(other_owner, hh, role=HouseholdMember.Role.OWNER)
+    return hh
+
+
+# ── TestLastSendGlance ────────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestLastSendGlance:
+    """BriefingSerializer.last_send field — null or most-recent log summary.
+
+    The list and retrieve endpoints both serialise the briefing with last_send.
+    We exercise retrieve here to keep each test minimal.
+    """
+
+    def _create_briefing(self, household, user, **kwargs) -> Briefing:
+        defaults = {"title": "Glance Test", "prompt": "Check me.", "is_private": False}
+        defaults.update(kwargs)
+        return Briefing.objects.create(household=household, created_by=user, **defaults)
+
+    def _create_log(self, briefing, user, household, **kwargs) -> BriefingSendLog:
+        defaults = {
+            "briefing": briefing,
+            "user": user,
+            "household": household,
+            "slot_date": datetime.date(2026, 7, 1),
+            "slot_time": datetime.time(8, 0),
+            "status": BriefingSendLog.Status.SENT,
+            "content": "Morning summary text.",
+        }
+        defaults.update(kwargs)
+        return BriefingSendLog.objects.create(**defaults)
+
+    def test_last_send_is_null_when_no_logs(self, owner, household):
+        b = self._create_briefing(household, owner)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-detail", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["last_send"] is None
+
+    def test_last_send_reflects_only_log_status_and_content(self, owner, household):
+        b = self._create_briefing(household, owner)
+        log = self._create_log(
+            b, owner, household, status=BriefingSendLog.Status.SENT, content="Hello world"
+        )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-detail", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        last = response.data["last_send"]
+        assert last is not None
+        assert last["status"] == BriefingSendLog.Status.SENT
+        assert last["content"] == "Hello world"
+        assert last["created_at"] is not None
+
+    def test_last_send_reflects_most_recent_log(self, owner, household):
+        """When there are multiple logs, last_send must be the newest."""
+        b = self._create_briefing(household, owner)
+        # Older log — different slot so uniqueness constraint is satisfied.
+        self._create_log(
+            b, owner, household,
+            slot_date=datetime.date(2026, 7, 1),
+            slot_time=datetime.time(7, 0),
+            status=BriefingSendLog.Status.ERROR,
+            content="",
+        )
+        # Newer log.
+        newer = self._create_log(
+            b, owner, household,
+            slot_date=datetime.date(2026, 7, 2),
+            slot_time=datetime.time(8, 0),
+            status=BriefingSendLog.Status.SENT,
+            content="Latest text",
+        )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-detail", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        last = response.data["last_send"]
+        assert last["status"] == BriefingSendLog.Status.SENT
+        assert last["content"] == "Latest text"
+        # Verify created_at matches the newer log exactly.
+        assert last["created_at"] == newer.created_at.isoformat()
+
+    def test_last_send_status_skipped_condition(self, owner, household):
+        b = self._create_briefing(household, owner)
+        self._create_log(
+            b, owner, household,
+            status=BriefingSendLog.Status.SKIPPED_CONDITION,
+            content="Weather is fine, skipping.",
+        )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-detail", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        last = response.data["last_send"]
+        assert last["status"] == BriefingSendLog.Status.SKIPPED_CONDITION
+        assert last["content"] == "Weather is fine, skipping."
+
+    def test_last_send_appears_on_list_endpoint(self, owner, household):
+        """last_send is also present on the list response (not only retrieve)."""
+        b = self._create_briefing(household, owner, title="List glance")
+        self._create_log(b, owner, household, content="List check text")
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-list"))
+        assert response.status_code == status.HTTP_200_OK
+        matching = [item for item in response.data if item["title"] == "List glance"]
+        assert len(matching) == 1
+        assert matching[0]["last_send"] is not None
+        assert matching[0]["last_send"]["content"] == "List check text"
+
+
+# ── TestHistoryEndpoint ───────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestHistoryEndpoint:
+    """GET /api/briefings/briefings/<id>/history/ — happy-path and ordering."""
+
+    def _create_briefing(self, household, user, **kwargs) -> Briefing:
+        defaults = {"title": "History Test", "prompt": "Tell me.", "is_private": False}
+        defaults.update(kwargs)
+        return Briefing.objects.create(household=household, created_by=user, **defaults)
+
+    def _create_log(self, briefing, user, household, **kwargs) -> BriefingSendLog:
+        defaults = {
+            "briefing": briefing,
+            "user": user,
+            "household": household,
+            "slot_date": datetime.date(2026, 7, 1),
+            "slot_time": datetime.time(8, 0),
+            "status": BriefingSendLog.Status.SENT,
+            "content": "Log content.",
+        }
+        defaults.update(kwargs)
+        return BriefingSendLog.objects.create(**defaults)
+
+    def test_history_returns_200_for_owner(self, owner, household):
+        b = self._create_briefing(household, owner)
+        self._create_log(b, owner, household)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_history_empty_list_when_no_logs(self, owner, household):
+        b = self._create_briefing(household, owner)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data == []
+
+    def test_history_contains_expected_serializer_fields(self, owner, household):
+        b = self._create_briefing(household, owner)
+        self._create_log(
+            b, owner, household,
+            status=BriefingSendLog.Status.SENT,
+            content="Morning report",
+            slot_date=datetime.date(2026, 7, 10),
+            slot_time=datetime.time(9, 0),
+        )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        item = response.data[0]
+        assert "id" in item
+        assert item["status"] == BriefingSendLog.Status.SENT
+        assert item["content"] == "Morning report"
+        assert str(item["slot_date"]) == "2026-07-10"
+        assert str(item["slot_time"]) == "09:00:00"
+        assert "user" in item
+        assert "user_name" in item
+        assert "created_at" in item
+
+    def test_history_user_name_matches_recipient(self, owner, household):
+        b = self._create_briefing(household, owner)
+        self._create_log(b, owner, household)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        item = response.data[0]
+        assert item["user_name"] == owner.full_name
+
+    def test_history_ordered_newest_first(self, owner, household):
+        """Logs must come back in -created_at order (slot dates used to force ordering)."""
+        b = self._create_briefing(household, owner)
+        # Create three logs on distinct slots so the uniqueness constraint is satisfied.
+        log_old = self._create_log(
+            b, owner, household,
+            slot_date=datetime.date(2026, 7, 1),
+            slot_time=datetime.time(8, 0),
+            content="Oldest",
+        )
+        log_mid = self._create_log(
+            b, owner, household,
+            slot_date=datetime.date(2026, 7, 2),
+            slot_time=datetime.time(8, 0),
+            content="Middle",
+        )
+        log_new = self._create_log(
+            b, owner, household,
+            slot_date=datetime.date(2026, 7, 3),
+            slot_time=datetime.time(8, 0),
+            content="Newest",
+        )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+        contents = [item["content"] for item in response.data]
+        # Newest (latest created_at) must be first.
+        assert contents[0] == "Newest"
+        assert contents[-1] == "Oldest"
+
+    def test_history_cap_at_30(self, owner, household):
+        """create 35 logs; history must return exactly 30 (HISTORY_PAGE_SIZE)."""
+        b = self._create_briefing(household, owner)
+        for i in range(35):
+            BriefingSendLog.objects.create(
+                briefing=b,
+                user=owner,
+                household=household,
+                slot_date=datetime.date(2026, 7, 1),
+                slot_time=datetime.time(i % 24, i // 24),
+                status=BriefingSendLog.Status.SENT,
+                content=f"Log {i}",
+            )
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 30
+
+
+# ── TestHistoryIsolation ──────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestHistoryIsolation:
+    """History must only include logs for the requested briefing — no cross-briefing leakage."""
+
+    def _create_briefing(self, household, user, **kwargs) -> Briefing:
+        defaults = {"title": "Isolation Test", "prompt": "Isolated.", "is_private": False}
+        defaults.update(kwargs)
+        return Briefing.objects.create(household=household, created_by=user, **defaults)
+
+    def _create_log(self, briefing, user, household, **kwargs) -> BriefingSendLog:
+        defaults = {
+            "briefing": briefing,
+            "user": user,
+            "household": household,
+            "slot_date": datetime.date(2026, 7, 1),
+            "slot_time": datetime.time(8, 0),
+            "status": BriefingSendLog.Status.SENT,
+            "content": "Isolation log.",
+        }
+        defaults.update(kwargs)
+        return BriefingSendLog.objects.create(**defaults)
+
+    def test_history_does_not_include_other_briefings_logs(self, owner, household):
+        b1 = self._create_briefing(household, owner, title="Briefing A")
+        b2 = self._create_briefing(household, owner, title="Briefing B")
+        self._create_log(b1, owner, household, content="Log for A")
+        self._create_log(b2, owner, household, content="Log for B")
+        client = _client_for(owner)
+        # Request history for b1 only — must not include b2's log.
+        response = client.get(reverse("briefing-history", args=[str(b1.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]["content"] == "Log for A"
+
+    def test_history_does_not_include_logs_from_other_household(
+        self, owner, household, other_owner, other_household
+    ):
+        """A briefing from another household cannot be accessed — 404 gates access."""
+        foreign_b = self._create_briefing(other_household, other_owner, title="Foreign B")
+        self._create_log(foreign_b, other_owner, other_household, content="Foreign log")
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(foreign_b.pk)]))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ── TestHistoryPermissions ────────────────────────────────────────────────────
+
+@pytest.mark.django_db
+class TestHistoryPermissions:
+    """Permission matrix for the history endpoint."""
+
+    def _create_briefing(self, household, user, **kwargs) -> Briefing:
+        defaults = {"title": "Perm Test", "prompt": "Permissioned.", "is_private": False}
+        defaults.update(kwargs)
+        return Briefing.objects.create(household=household, created_by=user, **defaults)
+
+    def _create_log(self, briefing, user, household, **kwargs) -> BriefingSendLog:
+        defaults = {
+            "briefing": briefing,
+            "user": user,
+            "household": household,
+            "slot_date": datetime.date(2026, 7, 1),
+            "slot_time": datetime.time(8, 0),
+            "status": BriefingSendLog.Status.SENT,
+            "content": "Perm log.",
+        }
+        defaults.update(kwargs)
+        return BriefingSendLog.objects.create(**defaults)
+
+    def test_creator_can_get_history_of_own_private_briefing(self, owner, household):
+        b = self._create_briefing(household, owner, is_private=True)
+        self._create_log(b, owner, household)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+
+    def test_other_member_cannot_get_history_of_private_briefing(
+        self, member, owner, household
+    ):
+        """Private briefing excluded from member queryset → 404."""
+        b = self._create_briefing(household, owner, is_private=True)
+        self._create_log(b, owner, household)
+        client = _client_for(member)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_member_can_get_history_of_shared_briefing(self, member, owner, household):
+        """Any household member may GET history of a shared briefing."""
+        b = self._create_briefing(household, owner, is_private=False)
+        self._create_log(b, owner, household)
+        client = _client_for(member)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_anonymous_gets_401(self, owner, household):
+        b = self._create_briefing(household, owner)
+        self._create_log(b, owner, household)
+        response = _anon_client().get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_cross_household_returns_404(self, owner, household, other_owner, other_household):
+        foreign = self._create_briefing(other_household, other_owner)
+        self._create_log(foreign, other_owner, other_household)
+        client = _client_for(owner)
+        response = client.get(reverse("briefing-history", args=[str(foreign.pk)]))
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_member_can_get_history_of_own_private_briefing(self, member, household):
+        """A member's own private briefing is visible to themselves."""
+        b = self._create_briefing(household, member, is_private=True)
+        self._create_log(b, member, household)
+        client = _client_for(member)
+        response = client.get(reverse("briefing-history", args=[str(b.pk)]))
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1

--- a/apps/briefings/views.py
+++ b/apps/briefings/views.py
@@ -13,10 +13,12 @@ from .conditions import evaluate_condition
 from .generation import generate_briefing_text, send_briefing_now
 from .models import Briefing
 from .permissions import CanManageBriefing
-from .serializers import BriefingSerializer
+from .serializers import BriefingSendLogSerializer, BriefingSerializer
 from .services import create_briefing, update_briefing
 
 logger = logging.getLogger(__name__)
+
+HISTORY_PAGE_SIZE = 30
 
 
 class BriefingViewSet(viewsets.ModelViewSet):
@@ -71,9 +73,18 @@ class BriefingViewSet(viewsets.ModelViewSet):
         # Preview is a read-grade action (generate, no side effect): any member
         # who can *see* the briefing may preview it — the queryset already hides
         # others' private briefings (404). Sending is a manage action.
-        if self.action == "preview":
+        if self.action in ("preview", "history"):
             return [IsHouseholdMember()]
         return [IsHouseholdMember(), CanManageBriefing()]
+
+    @action(detail=True, methods=["get"])
+    def history(self, request, pk=None):
+        """Recent send attempts for this briefing (lot 5) — read-grade access."""
+        briefing = self.get_object()
+        logs = briefing.send_logs.select_related("user").order_by("-created_at")[
+            :HISTORY_PAGE_SIZE
+        ]
+        return Response(BriefingSendLogSerializer(logs, many=True).data)
 
     @action(detail=True, methods=["post"])
     def preview(self, request, pk=None):

--- a/ui/src/features/briefings/BriefingCard.tsx
+++ b/ui/src/features/briefings/BriefingCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Clock, Eye, Lock, Pencil, Power, Trash2, Users } from 'lucide-react';
+import { Clock, Eye, History, Lock, Pencil, Power, Trash2, Users } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
@@ -14,15 +14,25 @@ interface Props {
   onDelete: (briefing: Briefing) => void;
   onToggleActive: (briefing: Briefing) => void;
   onPreview: (briefing: Briefing) => void;
+  onHistory: (briefing: Briefing) => void;
 }
 
-export default function BriefingCard({ briefing, onEdit, onDelete, onToggleActive, onPreview }: Props) {
+export default function BriefingCard({
+  briefing,
+  onEdit,
+  onDelete,
+  onToggleActive,
+  onPreview,
+  onHistory,
+}: Props) {
   const { t, i18n } = useTranslation();
 
   const nextSend = briefing.is_active ? formatNextSend(briefing.next_send_at, i18n.language) : null;
+  const lastSend = briefing.last_send;
 
   const actions: CardAction[] = [
     { label: t('briefings.preview.action'), icon: Eye, onClick: () => onPreview(briefing) },
+    { label: t('briefings.history.action'), icon: History, onClick: () => onHistory(briefing) },
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(briefing) },
     { label: t('common.delete'), icon: Trash2, onClick: () => onDelete(briefing), variant: 'danger' },
   ];
@@ -76,6 +86,15 @@ export default function BriefingCard({ briefing, onEdit, onDelete, onToggleActiv
           <span className="truncate text-xs text-muted-foreground">
             {t('briefings.schedule.nextSend')} : {nextSend}
           </span>
+        ) : lastSend ? (
+          <button
+            type="button"
+            onClick={() => onHistory(briefing)}
+            className="truncate text-xs text-muted-foreground hover:text-foreground"
+          >
+            {t(`briefings.history.status.${lastSend.status}`)} ·{' '}
+            {formatNextSend(lastSend.created_at, i18n.language)}
+          </button>
         ) : null}
       </div>
     </Card>

--- a/ui/src/features/briefings/BriefingHistoryDialog.tsx
+++ b/ui/src/features/briefings/BriefingHistoryDialog.tsx
@@ -1,0 +1,88 @@
+import { useTranslation } from 'react-i18next';
+import { AlertCircle, Check, Clock, X } from 'lucide-react';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Badge } from '@/design-system/badge';
+import type { Briefing, BriefingSendStatus } from '@/lib/api/briefings';
+import { useBriefingHistory } from './hooks';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  briefing?: Briefing;
+}
+
+const STATUS_ICON: Record<BriefingSendStatus, typeof Check> = {
+  sent: Check,
+  skipped_condition: X,
+  error: AlertCircle,
+};
+
+const STATUS_VARIANT: Record<BriefingSendStatus, 'default' | 'secondary' | 'destructive'> = {
+  sent: 'default',
+  skipped_condition: 'secondary',
+  error: 'destructive',
+};
+
+export default function BriefingHistoryDialog({ open, onOpenChange, briefing }: Props) {
+  const { t, i18n } = useTranslation();
+  const { data: entries = [], isLoading } = useBriefingHistory(briefing?.id, open);
+
+  function formatWhen(iso: string): string {
+    const d = new Date(iso);
+    return Number.isNaN(d.getTime())
+      ? iso
+      : d.toLocaleString(i18n.language, {
+          day: 'numeric',
+          month: 'short',
+          hour: '2-digit',
+          minute: '2-digit',
+        });
+  }
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('briefings.history.title')}>
+      {isLoading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-8 text-center text-sm text-muted-foreground">
+          <Clock className="h-6 w-6" />
+          <p>{t('briefings.history.empty')}</p>
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {entries.map((entry) => {
+            const Icon = STATUS_ICON[entry.status];
+            return (
+              <li key={entry.id} className="rounded-md border border-border bg-card p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <Badge variant={STATUS_VARIANT[entry.status]} className="gap-1">
+                    <Icon className="h-3 w-3" />
+                    {t(`briefings.history.status.${entry.status}`)}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">{formatWhen(entry.created_at)}</span>
+                </div>
+                {entry.content ? (
+                  <p className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+                    <span className="font-medium">
+                      {entry.status === 'skipped_condition'
+                        ? `${t('briefings.fields.condition')} : `
+                        : `${t('briefings.history.contentLabel')} : `}
+                    </span>
+                    {entry.content}
+                  </p>
+                ) : null}
+                {entry.user_name ? (
+                  <p className="mt-1 text-xs text-muted-foreground">{entry.user_name}</p>
+                ) : null}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/briefings/BriefingsPage.tsx
+++ b/ui/src/features/briefings/BriefingsPage.tsx
@@ -20,6 +20,7 @@ import {
 import BriefingCard from './BriefingCard';
 import BriefingDialog from './BriefingDialog';
 import BriefingPreviewDialog from './BriefingPreviewDialog';
+import BriefingHistoryDialog from './BriefingHistoryDialog';
 
 type FilterKey = 'all' | 'active' | 'inactive';
 
@@ -43,6 +44,8 @@ export default function BriefingsPage() {
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [previewing, setPreviewing] = React.useState<Briefing | undefined>();
   const [previewOpen, setPreviewOpen] = React.useState(false);
+  const [historyOf, setHistoryOf] = React.useState<Briefing | undefined>();
+  const [historyOpen, setHistoryOpen] = React.useState(false);
 
   const showSkeleton = useDelayedLoading(isLoading);
 
@@ -70,6 +73,11 @@ export default function BriefingsPage() {
   function openPreview(briefing: Briefing) {
     setPreviewing(briefing);
     setPreviewOpen(true);
+  }
+
+  function openHistory(briefing: Briefing) {
+    setHistoryOf(briefing);
+    setHistoryOpen(true);
   }
 
   function toggleActive(briefing: Briefing) {
@@ -139,6 +147,7 @@ export default function BriefingsPage() {
               onDelete={remove}
               onToggleActive={toggleActive}
               onPreview={openPreview}
+              onHistory={openHistory}
             />
           ))}
         </div>
@@ -146,6 +155,7 @@ export default function BriefingsPage() {
 
       <BriefingDialog open={dialogOpen} onOpenChange={setDialogOpen} existing={editing} />
       <BriefingPreviewDialog open={previewOpen} onOpenChange={setPreviewOpen} briefing={previewing} />
+      <BriefingHistoryDialog open={historyOpen} onOpenChange={setHistoryOpen} briefing={historyOf} />
     </div>
   );
 }

--- a/ui/src/features/briefings/hooks.ts
+++ b/ui/src/features/briefings/hooks.ts
@@ -3,24 +3,35 @@ import { useTranslation } from 'react-i18next';
 import {
   createBriefing,
   deleteBriefing,
+  fetchBriefingHistory,
   fetchBriefings,
   previewBriefing,
   sendBriefingNow,
   updateBriefing,
   type Briefing,
   type BriefingPayload,
+  type BriefingSendLogEntry,
 } from '@/lib/api/briefings';
 import { toast } from '@/lib/toast';
 
 export const briefingKeys = {
   all: ['briefings'] as const,
   list: () => [...briefingKeys.all, 'list'] as const,
+  history: (id: string) => [...briefingKeys.all, id, 'history'] as const,
 };
 
 export function useBriefings() {
   return useQuery<Briefing[]>({
     queryKey: briefingKeys.list(),
     queryFn: fetchBriefings,
+  });
+}
+
+export function useBriefingHistory(id: string | undefined, enabled: boolean) {
+  return useQuery<BriefingSendLogEntry[]>({
+    queryKey: briefingKeys.history(id ?? ''),
+    queryFn: () => fetchBriefingHistory(id as string),
+    enabled: Boolean(id) && enabled,
   });
 }
 

--- a/ui/src/lib/api/briefings.ts
+++ b/ui/src/lib/api/briefings.ts
@@ -2,6 +2,14 @@ import { api } from '@/lib/axios';
 
 export type BriefingType = 'recurring' | 'event';
 export type BriefingChannel = 'telegram';
+export type BriefingSendStatus = 'sent' | 'error' | 'skipped_condition';
+
+/** Compact summary of the most recent send attempt (card glance). */
+export interface BriefingLastSend {
+  status: BriefingSendStatus;
+  content: string;
+  created_at: string;
+}
 
 export interface Briefing {
   id: string;
@@ -19,6 +27,8 @@ export interface Briefing {
   weekdays: number[];
   /** Next fire instant (ISO), or null if inactive/no schedule. Read-only. */
   next_send_at: string | null;
+  /** Most recent send attempt, or null if never sent. Read-only. */
+  last_send: BriefingLastSend | null;
   created_at: string;
   updated_at: string;
   created_by: number | null;
@@ -108,4 +118,22 @@ export interface BriefingSendSummary {
 export async function sendBriefingNow(id: string): Promise<BriefingSendSummary> {
   const { data } = await api.post(`/briefings/briefings/${id}/send-now/`);
   return data as BriefingSendSummary;
+}
+
+/** One line of a briefing's send history (Lot 5). */
+export interface BriefingSendLogEntry {
+  id: string;
+  status: BriefingSendStatus;
+  /** Sent message (status=sent), skip reason (skipped_condition), or "" (error). */
+  content: string;
+  slot_date: string;
+  slot_time: string;
+  user: number | null;
+  user_name: string | null;
+  created_at: string;
+}
+
+export async function fetchBriefingHistory(id: string): Promise<BriefingSendLogEntry[]> {
+  const { data } = await api.get(`/briefings/briefings/${id}/history/`);
+  return normalizeList<BriefingSendLogEntry>(data);
 }

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -76,6 +76,17 @@
         "sat": "Sa",
         "sun": "So"
       }
+    },
+    "history": {
+      "action": "Verlauf",
+      "title": "Sendeverlauf",
+      "empty": "Noch kein Versand.",
+      "contentLabel": "Nachricht",
+      "status": {
+        "sent": "Gesendet",
+        "error": "Fehlgeschlagen",
+        "skipped_condition": "Übersprungen (Bedingung)"
+      }
     }
   },
   "shoppingList": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -76,6 +76,17 @@
         "sat": "Sat",
         "sun": "Sun"
       }
+    },
+    "history": {
+      "action": "History",
+      "title": "Send history",
+      "empty": "No send yet.",
+      "contentLabel": "Message",
+      "status": {
+        "sent": "Sent",
+        "error": "Failed",
+        "skipped_condition": "Skipped (condition)"
+      }
     }
   },
   "shoppingList": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -76,6 +76,17 @@
         "sat": "Sáb",
         "sun": "Dom"
       }
+    },
+    "history": {
+      "action": "Historial",
+      "title": "Historial de envíos",
+      "empty": "Aún no hay envíos.",
+      "contentLabel": "Mensaje",
+      "status": {
+        "sent": "Enviado",
+        "error": "Error",
+        "skipped_condition": "Omitido (condición)"
+      }
     }
   },
   "shoppingList": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -76,6 +76,17 @@
         "sat": "Sam",
         "sun": "Dim"
       }
+    },
+    "history": {
+      "action": "Historique",
+      "title": "Historique des envois",
+      "empty": "Aucun envoi pour l'instant.",
+      "contentLabel": "Message",
+      "status": {
+        "sent": "Envoyé",
+        "error": "Échec",
+        "skipped_condition": "Sauté (condition)"
+      }
     }
   },
   "shoppingList": {


### PR DESCRIPTION
Closes #344

## Quoi

Lot 5 du **parcours 23 — Briefings personnalisés** : l'historique des envois. Le modèle `BriefingSendLog` (posé au Lot 3) enregistrait déjà chaque tentative ; ce lot expose la **lecture** + l'**UI**.

**Backend**
- `BriefingSerializer.last_send` : résumé compact du dernier envoi (`status`, `content`, `created_at`) pour l'aperçu sur la carte (null si jamais envoyé).
- `BriefingSendLogSerializer` : une ligne d'historique (statut, contenu, jour/heure du créneau, destinataire, date).
- `GET /api/briefings/briefings/{id}/history/` : les 30 derniers envois, plus récent d'abord. **Grade lecture** (tout membre qui *voit* le briefing) — un privé d'autrui reste masqué (404).

**Frontend**
- `BriefingHistoryDialog` : liste avec badge de statut (**envoyé** / **sauté-condition** / **échec**) + contenu contextualisé (aperçu du message envoyé, ou raison du skip).
- Action « Historique » sur la carte + ligne « dernier envoi » cliquable (ouvre l'historique).
- i18n `briefings.history.*` (4 langues).

## Critères de l'issue #344

- [x] Par briefing : dernier envoi + statut (envoyé / sauté-condition / échec) + raison
- [x] Aperçu du dernier contenu généré
- [x] Distinction claire « sauté (condition non remplie) » vs « échec technique »

## Notes

- **Pas de migration** (serializer + vue uniquement — le modèle existait depuis le Lot 3).
- **Tests** : 19 nouveaux (`test_api_history_lot5.py` : `last_send`, endpoint history, ordre/cap 30, isolation entre briefings, permissions privé/partagé/anonyme/cross-household). Suite briefings **176 verts**.
- **`content` dual-usage** : message envoyé (statut `sent`), raison du skip (`skipped_condition`), vide (`error`) — l'UI l'étiquette selon le statut. Assumé pour la V1 (pas de colonne `reason` séparée).
- **Reste** : Lot 6 événementiel (timing web-dérivé, #345, V1.1). Le socle V1 des briefings est complet après ce lot.
