### PR TITLE
fix(banking): en-tête multipart sur l'upload de relevés (415)

### DIFF
--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -1,4 +1,4 @@
-import { api } from '@/lib/axios';
+import { api, postMultipart } from '@/lib/axios';
 
 /** Un compte du foyer — compte bancaire ou espèces (parcours 25, lot 1). */
 export interface BankAccount {
@@ -125,7 +125,7 @@ export async function fetchStatementImports(accountId?: string): Promise<Stateme
 export async function previewStatementFile(file: File): Promise<StatementPreview> {
   const form = new FormData();
   form.append('file', file);
-  const { data } = await api.post<StatementPreview>('/banking/imports/preview/', form);
+  const { data } = await postMultipart<StatementPreview>('/banking/imports/preview/', form);
   return data;
 }
 
@@ -144,7 +144,7 @@ export async function importStatementFile(params: {
   form.append('provider', params.provider);
   form.append('file', params.file);
   form.append('options', JSON.stringify(params.options));
-  const { data } = await api.post<StatementImport>('/banking/imports/', form);
+  const { data } = await postMultipart<StatementImport>('/banking/imports/', form);
   return data;
 }
 

--- a/ui/src/lib/axios.ts
+++ b/ui/src/lib/axios.ts
@@ -48,3 +48,16 @@ api.interceptors.response.use(
     return Promise.reject(error);
   }
 );
+
+/**
+ * POST d'un `FormData`.
+ *
+ * L'instance `api` impose `Content-Type: application/json` par défaut, et axios
+ * ne l'écrase pas tout seul quand le corps est un FormData : le serveur reçoit
+ * alors du JSON annoncé pour un corps multipart et répond **415**. Chaque upload
+ * doit donc poser l'en-tête — passer par ce helper évite de l'oublier, ce qui
+ * est arrivé sur l'import de relevés bancaires.
+ */
+export function postMultipart<T>(url: string, form: FormData) {
+  return api.post<T>(url, form, { headers: { 'Content-Type': 'multipart/form-data' } });
+}


### PR DESCRIPTION
Corrige l'import de relevés, cassé en production : le dépôt d'un fichier renvoyait **415** et l'écran affichait « Impossible de lire ce fichier ».

## La cause

L'instance axios pose `Content-Type: application/json` **globalement** (`ui/src/lib/axios.ts`), et axios ne l'écrase pas de lui-même quand le corps est un `FormData`. DRF recevait donc du JSON annoncé pour un corps multipart, et `MultiPartParser` refusait la requête.

Les quatre autres uploads du projet (documents, users, electricity ×2) écrasent cet en-tête **à la main**. Mes deux fonctions banking ne le faisaient pas.

## Pourquoi les tests ne l'ont pas vu

Le client de test DRF avec `format="multipart"` pose le bon en-tête lui-même. La suite passait donc au vert sur un chemin que le navigateur n'emprunte jamais. C'est un angle mort de la couverture backend, pas un test manquant : seul un appel navigateur réel — ou un E2E — expose ce cas.

## Le correctif

Un helper `postMultipart` dans `lib/axios`, utilisé par les deux fonctions banking. La répétition manuelle de l'en-tête dans quatre modules est exactement le piège dans lequel banking est tombé ; le helper le rend impossible à oublier pour le prochain upload.

Je n'ai **pas** converti les quatre appels existants dans ce correctif — ils fonctionnent, et je préfère garder un hotfix étroit. À faire en suivi si tu veux supprimer la duplication pour de bon.

## Vérifié

Parsing du vrai export Crédit Agricole (116 lignes) confirmé côté backend avec le mapping Débit/Crédit. `npm run build` et `npm run lint` verts.