### PR TITLE
refactor(interactions): drop redundant expense keys from metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,8 @@ interaction = create_expense_interaction(
 
 Le service :
 - localise le subject via `gettext_lazy` + le template enregistré dans `apps/interactions/services.py::AUTO_SUBJECT_TEMPLATES`
-- ajoute `metadata.kind` (discriminateur), `metadata.source_name`, `metadata.amount`, `metadata.unit_price`, `metadata.supplier`
+- renseigne les **colonnes** `amount`, `kind` (discriminateur), `supplier` (voir « Champs promus en colonnes » plus bas)
+- ajoute `metadata.source_name`, `metadata.unit_price` + les extras feature (`delta`, `unit`, `brand`…)
 - lie via la FK polymorphe
 - attache la zone du source si elle existe
 
@@ -163,7 +164,7 @@ Différences vs `create_expense_interaction` :
 
 ### Builder partagé `_build_expense_metadata`
 
-Les deux fonctions (`create_expense_interaction` + `create_manual_expense_interaction`) flow through un helper interne `_build_expense_metadata` qui garantit le shape `metadata` uniforme : `{kind, source_name, amount, unit_price, supplier}` + extra optionnel. Ajouter une clé standard (ex: `currency`) = touche un seul endroit.
+Les deux fonctions (`create_expense_interaction` + `create_manual_expense_interaction`) flow through un helper interne `_build_expense_metadata` qui garantit le shape `metadata` uniforme : `{source_name, unit_price}` + extra optionnel. Les champs monétaires **requêtés** (`amount`, `kind`, `supplier`) ne sont **pas** dans `metadata` — ce sont des colonnes (voir juste en dessous).
 
 ### Champs promus en colonnes : `amount` / `kind` / `supplier`
 
@@ -177,14 +178,15 @@ Voir `docs/fiches/CARTOGRAPHIE_DEPENSES.md`.
   unique) et somme la colonne `amount` — ne jamais réintroduire un cast JSON.
 - Le write path renseigne les colonnes ; un `kind` non-standard (ex: `recurring`
   depuis `confirm_recurring_occurrence`) se passe via le **param `kind`** des
-  créateurs, **jamais** via `extra_metadata` (sinon colonne et metadata divergent).
-- **Transition en cours** : le front édite encore via `metadata` ; le serializer
-  (`_sync_expense_columns`) resynchronise les colonnes à chaque écriture. `metadata`
-  reste écrit (rollback-safe). PR2 = front sur colonnes + strip des clés `metadata`
-  redondantes. `unit_price` et `source_name` restent en `metadata` (non requêtés).
+  créateurs, **jamais** via `extra_metadata`.
+- **Le front et l'API consomment les colonnes** : `amount`/`kind`/`supplier` sont
+  des champs de premier niveau du serializer (`InteractionSerializer`), lus et
+  écrits directement. Ces clés ne sont **plus** dans `metadata` (strippées par la
+  migration `interactions.0024`). `unit_price` et `source_name` restent en
+  `metadata` (non requêtés), avec les extras feature (`delta`, `unit`, `brand`…).
 - Le `kind` d'une entrée **non-dépense** (ex: `renovation`) reste en `metadata` —
   la colonne `kind` est propre aux dépenses ; l'endpoint liste générique filtre
-  donc toujours `metadata__kind` (pas la colonne).
+  donc `Q(kind=…) | Q(metadata__kind=…)` pour couvrir les deux.
 
 ### Ajouter un nouveau template d'auto-subject
 

--- a/apps/budget/tests/test_api_recurring.py
+++ b/apps/budget/tests/test_api_recurring.py
@@ -667,7 +667,7 @@ class TestRecurringConfirm:
             reverse("recurring-confirm", args=[rec.id]), {}, format="json"
         )
         interaction = Interaction.objects.get(id=response.data["interaction_id"])
-        assert Decimal(interaction.metadata["amount"]) == Decimal("55.00")
+        assert interaction.amount == Decimal("55.00")
 
     def test_amount_override_in_body(self):
         """Confirming with an edited amount in body overrides the recurring amount."""
@@ -681,7 +681,7 @@ class TestRecurringConfirm:
         )
         assert response.status_code == status.HTTP_200_OK
         interaction = Interaction.objects.get(id=response.data["interaction_id"])
-        assert Decimal(interaction.metadata["amount"]) == Decimal("72.50")
+        assert interaction.amount == Decimal("72.50")
 
     def test_interaction_metadata_kind_recurring(self):
         hh = HouseholdFactory()
@@ -691,7 +691,7 @@ class TestRecurringConfirm:
             reverse("recurring-confirm", args=[rec.id]), {}, format="json"
         )
         interaction = Interaction.objects.get(id=response.data["interaction_id"])
-        assert interaction.metadata["kind"] == "recurring"
+        assert interaction.kind == "recurring"
         assert interaction.metadata["recurring_id"] == str(rec.id)
 
     def test_member_can_confirm(self):

--- a/apps/budget/tests/test_models_recurring.py
+++ b/apps/budget/tests/test_models_recurring.py
@@ -359,12 +359,12 @@ class TestConfirmOccurrence:
         interaction, _ = confirm_recurring_occurrence(hh, user, rec)
         assert Interaction.objects.get(id=interaction.id).subject == "Electricity Bill"
 
-    def test_metadata_kind_is_recurring(self):
+    def test_kind_is_recurring(self):
         hh, user = _make_pair()
         rec = self._create_rec(hh, user)
         interaction, _ = confirm_recurring_occurrence(hh, user, rec)
         from_db = Interaction.objects.get(id=interaction.id)
-        assert from_db.metadata["kind"] == "recurring"
+        assert from_db.kind == "recurring"
 
     def test_metadata_recurring_id_matches(self):
         hh, user = _make_pair()
@@ -393,14 +393,14 @@ class TestConfirmOccurrence:
         rec = self._create_rec(hh, user, amount=Decimal("50.00"))
         interaction, _ = confirm_recurring_occurrence(hh, user, rec, amount=Decimal("65.00"))
         from_db = Interaction.objects.get(id=interaction.id)
-        assert Decimal(from_db.metadata["amount"]) == Decimal("65.00")
+        assert from_db.amount == Decimal("65.00")
 
     def test_no_amount_override_uses_recurring_amount(self):
         hh, user = _make_pair()
         rec = self._create_rec(hh, user, amount=Decimal("29.99"))
         interaction, _ = confirm_recurring_occurrence(hh, user, rec)
         from_db = Interaction.objects.get(id=interaction.id)
-        assert Decimal(from_db.metadata["amount"]) == Decimal("29.99")
+        assert from_db.amount == Decimal("29.99")
 
     def test_interaction_attached_to_budget(self):
         hh, user = _make_pair()

--- a/apps/chickens/tests/test_api_chickens.py
+++ b/apps/chickens/tests/test_api_chickens.py
@@ -753,9 +753,9 @@ class TestChickenPurchase:
         interaction = Interaction.objects.get(id=response.data["interaction_id"])
         assert interaction.household == hh
         assert interaction.type == "expense"
-        assert interaction.metadata["kind"] == "chickens_purchase"
+        assert interaction.kind == "chickens_purchase"
 
-    def test_purchase_stores_amount_in_metadata(self):
+    def test_purchase_stores_amount(self):
         hh = HouseholdFactory()
         owner = _make_owner(hh)
         chicken = ChickenFactory(household=hh, created_by=owner)
@@ -765,7 +765,7 @@ class TestChickenPurchase:
             format="json",
         )
         interaction = Interaction.objects.get(id=response.data["interaction_id"])
-        assert Decimal(interaction.metadata["amount"]) == Decimal("99.50")
+        assert interaction.amount == Decimal("99.50")
 
     def test_purchase_without_amount_accepted(self):
         """amount is optional on the purchase payload."""

--- a/apps/equipment/tests/test_api_equipment_purchase.py
+++ b/apps/equipment/tests/test_api_equipment_purchase.py
@@ -86,9 +86,9 @@ def test_register_purchase_snapshots_equipment_and_creates_expense(client, user,
     assert interaction.source_object_id == drill.id
     assert interaction.household_id == household.id
     assert interaction.subject == "Purchase — Cordless drill"
-    assert interaction.metadata["kind"] == "equipment_purchase"
-    assert interaction.metadata["amount"] == "199.00"
-    assert interaction.metadata["supplier"] == "ToolStore"
+    assert interaction.kind == "equipment_purchase"
+    assert interaction.amount == Decimal("199.00")
+    assert interaction.supplier == "ToolStore"
     assert interaction.metadata["equipment_name"] == "Cordless drill"
     assert interaction.zones.count() == 1
     assert interaction.zones.first().id == drill.zone_id
@@ -110,7 +110,7 @@ def test_register_purchase_without_amount_still_creates_interaction(client, user
     assert "interaction_id" in payload
 
     interaction = Interaction.objects.get(id=payload["interaction_id"])
-    assert interaction.metadata["amount"] is None
+    assert interaction.amount is None
 
 
 @pytest.mark.django_db

--- a/apps/interactions/migrations/0024_strip_expense_metadata_keys.py
+++ b/apps/interactions/migrations/0024_strip_expense_metadata_keys.py
@@ -1,0 +1,48 @@
+"""Strip the now-redundant amount/kind/supplier keys from expense metadata.
+
+Since PR « expense columns » these three fields are real columns on Interaction
+(backfilled by 0023) and every reader + the frontend use them. This migration
+removes the duplicated keys from ``metadata`` on expense interactions so the JSON
+carries only what stays there (source_name, unit_price, and feature extras like
+delta/unit/brand/recurring_id). Renovation entries (``type != 'expense'``) are
+left untouched — their ``metadata.kind == 'renovation'`` discriminator is not a
+column. See docs/fiches/CARTOGRAPHIE_DEPENSES.md.
+"""
+from django.db import migrations
+
+STRIPPED_KEYS = ("amount", "kind", "supplier")
+
+
+def strip(apps, schema_editor):
+    Interaction = apps.get_model("interactions", "Interaction")
+    batch = []
+    for it in Interaction.objects.filter(type="expense").iterator():
+        meta = it.metadata or {}
+        if not any(k in meta for k in STRIPPED_KEYS):
+            continue
+        for k in STRIPPED_KEYS:
+            meta.pop(k, None)
+        it.metadata = meta
+        batch.append(it)
+        if len(batch) >= 500:
+            Interaction.objects.bulk_update(batch, ["metadata"])
+            batch = []
+    if batch:
+        Interaction.objects.bulk_update(batch, ["metadata"])
+
+
+def noop(apps, schema_editor):
+    # Reverse is a no-op: the columns remain the source of truth; re-materializing
+    # the metadata keys is unnecessary (nothing reads them anymore).
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interactions", "0023_backfill_expense_columns"),
+    ]
+
+    operations = [
+        migrations.RunPython(strip, noop),
+    ]

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -157,6 +157,7 @@ class InteractionSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'household', 'subject', 'content', 'type',
             'is_private', 'occurred_at', 'tags', 'tags_input', 'metadata', 'enriched_text',
+            'amount', 'kind', 'supplier',
             'source_type', 'source_id', 'source_label',
             'zone_ids', 'zone_names', 'zone_id_list', 'document_count', 'linked_document_ids', 'document_ids',
             'contacts', 'contact_ids', 'structures', 'structure_ids',
@@ -225,31 +226,6 @@ class InteractionSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({'budget_id': str(exc)})
         else:
             interaction.budget = None
-
-    def _sync_expense_columns(self, interaction):
-        """Keep the promoted amount/kind/supplier columns in sync with metadata.
-
-        During the "expense columns" transition the frontend still edits expenses
-        through the ``metadata`` JSON field, while the aggregations read the
-        columns. Deriving the columns from ``metadata`` on every write keeps them
-        authoritative without requiring the client to change yet (that flip is a
-        later PR — see docs/fiches/CARTOGRAPHIE_DEPENSES.md). No-op for
-        non-expense interactions.
-        """
-        if interaction.type != 'expense':
-            return
-        meta = interaction.metadata or {}
-        raw = meta.get('amount')
-        if raw in (None, ''):
-            interaction.amount = None
-        else:
-            from decimal import Decimal, InvalidOperation
-            try:
-                interaction.amount = Decimal(str(raw))
-            except (InvalidOperation, ValueError):
-                interaction.amount = None
-        interaction.kind = meta.get('kind') or ''
-        interaction.supplier = meta.get('supplier') or ''
 
     def get_zone_names(self, obj):
         return [zone.name for zone in obj.zones.all()]
@@ -376,10 +352,9 @@ class InteractionSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             interaction = Interaction.objects.create(**validated_data)
 
-            self._sync_expense_columns(interaction)
             if budget_id:
                 self._apply_budget(interaction, budget_id)
-            interaction.save(update_fields=['amount', 'kind', 'supplier', 'budget'])
+                interaction.save(update_fields=['budget'])
 
             from zones.models import Zone
             for zone_id in zone_ids:
@@ -412,10 +387,10 @@ class InteractionSerializer(serializers.ModelSerializer):
             instance.household_id,
         )
 
-        # Update interaction fields
+        # Update interaction fields (amount/kind/supplier are now real columns,
+        # written directly from validated_data — no metadata round-trip).
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
-        self._sync_expense_columns(instance)
         if budget_id is not ...:
             self._apply_budget(instance, budget_id)
         instance.save()

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -56,28 +56,24 @@ def _source_name(source) -> str:
 
 def _build_expense_metadata(
     *,
-    kind: str,
     source_name: str | None,
-    amount: Decimal | None = None,
     unit_price: Decimal | None = None,
-    supplier: str = "",
     extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Single source of truth for the `metadata` shape on expense interactions.
 
-    Both `create_expense_interaction` and `create_manual_expense_interaction`
-    flow through this helper, so adding a new key (e.g. `currency`) in the
-    future means touching one place.
+    The queried money fields (``amount``, ``kind``, ``supplier``) live in real
+    columns on ``Interaction`` — set directly by the creators, NOT here (cf.
+    docs/fiches/CARTOGRAPHIE_DEPENSES.md). ``metadata`` only carries the display /
+    feature-specific extras: ``source_name``, ``unit_price``, and whatever the
+    caller passes in ``extra`` (delta, unit, brand, recurring_id…).
 
     `extra` overrides standard keys when collisions occur — intentional escape
     hatch for feature-specific metadata.
     """
     metadata: dict[str, Any] = {
-        "kind": kind,
         "source_name": source_name,
-        "amount": str(amount) if amount is not None else None,
         "unit_price": str(unit_price) if unit_price is not None else None,
-        "supplier": supplier or "",
     }
     if extra:
         metadata.update(extra)
@@ -384,11 +380,8 @@ def create_expense_interaction(
     subject = template.format(name=name)
 
     metadata = _build_expense_metadata(
-        kind=resolved_kind,
         source_name=name,
-        amount=amount,
         unit_price=unit_price,
-        supplier=supplier,
         extra=extra_metadata,
     )
 
@@ -460,11 +453,8 @@ def create_manual_expense_interaction(
         raise ValueError("create_manual_expense_interaction: subject is required")
 
     metadata = _build_expense_metadata(
-        kind=kind,
         source_name=None,
-        amount=amount,
         unit_price=None,
-        supplier=supplier,
         extra=extra_metadata,
     )
 

--- a/apps/interactions/tests/test_api_expense_manual.py
+++ b/apps/interactions/tests/test_api_expense_manual.py
@@ -69,9 +69,9 @@ class TestManualExpenseEndpoint:
         data = response.data
         assert data["subject"] == "Restaurant Le Bistrot"
         assert data["type"] == "expense"
-        assert data["metadata"]["kind"] == "manual"
-        assert data["metadata"]["amount"] == "32.00"
-        assert data["metadata"]["supplier"] == "Le Bistrot"
+        assert data["kind"] == "manual"
+        assert data["amount"] == "32.00"
+        assert data["supplier"] == "Le Bistrot"
         assert data["metadata"]["source_name"] is None
         assert data["source_type"] is None
 
@@ -88,7 +88,7 @@ class TestManualExpenseEndpoint:
             format="json",
         )
         assert response.status_code == status.HTTP_201_CREATED, response.content
-        assert response.data["metadata"]["amount"] is None
+        assert response.data["amount"] is None
 
     def test_subject_is_required(self, owner_client, household):
         response = owner_client.post(

--- a/apps/interactions/tests/test_api_expense_summary.py
+++ b/apps/interactions/tests/test_api_expense_summary.py
@@ -43,11 +43,6 @@ def _create_expense(household, user, zone, *, amount, occurred_at,
         amount=amount,
         kind=kind,
         supplier=supplier,
-        metadata={
-            'kind': kind,
-            'amount': str(amount) if amount is not None else None,
-            'supplier': supplier,
-        },
     )
     if zone is not None:
         InteractionZone.objects.create(interaction=interaction, zone=zone)
@@ -202,18 +197,18 @@ class TestExpenseSummary:
         assert response.data["total"] == "1.00"
         assert response.data["count"] == 1
 
-    def test_editing_expense_metadata_syncs_columns_and_aggregation(
+    def test_editing_expense_amount_field_updates_aggregation(
         self, owner_client, household, owner, zone
     ):
-        """Editing an expense through the JSON `metadata` field (the current front
-        contract) must keep the promoted columns — and thus the summary — in sync."""
+        """Editing an expense via the promoted `amount`/`supplier` fields (the
+        current front contract) updates the columns — and thus the summary."""
         exp = _create_expense(
             household, owner, zone,
             amount=Decimal("10.00"), occurred_at=timezone.now(), kind="manual",
         )
         resp = owner_client.patch(
             reverse("interaction-detail", kwargs={"pk": exp.id}),
-            {"metadata": {"kind": "manual", "amount": "80.00", "supplier": "Brico"}},
+            {"amount": "80.00", "supplier": "Brico"},
             format="json",
         )
         assert resp.status_code == status.HTTP_200_OK

--- a/apps/interactions/tests/test_services.py
+++ b/apps/interactions/tests/test_services.py
@@ -79,10 +79,10 @@ def test_creates_interaction_linked_to_stock_item(user, household, stock_item, m
     assert interaction.source_content_type == ContentType.objects.get_for_model(StockItem)
     assert interaction.source_object_id == stock_item.id
     assert interaction.subject == "Purchase — Pellets"
-    assert interaction.metadata["kind"] == "stock_purchase"
+    assert interaction.kind == "stock_purchase"
     assert interaction.metadata["source_name"] == "Pellets"
-    assert interaction.metadata["amount"] == "25.00"
-    assert interaction.metadata["supplier"] == "HardwareCo"
+    assert interaction.amount == Decimal("25.00")
+    assert interaction.supplier == "HardwareCo"
     # zone of the source is attached
     assert interaction.zones.count() == 1
     assert interaction.zones.first().id == stock_item.zone_id
@@ -99,7 +99,7 @@ def test_creates_interaction_linked_to_equipment(user, household, equipment, mem
     assert interaction.source == equipment
     assert interaction.source_content_type == ContentType.objects.get_for_model(Equipment)
     assert interaction.subject == "Purchase — Drill"
-    assert interaction.metadata["kind"] == "equipment_purchase"
+    assert interaction.kind == "equipment_purchase"
 
 
 @pytest.mark.django_db
@@ -109,7 +109,7 @@ def test_kind_override_takes_precedence(user, household, stock_item, membership)
         user=user,
         kind="custom_kind",
     )
-    assert interaction.metadata["kind"] == "custom_kind"
+    assert interaction.kind == "custom_kind"
 
 
 @pytest.mark.django_db
@@ -118,10 +118,10 @@ def test_extra_metadata_is_merged(user, stock_item, membership):
         source=stock_item,
         user=user,
         amount=Decimal("10"),
-        extra_metadata={"delta": "2.5", "unit": "bag", "amount": "OVERRIDDEN"},
+        extra_metadata={"delta": "2.5", "unit": "bag"},
     )
-    # extra_metadata can override standard keys (intentional escape hatch)
-    assert interaction.metadata["amount"] == "OVERRIDDEN"
+    # amount is a real column; feature-specific extras merge into metadata
+    assert interaction.amount == Decimal("10")
     assert interaction.metadata["delta"] == "2.5"
     assert interaction.metadata["unit"] == "bag"
 
@@ -166,11 +166,11 @@ def test_manual_creates_expense_with_user_subject(user, household, membership):
     assert interaction.created_by == user
     assert interaction.source_content_type_id is None
     assert interaction.source_object_id is None
-    assert interaction.metadata["kind"] == "manual"
+    assert interaction.kind == "manual"
     assert interaction.metadata["source_name"] is None
-    assert interaction.metadata["amount"] == "32.00"
+    assert interaction.amount == Decimal("32.00")
     assert interaction.metadata["unit_price"] is None
-    assert interaction.metadata["supplier"] == "Le Bistrot"
+    assert interaction.supplier == "Le Bistrot"
 
 
 @pytest.mark.django_db
@@ -222,7 +222,7 @@ def test_manual_amount_none_kept_as_null(user, household, membership):
         user=user,
         subject="Free lunch",
     )
-    assert interaction.metadata["amount"] is None
+    assert interaction.amount is None
 
 
 @pytest.mark.django_db
@@ -235,7 +235,7 @@ def test_manual_extra_metadata_is_merged(user, household, membership):
         extra_metadata={"category": "leisure"},
     )
     assert interaction.metadata["category"] == "leisure"
-    assert interaction.metadata["amount"] == "12"
+    assert interaction.amount == Decimal("12")
 
 
 # --- create_note_interaction ------------------------------------------------

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -138,19 +138,18 @@ class InteractionViewSet(viewsets.ModelViewSet):
             tag_list = tags.split(',')
             queryset = queryset.filter(tags__tag__name__in=tag_list).distinct()
 
-        # Filter by metadata.kind — generic across interaction subtypes, incl.
-        # non-expense ones (e.g. renovation) whose kind stays in metadata. The
-        # promoted `kind` column is expense-only; expense aggregations use it,
-        # but this shared list endpoint keeps the metadata lookup so every
-        # subtype filters uniformly.
-        metadata_kind = self.request.query_params.get('kind')
-        if metadata_kind:
-            queryset = queryset.filter(metadata__kind=metadata_kind)
+        # Filter by kind — generic across interaction subtypes. Expense kinds
+        # live in the promoted `kind` column; non-expense subtypes (e.g.
+        # renovation) keep their discriminator in metadata. Match either so this
+        # shared list endpoint filters every subtype uniformly.
+        kind = self.request.query_params.get('kind')
+        if kind:
+            queryset = queryset.filter(Q(kind=kind) | Q(metadata__kind=kind))
 
-        # Filter by metadata.supplier (exact match)
-        metadata_supplier = self.request.query_params.get('supplier')
-        if metadata_supplier is not None:
-            queryset = queryset.filter(metadata__supplier=metadata_supplier)
+        # Filter by supplier (expense-only, now a real column).
+        supplier = self.request.query_params.get('supplier')
+        if supplier is not None:
+            queryset = queryset.filter(supplier=supplier)
 
         return queryset
     

--- a/apps/projects/tests/test_api_project_purchase.py
+++ b/apps/projects/tests/test_api_project_purchase.py
@@ -82,9 +82,9 @@ def test_register_purchase_reflects_computed_actual_cost_and_creates_expense(
     assert interaction.source_object_id == project.id
     assert interaction.household_id == household.id
     assert interaction.subject == "Purchase — Kitchen reno"
-    assert interaction.metadata["kind"] == "project_purchase"
-    assert interaction.metadata["amount"] == "450.00"
-    assert interaction.metadata["supplier"] == "Leroy Merlin"
+    assert interaction.kind == "project_purchase"
+    assert interaction.amount == Decimal("450.00")
+    assert interaction.supplier == "Leroy Merlin"
     assert interaction.metadata["project_title"] == "Kitchen reno"
 
     # The DB column is dead: never written anymore (#234)
@@ -165,7 +165,7 @@ def test_register_purchase_without_amount_does_not_change_cost(client, user, pro
     assert "interaction_id" in payload
     assert payload["actual_cost_cached"] == "100.00"
     interaction = Interaction.objects.get(id=payload["interaction_id"])
-    assert interaction.metadata["amount"] is None
+    assert interaction.amount is None
 
 
 @pytest.mark.django_db

--- a/apps/stock/tests/test_agent_integration.py
+++ b/apps/stock/tests/test_agent_integration.py
@@ -158,7 +158,7 @@ def test_create_stock_purchase_restocks_and_records_expense(household, owner, fe
     assert feed.quantity == Decimal("22.000")  # 2 + 20
 
     interaction = Interaction.objects.get(pk=result.created[0]["id"])
-    assert interaction.metadata["kind"] == "stock_purchase"
+    assert interaction.kind == "stock_purchase"
     assert interaction.metadata["brand"] == "Gasco"
 
 

--- a/apps/stock/tests/test_api_stock_purchase.py
+++ b/apps/stock/tests/test_api_stock_purchase.py
@@ -102,9 +102,9 @@ def test_purchase_increments_quantity_and_creates_expense(client, user, househol
     assert interaction.household_id == household.id
     assert interaction.created_by_id == user.id
     assert interaction.subject == "Purchase — Firewood"
-    assert interaction.metadata["kind"] == "stock_purchase"
+    assert interaction.kind == "stock_purchase"
     assert interaction.metadata["stock_item_name"] == "Firewood"
-    assert interaction.metadata["amount"] == "342.00"
+    assert interaction.amount == Decimal("342.00")
     assert interaction.metadata["unit_price"] == "90.00"
     assert interaction.metadata["delta"] == "3.800"
     assert interaction.metadata["unit"] == "stere"
@@ -128,7 +128,7 @@ def test_purchase_without_amount_creates_interaction_without_unit_price(client, 
     assert payload["unit_price"] is None
 
     interaction = Interaction.objects.get(id=payload["interaction_id"])
-    assert interaction.metadata["amount"] is None
+    assert interaction.amount is None
     assert interaction.metadata["unit_price"] is None
 
 

--- a/docs/fiches/CARTOGRAPHIE_DEPENSES.md
+++ b/docs/fiches/CARTOGRAPHIE_DEPENSES.md
@@ -17,9 +17,15 @@
 > interaction ; stock hérite via son re-export. Rendu des montants désormais
 > localisé partout (« 12,00 € » en fr au lieu de « 12.00 € »).
 >
-> **Reste (PR3, optionnel)** : basculer le front sur les colonnes API + migration
-> de nettoyage qui strippe `amount/kind/supplier` de `metadata` + retire
-> `_sync_expense_columns`. Le reste de la fiche décrit l'état AVANT ces refactors.
+> **MàJ 2026-07-24 — transition terminée (PR « expense metadata cleanup »).**
+> `amount`/`kind`/`supplier` sont exposés en champs de premier niveau du
+> serializer ; le front (ExpenseList, détail/édition interaction, historique
+> stock) et l'API les lisent/écrivent en direct. Le shim `_sync_expense_columns`
+> est retiré et les clés sont strippées de `metadata` (migration
+> `interactions.0024`). `metadata` ne garde que `source_name`/`unit_price` + extras.
+> L'endpoint liste filtre `Q(kind) | Q(metadata__kind)` (dépense OU renovation).
+> **Chantier dépenses = terminé** (dettes ①②③ résolues). Le reste de la fiche
+> décrit l'état initial AVANT ces refactors.
 >
 > État : 2026-07-24. Photo de l'existant avant chantier d'amélioration.
 > Le mécanisme « dépense » s'est diffusé dans toute l'app depuis le parcours 08

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -9,13 +9,6 @@ interface ExpenseListProps {
   items: InteractionListItem[];
 }
 
-interface ExpenseMetadata {
-  amount?: string | null;
-  supplier?: string | null;
-  kind?: string | null;
-  unit_price?: string | null;
-}
-
 export default function ExpenseList({ items }: ExpenseListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -23,8 +16,7 @@ export default function ExpenseList({ items }: ExpenseListProps) {
   return (
     <ul className="space-y-2">
       {items.map((item) => {
-        const metadata = (item.metadata ?? {}) as ExpenseMetadata;
-        const amount = metadata.amount ? formatAmount(metadata.amount) : null;
+        const amount = item.amount ? formatAmount(item.amount) : null;
         return (
           <li key={item.id}>
             <Card
@@ -35,15 +27,15 @@ export default function ExpenseList({ items }: ExpenseListProps) {
                 <div className="min-w-0 flex-1">
                   <div className="flex flex-wrap items-center gap-2">
                     <CardTitle>{item.subject}</CardTitle>
-                    {metadata.kind ? (
+                    {item.kind ? (
                       <Badge variant="outline" className="text-xs">
-                        {t(`expenses.kind.${metadata.kind}`, { defaultValue: metadata.kind })}
+                        {t(`expenses.kind.${item.kind}`, { defaultValue: item.kind })}
                       </Badge>
                     ) : null}
                   </div>
                   <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                     <span>{formatDate(item.occurred_at)}</span>
-                    {metadata.supplier ? <span>{metadata.supplier}</span> : null}
+                    {item.supplier ? <span>{item.supplier}</span> : null}
                   </div>
                 </div>
                 {amount ? (

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -55,9 +55,8 @@ export default function InteractionDetailPage() {
     );
   }
 
-  const metadata = (interaction.metadata ?? {}) as Record<string, string | null | undefined>;
-  const amount = metadata.amount;
-  const supplier = metadata.supplier;
+  const amount = interaction.amount;
+  const supplier = interaction.supplier;
   const isExpense = interaction.type === 'expense';
 
   return (

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -96,9 +96,8 @@ export default function InteractionEditPage() {
     }
     setDescription(interaction.content ?? '');
     setTagsInput((interaction.tags ?? []).join(', '));
-    const md = (interaction.metadata ?? {}) as Record<string, string | null | undefined>;
-    setAmount(md.amount ?? '');
-    setSupplier(md.supplier ?? '');
+    setAmount(interaction.amount ?? '');
+    setSupplier(interaction.supplier ?? '');
     setContactId(interaction.contacts?.[0]?.id ?? '');
     setStructureId(interaction.structures?.[0]?.id ?? '');
     setEquipmentId(interaction.equipments?.[0]?.id ?? '');
@@ -140,17 +139,12 @@ export default function InteractionEditPage() {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    // Merge metadata for expense-specific fields, preserving any existing keys.
-    let nextMetadata: Record<string, unknown> | undefined;
-    if (isExpense) {
-      const existing = (interaction?.metadata ?? {}) as Record<string, unknown>;
-      const trimmedAmount = amount.trim();
-      nextMetadata = {
-        ...existing,
-        amount: trimmedAmount ? trimmedAmount : null,
-        supplier: supplier.trim(),
-      };
-    }
+    // Expense amount/supplier are now real columns — sent as top-level fields
+    // (no metadata round-trip). kind stays as-is; unit_price and other extras
+    // remain in metadata and are left untouched by omitting `metadata` here.
+    const expenseFields = isExpense
+      ? { amount: amount.trim() ? amount.trim() : null, supplier: supplier.trim() }
+      : {};
 
     try {
       setSubmitting(true);
@@ -164,7 +158,7 @@ export default function InteractionEditPage() {
         contact_ids: contactId ? [contactId] : [],
         structure_ids: structureId ? [structureId] : [],
         equipment_ids: equipmentId ? [equipmentId] : [],
-        ...(nextMetadata ? { metadata: nextMetadata } : {}),
+        ...expenseFields,
       });
       navigate(-1);
     } catch {
@@ -273,7 +267,7 @@ export default function InteractionEditPage() {
             sourceLabel={interaction.source_label}
             sourceType={interaction.source_type}
             sourceId={interaction.source_id}
-            kind={(metadata.kind ?? null) as string | null}
+            kind={interaction.kind ?? null}
             unitPrice={(metadata.unit_price ?? null) as string | null}
             unit={(metadata.unit ?? null) as string | null}
           />

--- a/ui/src/features/stock/StockItemDetailPage.tsx
+++ b/ui/src/features/stock/StockItemDetailPage.tsx
@@ -271,9 +271,9 @@ export default function StockItemDetailPage() {
                           >
                             <div className="flex items-start justify-between gap-2">
                               <span className="font-medium">{entry.subject || '—'}</span>
-                              {entry.metadata?.amount != null ? (
+                              {entry.amount != null ? (
                                 <span className="shrink-0 font-medium">
-                                  {formatAmount(entry.metadata.amount)}
+                                  {formatAmount(entry.amount)}
                                 </span>
                               ) : null}
                             </div>
@@ -283,7 +283,7 @@ export default function StockItemDetailPage() {
                                 ? ` · +${formatQty(entry.metadata.delta, entry.metadata.unit)}`
                                 : ''}
                               {entry.metadata?.brand ? ` · ${entry.metadata.brand}` : ''}
-                              {entry.metadata?.supplier ? ` · ${entry.metadata.supplier}` : ''}
+                              {entry.supplier ? ` · ${entry.supplier}` : ''}
                             </p>
                           </Card>
                         </li>

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -27,6 +27,10 @@ export interface InteractionListItem {
   document_count: number;
   created_by_name?: string;
   metadata?: Record<string, unknown>;
+  // Expense columns (promoted out of metadata). Only meaningful for type='expense'.
+  amount?: string | null;
+  kind?: string;
+  supplier?: string;
   source_type?: string | null;
   source_id?: string | null;
   source_label?: string | null;
@@ -43,6 +47,9 @@ export interface CreateInteractionInput {
   zone_ids: string[];
   tags_input?: string[];
   metadata?: Record<string, unknown>;
+  amount?: string | null;
+  kind?: string;
+  supplier?: string;
   document_ids?: string[];
   source_type?: string | null;
   source_id?: string | null;

--- a/ui/src/lib/api/stock.ts
+++ b/ui/src/lib/api/stock.ts
@@ -213,11 +213,12 @@ export interface StockItemInteractionItem {
   subject: string;
   type: string;
   occurred_at: string;
+  // Expense columns (promoted out of metadata).
+  amount?: string | null;
+  kind?: string;
+  supplier?: string;
   metadata: {
-    kind?: string;
-    amount?: string | number | null;
     unit_price?: string | number | null;
-    supplier?: string | null;
     brand?: string | null;
     delta?: string;
     unit?: string;


### PR DESCRIPTION
## Quoi

Dernière étape du chantier dépenses (dette ③ de `docs/fiches/CARTOGRAPHIE_DEPENSES.md`) : les champs `amount`/`kind`/`supplier` deviennent le **contrat API**, et le JSON `metadata` ne les duplique plus.

- **Serializer** : `amount`/`kind`/`supplier` exposés en champs de premier niveau (lecture + écriture). Le shim `_sync_expense_columns` (introduit en transition) est **retiré** — le front écrit les colonnes directement.
- **Services** : `_build_expense_metadata` ne stocke plus `amount`/`kind`/`supplier` (garde `source_name`/`unit_price` + extras `delta`/`unit`/`brand`…).
- **Migration `0024`** : strippe `amount`/`kind`/`supplier` du `metadata` des dépenses. Les entrées `renovation` gardent `metadata.kind` (non promu).
- **Front** : lecture des colonnes → `ExpenseList`, détail/édition interaction, historique d'achat stock. Types API (`interactions.ts`, `stock.ts`) enrichis.
- **Endpoint liste** : le filtre `?kind=` matche `Q(kind) | Q(metadata__kind)` (dépense via colonne **ou** renovation via metadata) ; `?supplier=` filtre la colonne.

## Contrat final

`metadata` d'une dépense ne contient plus que `source_name`, `unit_price` et les extras feature. Toute lecture/agrégation/édition passe par les colonnes. Plus de source de vérité double.

## Validation

- Suite backend complète verte : **2773 passed, 2 skipped**. ~30 assertions de tests migrées de `metadata[...]` vers les colonnes.
- `npx tsc -b` OK, `npm run lint` (0 erreur).
- Migration `0024` appliquée proprement (test DB `--create-db`).
