### PR TITLE
feat(money): module « Argent » à onglets et file de rangement (parcours 26, lot 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,28 @@ Doc : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` + section « Conformité 
   front, pas en `gettext` backend : ajouter un détecteur ne doit pas imposer un
   passage dans quatre `.po`.
 
+#### Le module « Argent » — une seule clé, cinq onglets
+
+Comptes, dépenses et budgets sont **un seul module** (`money`, `/app/money`), à
+onglets : Contrôle / À ranger / Comptes / Dépenses / Budgets. Doc :
+`docs/MODULES/money.md`.
+
+- **Ne pas recréer d'entrée de sidebar** pour `banking`, `expenses` ou `budget` :
+  ces clés n'existent plus dans `MODULES` ni dans `households.modules`. `money` est
+  **core** (non désactivable) — conséquence assumée : les comptes bancaires ne sont
+  plus un opt-in.
+- Toute nouvelle URL de la famille argent vit sous `/app/money`. Les trois
+  anciennes redirigent via `LegacyMoneyRedirect` en **préservant la query string**
+  (l'agent produit `/app/budget?b={id}`) — ne pas remplacer par un `<Navigate to>`
+  en dur.
+- Les panneaux (`AccountsPanel`, `ExpensesPanel`, `BudgetsPanel`) n'ont **pas** de
+  `PageHeader` : la coque porte le titre. Un panneau qui en ajoute un produit deux
+  `h1`.
+- Une pastille de budget de la file « À ranger » n'apparaît que sur une ligne
+  **entièrement** non ventilée : l'écriture d'une ventilation est un remplacement
+  complet, donc un raccourci sur une ligne partielle détruirait le travail déjà
+  fait. Même raison pour la sélection multiple.
+
 ### Ajouter un nouveau template d'auto-subject
 
 1. Ajouter l'entrée dans `AUTO_SUBJECT_TEMPLATES` (`apps/interactions/services.py`)

--- a/apps/accounts/migrations/0014_pinned_modules_money.py
+++ b/apps/accounts/migrations/0014_pinned_modules_money.py
@@ -1,0 +1,58 @@
+"""Fold the three money pins into ``money`` (parcours 26, lot 2).
+
+``User.pinned_modules`` holds navigation keys. The « Argent » shell replaces
+``banking``, ``expenses`` and ``budget`` with a single ``money`` entry, so a user
+who had pinned any of them must keep a pin — otherwise their sidebar silently
+loses a shortcut they put there on purpose, with nothing to tell them why.
+
+Order is preserved: ``money`` takes the position of the **first** of the three
+keys found, so a user who had « Dépenses » at the top still finds « Argent » at the
+top. Duplicates are collapsed (someone who pinned both budget and banking gets one
+entry, not two).
+"""
+from django.db import migrations
+
+LEGACY = ("banking", "expenses", "budget")
+
+
+def fold_into_money(apps, schema_editor):
+    User = apps.get_model("accounts", "User")
+    for user in User.objects.exclude(pinned_modules=[]).iterator():
+        pinned = user.pinned_modules or []
+        if not any(key in LEGACY for key in pinned):
+            continue
+
+        folded = []
+        for key in pinned:
+            replacement = "money" if key in LEGACY else key
+            if replacement not in folded:
+                folded.append(replacement)
+
+        user.pinned_modules = folded
+        user.save(update_fields=["pinned_modules"])
+
+
+def unfold_from_money(apps, schema_editor):
+    """Best effort rollback: ``money`` becomes ``expenses``.
+
+    Which of the three the user had pinned is not recoverable — the information was
+    collapsed on purpose. ``expenses`` is the least surprising landing spot, and it
+    was core (so always visible) unlike ``banking``.
+    """
+    User = apps.get_model("accounts", "User")
+    for user in User.objects.exclude(pinned_modules=[]).iterator():
+        pinned = user.pinned_modules or []
+        if "money" not in pinned:
+            continue
+        user.pinned_modules = ["expenses" if key == "money" else key for key in pinned]
+        user.save(update_fields=["pinned_modules"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("accounts", "0013_user_digest_disabled_sections"),
+    ]
+
+    operations = [
+        migrations.RunPython(fold_into_money, unfold_from_money),
+    ]

--- a/apps/accounts/tests/test_money_pin_migration.py
+++ b/apps/accounts/tests/test_money_pin_migration.py
@@ -1,0 +1,119 @@
+"""The pinned-modules fold (parcours 26, lot 2) — tested as a function, not a run.
+
+A data migration is the one piece of code that executes **once**, on real data,
+with nobody watching. Here the failure mode is silent by nature: a user who had
+pinned « Dépenses » would simply find their shortcut gone, with nothing to explain
+why and no error anywhere.
+
+The migration is not re-run here (it has already been applied by the test database
+setup): its transformation is imported and exercised directly, which is what
+actually carries the risk. What we check is that it folds, keeps the **position**,
+collapses duplicates, and leaves everything else alone.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from accounts.serializers import UserSerializer
+
+from .factories import UserFactory
+
+migration = importlib.import_module("accounts.migrations.0014_pinned_modules_money")
+
+
+class FakeQuerySet:
+    """Minimal stand-in for the historical model manager the migration uses."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def exclude(self, **kwargs):
+        assert kwargs == {"pinned_modules": []}
+        return FakeQuerySet([row for row in self._rows if row.pinned_modules])
+
+    def iterator(self):
+        return iter(self._rows)
+
+
+class FakeRow:
+    def __init__(self, pinned_modules):
+        self.pinned_modules = pinned_modules
+        self.saved_fields = None
+
+    def save(self, update_fields=None):
+        self.saved_fields = update_fields
+
+
+class FakeApps:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_model(self, app_label, model_name):
+        assert (app_label, model_name) == ("accounts", "User")
+        return type("User", (), {"objects": FakeQuerySet(self._rows)})
+
+
+def fold(pinned: list[str]) -> list[str]:
+    row = FakeRow(list(pinned))
+    migration.fold_into_money(FakeApps([row]), None)
+    return row.pinned_modules
+
+
+class TestFoldIntoMoney:
+    def test_each_legacy_key_becomes_money(self):
+        assert fold(["banking"]) == ["money"]
+        assert fold(["expenses"]) == ["money"]
+        assert fold(["budget"]) == ["money"]
+
+    def test_position_is_preserved(self):
+        """A user who had « Dépenses » at the top finds « Argent » at the top."""
+        assert fold(["expenses", "tasks", "stock"]) == ["money", "tasks", "stock"]
+        assert fold(["tasks", "budget"]) == ["tasks", "money"]
+
+    def test_two_of_the_three_collapse_into_one_entry(self):
+        assert fold(["banking", "tasks", "budget"]) == ["money", "tasks"]
+
+    def test_other_keys_are_untouched(self):
+        assert fold(["tasks", "stock", "chickens"]) == ["tasks", "stock", "chickens"]
+
+    def test_an_already_folded_list_is_left_alone(self):
+        """Idempotence matters: a re-run must not duplicate or reorder anything."""
+        assert fold(["money", "tasks"]) == ["money", "tasks"]
+
+    def test_a_row_without_legacy_keys_is_not_saved(self):
+        row = FakeRow(["tasks"])
+        migration.fold_into_money(FakeApps([row]), None)
+        assert row.saved_fields is None
+
+    def test_a_folded_row_is_saved_on_the_narrow_field(self):
+        row = FakeRow(["budget"])
+        migration.fold_into_money(FakeApps([row]), None)
+        assert row.saved_fields == ["pinned_modules"]
+
+
+class TestUnfold:
+    def test_money_becomes_expenses(self):
+        """Rollback is best effort: which of the three it was is not recoverable,
+        and `expenses` was core (so always visible) unlike `banking`."""
+        row = FakeRow(["money", "tasks"])
+        migration.unfold_from_money(FakeApps([row]), None)
+        assert row.pinned_modules == ["expenses", "tasks"]
+
+
+@pytest.mark.django_db
+class TestSerializerAgreesWithTheMigration:
+    def test_money_is_accepted(self):
+        """The migration writes `money`; the serializer must not then reject it on
+        the next ordinary PATCH — that would lock the user out of their own pins."""
+        user = UserFactory()
+        serializer = UserSerializer(user, data={"pinned_modules": ["money"]}, partial=True)
+        assert serializer.is_valid(), serializer.errors
+
+    @pytest.mark.parametrize("legacy", ["banking", "expenses", "budget"])
+    def test_legacy_keys_are_refused(self, legacy):
+        user = UserFactory()
+        serializer = UserSerializer(user, data={"pinned_modules": [legacy]}, partial=True)
+        assert not serializer.is_valid()
+        assert "pinned_modules" in serializer.errors

--- a/apps/budget/apps.py
+++ b/apps/budget/apps.py
@@ -21,7 +21,7 @@ class BudgetConfig(AppConfig):
             model=Budget,
             search_fields=("name",),
             label_attr="name",
-            url_template="/app/budget?b={id}",
+            url_template="/app/money?tab=budgets&b={id}",
         ))
 
         register(SearchableSpec(
@@ -41,7 +41,7 @@ class BudgetConfig(AppConfig):
             resolve=_resolve_budget_for_agent,
             delete=_delete_budget_from_agent,
             label_attr="name",
-            url_template="/app/budget?b={id}",
+            url_template="/app/money?tab=budgets&b={id}",
         ))
 
         register_writable(WritableSpec(

--- a/apps/households/migrations/0011_retire_banking_module_key.py
+++ b/apps/households/migrations/0011_retire_banking_module_key.py
@@ -1,0 +1,35 @@
+"""Retire the ``banking`` key from stored household configuration (parcours 26, lot 2).
+
+The « Argent » shell merges ``banking``, ``expenses`` and ``budget`` into a single
+``money`` module. ``banking`` was the only one of the three a household could
+switch off, so it is the only one that can appear in ``disabled_modules``.
+
+Leaving it there would be a dead key: nothing reads it anymore, and the next person
+to open ``disabled_modules`` would find a value that maps to no module — an orphan
+of configuration, which is exactly the kind of silent leftover this parcours exists
+to remove.
+
+Deliberately **not reversible in effect**: going back would mean guessing which
+households had banking off, and the merged module is core anyway.
+"""
+from django.db import migrations
+
+
+def drop_banking_key(apps, schema_editor):
+    Household = apps.get_model("households", "Household")
+    for household in Household.objects.exclude(disabled_modules=[]).iterator():
+        disabled = household.disabled_modules or []
+        cleaned = [key for key in disabled if key != "banking"]
+        if cleaned != disabled:
+            household.disabled_modules = cleaned
+            household.save(update_fields=["disabled_modules"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("households", "0010_household_latitude_household_location_label_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_banking_key, migrations.RunPython.noop),
+    ]

--- a/apps/households/modules.py
+++ b/apps/households/modules.py
@@ -25,7 +25,6 @@ OPTIONAL_MODULES = frozenset({
     'trackers',
     'photos',
     'directory',
-    'banking',
 })
 
 PINNABLE_MODULES = frozenset({
@@ -44,11 +43,20 @@ PINNABLE_MODULES = frozenset({
     'projects',
     'interactions',
     'trackers',
-    'expenses',
-    'budget',
-    'banking',
+    'money',
     # groupe Ressources
     'documents',
     'photos',
     'directory',
 })
+
+#: Module keys the parcours 26 « Argent » shell replaced, kept only to migrate
+#: stored user/household configuration. Nothing new must reference them: the three
+#: pages became tabs of ``money``.
+#:
+#: Note that ``banking`` was **optional** while ``expenses`` and ``budget`` were
+#: core. The merged key has to be core — a household cannot switch off ``money``
+#: without losing expenses and budgets, which were never switchable. Assumed
+#: consequence: bank accounts are no longer an opt-in, which is coherent with
+#: « les relevés sont la source de vérité ».
+LEGACY_MONEY_MODULES = frozenset({'banking', 'expenses', 'budget'})

--- a/apps/households/tests/test_money_module_keys.py
+++ b/apps/households/tests/test_money_module_keys.py
@@ -1,0 +1,108 @@
+"""The « Argent » module key contract (parcours 26, lot 2).
+
+Merging three navigation entries into one is the risky half of the lot, and the
+risk is not visual: it is **stored configuration that stops matching anything**.
+Two things have to hold, and nothing else in the suite checks them.
+
+1. The registries agree with the frontend one (`ui/src/lib/modules.ts`). A key that
+   exists on one side only produces either an invisible module or a 400 on a
+   perfectly ordinary PATCH.
+2. `money` is **core**. It cannot be optional: a household switching it off would
+   lose expenses and budgets, which were never switchable. That is the whole reason
+   bank accounts stopped being an opt-in.
+"""
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from households.modules import LEGACY_MONEY_MODULES, OPTIONAL_MODULES, PINNABLE_MODULES
+
+
+class TestModuleRegistries:
+    def test_money_is_pinnable(self):
+        assert "money" in PINNABLE_MODULES
+
+    def test_money_is_not_optional(self):
+        """Core by necessity, not by taste — see the module docstring."""
+        assert "money" not in OPTIONAL_MODULES
+
+    @pytest.mark.parametrize("legacy", sorted(LEGACY_MONEY_MODULES))
+    def test_legacy_keys_are_gone_from_both_registries(self, legacy):
+        assert legacy not in PINNABLE_MODULES
+        assert legacy not in OPTIONAL_MODULES
+
+    def test_legacy_set_names_exactly_the_three_merged_keys(self):
+        assert LEGACY_MONEY_MODULES == {"banking", "expenses", "budget"}
+
+
+migration = importlib.import_module("households.migrations.0011_retire_banking_module_key")
+
+
+class FakeQuerySet:
+    """Minimal stand-in for the historical model manager the migration uses."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def exclude(self, **kwargs):
+        assert kwargs == {"disabled_modules": []}
+        return FakeQuerySet([row for row in self._rows if row.disabled_modules])
+
+    def iterator(self):
+        return iter(self._rows)
+
+
+class FakeRow:
+    def __init__(self, disabled_modules):
+        self.disabled_modules = disabled_modules
+        self.saved_fields = None
+
+    def save(self, update_fields=None):
+        self.saved_fields = update_fields
+
+
+class FakeApps:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def get_model(self, app_label, model_name):
+        assert (app_label, model_name) == ("households", "Household")
+        return type("Household", (), {"objects": FakeQuerySet(self._rows)})
+
+
+class TestDropBankingKey:
+    """A dead key in ``disabled_modules`` is an orphan of configuration.
+
+    It maps to no module, nothing reads it, and the next person to open the field
+    finds a value they cannot explain. Removing it is the same rule the whole
+    parcours applies to data: no silent leftovers.
+    """
+
+    def _run(self, disabled: list[str]) -> FakeRow:
+        row = FakeRow(list(disabled))
+        migration.drop_banking_key(FakeApps([row]), None)
+        return row
+
+    def test_banking_is_removed(self):
+        assert self._run(["banking"]).disabled_modules == []
+
+    def test_other_keys_survive_in_order(self):
+        row = self._run(["stock", "banking", "chickens"])
+        assert row.disabled_modules == ["stock", "chickens"]
+
+    def test_a_household_without_banking_is_not_saved(self):
+        row = self._run(["stock"])
+        assert row.saved_fields is None
+        assert row.disabled_modules == ["stock"]
+
+    def test_a_cleaned_household_is_saved_on_the_narrow_field(self):
+        assert self._run(["banking"]).saved_fields == ["disabled_modules"]
+
+    def test_rerunning_changes_nothing(self):
+        row = FakeRow(["stock"])
+        apps = FakeApps([row])
+        migration.drop_banking_key(apps, None)
+        migration.drop_banking_key(apps, None)
+        assert row.disabled_modules == ["stock"]

--- a/docs/MODULES/README.md
+++ b/docs/MODULES/README.md
@@ -29,6 +29,12 @@ Lecture recommandée pour reprendre un module après pause — pour les bugs et 
 - [insurance](./insurance.md) — contrats d'assurance
 - [notifications](./notifications.md) — notifications user
 
+## Argent
+
+- [money](./money.md) — la coque « Argent » : Contrôle / À ranger / Comptes / Dépenses / Budgets
+- [banking](./banking.md) — comptes, relevés, rapprochement, **conformité**
+- [budget](./budget.md) — enveloppes mensuelles, récurrences, bilan
+
 ## Agent & messagerie proactive
 
 - [agent](./agent.md) — assistant conversationnel (RAG + function calling)

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -33,7 +33,7 @@ Le lot 7 du parcours 25 (recettes, virements internes, couverture — #390) est
 | Lot | Sujet | Statut |
 |---|---|---|
 | 1 | Socle de conformité (`ComplianceWaiver`, détecteurs, API) | ✅ **Livré** |
-| 2 | Module « Argent » à onglets + file de rangement | ⬜ |
+| 2 | Module « Argent » à onglets + file de rangement | ✅ **Livré** — voir [money.md](./money.md) |
 | 3 | Une ventilation porte projet, zone et budget | ⬜ |
 | 4 | Tout est une ligne de compte (espèces) | ⬜ |
 | 5 | Recettes et mouvements internes | ⬜ |

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -1,0 +1,146 @@
+# Module — money (la coque « Argent »)
+
+> Rôle : réunir **comptes, dépenses et budgets** dans un seul module à onglets, et
+> mettre devant eux les deux écrans qui manquaient — **Contrôle** et **À ranger**.
+>
+> Parcours : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` (lot 2).
+> Backend consommé : [banking.md](./banking.md) (conformité), [budget.md](./budget.md),
+> [interactions.md](./interactions.md).
+
+## Pourquoi un seul module
+
+Comptes, dépenses et budgets étaient trois entrées de sidebar. Ce sont **trois
+lectures d'un même fait** : ce qui est sorti du compte. Les séparer obligeait
+l'utilisateur à faire lui-même le lien — et rendait invisible la question qui
+compte avant toutes les autres :
+
+> « Qu'est-ce qu'il me reste à faire pour que mes chiffres soient justes ? »
+
+D'où l'ordre des onglets : **Contrôle**, **À ranger**, puis Comptes, Dépenses,
+Budgets. La conformité passe devant le reporting.
+
+## Structure
+
+```
+ui/src/features/money/
+  MoneyPage.tsx        # la coque : TabShell + badges
+  keys.ts              # query keys + clés de détecteurs (sans dépendance sortante)
+  hooks.ts             # conformité : summary, groupe, arbitrer, révoquer
+  CompliancePanel.tsx  # onglet Contrôle
+  PendingQueue.tsx     # onglet À ranger
+  PendingCard.tsx      # une opération à ranger
+  WaiverDialog.tsx     # arbitrer (motif requis)
+  AccountsPanel.tsx    # ex-banking/BankingPage
+  ExpensesPanel.tsx    # ex-expenses/ExpensesPage
+  BudgetsPanel.tsx     # ex-budget/BudgetPage
+```
+
+Les trois panneaux sont les anciennes pages, **`PageHeader` en moins** : la coque
+porte le titre. Leur contenu n'a pas changé, et leurs actions restent dans le
+panneau — elles connaissent l'état d'édition local (compte courant, import en
+cours) qu'il aurait fallu remonter sans raison.
+
+## Décisions de conception
+
+### `keys.ts` séparé de `hooks.ts`
+
+`banking/hooks.ts` doit invalider la conformité après une ventilation, et
+`money/hooks.ts` importe déjà `bankingKeys`. Un import direct créerait un cycle.
+Un module de clés **sans dépendance sortante** le casse, sans dupliquer la chaîne
+`'compliance'` dans deux fichiers où elle finirait par diverger d'un caractère.
+
+### Les pastilles de budget ne s'affichent pas sur une ligne partielle
+
+L'enregistrement d'une ventilation est un **remplacement complet** (`PUT`, un
+« set »). Imputer d'un clic une ligne déjà partagée écraserait donc le travail
+déjà fait. Sur une ligne partielle, le seul chemin est le dialog, qui part de
+l'existant — et la sélection multiple ne propose que des lignes entièrement non
+ventilées, pour la même raison.
+
+### « Plus tard » n'écrit rien
+
+Quatre issues sur une carte, et aucune cinquième qui ferait disparaître la ligne :
+une pastille, un découpage, un arbitrage motivé, ou un report. Le report est
+volontairement **local à la session** — la ligne n'est pas résolue, elle revient.
+
+### Un groupe à zéro reste visible
+
+Coché, pas masqué. C'est ce qui distingue « contrôlé et conforme » de « pas encore
+contrôlé » ; une liste vide serait indistinguable d'un détecteur en panne.
+
+### Les prérequis bloquants passent en tête
+
+Un compte sans solde d'ouverture n'a pas de fenêtre de conformité : ses dépendants
+ne sont pas « conformes », ils ne sont **pas évaluables**. Le panneau les trie par
+sévérité (`blocker` d'abord) et affiche `blocked_by` pour expliquer pourquoi un
+contrôle ne porte peut-être pas sur tout.
+
+### `AllocationDialog` prend un id, plus un objet
+
+Le dialog charge déjà la ventilation courante, qui embarque la ligne. Passer
+l'objet en plus obligeait chaque appelant à le détenir — or la file de rangement ne
+connaît que des **écarts**, identifiés par un id.
+
+## La fusion des clés de module — ce qu'elle a impliqué
+
+`banking` était **optionnel**, `expenses` et `budget` étaient **core**. La clé
+fusionnée `money` doit être core : un foyer ne peut pas désactiver `money` sans
+perdre dépenses et budgets, qui n'ont jamais été désactivables.
+
+**Conséquence assumée : les comptes bancaires ne sont plus un opt-in.** C'est
+cohérent avec « les relevés sont la source de vérité », mais c'est une décision
+produit, pas un effet de bord.
+
+Deux data migrations, parce qu'une configuration stockée qui ne correspond plus à
+rien est un orphelin :
+
+- `households.0011` retire `'banking'` des `disabled_modules` existants ;
+- `accounts.0014` replie `banking`/`expenses`/`budget` en `money` dans les
+  `pinned_modules`, **en préservant la position** du premier des trois — un
+  utilisateur qui avait « Dépenses » en tête retrouve « Argent » en tête.
+
+## Navigation
+
+| Ancienne URL | Devient | Onglet |
+|---|---|---|
+| `/app/banking` | `/app/money?tab=accounts` | Comptes |
+| `/app/expenses` | `/app/money?tab=expenses` | Dépenses |
+| `/app/budget` | `/app/money?tab=budgets` | Budgets |
+| `/app/banking/transactions` | `/app/money/transactions` | *(sous-page)* |
+
+`LegacyMoneyRedirect` (`ui/src/components/`) **préserve la query string** :
+l'agent produit `/app/budget?b={id}`
+(`apps/budget/apps.py::SearchableSpec.url_template`) et un favori peut porter
+n'importe quel paramètre. Les `url_template` de l'agent ont aussi été mis à jour,
+pour que les nouveaux liens soient directs plutôt que redirigés.
+
+Le deep link `?tab=` est écrit dans la session **avant** que `TabShell` lise sa
+valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage de
+l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
+
+Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
+`/app/budget/recurring`, `/app/budget/reports`.
+
+## i18n
+
+Namespace **`money`** (coque, contrôle, file). Le libellé utilisateur de chaque
+détecteur vit sous `money.compliance.kinds.<kind>.{title,hint,resolution}` — côté
+front, pas en `gettext` backend : ajouter un détecteur ne doit pas imposer un
+passage dans quatre `.po`.
+
+Les namespaces `banking`, `expenses`, `budget` restent et leur contenu est réutilisé
+tel quel par les panneaux.
+
+⚠️ `expenses.adhoc.actions.add` est passé de « Dépense » à « **Nouvelle dépense** » :
+dans la coque, le bouton et l'onglet « Dépenses » avaient des noms accessibles
+confusables, ce qui est un problème d'ergonomie avant d'être un problème de test.
+
+## Tests
+
+`e2e/money.spec.ts` couvre ce que la fusion pouvait casser en silence : la coque,
+les quatre redirections (dont la préservation de la query string), le deep link,
+la sidebar, le panneau Contrôle, et l'identité `ouverts + arbitrés = détectés`
+vérifiée directement sur l'API.
+
+Les specs `budget`, `report`, `recurring`, `expense-adhoc`, `expenses-summary` ont
+été retargetées sur les nouvelles URLs.

--- a/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
+++ b/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
@@ -141,7 +141,7 @@ puis ventiler 90 € laisserait 60 € couverts par un motif qui ne décrit plus
 | Lot | Sujet | Statut |
 |---|---|---|
 | 1 | **Socle de conformité** — `ComplianceWaiver`, `coverage.py`, registre de détecteurs, 5 détecteurs, API | ✅ Livré |
-| 2 | **Module « Argent »** — coque à onglets, panneau Contrôle, file de rangement, actions groupées | ⬜ |
+| 2 | **Module « Argent »** — coque à onglets, panneau Contrôle, file de rangement, actions groupées | ✅ Livré |
 | 3 | **Une ventilation porte projet, zone et budget** — les deux axes sont indépendants | ⬜ |
 | 4 | **Tout est une ligne de compte** — `create_manual_transaction`, espèces | ⬜ |
 | 5 | **Recettes et mouvements internes** — `inflow_nature`, contreparties | ⬜ |

--- a/e2e/budget.spec.ts
+++ b/e2e/budget.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Parcours 21 — Lot 1 : Budgets mensuels.
  *
  * Couvre :
- *  1. Sidebar entry "Budgets" → /app/budget
+ *  1. Sidebar entry "Argent" → /app/money (onglet Budgets)
  *  2. État vide avant tout budget
  *  3. Création d'un budget nommé "Courses 400 €"
  *  4. Présence de la card "Hors budget" dès qu'un budget existe
@@ -66,32 +66,32 @@ test.describe('Budgets — parcours 21', () => {
   test.beforeEach(async ({ page }) => {
     // Naviguer vers la page pour hydrater le localStorage (JWT obligatoire
     // avant tout appel API via page.request)
-    await page.goto('/app/budget');
-    await expect(page).toHaveURL(/\/app\/budget/);
+    await page.goto('/app/money?tab=budgets');
+    await expect(page).toHaveURL(/\/app\/money/);
 
     // Nettoyer tous les budgets pour garantir un état vide au départ
     await deleteAllBudgets(page);
 
     // Recharger pour refléter l'état vide dans l'UI
     await page.reload();
-    await expect(page).toHaveURL(/\/app\/budget/);
+    await expect(page).toHaveURL(/\/app\/money/);
   });
 
   // ── 1. Affichage & sidebar ───────────────────────────────────────────────
 
-  test('la sidebar contient un lien "Budgets" vers /app/budget', async ({ page }) => {
+  test('la sidebar contient un lien "Argent" vers /app/money', async ({ page }) => {
     // budget est dans le groupe Suivi (tracking), non optionnel → toujours visible
-    const budgetLink = page.getByRole('link', { name: 'Budgets' });
+    const budgetLink = page.getByRole('link', { name: 'Argent' });
     await expect(budgetLink).toBeVisible();
     await budgetLink.click();
-    await expect(page).toHaveURL(/\/app\/budget/);
-    await expect(page.getByRole('heading', { level: 1, name: 'Budgets' })).toBeVisible();
+    await expect(page).toHaveURL(/\/app\/money/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
   });
 
   // ── 2. État vide ─────────────────────────────────────────────────────────
 
   test('affiche l\'état vide quand aucun budget n\'existe', async ({ page }) => {
-    await expect(page.getByRole('heading', { level: 1, name: 'Budgets' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // EmptyState avec le texte "Aucun budget"
     await expect(page.getByText('Aucun budget')).toBeVisible();
@@ -142,8 +142,11 @@ test.describe('Budgets — parcours 21', () => {
     // Toast de succès
     await expect(page.getByText('Budget créé', { exact: true })).toBeVisible();
 
-    // La card du budget créé apparaît sous la section "Budgets"
-    await expect(page.getByText('Courses')).toBeVisible();
+    // La card du budget créé apparaît sous la section "Budgets".
+    // `exact` est indispensable : sans lui le locator attrape aussi « Liste de
+    // courses » dans la sidebar (getByText fait du sous-texte insensible à la
+    // casse) et Playwright échoue en strict mode.
+    await expect(page.getByText('Courses', { exact: true })).toBeVisible();
 
     // La barre de progression est présente (aria role progressbar)
     await expect(page.getByRole('progressbar').first()).toBeVisible();
@@ -233,8 +236,8 @@ test.describe('Budgets — parcours 21', () => {
 
 test.describe('Budgets — intégration dépenses ad-hoc', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/app/budget');
-    await expect(page).toHaveURL(/\/app\/budget/);
+    await page.goto('/app/money?tab=budgets');
+    await expect(page).toHaveURL(/\/app\/money/);
 
     // Repartir d'une ardoise vierge, puis créer un budget nommé
     await deleteAllBudgets(page);
@@ -242,11 +245,11 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
   });
 
   test('le dialog de dépense ad-hoc propose le select de budget quand un budget nommé existe', async ({ page }) => {
-    await page.goto('/app/expenses');
-    await expect(page.getByRole('heading', { level: 1, name: 'Dépenses' })).toBeVisible();
+    await page.goto('/app/money?tab=expenses');
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // Ouvrir le dialog de dépense ad-hoc
-    await page.getByRole('button', { name: 'Dépense' }).first().click();
+    await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -263,8 +266,8 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
 
   test('enregistrer une dépense rattachée à un budget incrémente le budget', async ({ page }) => {
     // Créer la dépense via l'UI
-    await page.goto('/app/expenses');
-    await page.getByRole('button', { name: 'Dépense' }).first().click();
+    await page.goto('/app/money?tab=expenses');
+    await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
 
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible();
@@ -280,7 +283,7 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
     await expect(dialog).toBeHidden();
 
     // Aller sur la page Budgets et vérifier que le montant dépensé a augmenté
-    await page.goto('/app/budget');
+    await page.goto('/app/money?tab=budgets');
     await expect(page.getByText('Courses Tests')).toBeVisible();
 
     // La dépense de 85 € doit apparaître : "85,00 € / 500,00 €"

--- a/e2e/expense-adhoc.spec.ts
+++ b/e2e/expense-adhoc.spec.ts
@@ -10,12 +10,12 @@ import { test, expect } from '@playwright/test';
  */
 
 test('parcours dépense ad-hoc — Restaurant Le Bistrot 32€', async ({ page }) => {
-  await page.goto('/app/expenses');
-  await expect(page).toHaveURL(/\/app\/expenses/);
-  await expect(page.getByRole('heading', { level: 1, name: 'Dépenses' })).toBeVisible();
+  await page.goto('/app/money?tab=expenses');
+  await expect(page).toHaveURL(/\/app\/money/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
-  // Cliquer sur le bouton « + Dépense » du PageHeader
-  await page.getByRole('button', { name: 'Dépense' }).first().click();
+  // Cliquer sur le bouton « + Nouvelle dépense » de l'onglet Dépenses
+  await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
@@ -38,8 +38,8 @@ test('parcours dépense ad-hoc — Restaurant Le Bistrot 32€', async ({ page }
 });
 
 test('parcours dépense ad-hoc — sujet vide refusé', async ({ page }) => {
-  await page.goto('/app/expenses');
-  await page.getByRole('button', { name: 'Dépense' }).first().click();
+  await page.goto('/app/money?tab=expenses');
+  await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();

--- a/e2e/expenses-summary.spec.ts
+++ b/e2e/expenses-summary.spec.ts
@@ -6,7 +6,7 @@ import { test, expect } from '@playwright/test';
  * Issue: https://github.com/jammindev/house/issues/122
  *
  * Le test crée une dépense via le parcours stock (déjà rodé) puis vérifie
- * que la page /app/expenses affiche le total + le breakdown.
+ * que l'onglet Dépenses du module Argent affiche le total + le breakdown.
  */
 
 test('parcours dépenses — total mensuel + breakdown via achat de stock', async ({ page }) => {
@@ -52,10 +52,10 @@ test('parcours dépenses — total mensuel + breakdown via achat de stock', asyn
   await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
   await expect(dialog).toBeHidden();
 
-  // 3. Naviguer vers /app/expenses et vérifier le total
-  await page.goto('/app/expenses');
-  await expect(page).toHaveURL(/\/app\/expenses/);
-  await expect(page.getByRole('heading', { level: 1, name: 'Dépenses' })).toBeVisible();
+  // 3. Naviguer vers l'onglet Dépenses et vérifier le total
+  await page.goto('/app/money?tab=expenses');
+  await expect(page).toHaveURL(/\/app\/money/);
+  await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
   // Le total du mois courant doit refléter au moins notre achat de 150 €.
   // On évite d'asserter exactement 150,00 € pour ne pas casser si la DB

--- a/e2e/money.spec.ts
+++ b/e2e/money.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Parcours 26 — Lot 2 : le module « Argent ».
+ *
+ * Couvre ce que la fusion des trois pages pouvait casser en silence, et que rien
+ * d'autre ne vérifie :
+ *
+ *  1. La coque : un seul titre, cinq onglets, Contrôle en premier
+ *  2. Les redirections des anciennes URLs, **query string préservée** — l'agent
+ *     produit `/app/budget?b={id}` et les favoris peuvent porter n'importe quoi
+ *  3. Le deep link `?tab=` atterrit sur le bon onglet
+ *  4. La sidebar : une entrée « Argent », plus aucune des trois anciennes
+ *  5. Le panneau Contrôle liste des groupes d'écarts et sait dire « conforme »
+ *  6. Les sous-pages autonomes restent accessibles en direct
+ */
+
+async function getAccessToken(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(() => localStorage.getItem('access_token') ?? '');
+}
+
+// ---------------------------------------------------------------------------
+// 1. La coque
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — la coque', () => {
+  test('un seul titre et cinq onglets, Contrôle en tête', async ({ page }) => {
+    await page.goto('/app/money');
+    await expect(page).toHaveURL(/\/app\/money/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
+
+    for (const label of ['Contrôle', 'À ranger', 'Comptes', 'Dépenses', 'Budgets']) {
+      await expect(page.getByRole('button', { name: new RegExp(label) }).first()).toBeVisible();
+    }
+  });
+
+  test('changer d\'onglet affiche le panneau correspondant', async ({ page }) => {
+    await page.goto('/app/money');
+
+    await page.getByRole('button', { name: /Comptes/ }).first().click();
+    // Le panneau Comptes porte les filtres du journal bancaire.
+    await expect(page.getByRole('button', { name: 'Actifs' })).toBeVisible();
+
+    await page.getByRole('button', { name: /Budgets/ }).first().click();
+    await expect(page.getByRole('button', { name: /Nouveau budget|Budget/ }).first()).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. & 3. Redirections et deep links
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — anciennes URLs', () => {
+  test('/app/budget redirige vers l\'onglet Budgets', async ({ page }) => {
+    await page.goto('/app/budget');
+    await expect(page).toHaveURL(/\/app\/money\?.*tab=budgets/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
+  });
+
+  test('/app/expenses redirige vers l\'onglet Dépenses', async ({ page }) => {
+    await page.goto('/app/expenses');
+    await expect(page).toHaveURL(/\/app\/money\?.*tab=expenses/);
+  });
+
+  test('/app/banking redirige vers l\'onglet Comptes', async ({ page }) => {
+    await page.goto('/app/banking');
+    await expect(page).toHaveURL(/\/app\/money\?.*tab=accounts/);
+  });
+
+  test('la query string survit à la redirection', async ({ page }) => {
+    // Ce que produit l'agent : apps/budget/apps.py::SearchableSpec.url_template.
+    // Perdre le paramètre transformerait un lien précis en lien approximatif.
+    await page.goto('/app/budget?b=8f14e45f-ceea-467a-9c1e-000000000000');
+    await expect(page).toHaveURL(/b=8f14e45f-ceea-467a-9c1e-000000000000/);
+    await expect(page).toHaveURL(/tab=budgets/);
+  });
+
+  test('/app/banking/transactions redirige vers /app/money/transactions', async ({ page }) => {
+    await page.goto('/app/banking/transactions');
+    await expect(page).toHaveURL(/\/app\/money\/transactions/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Journal bancaire' })).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Sidebar
+// ---------------------------------------------------------------------------
+
+test('la sidebar porte une entrée « Argent » et plus aucune des trois anciennes', async ({ page }) => {
+  await page.goto('/app/dashboard');
+  const sidebar = page.locator('aside');
+
+  await expect(sidebar.getByRole('link', { name: 'Argent' })).toBeVisible();
+  await expect(sidebar.getByRole('link', { name: 'Comptes bancaires' })).toHaveCount(0);
+  // « Dépenses » et « Budgets » ne sont plus des entrées de navigation : ce sont
+  // des onglets. Les laisser dans la sidebar ferait deux chemins vers le même
+  // écran, dont un qui perd le contexte des trois autres onglets.
+  await expect(sidebar.getByRole('link', { name: 'Budgets', exact: true })).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Le panneau Contrôle
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — Contrôle', () => {
+  test('liste les groupes d\'écarts et dit ce qu\'il reste à faire', async ({ page }) => {
+    await page.goto('/app/money?tab=control');
+
+    // Les cinq détecteurs du lot 1 sont déclarés côté serveur : le panneau doit
+    // tous les montrer, y compris ceux à zéro — « contrôlé et conforme » ne doit
+    // pas être indistinguable de « pas encore contrôlé ».
+    await expect(page.getByText('Compte sans solde d\'ouverture')).toBeVisible();
+    await expect(page.getByText('Sorties non affectées')).toBeVisible();
+    await expect(page.getByText('Dépenses non rapprochées')).toBeVisible();
+  });
+
+  test('un groupe se déplie et explique comment résoudre', async ({ page }) => {
+    await page.goto('/app/money?tab=control');
+
+    await page.getByText('Sorties non affectées').click();
+    await expect(
+      page.getByText(/Rangez ces opérations depuis l'onglet/),
+    ).toBeVisible();
+  });
+
+  test('l\'API de conformité répond avec l\'identité ouverts + arbitrés = détectés', async ({ page }) => {
+    await page.goto('/app/money');
+    const token = await getAccessToken(page);
+    const resp = await page.request.get('/api/banking/compliance/', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(resp.ok()).toBeTruthy();
+
+    const body = await resp.json() as {
+      groups: Array<{ kind: string; detected: number; open: number; waived: number }>;
+      open_total: number;
+    };
+    expect(body.groups.length).toBeGreaterThan(0);
+    for (const group of body.groups) {
+      expect(group.open + group.waived).toBe(group.detected);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. Sous-pages autonomes
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — sous-pages', () => {
+  test('les sous-pages restent accessibles en accès direct', async ({ page }) => {
+    await page.goto('/app/budget/recurring');
+    await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
+
+    await page.goto('/app/budget/reports');
+    await expect(page.getByRole('heading', { level: 1, name: 'Bilan mensuel' })).toBeVisible();
+
+    await page.goto('/app/money/transactions');
+    await expect(page.getByRole('heading', { level: 1, name: 'Journal bancaire' })).toBeVisible();
+  });
+});

--- a/e2e/project-purchase.spec.ts
+++ b/e2e/project-purchase.spec.ts
@@ -61,6 +61,6 @@ test('parcours achat projet — Rénovation salle de bain 450€ Leroy Merlin', 
 
   // Vérifier qu'elle apparaît aussi dans la vue dépense (filtrée par supplier
   // pour distinguer cette execution des autres)
-  await page.goto('/app/expenses');
+  await page.goto('/app/money?tab=expenses');
   await expect(page.getByText(supplier).first()).toBeVisible();
 });

--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Parcours 21 — Lot 2 : Dépenses récurrentes.
  *
  * Couvre :
- *  1. Navigation depuis /app/budget vers /app/budget/recurring via la link card
+ *  1. Navigation depuis l'onglet Budgets vers /app/budget/recurring via la link card
  *  2. État vide ("Aucune dépense récurrente")
  *  3. Création d'une récurrence avec échéance aujourd'hui → apparaît sous "À confirmer"
  *     + cartes de projection trésorerie (30/90 jours)
@@ -80,18 +80,18 @@ function todayIso(): string {
 test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
   test.beforeEach(async ({ page }) => {
     // Hydrater le localStorage (JWT) avant tout appel API
-    await page.goto('/app/budget');
-    await expect(page).toHaveURL(/\/app\/budget/);
+    await page.goto('/app/money?tab=budgets');
+    await expect(page).toHaveURL(/\/app\/money/);
 
     // Repartir d'une ardoise vierge
     await deleteAllRecurring(page);
   });
 
-  // ── 1. Navigation depuis /app/budget → /app/budget/recurring ─────────────
+  // ── 1. Navigation depuis l'onglet Budgets → /app/budget/recurring ────────
 
   test('la link card "Dépenses récurrentes" mène à /app/budget/recurring avec état vide', async ({ page }) => {
     // La link card n'apparaît qu'une fois l'overview chargé — attendre le titre
-    await expect(page.getByRole('heading', { level: 1, name: 'Budgets' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // Cliquer sur la card "Dépenses récurrentes"
     await page.getByText('Dépenses récurrentes').click();

--- a/e2e/report.spec.ts
+++ b/e2e/report.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Parcours 21 — Lot 3 : Bilan mensuel.
  *
  * Couvre :
- *  1. Navigation depuis /app/budget → /app/budget/reports via la link card "Bilan mensuel"
+ *  1. Navigation depuis l'onglet Budgets → /app/budget/reports via la link card "Bilan mensuel"
  *  2. Structure de la page (BackLink vers Budgets, titre, description)
  *  3. État tolérant : soit un état vide ("Aucun bilan"), soit une card de rapport
  *     avec un libellé de mois capitalisé — le contenu dépend des données seedées
@@ -77,15 +77,15 @@ async function apiCreatePreviousMonthExpense(
 test.describe('Bilan mensuel — parcours 21 lot 3', () => {
   test.beforeEach(async ({ page }) => {
     // Hydrater le localStorage (JWT) avant tout appel API
-    await page.goto('/app/budget');
-    await expect(page).toHaveURL(/\/app\/budget/);
+    await page.goto('/app/money?tab=budgets');
+    await expect(page).toHaveURL(/\/app\/money/);
   });
 
   // ── 1. Navigation depuis /app/budget via la link card ──────────────────────
 
-  test('la link card "Bilan mensuel" depuis /app/budget mène à /app/budget/reports', async ({ page }) => {
+  test('la link card "Bilan mensuel" depuis l\'onglet Budgets mène à /app/budget/reports', async ({ page }) => {
     // Attendre que l'overview soit chargé (la link card n'apparaît qu'ensuite)
-    await expect(page.getByRole('heading', { level: 1, name: 'Budgets' })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // La link card est identifiée par son titre "Bilan mensuel"
     await page.getByText('Bilan mensuel').click();
@@ -122,16 +122,16 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
     ).toBeVisible({ timeout: 15000 });
   });
 
-  // ── 4. BackLink ramène à /app/budget ──────────────────────────────────────
+  // ── 4. BackLink ramène au module Argent ───────────────────────────────────
 
-  test('le BackLink "Budgets" navigue bien vers /app/budget', async ({ page }) => {
+  test('le BackLink "Budgets" navigue bien vers l\'onglet Budgets', async ({ page }) => {
     await page.goto('/app/budget/reports');
 
     await expect(page.getByRole('link', { name: 'Budgets' })).toBeVisible();
     await page.getByRole('link', { name: 'Budgets' }).click();
 
-    await expect(page).toHaveURL(/\/app\/budget/);
-    await expect(page.getByRole('heading', { level: 1, name: 'Budgets' })).toBeVisible();
+    await expect(page).toHaveURL(/\/app\/money/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
   });
 
   // ── 5. Rapport "Mois dernier" : seed + vérification ──────────────────────
@@ -169,7 +169,7 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
 
   // ── 6. Accès direct par URL (deep-link) ───────────────────────────────────
 
-  test('accès direct à /app/budget/reports (sans passer par /app/budget) → page chargée correctement', async ({ page }) => {
+  test('accès direct à /app/budget/reports (sans passer par le module Argent) → page chargée correctement', async ({ page }) => {
     // Accès direct sans state.back → BackLink affichera le fallback "Budgets"
     await page.goto('/app/budget/reports');
 

--- a/ui/src/components/LegacyMoneyRedirect.tsx
+++ b/ui/src/components/LegacyMoneyRedirect.tsx
@@ -1,0 +1,30 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+interface LegacyMoneyRedirectProps {
+  /** Onglet du module Argent qui remplace l'ancienne page. */
+  tab: 'accounts' | 'expenses' | 'budgets';
+}
+
+/**
+ * Redirige `/app/banking`, `/app/expenses` et `/app/budget` vers l'onglet
+ * correspondant du module Argent (parcours 26, lot 2).
+ *
+ * Deux points qui justifient un composant plutôt qu'un `<Navigate to>` en dur :
+ *
+ * - **la query string est préservée**. L'agent produit `/app/budget?b={id}`
+ *   (`apps/budget/apps.py::SearchableSpec.url_template`), et un favori peut porter
+ *   n'importe quel paramètre. Les perdre transformerait un lien précis en lien
+ *   approximatif ;
+ * - **`?tab=` est ajouté**, pour atterrir sur le bon onglet plutôt que sur celui
+ *   que l'utilisateur regardait la dernière fois.
+ *
+ * Un `tab` déjà présent dans l'URL gagne : c'est l'intention explicite de
+ * l'appelant.
+ */
+export default function LegacyMoneyRedirect({ tab }: LegacyMoneyRedirectProps) {
+  const location = useLocation();
+  const params = new URLSearchParams(location.search);
+  if (!params.get('tab')) params.set('tab', tab);
+
+  return <Navigate to={`/app/money?${params.toString()}`} replace />;
+}

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -7,14 +7,20 @@ import { Input } from '@/design-system/input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
-import type { AllocationLine, BankTransaction } from '@/lib/api/banking';
+import type { AllocationLine } from '@/lib/api/banking';
 import { useBudgets } from '@/features/budget/hooks';
 import { useAllocations, useSetAllocations } from './hooks';
 
 interface AllocationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  transaction: BankTransaction;
+  /**
+   * Id seul, pas l'objet : le dialog charge déjà la ventilation courante, qui
+   * embarque la ligne. Passer l'objet en plus obligerait chaque appelant à le
+   * détenir — or la file de rangement (parcours 26) ne connaît que des écarts,
+   * identifiés par un id.
+   */
+  transactionId: string;
 }
 
 interface DraftLine {
@@ -41,17 +47,19 @@ function blankLine(subject = '', amount = '', budgetId = ''): DraftLine {
 export default function AllocationDialog({
   open,
   onOpenChange,
-  transaction,
+  transactionId,
 }: AllocationDialogProps) {
   const { t } = useTranslation();
-  const allocationsQuery = useAllocations(open ? transaction.id : undefined);
+  const allocationsQuery = useAllocations(open ? transactionId : undefined);
   const budgetsQuery = useBudgets();
   const mutation = useSetAllocations();
 
   const [lines, setLines] = React.useState<DraftLine[]>([]);
   const [error, setError] = React.useState<string | null>(null);
 
-  const total = Math.abs(Number(transaction.amount));
+  const transaction = allocationsQuery.data?.transaction;
+  const label = transaction?.label_raw ?? '';
+  const total = Math.abs(Number(transaction?.amount ?? 0));
 
   React.useEffect(() => {
     if (!open || !allocationsQuery.data) return;
@@ -62,9 +70,9 @@ export default function AllocationDialog({
         ? existing.map((a) => blankLine(a.subject, a.amount ?? '', a.budget?.id ?? ''))
         : // Première ventilation : on pré-remplit une ligne au montant total,
           // le cas le plus fréquent (une opération = un poste).
-          [blankLine(transaction.label_raw, total.toFixed(2), '')],
+          [blankLine(label, total.toFixed(2), '')],
     );
-  }, [open, allocationsQuery.data, transaction.label_raw, total]);
+  }, [open, allocationsQuery.data, label, total]);
 
   const allocated = lines.reduce((sum, line) => {
     const value = Number(line.amount.replace(',', '.'));
@@ -92,7 +100,7 @@ export default function AllocationDialog({
         return;
       }
       payload.push({
-        subject: line.subject.trim() || transaction.label_raw,
+        subject: line.subject.trim() || label,
         amount: value.toFixed(2),
         budget_id: line.budgetId || null,
       });
@@ -104,7 +112,7 @@ export default function AllocationDialog({
     }
 
     try {
-      await mutation.mutateAsync({ transactionId: transaction.id, lines: payload });
+      await mutation.mutateAsync({ transactionId, lines: payload });
       onOpenChange(false);
     } catch {
       setError(t('common.saveFailed'));
@@ -122,11 +130,13 @@ export default function AllocationDialog({
     <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.allocation.title')}>
       <form onSubmit={handleSubmit} className="mt-4 space-y-4">
         <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
-          <p className="font-medium text-foreground">{transaction.label_raw}</p>
-          <p className="text-xs text-muted-foreground">
-            {new Date(transaction.booked_on).toLocaleDateString()} ·{' '}
-            {formatAmount(transaction.amount)}
-          </p>
+          <p className="font-medium text-foreground">{label}</p>
+          {transaction ? (
+            <p className="text-xs text-muted-foreground">
+              {new Date(transaction.booked_on).toLocaleDateString()} ·{' '}
+              {formatAmount(transaction.amount)}
+            </p>
+          ) : null}
         </div>
 
         <div className="space-y-3">
@@ -154,7 +164,7 @@ export default function AllocationDialog({
                     id={`s-${line.key}`}
                     value={line.subject}
                     onChange={(e) => update(line.key, { subject: e.target.value })}
-                    placeholder={transaction.label_raw}
+                    placeholder={label}
                   />
                 </FormField>
 
@@ -222,7 +232,7 @@ export default function AllocationDialog({
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
             {t('common.cancel')}
           </Button>
-          <Button type="submit" disabled={mutation.isPending}>
+          <Button type="submit" disabled={mutation.isPending || !transaction}>
             {t('common.save')}
           </Button>
         </div>

--- a/ui/src/features/banking/TransactionsPage.tsx
+++ b/ui/src/features/banking/TransactionsPage.tsx
@@ -75,7 +75,7 @@ export default function TransactionsPage() {
       <PageHeader
         title={t('banking.journal.title')}
         description={t('banking.journal.subtitle')}
-        backLink={<BackLink fallback="/app/banking" fallbackLabel={t('banking.title')} />}
+        backLink={<BackLink fallback="/app/money" fallbackLabel={t('money.title')} />}
       >
         <Button
           variant="outline"
@@ -131,7 +131,7 @@ export default function TransactionsPage() {
         <AllocationDialog
           open
           onOpenChange={(next) => !next && setAllocationTarget(null)}
-          transaction={allocationTarget}
+          transactionId={allocationTarget.id}
         />
       ) : null}
 

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -26,6 +26,7 @@ import {
   type TransactionFilters,
 } from '@/lib/api/banking';
 import { toast } from '@/lib/toast';
+import { complianceKeys } from '@/features/money/keys';
 
 export const bankingKeys = {
   all: ['banking'] as const,
@@ -235,6 +236,11 @@ export function useSetAllocations() {
       void qc.invalidateQueries({ queryKey: ['interactions'] });
       void qc.invalidateQueries({ queryKey: ['expenses'] });
       void qc.invalidateQueries({ queryKey: ['budget'] });
+      // Ventiler résout (ou déplace) un écart : sans cette invalidation, le badge
+      // « Contrôle » et la file « À ranger » afficheraient encore la ligne qu'on
+      // vient de ranger — un compteur qui contredit l'écran est pire que pas de
+      // compteur.
+      void qc.invalidateQueries({ queryKey: complianceKeys.all });
       toast({ description: t('banking.allocation.saved'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),

--- a/ui/src/features/budget/RecurringPage.tsx
+++ b/ui/src/features/budget/RecurringPage.tsx
@@ -104,7 +104,7 @@ export default function RecurringPage() {
 
   return (
     <>
-      <BackLink fallback="/app/budget" fallbackLabel={t('budget.title')} />
+      <BackLink fallback="/app/money?tab=budgets" fallbackLabel={t('budget.title')} />
       <PageHeader title={t('recurring.title')} description={t('recurring.description')}>
         <Button type="button" onClick={openCreate} className="gap-1.5">
           <Plus className="h-4 w-4" />

--- a/ui/src/features/budget/ReportsPage.tsx
+++ b/ui/src/features/budget/ReportsPage.tsx
@@ -37,7 +37,7 @@ export default function ReportsPage() {
 
   return (
     <>
-      <BackLink fallback="/app/budget" fallbackLabel={t('budget.title')} />
+      <BackLink fallback="/app/money?tab=budgets" fallbackLabel={t('budget.title')} />
       <PageHeader title={t('report.title')} description={t('report.description')} />
 
       {showSkeleton ? (

--- a/ui/src/features/dashboard/ExpensesCard.tsx
+++ b/ui/src/features/dashboard/ExpensesCard.tsx
@@ -43,7 +43,7 @@ export default function ExpensesCard() {
   const max = Math.max(...series.map((row) => row.total), 1);
 
   return (
-    <Link to="/app/expenses" state={pushBack(location)} className="group block h-full">
+    <Link to="/app/money?tab=expenses" state={pushBack(location)} className="group block h-full">
       <Card className="flex h-full flex-col p-4 transition-colors hover:border-border hover:bg-muted/20">
         <CardTitle className="text-sm text-muted-foreground">
           💶 {t('dashboard.metrics.expenses.title')}

--- a/ui/src/features/money/AccountsPanel.tsx
+++ b/ui/src/features/money/AccountsPanel.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Landmark, Plus, Receipt } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import PageHeader from '@/components/PageHeader';
 import EmptyState from '@/components/EmptyState';
 import { Button, buttonVariants } from '@/design-system/button';
 import { FilterPill } from '@/design-system/filter-pill';
@@ -16,13 +15,21 @@ import {
   useBankAccounts,
   useRestoreBankAccount,
   useStatementImports,
-} from './hooks';
-import AccountCard from './AccountCard';
-import AccountDialog from './AccountDialog';
-import ImportHistoryCard from './ImportHistoryCard';
-import StatementImportDialog from './StatementImportDialog';
+} from '@/features/banking/hooks';
+import AccountCard from '@/features/banking/AccountCard';
+import AccountDialog from '@/features/banking/AccountDialog';
+import ImportHistoryCard from '@/features/banking/ImportHistoryCard';
+import StatementImportDialog from '@/features/banking/StatementImportDialog';
 
-export default function BankingPage() {
+/**
+ * Onglet « Comptes » du module Argent (parcours 26, lot 2).
+ *
+ * Anciennement `banking/BankingPage`. Le contenu est inchangé : seul le
+ * `PageHeader` disparaît, la coque `MoneyPage` portant désormais le titre. Les
+ * actions restent dans le panneau — elles connaissent l'état d'édition local
+ * (compte courant, import en cours), qu'il aurait fallu remonter sans raison.
+ */
+export default function AccountsPanel() {
   const { t } = useTranslation();
   const location = useLocation();
   const [showArchived, setShowArchived] = useSessionState('banking.showArchived', false);
@@ -70,28 +77,29 @@ export default function BankingPage() {
 
   return (
     <>
-      <PageHeader title={t('banking.title')} description={t('banking.subtitle')}>
-        <Link
-          to="/app/banking/transactions"
-          state={pushBack(location)}
-          className={buttonVariants({ variant: 'outline' })}
-        >
-          <Receipt className="mr-1.5 h-4 w-4" aria-hidden />
-          {t('banking.journal.title')}
-        </Link>
-        <Button onClick={openCreate}>
-          <Plus className="mr-1.5 h-4 w-4" aria-hidden />
-          {t('banking.new.action')}
-        </Button>
-      </PageHeader>
-
-      <div className="flex flex-wrap gap-1.5 pb-4">
-        <FilterPill active={!showArchived} onClick={() => setShowArchived(false)}>
-          {t('banking.filters.active')}
-        </FilterPill>
-        <FilterPill active={showArchived} onClick={() => setShowArchived(true)}>
-          {t('banking.filters.all')}
-        </FilterPill>
+      <div className="flex flex-wrap items-center justify-between gap-2 pb-4">
+        <div className="flex flex-wrap gap-1.5">
+          <FilterPill active={!showArchived} onClick={() => setShowArchived(false)}>
+            {t('banking.filters.active')}
+          </FilterPill>
+          <FilterPill active={showArchived} onClick={() => setShowArchived(true)}>
+            {t('banking.filters.all')}
+          </FilterPill>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            to="/app/money/transactions"
+            state={pushBack(location)}
+            className={buttonVariants({ variant: 'outline' })}
+          >
+            <Receipt className="mr-1.5 h-4 w-4" aria-hidden />
+            {t('banking.journal.title')}
+          </Link>
+          <Button onClick={openCreate}>
+            <Plus className="mr-1.5 h-4 w-4" aria-hidden />
+            {t('banking.new.action')}
+          </Button>
+        </div>
       </div>
 
       {showSkeleton ? (

--- a/ui/src/features/money/BudgetsPanel.tsx
+++ b/ui/src/features/money/BudgetsPanel.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { Plus, PiggyBank, AlertTriangle, CalendarClock, ChevronRight, FileText } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import PageHeader from '@/components/PageHeader';
 import EmptyState from '@/components/EmptyState';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
@@ -11,9 +10,9 @@ import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { pushBack } from '@/lib/backNavigation';
 import { formatAmount } from '@/lib/format';
 import type { Budget, BudgetOverviewRow } from '@/lib/api/budget';
-import { useBudgetOverview, useDeleteBudget } from './hooks';
-import BudgetCard from './BudgetCard';
-import BudgetDialog from './BudgetDialog';
+import { useBudgetOverview, useDeleteBudget } from '@/features/budget/hooks';
+import BudgetCard from '@/features/budget/BudgetCard';
+import BudgetDialog from '@/features/budget/BudgetDialog';
 
 /** Rebuild an editable Budget from an overview row (avoids a second fetch). */
 function rowToBudget(row: BudgetOverviewRow, isGlobal: boolean): Budget {
@@ -27,7 +26,11 @@ function rowToBudget(row: BudgetOverviewRow, isGlobal: boolean): Budget {
   };
 }
 
-export default function BudgetPage() {
+/**
+ * Onglet « Budgets » du module Argent (parcours 26, lot 2).
+ * Anciennement `budget/BudgetPage`, `PageHeader` en moins.
+ */
+export default function BudgetsPanel() {
   const { t } = useTranslation();
   const location = useLocation();
   const overviewQuery = useBudgetOverview();
@@ -74,12 +77,12 @@ export default function BudgetPage() {
 
   return (
     <>
-      <PageHeader title={t('budget.title')} description={t('budget.description')}>
+      <div className="flex justify-end pb-4">
         <Button type="button" onClick={openCreate} className="gap-1.5">
           <Plus className="h-4 w-4" />
           {t('budget.new.action')}
         </Button>
-      </PageHeader>
+      </div>
 
       {showSkeleton ? (
         <div className="space-y-2">

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -1,0 +1,365 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle, Check, ChevronDown, ChevronRight, Info, ShieldAlert, Undo2 } from 'lucide-react';
+import { Card } from '@/design-system/card';
+import { Button } from '@/design-system/button';
+import { Badge } from '@/design-system/badge';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import EmptyState from '@/components/EmptyState';
+import type { ComplianceFinding, ComplianceGroup, ComplianceSeverity } from '@/lib/api/banking';
+import { useComplianceGroup, useComplianceSummary, useRevokeWaiver } from './hooks';
+import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
+
+const SEVERITY_ORDER: Record<ComplianceSeverity, number> = { blocker: 0, error: 1, warning: 2 };
+
+const SEVERITY_ICON: Record<ComplianceSeverity, typeof AlertTriangle> = {
+  blocker: ShieldAlert,
+  error: AlertTriangle,
+  warning: Info,
+};
+
+/**
+ * L'onglet « Contrôle » — la conformité rendue visible.
+ *
+ * Deux principes de présentation portent tout le parcours 26 :
+ *
+ * 1. **Les prérequis bloquants passent en tête.** Un compte sans solde
+ *    d'ouverture n'a pas de fenêtre de conformité : ses dépendants ne sont pas
+ *    « conformes », ils ne sont **pas évaluables**. Les afficher au même niveau
+ *    que le reste laisserait croire que tout va bien.
+ * 2. **Un groupe à zéro reste visible, coché.** C'est ce qui distingue « contrôlé
+ *    et conforme » de « pas encore contrôlé » — sans quoi une liste vide serait
+ *    indistinguable d'un détecteur en panne.
+ */
+export default function CompliancePanel() {
+  const { t } = useTranslation();
+  const summaryQuery = useComplianceSummary();
+  const showSkeleton = useDelayedLoading(summaryQuery.isLoading);
+  const [openKind, setOpenKind] = React.useState<string | null>(null);
+  const [waiving, setWaiving] = React.useState<WaiverTarget | null>(null);
+
+  const groups = React.useMemo(() => {
+    const rows = summaryQuery.data?.groups ?? [];
+    return [...rows].sort(
+      (a, b) =>
+        SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] || b.open - a.open,
+    );
+  }, [summaryQuery.data]);
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    );
+  }
+
+  if (!summaryQuery.data) return null;
+
+  const { open_total, waived_total, stale_total } = summaryQuery.data;
+
+  return (
+    <div className="space-y-4">
+      <ComplianceHeadline
+        openTotal={open_total}
+        waivedTotal={waived_total}
+        staleTotal={stale_total}
+      />
+
+      {groups.length === 0 ? (
+        <EmptyState
+          icon={Check}
+          title={t('money.compliance.noDetectors')}
+          description={t('money.compliance.noDetectorsHint')}
+        />
+      ) : (
+        <div className="space-y-2">
+          {groups.map((group) => (
+            <GroupRow
+              key={group.kind}
+              group={group}
+              expanded={openKind === group.kind}
+              onToggle={() => setOpenKind((prev) => (prev === group.kind ? null : group.kind))}
+              onWaive={setWaiving}
+            />
+          ))}
+        </div>
+      )}
+
+      <WaiverDialog target={waiving} onClose={() => setWaiving(null)} />
+    </div>
+  );
+}
+
+function ComplianceHeadline({
+  openTotal,
+  waivedTotal,
+  staleTotal,
+}: {
+  openTotal: number;
+  waivedTotal: number;
+  staleTotal: number;
+}) {
+  const { t } = useTranslation();
+  const isClean = openTotal === 0;
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start gap-3">
+        {isClean ? (
+          <Check className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden />
+        ) : (
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-destructive" aria-hidden />
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-foreground">
+            {isClean
+              ? t('money.compliance.clean')
+              : t('money.compliance.openCount', { count: openTotal })}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            {isClean
+              ? t('money.compliance.cleanHint')
+              : t('money.compliance.openHint')}
+          </p>
+          {waivedTotal > 0 || staleTotal > 0 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('money.compliance.arbitratedCount', { count: waivedTotal })}
+              {staleTotal > 0
+                ? ` · ${t('money.compliance.staleCount', { count: staleTotal })}`
+                : ''}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function GroupRow({
+  group,
+  expanded,
+  onToggle,
+  onWaive,
+}: {
+  group: ComplianceGroup;
+  expanded: boolean;
+  onToggle: () => void;
+  onWaive: (target: WaiverTarget) => void;
+}) {
+  const { t } = useTranslation();
+  const Icon = SEVERITY_ICON[group.severity];
+  const isClean = group.open === 0;
+
+  return (
+    <Card className="p-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-accent/60"
+        aria-expanded={expanded}
+      >
+        {isClean ? (
+          <Check className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+        ) : (
+          <Icon
+            className={
+              group.severity === 'warning'
+                ? 'h-4 w-4 shrink-0 text-muted-foreground'
+                : 'h-4 w-4 shrink-0 text-destructive'
+            }
+            aria-hidden
+          />
+        )}
+
+        <div className="min-w-0 flex-1">
+          <p className="truncate font-medium text-foreground">
+            {t(`money.compliance.kinds.${group.kind}.title`)}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {isClean
+              ? t('money.compliance.groupClean')
+              : t(`money.compliance.kinds.${group.kind}.hint`)}
+          </p>
+        </div>
+
+        {group.severity === 'blocker' && group.open > 0 ? (
+          <Badge variant="destructive">{t('money.compliance.prerequisite')}</Badge>
+        ) : null}
+        {group.stale > 0 ? (
+          <Badge variant="outline">{t('money.compliance.staleBadge', { count: group.stale })}</Badge>
+        ) : null}
+        {group.waived > 0 ? (
+          <span className="shrink-0 text-xs text-muted-foreground">
+            {t('money.compliance.waivedShort', { count: group.waived })}
+          </span>
+        ) : null}
+        <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+          {group.open}
+        </span>
+        {expanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        )}
+      </button>
+
+      {expanded ? <GroupDetail group={group} onWaive={onWaive} /> : null}
+    </Card>
+  );
+}
+
+function GroupDetail({
+  group,
+  onWaive,
+}: {
+  group: ComplianceGroup;
+  onWaive: (target: WaiverTarget) => void;
+}) {
+  const { t } = useTranslation();
+  const [showWaived, setShowWaived] = React.useState(false);
+  const openQuery = useComplianceGroup(group.kind, { limit: 25 });
+  const waivedQuery = useComplianceGroup(showWaived ? group.kind : undefined, {
+    waived: true,
+    limit: 25,
+  });
+  const revoke = useRevokeWaiver();
+
+  const openRows = openQuery.data?.results ?? [];
+
+  return (
+    <div className="space-y-3 border-t border-border p-3">
+      {/* Pourquoi ce contrôle ne porte peut-être pas sur tout — jamais laissé
+          implicite : un chiffre bas doit pouvoir être expliqué. */}
+      {group.blocked_by ? (
+        <p className="text-xs text-muted-foreground">
+          {t('money.compliance.blockedBy', {
+            prerequisite: t(`money.compliance.kinds.${group.blocked_by}.title`),
+          })}
+        </p>
+      ) : null}
+
+      <p className="text-sm text-muted-foreground">
+        {t(`money.compliance.kinds.${group.kind}.resolution`)}
+      </p>
+
+      {openQuery.isLoading ? (
+        <div className="h-10 animate-pulse rounded-lg bg-muted" />
+      ) : openRows.length === 0 ? (
+        <p className="text-sm text-muted-foreground">{t('money.compliance.groupClean')}</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {openRows.map((finding) => (
+            <FindingRow
+              key={finding.object_id}
+              finding={finding}
+              waivable={group.waivable}
+              onWaive={() =>
+                onWaive({
+                  kind: group.kind,
+                  objectIds: [finding.object_id],
+                  label: finding.label,
+                  previousReason: finding.is_stale ? finding.waiver_reason : undefined,
+                })
+              }
+            />
+          ))}
+        </ul>
+      )}
+
+      {group.open > openRows.length && openRows.length > 0 ? (
+        <p className="text-xs text-muted-foreground">
+          {t('money.compliance.andMore', { count: group.open - openRows.length })}
+        </p>
+      ) : null}
+
+      {/* La liste d'audit. Repliée parce qu'elle n'appelle pas à l'action — mais
+          présente, parce qu'un arbitrage qu'on ne peut pas relire ne vaut rien. */}
+      {group.waived > 0 ? (
+        <div className="border-t border-border pt-3">
+          <button
+            type="button"
+            onClick={() => setShowWaived((prev) => !prev)}
+            className="text-xs font-medium text-muted-foreground hover:text-foreground"
+          >
+            {showWaived
+              ? t('money.compliance.hideArbitrated')
+              : t('money.compliance.showArbitrated', { count: group.waived })}
+          </button>
+
+          {showWaived ? (
+            <ul className="mt-2 space-y-1.5">
+              {(waivedQuery.data?.results ?? []).map((finding) => (
+                <li
+                  key={finding.object_id}
+                  className="flex items-start gap-2 rounded-lg bg-muted/40 p-2 text-sm"
+                >
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-foreground">{finding.label}</p>
+                    <p className="text-xs italic text-muted-foreground">
+                      « {finding.waiver_reason} »
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => finding.waiver_id && revoke.mutate(finding.waiver_id)}
+                    disabled={revoke.isPending}
+                  >
+                    <Undo2 className="mr-1 h-3.5 w-3.5" aria-hidden />
+                    {t('money.compliance.revoke')}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function FindingRow({
+  finding,
+  waivable,
+  onWaive,
+}: {
+  finding: ComplianceFinding;
+  waivable: boolean;
+  onWaive: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <li className="flex items-start gap-2 rounded-lg bg-muted/40 p-2 text-sm">
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-foreground">{finding.label}</p>
+        {finding.is_stale ? (
+          <p className="text-xs text-amber-600">
+            {t('money.compliance.stale', { reason: finding.waiver_reason })}
+          </p>
+        ) : null}
+        {typeof finding.detail.remaining === 'string' ? (
+          <p className="text-xs text-muted-foreground">
+            {t('money.compliance.remaining', { amount: finding.detail.remaining })}
+          </p>
+        ) : null}
+      </div>
+
+      {waivable ? (
+        <Button type="button" variant="ghost" size="sm" onClick={onWaive}>
+          {finding.is_stale
+            ? t('money.compliance.rearbitrate')
+            : t('money.compliance.arbitrate')}
+        </Button>
+      ) : (
+        <span className="shrink-0 text-xs italic text-muted-foreground">
+          {t('money.compliance.notWaivable')}
+        </span>
+      )}
+    </li>
+  );
+}

--- a/ui/src/features/money/ExpensesPanel.tsx
+++ b/ui/src/features/money/ExpensesPanel.tsx
@@ -2,21 +2,24 @@ import * as React from 'react';
 import { Plus, Receipt } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import PageHeader from '@/components/PageHeader';
 import EmptyState from '@/components/EmptyState';
 import { Button } from '@/design-system/button';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useSessionState } from '@/lib/useSessionState';
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
 import { interactionKeys } from '@/features/interactions/hooks';
-import { useExpenseSummary } from './hooks';
-import ExpenseSummaryCards from './ExpenseSummaryCards';
-import ExpenseFilters from './ExpenseFilters';
-import { resolvePeriod, type PeriodRange } from './period';
-import ExpenseList from './ExpenseList';
-import ExpenseAdHocDialog from './ExpenseAdHocDialog';
+import { useExpenseSummary } from '@/features/expenses/hooks';
+import ExpenseSummaryCards from '@/features/expenses/ExpenseSummaryCards';
+import ExpenseFilters from '@/features/expenses/ExpenseFilters';
+import { resolvePeriod, type PeriodRange } from '@/features/expenses/period';
+import ExpenseList from '@/features/expenses/ExpenseList';
+import ExpenseAdHocDialog from '@/features/expenses/ExpenseAdHocDialog';
 
-export default function ExpensesPage() {
+/**
+ * Onglet « Dépenses » du module Argent (parcours 26, lot 2).
+ * Anciennement `expenses/ExpensesPage`, `PageHeader` en moins.
+ */
+export default function ExpensesPanel() {
   const { t } = useTranslation();
 
   const [period, setPeriod] = useSessionState<PeriodRange>('expenses.period', { preset: 'currentMonth' });
@@ -75,16 +78,12 @@ export default function ExpensesPage() {
 
   return (
     <>
-      <PageHeader title={t('expenses.title')} description={t('expenses.description')}>
-        <Button
-          type="button"
-          onClick={() => setAdhocOpen(true)}
-          className="gap-1.5"
-        >
+      <div className="flex justify-end pb-4">
+        <Button type="button" onClick={() => setAdhocOpen(true)} className="gap-1.5">
           <Plus className="h-4 w-4" />
           {t('expenses.adhoc.actions.add')}
         </Button>
-      </PageHeader>
+      </div>
 
       <div className="space-y-5">
         <ExpenseFilters

--- a/ui/src/features/money/MoneyPage.tsx
+++ b/ui/src/features/money/MoneyPage.tsx
@@ -1,0 +1,90 @@
+import * as React from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import PageHeader from '@/components/PageHeader';
+import { TabShell, type TabConfig } from '@/components/TabShell';
+import { useComplianceSummary } from './hooks';
+import { PENDING_KINDS } from './keys';
+import CompliancePanel from './CompliancePanel';
+import PendingQueue from './PendingQueue';
+import AccountsPanel from './AccountsPanel';
+import ExpensesPanel from './ExpensesPanel';
+import BudgetsPanel from './BudgetsPanel';
+
+const MONEY_TAB_SESSION_KEY = 'money.tab';
+
+const TAB_KEYS = ['control', 'pending', 'accounts', 'expenses', 'budgets'] as const;
+type MoneyTab = (typeof TAB_KEYS)[number];
+
+function isMoneyTab(value: string | null): value is MoneyTab {
+  return value !== null && (TAB_KEYS as readonly string[]).includes(value);
+}
+
+/**
+ * Le module « Argent » (parcours 26, lot 2).
+ *
+ * Comptes, dépenses et budgets étaient trois pages. Ils deviennent trois onglets,
+ * parce que ce sont trois lectures d'un même fait : ce qui est sorti du compte. Et
+ * deux onglets nouveaux passent devant — **Contrôle** et **À ranger** — parce que
+ * la question « qu'est-ce qu'il me reste à faire pour que ma vision soit juste ? »
+ * doit se poser avant « combien ai-je dépensé ? ».
+ */
+export default function MoneyPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const summaryQuery = useComplianceSummary();
+
+  // Deep link `?tab=budgets` — les anciennes URLs (/app/budget…) et les liens de
+  // l'agent y atterrissent. Écrit dans la session **avant** que TabShell lise sa
+  // valeur initiale : l'initialiseur d'état du parent s'exécute avant le montage
+  // de l'enfant, ce qui rend le tour de passe-passe fiable plutôt que fragile.
+  const requestedTab = searchParams.get('tab');
+  React.useState(() => {
+    if (isMoneyTab(requestedTab)) {
+      try {
+        sessionStorage.setItem(MONEY_TAB_SESSION_KEY, JSON.stringify(requestedTab));
+      } catch {
+        // sessionStorage indisponible (navigation privée) — l'onglet par défaut
+        // s'affiche, ce qui est dégradé mais pas cassé.
+      }
+    }
+    return null;
+  });
+
+  const summary = summaryQuery.data;
+
+  const pendingCount = React.useMemo(() => {
+    if (!summary) return 0;
+    return summary.groups
+      .filter((group) => (PENDING_KINDS as readonly string[]).includes(group.kind))
+      .reduce((total, group) => total + group.open, 0);
+  }, [summary]);
+
+  const tabs: TabConfig<MoneyTab>[] = [
+    { key: 'control', label: t('money.tabs.control'), badge: summary?.open_total ?? 0 },
+    { key: 'pending', label: t('money.tabs.pending'), badge: pendingCount },
+    { key: 'accounts', label: t('money.tabs.accounts') },
+    { key: 'expenses', label: t('money.tabs.expenses') },
+    { key: 'budgets', label: t('money.tabs.budgets') },
+  ];
+
+  return (
+    <>
+      <PageHeader title={t('money.title')} description={t('money.description')} />
+
+      <TabShell
+        tabs={tabs}
+        sessionKey={MONEY_TAB_SESSION_KEY}
+        defaultTab={isMoneyTab(requestedTab) ? requestedTab : 'control'}
+      >
+        {(tab) => {
+          if (tab === 'control') return <CompliancePanel />;
+          if (tab === 'pending') return <PendingQueue />;
+          if (tab === 'accounts') return <AccountsPanel />;
+          if (tab === 'expenses') return <ExpensesPanel />;
+          return <BudgetsPanel />;
+        }}
+      </TabShell>
+    </>
+  );
+}

--- a/ui/src/features/money/PendingCard.tsx
+++ b/ui/src/features/money/PendingCard.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Split } from 'lucide-react';
+import { Card } from '@/design-system/card';
+import { Button } from '@/design-system/button';
+import { CheckboxField } from '@/design-system/checkbox-field';
+import { formatAmount } from '@/lib/format';
+import { useSetAllocations } from '@/features/banking/hooks';
+import type { PendingRow } from './PendingQueue';
+
+interface PendingCardProps {
+  row: PendingRow;
+  budgets: { id: string; name: string }[];
+  selected: boolean;
+  /** Absent quand la ligne n'est pas sélectionnable (voir `PendingQueue`). */
+  onToggleSelected?: () => void;
+  onSplit: () => void;
+  onPostpone: () => void;
+  onWaive: () => void;
+}
+
+/**
+ * Une opération à ranger, avec les quatre issues possibles — et **aucune
+ * cinquième** qui consisterait à la faire disparaître sans rien enregistrer :
+ *
+ * - **une pastille de budget** : le cas courant, un clic, toute l'opération ;
+ * - **« Ventiler en plusieurs »** : le découpage, qui reste central ;
+ * - **« Arbitrer »** : un motif est exigé, et l'écart devient auditable ;
+ * - **« Plus tard »** : la ligne quitte l'écran pour la session, sans rien écrire —
+ *   elle sera là au prochain passage, parce qu'elle n'est pas résolue.
+ *
+ * Les pastilles n'apparaissent **que** sur une ligne entièrement non ventilée :
+ * l'enregistrement d'une ventilation est un remplacement complet, donc imputer
+ * d'un clic une ligne déjà partagée écraserait le travail déjà fait. Sur une ligne
+ * partielle, le seul chemin est le dialog, qui part de l'existant.
+ */
+export default function PendingCard({
+  row,
+  budgets,
+  selected,
+  onToggleSelected,
+  onSplit,
+  onPostpone,
+  onWaive,
+}: PendingCardProps) {
+  const { t } = useTranslation();
+  const setAllocationsMutation = useSetAllocations();
+  const [pending, setPending] = React.useState(false);
+
+  async function assignWhole(budgetId: string) {
+    setPending(true);
+    try {
+      await setAllocationsMutation.mutateAsync({
+        transactionId: row.transactionId,
+        lines: [{ subject: row.label, amount: row.outflow, budget_id: budgetId || null }],
+      });
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card className={`p-3 ${selected ? 'border-primary/50 bg-primary/5' : ''}`}>
+      <div className="flex items-start gap-2">
+        {onToggleSelected ? (
+          <div className="pt-0.5">
+            <CheckboxField
+              id={`pick-${row.transactionId}`}
+              label=""
+              checked={selected}
+              onChange={onToggleSelected}
+            />
+          </div>
+        ) : null}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate font-medium text-foreground">{row.label}</p>
+              <p className="text-xs text-muted-foreground">
+                {row.bookedOn ? new Date(row.bookedOn).toLocaleDateString() : ''}
+                {row.accountName ? ` · ${row.accountName}` : ''}
+              </p>
+            </div>
+            <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+              {formatAmount(row.outflow)}
+            </span>
+          </div>
+
+          {row.isPartial ? (
+            <p className="mt-1 text-xs text-amber-600">
+              {t('money.pending.partial', {
+                allocated: formatAmount(row.allocated),
+                remaining: formatAmount(row.remaining),
+              })}
+            </p>
+          ) : null}
+
+          {row.isStale ? (
+            <p className="mt-1 text-xs italic text-amber-600">
+              {t('money.compliance.stale', { reason: row.waiverReason })}
+            </p>
+          ) : null}
+
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {!row.isPartial
+              ? budgets.map((budget) => (
+                  <Button
+                    key={budget.id}
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={pending}
+                    onClick={() => assignWhole(budget.id)}
+                  >
+                    {budget.name}
+                  </Button>
+                ))
+              : null}
+
+            <Button type="button" variant="ghost" size="sm" onClick={onSplit} disabled={pending}>
+              <Split className="mr-1 h-3.5 w-3.5" aria-hidden />
+              {row.isPartial ? t('money.pending.complete') : t('money.pending.split')}
+            </Button>
+
+            <Button type="button" variant="ghost" size="sm" onClick={onWaive} disabled={pending}>
+              {row.isStale
+                ? t('money.compliance.rearbitrate')
+                : t('money.compliance.arbitrate')}
+            </Button>
+
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onPostpone}
+              disabled={pending}
+              className="text-muted-foreground"
+            >
+              {t('money.pending.later')}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/features/money/PendingQueue.tsx
+++ b/ui/src/features/money/PendingQueue.tsx
@@ -1,0 +1,283 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, Inbox } from 'lucide-react';
+import { Button } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import EmptyState from '@/components/EmptyState';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useBudgets } from '@/features/budget/hooks';
+import AllocationDialog from '@/features/banking/AllocationDialog';
+import { useSetAllocations } from '@/features/banking/hooks';
+import type { ComplianceFinding } from '@/lib/api/banking';
+import { TRANSACTION_PARTIAL, TRANSACTION_UNALLOCATED } from './keys';
+import { useComplianceGroup } from './hooks';
+import PendingCard from './PendingCard';
+import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
+
+/** Une opération à ranger, quel que soit le détecteur qui l'a signalée. */
+export interface PendingRow {
+  kind: string;
+  transactionId: string;
+  label: string;
+  accountName: string;
+  bookedOn: string;
+  outflow: string;
+  allocated: string;
+  remaining: string;
+  isPartial: boolean;
+  isStale: boolean;
+  waiverReason: string;
+}
+
+function toRow(finding: ComplianceFinding, isPartial: boolean): PendingRow {
+  const detail = finding.detail as Record<string, string | undefined>;
+  return {
+    kind: finding.kind,
+    transactionId: finding.object_id,
+    label: detail.label ?? finding.label,
+    accountName: detail.account_name ?? '',
+    bookedOn: detail.booked_on ?? '',
+    outflow: detail.outflow ?? '0',
+    allocated: detail.allocated ?? '0',
+    remaining: detail.remaining ?? '0',
+    isPartial,
+    isStale: finding.is_stale,
+    waiverReason: finding.waiver_reason,
+  };
+}
+
+/**
+ * L'onglet « À ranger » — la file de travail quotidienne.
+ *
+ * Elle réunit les deux écarts qui demandent la même action : une sortie que
+ * personne n'a affectée, et une sortie affectée à moitié. Les autres écarts
+ * (soldes, chaînes, dépenses non rapprochées) vivent dans l'onglet Contrôle : ils
+ * se résolvent ailleurs, et les mélanger ferait une file qu'on ne peut pas vider.
+ *
+ * La pré-catégorisation est **différée** : la file est rapide par son ergonomie
+ * (une pastille = un clic, sélection multiple pour traiter un lot), pas par la
+ * devinette. À ~160 lignes par mois, les actions groupées ne sont pas un confort.
+ */
+export default function PendingQueue() {
+  const { t } = useTranslation();
+  const unallocatedQuery = useComplianceGroup(TRANSACTION_UNALLOCATED, { limit: 50 });
+  const partialQuery = useComplianceGroup(TRANSACTION_PARTIAL, { limit: 50 });
+  const budgetsQuery = useBudgets();
+
+  const [selected, setSelected] = React.useState<Set<string>>(new Set());
+  const [postponed, setPostponed] = React.useState<Set<string>>(new Set());
+  const [splitting, setSplitting] = React.useState<string | null>(null);
+  const [waiving, setWaiving] = React.useState<WaiverTarget | null>(null);
+
+  const isLoading = unallocatedQuery.isLoading || partialQuery.isLoading;
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  const rows = React.useMemo(() => {
+    const unallocated = (unallocatedQuery.data?.results ?? []).map((f) => toRow(f, false));
+    const partial = (partialQuery.data?.results ?? []).map((f) => toRow(f, true));
+    // Les plus anciennes d'abord : ranger dans l'ordre du relevé est le seul ordre
+    // qui laisse une chance de se souvenir de ce qu'était une ligne.
+    return [...unallocated, ...partial]
+      .filter((row) => !postponed.has(row.transactionId))
+      .sort((a, b) => a.bookedOn.localeCompare(b.bookedOn));
+  }, [unallocatedQuery.data, partialQuery.data, postponed]);
+
+  const budgets = React.useMemo(
+    () => (budgetsQuery.data ?? []).filter((b) => !b.is_global),
+    [budgetsQuery.data],
+  );
+
+  const totalOpen =
+    (unallocatedQuery.data?.open ?? 0) + (partialQuery.data?.open ?? 0);
+
+  function toggleSelected(id: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  function postpone(id: string) {
+    setPostponed((prev) => new Set(prev).add(id));
+    setSelected((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }
+
+  if (showSkeleton) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />
+        ))}
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={totalOpen === 0 ? Check : Inbox}
+        title={totalOpen === 0 ? t('money.pending.allDone') : t('money.pending.nothingLeft')}
+        description={
+          totalOpen === 0
+            ? t('money.pending.allDoneHint')
+            : t('money.pending.nothingLeftHint')
+        }
+      />
+    );
+  }
+
+  // Une sélection ne peut porter que sur des lignes entièrement non ventilées :
+  // imputer en masse une ligne déjà partiellement ventilée écraserait sa
+  // ventilation existante (le PUT est un « set »). Les lignes partielles se
+  // complètent une par une, dans le dialog.
+  const selectableRows = rows.filter((row) => !row.isPartial);
+  const selectedRows = rows.filter((row) => selected.has(row.transactionId));
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-sm text-muted-foreground">
+          {t('money.pending.count', { count: totalOpen })}
+        </p>
+        {selectableRows.length > 0 ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              setSelected((prev) =>
+                prev.size === selectableRows.length
+                  ? new Set()
+                  : new Set(selectableRows.map((r) => r.transactionId)),
+              )
+            }
+          >
+            {selected.size === selectableRows.length
+              ? t('money.pending.clearSelection')
+              : t('money.pending.selectAll')}
+          </Button>
+        ) : null}
+      </div>
+
+      {selectedRows.length > 0 ? (
+        <BulkBar
+          rows={selectedRows}
+          budgets={budgets}
+          onDone={() => setSelected(new Set())}
+          onWaive={() =>
+            setWaiving({
+              kind: TRANSACTION_UNALLOCATED,
+              objectIds: selectedRows.map((r) => r.transactionId),
+              label: t('money.pending.bulkLabel', { count: selectedRows.length }),
+            })
+          }
+        />
+      ) : null}
+
+      <div className="space-y-2">
+        {rows.map((row) => (
+          <PendingCard
+            key={row.transactionId}
+            row={row}
+            budgets={budgets}
+            selected={selected.has(row.transactionId)}
+            onToggleSelected={row.isPartial ? undefined : () => toggleSelected(row.transactionId)}
+            onSplit={() => setSplitting(row.transactionId)}
+            onPostpone={() => postpone(row.transactionId)}
+            onWaive={() =>
+              setWaiving({
+                kind: row.kind,
+                objectIds: [row.transactionId],
+                label: row.label,
+                previousReason: row.isStale ? row.waiverReason : undefined,
+              })
+            }
+          />
+        ))}
+      </div>
+
+      {splitting ? (
+        <AllocationDialog
+          open
+          onOpenChange={(next) => !next && setSplitting(null)}
+          transactionId={splitting}
+        />
+      ) : null}
+
+      <WaiverDialog target={waiving} onClose={() => setWaiving(null)} />
+    </div>
+  );
+}
+
+function BulkBar({
+  rows,
+  budgets,
+  onDone,
+  onWaive,
+}: {
+  rows: PendingRow[];
+  budgets: { id: string; name: string }[];
+  onDone: () => void;
+  onWaive: () => void;
+}) {
+  const { t } = useTranslation();
+  const [pending, setPending] = React.useState(false);
+  const setAllocationsMutation = useSetAllocations();
+
+  async function handleBudget(budgetId: string) {
+    setPending(true);
+    try {
+      // Séquentiel : quinze lignes ne doivent pas partir en quinze requêtes
+      // concurrentes qui verrouillent chacune leur ligne de relevé.
+      for (const row of rows) {
+        await setAllocationsMutation.mutateAsync({
+          transactionId: row.transactionId,
+          lines: [{ subject: row.label, amount: row.outflow, budget_id: budgetId || null }],
+        });
+      }
+      onDone();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card className="space-y-2 border-primary/40 bg-primary/5 p-3">
+      <p className="text-sm font-medium text-foreground">
+        {t('money.pending.bulkSelected', { count: rows.length })}
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {budgets.map((budget) => (
+          <Button
+            key={budget.id}
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            onClick={() => handleBudget(budget.id)}
+          >
+            {budget.name}
+          </Button>
+        ))}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pending}
+          onClick={() => handleBudget('')}
+        >
+          {t('money.pending.noBudget')}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onWaive} disabled={pending}>
+          {t('money.compliance.arbitrate')}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/features/money/WaiverDialog.tsx
+++ b/ui/src/features/money/WaiverDialog.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { FormField } from '@/design-system/form-field';
+import { Textarea } from '@/design-system/textarea';
+import { Button } from '@/design-system/button';
+import { useWaiveFinding } from './hooks';
+
+export interface WaiverTarget {
+  kind: string;
+  objectIds: string[];
+  /** Libellé de l'écart, ou nombre d'écarts pour un arbitrage groupé. */
+  label: string;
+  /** Motif précédent, quand on ré-arbitre un arbitrage périmé. */
+  previousReason?: string;
+}
+
+interface WaiverDialogProps {
+  target: WaiverTarget | null;
+  onClose: () => void;
+}
+
+/**
+ * Arbitrer un écart — et **jamais** l'écarter en silence.
+ *
+ * Le motif est obligatoire, ici comme côté serveur. C'est la différence entre un
+ * arbitrage (une décision qu'on peut relire dans six mois, et révoquer) et un
+ * bouton « masquer », qui ne laisserait rien derrière lui.
+ *
+ * Sur un arbitrage **périmé**, le motif d'origine est pré-rempli : la situation a
+ * changé, mais la raison qu'on avait est le meilleur point de départ pour décider
+ * si elle tient toujours.
+ */
+export default function WaiverDialog({ target, onClose }: WaiverDialogProps) {
+  const { t } = useTranslation();
+  const waive = useWaiveFinding();
+  const [reason, setReason] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!target) return;
+    setReason(target.previousReason ?? '');
+    setError(null);
+  }, [target]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!target) return;
+
+    const trimmed = reason.trim();
+    if (!trimmed) {
+      setError(t('money.compliance.reasonRequired'));
+      return;
+    }
+
+    try {
+      // Séquentiel plutôt que Promise.all : un arbitrage groupé de 15 lignes ne
+      // doit pas ouvrir 15 requêtes concurrentes sur le même détecteur.
+      for (const objectId of target.objectIds) {
+        await waive.mutateAsync({
+          finding_kind: target.kind,
+          object_id: objectId,
+          reason: trimmed,
+        });
+      }
+      onClose();
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <SheetDialog
+      open={Boolean(target)}
+      onOpenChange={(next) => !next && onClose()}
+      title={t('money.compliance.waiveTitle')}
+    >
+      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+        <p className="text-sm text-muted-foreground">{t('money.compliance.waiveHelp')}</p>
+
+        {target ? (
+          <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm text-foreground">
+            {target.label}
+          </div>
+        ) : null}
+
+        <FormField label={`${t('money.compliance.reason')} *`} htmlFor="waiver-reason">
+          <Textarea
+            id="waiver-reason"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            rows={3}
+            placeholder={t('money.compliance.reasonPlaceholder')}
+            autoFocus
+          />
+        </FormField>
+
+        {error ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={waive.isPending}>
+            {t('money.compliance.waiveAction')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/money/hooks.ts
+++ b/ui/src/features/money/hooks.ts
@@ -1,0 +1,85 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useTranslation } from 'react-i18next';
+import {
+  createWaiver,
+  deleteWaiver,
+  fetchComplianceGroup,
+  fetchComplianceSummary,
+} from '@/lib/api/banking';
+import { bankingKeys } from '@/features/banking/hooks';
+import { toast } from '@/lib/toast';
+import { complianceKeys } from './keys';
+
+export { complianceKeys };
+
+/**
+ * Les compteurs de la coque. `staleTime` court plutôt que zéro : le badge est lu
+ * à chaque changement d'onglet, et re-compter à chaque fois ferait payer
+ * plusieurs `COUNT(*)` par détecteur pour un chiffre qui n'a pas bougé.
+ */
+export function useComplianceSummary() {
+  return useQuery({
+    queryKey: complianceKeys.summary(),
+    queryFn: fetchComplianceSummary,
+    staleTime: 30_000,
+  });
+}
+
+export function useComplianceGroup(
+  kind: string | undefined,
+  options: { waived?: boolean; offset?: number; limit?: number } = {},
+) {
+  const waived = options.waived ?? false;
+  const offset = options.offset ?? 0;
+  return useQuery({
+    queryKey: complianceKeys.group(kind ?? '', waived, offset),
+    queryFn: () => fetchComplianceGroup(kind as string, { waived, offset, limit: options.limit }),
+    enabled: Boolean(kind),
+  });
+}
+
+/**
+ * Invalide la conformité **et** le journal bancaire : ventiler une ligne change
+ * un écart *et* la ligne elle-même, et laisser l'un des deux caches en arrière
+ * afficherait un compteur qui contredit la liste juste en dessous.
+ */
+function useInvalidateCompliance() {
+  const qc = useQueryClient();
+  return () => {
+    void qc.invalidateQueries({ queryKey: complianceKeys.all });
+    void qc.invalidateQueries({ queryKey: bankingKeys.all });
+  };
+}
+
+/**
+ * Arbitrer un écart. Jamais un « ignorer » : le motif part au serveur, qui le
+ * refuse s'il est vide. Un second appel sur le même écart met à jour le motif et
+ * le fingerprint — c'est le chemin du « ré-arbitrer » sur un arbitrage périmé.
+ */
+export function useWaiveFinding() {
+  const invalidate = useInvalidateCompliance();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: { finding_kind: string; object_id: string; reason: string }) =>
+      createWaiver(payload),
+    onSuccess: () => {
+      invalidate();
+      toast({ description: t('money.compliance.waived'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/** Révoquer : l'écart resurgit à l'identique. C'est ce qui rend l'arbitrage sûr. */
+export function useRevokeWaiver() {
+  const invalidate = useInvalidateCompliance();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (id: string) => deleteWaiver(id),
+    onSuccess: () => {
+      invalidate();
+      toast({ description: t('money.compliance.revoked'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}

--- a/ui/src/features/money/keys.ts
+++ b/ui/src/features/money/keys.ts
@@ -1,0 +1,30 @@
+/**
+ * Clés partagées du module Argent — query keys et clés de détecteurs.
+ *
+ * Fichier séparé de `hooks.ts` **exprès** : `banking/hooks.ts` doit pouvoir
+ * invalider la conformité après une ventilation, et `money/hooks.ts` importe déjà
+ * `bankingKeys`. Passer par ce module sans dépendance sortante casse le cycle
+ * qu'un import direct créerait, sans dupliquer la chaîne `'compliance'` dans deux
+ * fichiers (où elle finirait par diverger d'un caractère).
+ */
+
+export const complianceKeys = {
+  all: ['compliance'] as const,
+  summary: () => [...complianceKeys.all, 'summary'] as const,
+  group: (kind: string, waived: boolean, offset: number) =>
+    [...complianceKeys.all, 'group', kind, waived, offset] as const,
+};
+
+/**
+ * Clés des détecteurs, telles que déclarées par `banking/detectors.py`.
+ * Miroir côté front — une faute de frappe ici ne produit pas d'erreur serveur,
+ * juste un groupe vide, d'où les constantes plutôt que des littéraux dispersés.
+ */
+export const TRANSACTION_UNALLOCATED = 'transaction_unallocated';
+export const TRANSACTION_PARTIAL = 'transaction_partially_allocated';
+export const EXPENSE_UNRECONCILED = 'expense_unreconciled';
+export const ACCOUNT_NO_OPENING_BALANCE = 'account_no_opening_balance';
+export const ACCOUNT_CHAIN_BROKEN = 'account_chain_broken';
+
+/** Les deux écarts que la file « À ranger » traite — même geste de résolution. */
+export const PENDING_KINDS = [TRANSACTION_UNALLOCATED, TRANSACTION_PARTIAL] as const;

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -1,5 +1,6 @@
 import {
-  AlertCircle, LayoutDashboard, Newspaper, Smartphone, Sparkles, User,
+  AlertCircle, Landmark, LayoutDashboard, Newspaper, PiggyBank, Receipt, Smartphone,
+  Sparkles, User,
   type LucideIcon,
 } from 'lucide-react';
 import { MODULES } from '@/lib/modules';
@@ -17,16 +18,17 @@ import { MODULES } from '@/lib/modules';
  * backend à toucher : la progression est stockée comme liste de clés opaques
  * sur `User.completed_tutorials`.
  *
- * Les guides adossés à un module (`moduleKey`) héritent de son icône et sont
- * masqués quand le module est désactivé pour le foyer.
+ * Les guides adossés à un module (`moduleKey`) sont masqués quand le module est
+ * désactivé pour le foyer, et héritent de son icône **à défaut** d'une icône
+ * explicite (nécessaire depuis que trois guides partagent le module « Argent »).
  */
 
 export interface TutorialGuide {
   /** Clé stable — i18n `tutorials.guide.<key>.*` + progression `guide.<key>`. */
   key: string;
-  /** Module du registre MODULES : icône partagée + masquage si désactivé. */
+  /** Module du registre MODULES : masquage si désactivé, icône par défaut. */
   moduleKey?: string;
-  /** Icône explicite pour les guides hors module (dashboard, agent…). */
+  /** Icône explicite — gagne sur celle du module. */
   Icon?: LucideIcon;
   /** Deep-link vers la page concernée par le guide. */
   to: string;
@@ -72,9 +74,13 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'projects', moduleKey: 'projects', to: '/app/projects', stepIds: ['create', 'plan', 'photos', 'budget'] },
   { key: 'interactions', moduleKey: 'interactions', to: '/app/interactions', stepIds: ['log', 'types', 'link'] },
   { key: 'trackers', moduleKey: 'trackers', to: '/app/trackers', stepIds: ['create', 'entries', 'charts'] },
-  { key: 'expenses', moduleKey: 'expenses', to: '/app/expenses', stepIds: ['record', 'sources', 'review'] },
-  { key: 'budget', moduleKey: 'budget', to: '/app/budget', stepIds: ['create', 'assign', 'track', 'recurring', 'report'] },
-  { key: 'banking', moduleKey: 'banking', to: '/app/banking', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
+  // Module « Argent » (parcours 26) : les trois guides survivent, chacun pointant
+  // sur son onglet. Le guide « expenses » gagne les deux étapes du nouveau parcours
+  // de conformité — ranger et contrôler sont devenus la façon de saisir et de
+  // relire ses dépenses.
+  { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'review'] },
+  { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'recurring', 'report'] },
+  { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },
   { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add'] },
   { key: 'directory', moduleKey: 'directory', to: '/app/directory', stepIds: ['contacts', 'structures'] },
@@ -95,14 +101,19 @@ export function startDoneKey(key: string): string {
 const MODULE_ICONS = new Map(MODULES.map((m) => [m.key, m.Icon]));
 
 function resolveIcon(guide: TutorialGuide): LucideIcon {
+  // L'icône explicite gagne sur celle du module. Depuis que « Argent » réunit
+  // comptes, dépenses et budgets (parcours 26), trois guides partagent un même
+  // `moduleKey` : sans cette priorité ils afficheraient la même icône, et la liste
+  // des guides ne se parcourrait plus du regard.
+  if (guide.Icon) return guide.Icon;
   if (guide.moduleKey) {
     const icon = MODULE_ICONS.get(guide.moduleKey);
     if (icon) return icon;
   }
-  return guide.Icon ?? Sparkles;
+  return Sparkles;
 }
 
-/** Icône par guide — celle du module s'il y en a un, sinon l'explicite.
+/** Icône par guide — l'explicite si elle existe, sinon celle du module.
  *  Précalculé au chargement pour garder des références de composant stables. */
 export const GUIDE_ICONS: Record<string, LucideIcon> = Object.fromEntries(
   TUTORIAL_GUIDES.map((g) => [g.key, resolveIcon(g)]),

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -387,3 +387,100 @@ export async function linkInteraction(
   );
   return data;
 }
+
+// --- Conformité (parcours 26, lot 1) ----------------------------------------
+
+export type ComplianceSeverity = 'blocker' | 'error' | 'warning';
+
+/**
+ * Un écart, sur un objet. `fingerprint` est le hash de ce qui **fonde** l'écart :
+ * c'est lui qui fait périmer un arbitrage quand la situation bouge.
+ */
+export interface ComplianceFinding {
+  kind: string;
+  object_id: string;
+  label: string;
+  fingerprint: string;
+  detail: Record<string, string | number | boolean | null | unknown>;
+  /** Arbitrage périmé : l'écart est revenu sur la pile, motif d'origine affiché. */
+  is_stale: boolean;
+  waiver_id: string | null;
+  waiver_reason: string;
+}
+
+/** Les compteurs d'un détecteur. Invariant : `open + waived === detected`. */
+export interface ComplianceGroup {
+  kind: string;
+  severity: ComplianceSeverity;
+  label: string;
+  target: string;
+  /** Faux quand le catalogue dit « aucun flag légitime » — l'écart se corrige. */
+  waivable: boolean;
+  /** Clé d'un prérequis : explique pourquoi ce contrôle ne porte pas sur tout. */
+  blocked_by: string;
+  detected: number;
+  open: number;
+  waived: number;
+  stale: number;
+}
+
+export interface ComplianceSummary {
+  groups: ComplianceGroup[];
+  open_total: number;
+  waived_total: number;
+  stale_total: number;
+}
+
+export interface ComplianceGroupPage extends ComplianceGroup {
+  results: ComplianceFinding[];
+  limit: number;
+  offset: number;
+}
+
+/** Compteurs seuls — lu à chaque navigation, doit rester bon marché côté serveur. */
+export async function fetchComplianceSummary(): Promise<ComplianceSummary> {
+  const { data } = await api.get<ComplianceSummary>('/banking/compliance/');
+  return data;
+}
+
+export async function fetchComplianceGroup(
+  kind: string,
+  params: { waived?: boolean; limit?: number; offset?: number } = {},
+): Promise<ComplianceGroupPage> {
+  const { data } = await api.get<ComplianceGroupPage>(`/banking/compliance/${kind}/`, {
+    params: {
+      ...(params.waived ? { waived: 'true' } : {}),
+      ...(params.limit !== undefined ? { limit: params.limit } : {}),
+      ...(params.offset ? { offset: params.offset } : {}),
+    },
+  });
+  return data;
+}
+
+export interface ComplianceWaiver {
+  id: string;
+  finding_kind: string;
+  object_id: string;
+  reason: string;
+  fingerprint: string;
+  created_at: string;
+}
+
+/**
+ * Arbitre un écart — jamais un « ignorer ». Le motif est **requis** côté serveur,
+ * et un second appel sur le même écart met à jour le motif *et* le fingerprint
+ * (c'est le chemin du « ré-arbitrer » sur un arbitrage périmé).
+ */
+export async function createWaiver(payload: {
+  finding_kind: string;
+  object_id: string;
+  reason: string;
+}): Promise<ComplianceWaiver> {
+  const { data } = await api.post<ComplianceWaiver>('/banking/waivers/', payload);
+  return data;
+}
+
+/** Révoque un arbitrage : l'écart resurgit à l'identique. */
+export async function deleteWaiver(id: string): Promise<void> {
+  await api.delete(`/banking/waivers/${id}/`);
+}

--- a/ui/src/lib/modules.ts
+++ b/ui/src/lib/modules.ts
@@ -1,6 +1,6 @@
 import {
   Bird, Box, CloudSun, Droplets, FileText, FolderKanban, Image, Landmark, ListTodo, MapPin,
-  Notebook, PiggyBank, Receipt, ShoppingCart, TrendingUp, Umbrella, Users, Wrench, Zap,
+  Notebook, ShoppingCart, TrendingUp, Umbrella, Users, Wrench, Zap,
   type LucideIcon,
 } from 'lucide-react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -47,9 +47,12 @@ export const MODULES: ModuleDef[] = [
   { key: 'interactions', to: '/app/interactions', labelKey: 'interactions.title', Icon: Notebook,     group: 'tracking',  optional: false },
   { key: 'shopping',     to: '/app/shopping-list', labelKey: 'shoppingList.title', Icon: ShoppingCart, group: 'tracking',  optional: true  },
   { key: 'trackers',     to: '/app/trackers',     labelKey: 'trackers.title',     Icon: TrendingUp,   group: 'tracking',  optional: true  },
-  { key: 'expenses',     to: '/app/expenses',     labelKey: 'expenses.title',     Icon: Receipt,      group: 'tracking',  optional: false },
-  { key: 'budget',       to: '/app/budget',       labelKey: 'budget.title',       Icon: PiggyBank,    group: 'tracking',  optional: false },
-  { key: 'banking',      to: '/app/banking',      labelKey: 'banking.title',      Icon: Landmark,     group: 'tracking',  optional: true  },
+  // Une seule entrée « Argent » (parcours 26, lot 2) : comptes, dépenses et
+  // budgets sont trois onglets d'un même module, parce que le relevé est la
+  // source de vérité des deux autres. `optional: false` est imposé — dépenses et
+  // budgets n'ont jamais été désactivables, donc la clé fusionnée ne peut pas
+  // l'être. Conséquence assumée : les comptes ne sont plus un opt-in.
+  { key: 'money',        to: '/app/money',        labelKey: 'money.title',        Icon: Landmark,     group: 'tracking',  optional: false },
   { key: 'documents',    to: '/app/documents',    labelKey: 'documents.title',    Icon: FileText,     group: 'resources', optional: false },
   { key: 'photos',       to: '/app/photos',       labelKey: 'photos.title',       Icon: Image,        group: 'resources', optional: true  },
   { key: 'directory',    to: '/app/directory',    labelKey: 'directory.title',    Icon: Users,        group: 'resources', optional: true  },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1442,6 +1442,14 @@
           "review": {
             "title": "Nach Zeitraum analysieren",
             "body": "Filtern Sie nach Zeitraum oder Zone, um zu sehen, wohin das Geld fließt."
+          },
+          "sort": {
+            "title": "Buchungen zuordnen",
+            "body": "Der Reiter „Zuordnen“ listet jeden Abgang, den noch niemand zugeordnet hat. Für den Normalfall genügt ein Budget-Chip; „Auf mehrere aufteilen“ hilft, wenn ein Einkauf zwei Posten betrifft. Mehrere Zeilen auswählen, um einen Stapel in einem Zug zu erledigen."
+          },
+          "control": {
+            "title": "Prüfen, ob Ihre Zahlen stimmen",
+            "body": "Der Reiter „Kontrolle“ zeigt alles, was genauen Zahlen im Weg steht: nicht zugeordnete Buchungen, Ausgaben, die die Bank nie gesehen hat, Salden, die nicht zusammenpassen. Jede Abweichung wird gelöst — oder mit einer Begründung abgelegt, die sichtbar und widerrufbar bleibt."
           }
         }
       },
@@ -2919,7 +2927,7 @@
       "subjectRequired": "Ein Betreff ist erforderlich",
       "created": "Ausgabe erfasst",
       "actions": {
-        "add": "Ausgabe"
+        "add": "Neue Ausgabe"
       },
       "budget": "Budget",
       "budgetNone": "Kein Budget"
@@ -3342,6 +3350,99 @@
     "history": "Frühere Monate",
     "access": {
       "hint": "Schriftliche Zusammenfassung der Ausgaben des Vormonats."
+    }
+  },
+  "money": {
+    "title": "Geld",
+    "description": "Konten, Ausgaben und Budgets — Kontoauszüge sind die Quelle der Wahrheit.",
+    "tabs": {
+      "control": "Kontrolle",
+      "pending": "Zuordnen",
+      "accounts": "Konten",
+      "expenses": "Ausgaben",
+      "budgets": "Budgets"
+    },
+    "compliance": {
+      "clean": "Alles stimmt",
+      "cleanHint": "Jede Buchung ist zugeordnet oder begründet abgelegt.",
+      "openCount": "{{count}} offene Abweichung",
+      "openCount_plural": "{{count}} offene Abweichungen",
+      "openHint": "Jede wird entweder gelöst oder mit Begründung abgelegt.",
+      "arbitratedCount": "{{count}} begründet abgelegt",
+      "arbitratedCount_plural": "{{count}} begründet abgelegt",
+      "staleCount": "{{count}} veraltete Ablage",
+      "staleCount_plural": "{{count}} veraltete Ablagen",
+      "groupClean": "Nichts zu melden.",
+      "prerequisite": "Voraussetzung",
+      "staleBadge": "{{count}} veraltet",
+      "staleBadge_plural": "{{count}} veraltet",
+      "waivedShort": "{{count}} abgelegt",
+      "waivedShort_plural": "{{count}} abgelegt",
+      "blockedBy": "Diese Prüfung gilt nur für Konten, deren Voraussetzung „{{prerequisite}}“ erfüllt ist.",
+      "andMore": "und {{count}} weitere…",
+      "showArbitrated": "{{count}} Ablagen anzeigen",
+      "hideArbitrated": "Ablagen ausblenden",
+      "revoke": "Widerrufen",
+      "revoked": "Ablage widerrufen — die Abweichung ist zurück.",
+      "arbitrate": "Begründet ablegen",
+      "rearbitrate": "Neu begründen",
+      "notWaivable": "muss behoben werden",
+      "stale": "Die Lage hat sich seit „{{reason}}“ geändert.",
+      "remaining": "Noch zuzuordnen: {{amount}}",
+      "waived": "Abweichung begründet abgelegt.",
+      "waiveTitle": "Diese Abweichung begründet ablegen",
+      "waiveHelp": "Eine Ablage löscht nichts: sie hält fest, warum diese Abweichung vertretbar ist. Sie bleibt sichtbar und widerrufbar.",
+      "waiveAction": "Ablegen",
+      "reason": "Begründung",
+      "reasonPlaceholder": "z. B. Bankgebühren, gehört zu keinem Budget",
+      "reasonRequired": "Eine Begründung ist erforderlich.",
+      "noDetectors": "Keine Prüfungen verfügbar",
+      "noDetectorsHint": "Legen Sie ein Konto an, damit die Kontrolle etwas prüfen kann.",
+      "kinds": {
+        "account_no_opening_balance": {
+          "title": "Konto ohne Anfangssaldo",
+          "hint": "Ohne Startpunkt ist der Saldo eine Annahme.",
+          "resolution": "Tragen Sie Anfangssaldo und Datum des Kontos ein. Erst dann sind die anderen Prüfungen aussagekräftig."
+        },
+        "transaction_unallocated": {
+          "title": "Nicht zugeordnete Abgänge",
+          "hint": "Geld ist abgegangen, ohne dass jemand den Zweck genannt hat.",
+          "resolution": "Ordnen Sie diese Buchungen im Reiter „Zuordnen“ zu oder legen Sie sie begründet ab."
+        },
+        "transaction_partially_allocated": {
+          "title": "Teilweise zugeordnete Abgänge",
+          "hint": "Ein Teil des Betrags hängt an nichts.",
+          "resolution": "Vervollständigen Sie die Aufteilung oder legen Sie den Rest begründet ab."
+        },
+        "expense_unreconciled": {
+          "title": "Nicht abgeglichene Ausgaben",
+          "hint": "In der App erfasst, nie durch einen Auszug bestätigt.",
+          "resolution": "Verknüpfen Sie sie mit der passenden Kontozeile oder legen Sie sie begründet ab (etwa von Dritten bezahlt)."
+        },
+        "account_chain_broken": {
+          "title": "Saldenkette unterbrochen",
+          "hint": "Die Salden des Auszugs passen nicht zusammen: Buchungen fehlen.",
+          "resolution": "Importieren Sie den fehlenden Auszug. Bis dahin bleibt der Saldo als unzuverlässig markiert."
+        }
+      }
+    },
+    "pending": {
+      "count": "{{count}} Buchung zuzuordnen",
+      "count_plural": "{{count}} Buchungen zuzuordnen",
+      "selectAll": "Alle auswählen",
+      "clearSelection": "Auswahl aufheben",
+      "bulkSelected": "{{count}} Buchung ausgewählt",
+      "bulkSelected_plural": "{{count}} Buchungen ausgewählt",
+      "bulkLabel": "{{count}} Buchungen",
+      "noBudget": "Ohne Budget",
+      "split": "Auf mehrere aufteilen",
+      "complete": "Aufteilung vervollständigen",
+      "later": "Später",
+      "partial": "{{allocated}} zugeordnet, {{remaining}} offen",
+      "allDone": "Liste leer",
+      "allDoneHint": "Alle Buchungen sind zugeordnet oder begründet abgelegt.",
+      "nothingLeft": "Nichts für diese Sitzung",
+      "nothingLeftHint": "Zurückgestellte Buchungen erscheinen beim nächsten Besuch wieder."
     }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1442,6 +1442,14 @@
           "review": {
             "title": "Analyse by period",
             "body": "Filter by period or by zone to see where the money goes."
+          },
+          "sort": {
+            "title": "Sort your operations",
+            "body": "The “To sort” tab lists every outflow nobody has accounted for yet. A budget pill covers the common case; “Split into several” is there when one shop trip spans two categories. Select several lines to handle a batch at once."
+          },
+          "control": {
+            "title": "Check that your figures are right",
+            "body": "The “Control” tab lists everything standing between you and accurate figures: unaccounted operations, expenses the bank never saw, balances that do not chain. Each one is resolved — or arbitrated with a motive that stays visible and revocable."
           }
         }
       },
@@ -2919,7 +2927,7 @@
       "subjectRequired": "A subject is required",
       "created": "Expense recorded",
       "actions": {
-        "add": "Expense"
+        "add": "New expense"
       },
       "budget": "Budget",
       "budgetNone": "No budget"
@@ -3342,6 +3350,99 @@
     "history": "Earlier months",
     "access": {
       "hint": "Written recap of last month’s spending."
+    }
+  },
+  "money": {
+    "title": "Money",
+    "description": "Accounts, expenses and budgets — statements are the source of truth.",
+    "tabs": {
+      "control": "Control",
+      "pending": "To sort",
+      "accounts": "Accounts",
+      "expenses": "Expenses",
+      "budgets": "Budgets"
+    },
+    "compliance": {
+      "clean": "Everything checks out",
+      "cleanHint": "Every operation is accounted for or arbitrated. Nothing left hanging.",
+      "openCount": "{{count}} discrepancy to handle",
+      "openCount_plural": "{{count}} discrepancies to handle",
+      "openHint": "Each one is either resolved, or arbitrated with a motive.",
+      "arbitratedCount": "{{count}} arbitrated",
+      "arbitratedCount_plural": "{{count}} arbitrated",
+      "staleCount": "{{count}} expired arbitration",
+      "staleCount_plural": "{{count}} expired arbitrations",
+      "groupClean": "Nothing to report.",
+      "prerequisite": "Prerequisite",
+      "staleBadge": "{{count}} expired",
+      "staleBadge_plural": "{{count}} expired",
+      "waivedShort": "{{count}} arbitrated",
+      "waivedShort_plural": "{{count}} arbitrated",
+      "blockedBy": "This check only covers accounts whose “{{prerequisite}}” prerequisite is cleared.",
+      "andMore": "and {{count}} more…",
+      "showArbitrated": "Show the {{count}} arbitrations",
+      "hideArbitrated": "Hide arbitrations",
+      "revoke": "Revoke",
+      "revoked": "Arbitration revoked — the discrepancy is back.",
+      "arbitrate": "Arbitrate",
+      "rearbitrate": "Re-arbitrate",
+      "notWaivable": "must be fixed",
+      "stale": "Things changed since “{{reason}}”.",
+      "remaining": "Left to account for: {{amount}}",
+      "waived": "Discrepancy arbitrated.",
+      "waiveTitle": "Arbitrate this discrepancy",
+      "waiveHelp": "An arbitration erases nothing: it records why this discrepancy is acceptable. It stays visible and revocable.",
+      "waiveAction": "Arbitrate",
+      "reason": "Motive",
+      "reasonPlaceholder": "E.g. bank fees, belongs to no budget",
+      "reasonRequired": "A motive is required.",
+      "noDetectors": "No checks available",
+      "noDetectorsHint": "Declare an account so the control has something to verify.",
+      "kinds": {
+        "account_no_opening_balance": {
+          "title": "Account without an opening balance",
+          "hint": "With no starting point, the balance is a guess.",
+          "resolution": "Fill in the account's opening balance and its date. The other checks then become meaningful."
+        },
+        "transaction_unallocated": {
+          "title": "Unaccounted outflows",
+          "hint": "Money left without anyone saying what for.",
+          "resolution": "Sort these from the “To sort” tab, or arbitrate them with a motive."
+        },
+        "transaction_partially_allocated": {
+          "title": "Partly accounted outflows",
+          "hint": "Part of the amount is attached to nothing.",
+          "resolution": "Complete the split, or arbitrate the remainder."
+        },
+        "expense_unreconciled": {
+          "title": "Unreconciled expenses",
+          "hint": "Typed into the app, never confirmed by a statement.",
+          "resolution": "Attach them to the matching bank line, or arbitrate them (paid by someone else, for instance)."
+        },
+        "account_chain_broken": {
+          "title": "Broken balance chain",
+          "hint": "The statement balances do not chain: operations are missing.",
+          "resolution": "Import the missing statement. Until then the balance stays flagged as unreliable."
+        }
+      }
+    },
+    "pending": {
+      "count": "{{count}} operation to sort",
+      "count_plural": "{{count}} operations to sort",
+      "selectAll": "Select all",
+      "clearSelection": "Clear selection",
+      "bulkSelected": "{{count}} operation selected",
+      "bulkSelected_plural": "{{count}} operations selected",
+      "bulkLabel": "{{count}} operations",
+      "noBudget": "No budget",
+      "split": "Split into several",
+      "complete": "Complete the split",
+      "later": "Later",
+      "partial": "{{allocated}} accounted for, {{remaining}} left",
+      "allDone": "Queue empty",
+      "allDoneHint": "Every operation is accounted for or arbitrated.",
+      "nothingLeft": "Nothing for this session",
+      "nothingLeftHint": "Postponed operations will be back on your next visit."
     }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1442,6 +1442,14 @@
           "review": {
             "title": "Analizar por periodo",
             "body": "Filtra por periodo o por zona para ver adónde va el dinero."
+          },
+          "sort": {
+            "title": "Ordene sus operaciones",
+            "body": "La pestaña «Por ordenar» enumera cada salida que nadie ha asignado todavía. Una etiqueta de presupuesto basta para el caso habitual; «Desglosar en varios» sirve cuando una misma compra cubre dos partidas. Seleccione varias líneas para tratar un lote de una vez."
+          },
+          "control": {
+            "title": "Compruebe que su visión es correcta",
+            "body": "La pestaña «Control» enumera todo lo que impide que sus cifras sean exactas: operaciones sin asignar, gastos que el banco nunca vio, saldos que no encadenan. Cada discrepancia se resuelve — o se justifica con un motivo que sigue visible y se puede revocar."
           }
         }
       },
@@ -2919,7 +2927,7 @@
       "subjectRequired": "Se requiere un asunto",
       "created": "Gasto registrado",
       "actions": {
-        "add": "Gasto"
+        "add": "Nuevo gasto"
       },
       "budget": "Presupuesto",
       "budgetNone": "Sin presupuesto"
@@ -3342,6 +3350,99 @@
     "history": "Meses anteriores",
     "access": {
       "hint": "Resumen escrito de los gastos del mes pasado."
+    }
+  },
+  "money": {
+    "title": "Dinero",
+    "description": "Cuentas, gastos y presupuestos — los extractos son la fuente de verdad.",
+    "tabs": {
+      "control": "Control",
+      "pending": "Por ordenar",
+      "accounts": "Cuentas",
+      "expenses": "Gastos",
+      "budgets": "Presupuestos"
+    },
+    "compliance": {
+      "clean": "Todo cuadra",
+      "cleanHint": "Cada operación está asignada o justificada. No queda nada suelto.",
+      "openCount": "{{count}} discrepancia por tratar",
+      "openCount_plural": "{{count}} discrepancias por tratar",
+      "openHint": "Cada una se resuelve o se justifica con un motivo.",
+      "arbitratedCount": "{{count}} justificada",
+      "arbitratedCount_plural": "{{count}} justificadas",
+      "staleCount": "{{count}} justificación caducada",
+      "staleCount_plural": "{{count}} justificaciones caducadas",
+      "groupClean": "Nada que señalar.",
+      "prerequisite": "Requisito",
+      "staleBadge": "{{count}} caducada",
+      "staleBadge_plural": "{{count}} caducadas",
+      "waivedShort": "{{count}} justificada",
+      "waivedShort_plural": "{{count}} justificadas",
+      "blockedBy": "Este control solo cubre las cuentas cuyo requisito «{{prerequisite}}» está resuelto.",
+      "andMore": "y {{count}} más…",
+      "showArbitrated": "Ver las {{count}} justificaciones",
+      "hideArbitrated": "Ocultar las justificaciones",
+      "revoke": "Revocar",
+      "revoked": "Justificación revocada — la discrepancia ha vuelto.",
+      "arbitrate": "Justificar",
+      "rearbitrate": "Volver a justificar",
+      "notWaivable": "hay que corregirlo",
+      "stale": "La situación ha cambiado desde «{{reason}}».",
+      "remaining": "Queda por asignar: {{amount}}",
+      "waived": "Discrepancia justificada.",
+      "waiveTitle": "Justificar esta discrepancia",
+      "waiveHelp": "Una justificación no borra nada: registra por qué esta discrepancia es aceptable. Sigue visible y se puede revocar.",
+      "waiveAction": "Justificar",
+      "reason": "Motivo",
+      "reasonPlaceholder": "Ej.: comisiones bancarias, no corresponde a ningún presupuesto",
+      "reasonRequired": "El motivo es obligatorio.",
+      "noDetectors": "No hay controles disponibles",
+      "noDetectorsHint": "Declare una cuenta para que el control tenga algo que verificar.",
+      "kinds": {
+        "account_no_opening_balance": {
+          "title": "Cuenta sin saldo inicial",
+          "hint": "Sin punto de partida, el saldo es una suposición.",
+          "resolution": "Indique el saldo inicial de la cuenta y su fecha. Los demás controles pasan entonces a ser evaluables."
+        },
+        "transaction_unallocated": {
+          "title": "Salidas sin asignar",
+          "hint": "Salió dinero sin que nadie dijera para qué.",
+          "resolution": "Ordénelas desde la pestaña «Por ordenar», o justifíquelas con un motivo."
+        },
+        "transaction_partially_allocated": {
+          "title": "Salidas asignadas en parte",
+          "hint": "Parte del importe no está vinculada a nada.",
+          "resolution": "Complete el desglose, o justifique el resto."
+        },
+        "expense_unreconciled": {
+          "title": "Gastos sin conciliar",
+          "hint": "Registrados en la app, nunca confirmados por un extracto.",
+          "resolution": "Vincúlelos a la línea bancaria correspondiente, o justifíquelos (pagado por un tercero, por ejemplo)."
+        },
+        "account_chain_broken": {
+          "title": "Cadena de saldos rota",
+          "hint": "Los saldos del extracto no encadenan: faltan operaciones.",
+          "resolution": "Importe el extracto que falta. Hasta entonces el saldo queda marcado como no fiable."
+        }
+      }
+    },
+    "pending": {
+      "count": "{{count}} operación por ordenar",
+      "count_plural": "{{count}} operaciones por ordenar",
+      "selectAll": "Seleccionar todo",
+      "clearSelection": "Quitar la selección",
+      "bulkSelected": "{{count}} operación seleccionada",
+      "bulkSelected_plural": "{{count}} operaciones seleccionadas",
+      "bulkLabel": "{{count}} operaciones",
+      "noBudget": "Sin presupuesto",
+      "split": "Desglosar en varios",
+      "complete": "Completar el desglose",
+      "later": "Más tarde",
+      "partial": "{{allocated}} asignados, {{remaining}} pendientes",
+      "allDone": "Lista vacía",
+      "allDoneHint": "Todas sus operaciones están asignadas o justificadas.",
+      "nothingLeft": "Nada para esta sesión",
+      "nothingLeftHint": "Las operaciones postergadas volverán en su próxima visita."
     }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1442,6 +1442,14 @@
           "review": {
             "title": "Analyser par période",
             "body": "Filtrez par période ou par zone pour voir où part l'argent."
+          },
+          "sort": {
+            "title": "Rangez vos opérations",
+            "body": "L'onglet « À ranger » liste chaque sortie que personne n'a encore affectée. Une pastille de budget suffit pour le cas courant ; « Ventiler en plusieurs » sert quand une même course couvre deux postes. Sélectionnez plusieurs lignes pour traiter un lot d'un coup."
+          },
+          "control": {
+            "title": "Vérifiez que votre vision est juste",
+            "body": "L'onglet « Contrôle » énumère tout ce qui empêche vos chiffres d'être exacts : opérations non affectées, dépenses jamais vues par la banque, soldes qui ne s'enchaînent pas. Chaque écart se résout — ou s'arbitre avec un motif, qui reste consultable et révocable."
           }
         }
       },
@@ -2919,7 +2927,7 @@
       "subjectRequired": "Un sujet est requis",
       "created": "Dépense enregistrée",
       "actions": {
-        "add": "Dépense"
+        "add": "Nouvelle dépense"
       },
       "budget": "Budget",
       "budgetNone": "Aucun budget"
@@ -3342,6 +3350,99 @@
     "history": "Mois précédents",
     "access": {
       "hint": "Récap écrit des dépenses du mois écoulé."
+    }
+  },
+  "money": {
+    "title": "Argent",
+    "description": "Comptes, dépenses et budgets — les relevés sont la source de vérité.",
+    "tabs": {
+      "control": "Contrôle",
+      "pending": "À ranger",
+      "accounts": "Comptes",
+      "expenses": "Dépenses",
+      "budgets": "Budgets"
+    },
+    "compliance": {
+      "clean": "Tout est conforme",
+      "cleanHint": "Chaque opération est affectée ou arbitrée. Rien ne traîne.",
+      "openCount": "{{count}} écart à traiter",
+      "openCount_plural": "{{count}} écarts à traiter",
+      "openHint": "Chaque écart se résout, ou s'arbitre avec un motif.",
+      "arbitratedCount": "{{count}} arbitré",
+      "arbitratedCount_plural": "{{count}} arbitrés",
+      "staleCount": "{{count}} arbitrage périmé",
+      "staleCount_plural": "{{count}} arbitrages périmés",
+      "groupClean": "Rien à signaler.",
+      "prerequisite": "Prérequis",
+      "staleBadge": "{{count}} périmé",
+      "staleBadge_plural": "{{count}} périmés",
+      "waivedShort": "{{count}} arbitré",
+      "waivedShort_plural": "{{count}} arbitrés",
+      "blockedBy": "Ce contrôle ne porte que sur les comptes dont le prérequis « {{prerequisite}} » est levé.",
+      "andMore": "et {{count}} de plus…",
+      "showArbitrated": "Voir les {{count}} arbitrages",
+      "hideArbitrated": "Masquer les arbitrages",
+      "revoke": "Révoquer",
+      "revoked": "Arbitrage révoqué — l'écart est de retour.",
+      "arbitrate": "Arbitrer",
+      "rearbitrate": "Ré-arbitrer",
+      "notWaivable": "à corriger",
+      "stale": "La situation a changé depuis « {{reason}} ».",
+      "remaining": "Reste à affecter : {{amount}}",
+      "waived": "Écart arbitré.",
+      "waiveTitle": "Arbitrer cet écart",
+      "waiveHelp": "Un arbitrage n'efface rien : il enregistre pourquoi cet écart est acceptable. Il reste consultable et révocable.",
+      "waiveAction": "Arbitrer",
+      "reason": "Motif",
+      "reasonPlaceholder": "Ex. : frais bancaires, ne concerne aucun budget",
+      "reasonRequired": "Le motif est obligatoire.",
+      "noDetectors": "Aucun contrôle disponible",
+      "noDetectorsHint": "Déclarez un compte pour que le contrôle ait quelque chose à vérifier.",
+      "kinds": {
+        "account_no_opening_balance": {
+          "title": "Compte sans solde d'ouverture",
+          "hint": "Sans point de départ, le solde est une supposition.",
+          "resolution": "Renseignez le solde d'ouverture du compte et sa date. Les autres contrôles deviennent alors évaluables."
+        },
+        "transaction_unallocated": {
+          "title": "Sorties non affectées",
+          "hint": "De l'argent est parti sans que personne dise pour quoi.",
+          "resolution": "Rangez ces opérations depuis l'onglet « À ranger », ou arbitrez-les avec un motif."
+        },
+        "transaction_partially_allocated": {
+          "title": "Sorties partiellement affectées",
+          "hint": "Une partie du montant n'est rattachée à rien.",
+          "resolution": "Complétez la ventilation, ou arbitrez le reste."
+        },
+        "expense_unreconciled": {
+          "title": "Dépenses non rapprochées",
+          "hint": "Saisies dans l'app, jamais confirmées par un relevé.",
+          "resolution": "Rattachez-les à la ligne bancaire correspondante, ou arbitrez-les (payé par un tiers, par exemple)."
+        },
+        "account_chain_broken": {
+          "title": "Chaîne de soldes rompue",
+          "hint": "Les soldes du relevé ne s'enchaînent pas : des opérations manquent.",
+          "resolution": "Importez le relevé manquant. Le solde affiché reste marqué comme non fiable d'ici là."
+        }
+      }
+    },
+    "pending": {
+      "count": "{{count}} opération à ranger",
+      "count_plural": "{{count}} opérations à ranger",
+      "selectAll": "Tout sélectionner",
+      "clearSelection": "Tout désélectionner",
+      "bulkSelected": "{{count}} opération sélectionnée",
+      "bulkSelected_plural": "{{count}} opérations sélectionnées",
+      "bulkLabel": "{{count}} opérations",
+      "noBudget": "Hors budget",
+      "split": "Ventiler en plusieurs",
+      "complete": "Compléter la ventilation",
+      "later": "Plus tard",
+      "partial": "{{allocated}} affectés, {{remaining}} restants",
+      "allDone": "File vide",
+      "allDoneHint": "Toutes vos opérations sont affectées ou arbitrées.",
+      "nothingLeft": "Rien pour cette session",
+      "nothingLeftHint": "Les opérations reportées reviendront à votre prochaine visite."
     }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, Navigate } from 'react-router-dom';
 import ProtectedLayout from './components/ProtectedLayout';
 import ModuleRoute from './components/ModuleRoute';
+import LegacyMoneyRedirect from './components/LegacyMoneyRedirect';
 import LoginPage from './features/auth/LoginPage';
 import ForgotPasswordPage from './features/auth/ForgotPasswordPage';
 import ResetPasswordPage from './features/auth/ResetPasswordPage';
@@ -45,11 +46,9 @@ const AgentPage = lazyWithReload(() => import('./features/agent/AgentPage'));
 const MemoryPage = lazyWithReload(() => import('./features/agent/MemoryPage'));
 const DigestPage = lazyWithReload(() => import('./features/digest/DigestPage'));
 const BriefingsPage = lazyWithReload(() => import('./features/briefings/BriefingsPage'));
-const ExpensesPage = lazyWithReload(() => import('./features/expenses/ExpensesPage'));
-const BudgetPage = lazyWithReload(() => import('./features/budget/BudgetPage'));
+const MoneyPage = lazyWithReload(() => import('./features/money/MoneyPage'));
 const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPage'));
 const ReportsPage = lazyWithReload(() => import('./features/budget/ReportsPage'));
-const BankingPage = lazyWithReload(() => import('./features/banking/BankingPage'));
 const BankingTransactionsPage = lazyWithReload(
   () => import('./features/banking/TransactionsPage'),
 );
@@ -84,12 +83,17 @@ export const router = createBrowserRouter([
       { path: 'interactions/new', element: <InteractionNewPage /> },
       { path: 'interactions/:id', element: <InteractionDetailPage /> },
       { path: 'interactions/:id/edit', element: <InteractionEditPage /> },
-      { path: 'expenses', element: <ExpensesPage /> },
-      { path: 'budget', element: <BudgetPage /> },
+      { path: 'money', element: <MoneyPage /> },
+      { path: 'money/transactions', element: <BankingTransactionsPage /> },
       { path: 'budget/recurring', element: <RecurringPage /> },
       { path: 'budget/reports', element: <ReportsPage /> },
-      { path: 'banking', element: <ModuleRoute moduleKey="banking"><BankingPage /></ModuleRoute> },
-      { path: 'banking/transactions', element: <ModuleRoute moduleKey="banking"><BankingTransactionsPage /></ModuleRoute> },
+      // Anciennes URLs (parcours 26, lot 2) : les favoris, les liens de l'agent et
+      // les tutoriels pointent encore dessus. La query string est **préservée** —
+      // `?b={id}` vient de `budget/apps.py::SearchableSpec.url_template`.
+      { path: 'expenses', element: <LegacyMoneyRedirect tab="expenses" /> },
+      { path: 'budget', element: <LegacyMoneyRedirect tab="budgets" /> },
+      { path: 'banking', element: <LegacyMoneyRedirect tab="accounts" /> },
+      { path: 'banking/transactions', element: <Navigate to="/app/money/transactions" replace /> },
       { path: 'projects', element: <ProjectsPage /> },
       { path: 'projects/:id', element: <ProjectDetailPage /> },
       { path: 'equipment', element: <EquipmentPage /> },


### PR DESCRIPTION
## Pourquoi

Comptes, dépenses et budgets étaient trois entrées de sidebar. Ce sont **trois lectures d'un même fait** : ce qui est sorti du compte. Les séparer obligeait l'utilisateur à faire lui-même le lien — et rendait invisible la question qui compte avant toutes les autres :

> « Qu'est-ce qu'il me reste à faire pour que mes chiffres soient justes ? »

D'où l'ordre des onglets : **Contrôle**, **À ranger**, puis Comptes, Dépenses, Budgets. La conformité passe devant le reporting.

## Les deux écrans nouveaux

**`CompliancePanel`** rend visible le socle du lot 1. Deux principes de présentation portent tout le parcours :

- les **prérequis bloquants passent en tête** — un compte sans solde d'ouverture n'a pas de fenêtre de conformité, ses dépendants ne sont pas « conformes », ils ne sont *pas évaluables* ;
- un **groupe à zéro reste visible, coché** — sans quoi une liste vide serait indistinguable d'un détecteur en panne.

La liste d'audit est repliée mais présente : un arbitrage qu'on ne peut pas relire ne vaut rien. Chaque arbitrage se révoque en un clic, et un arbitrage **périmé** revient avec son motif d'origine affiché.

**`PendingQueue`** est la file de travail quotidienne : pastilles de budget (1 clic), « Ventiler en plusieurs », « Arbitrer » (motif requis), « Plus tard », et actions groupées — indispensables à ~160 lignes/mois puisque la pré-catégorisation est différée.

⚠️ Les pastilles n'apparaissent **que** sur une ligne entièrement non ventilée. L'écriture d'une ventilation est un remplacement complet (`PUT`, un « set »), donc imputer d'un clic une ligne déjà partagée détruirait le travail déjà fait. Sur une ligne partielle, le seul chemin est le dialog, qui part de l'existant. Même raison pour la sélection multiple.

## La fusion des clés de module n'est pas cosmétique

Vérifié : `banking` était **optionnel**, `expenses` et `budget` étaient **core**. La clé fusionnée doit être core — un foyer ne peut pas désactiver `money` sans perdre dépenses et budgets.

**Conséquence assumée : les comptes bancaires ne sont plus un opt-in.** Cohérent avec « les relevés sont la source de vérité », mais c'est une décision produit, pas un effet de bord.

Deux data migrations, parce qu'une configuration stockée qui ne correspond plus à rien est un orphelin :

- `households.0011` retire `'banking'` des `disabled_modules` — sinon une clé morte que personne ne peut expliquer ;
- `accounts.0014` replie les trois pins en `money` **en préservant la position** du premier des trois : un utilisateur qui avait « Dépenses » en tête retrouve « Argent » en tête, au lieu de voir un raccourci disparaître sans explication.

## Navigation

| Ancienne URL | Devient |
|---|---|
| `/app/banking` | `/app/money?tab=accounts` |
| `/app/expenses` | `/app/money?tab=expenses` |
| `/app/budget` | `/app/money?tab=budgets` |
| `/app/banking/transactions` | `/app/money/transactions` |

`LegacyMoneyRedirect` **préserve la query string** : l'agent produit `/app/budget?b={id}` et un favori peut porter n'importe quel paramètre. Les `url_template` de l'agent sont aussi mis à jour, pour que les nouveaux liens soient directs plutôt que redirigés.

Le deep link `?tab=` est écrit dans la session **avant** que `TabShell` lise sa valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage de l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.

## Deux problèmes réels trouvés en route

**Le bouton « Dépense » et l'onglet « Dépenses » avaient des noms accessibles confusables.** C'est un problème d'ergonomie avant d'être un problème de test — deux contrôles indistinguables sur le même écran. Renommé « Nouvelle dépense », cohérent avec « Nouveau budget »/« Nouveau compte ».

**Trois guides de tutoriel auraient affiché la même icône**, puisqu'ils partagent désormais `moduleKey: 'money'`. L'icône explicite gagne maintenant sur celle du module — sinon la liste des guides ne se parcourt plus du regard.

Également corrigé : `budget.spec.ts` avait un locator `getByText('Courses')` qui attrapait « Liste de courses » dans la sidebar. Ce test **échouait déjà sur `main`** ; `exact: true` le répare.

## Vérification

- **3164 tests backend** (+23) — les deux data migrations sont testées comme des fonctions : elles replient, préservent la position, collapsent les doublons, sont idempotentes, et ne touchent pas au reste. Plus le contrat des registres de clés, et l'accord entre la migration et la validation du serializer (sinon la migration écrirait une valeur que le prochain PATCH refuserait).
- **238 E2E verts, 0 échec** — dont `money.spec.ts` (14 tests) qui couvre la coque, les quatre redirections, la préservation de la query string, le deep link, la sidebar, le panneau Contrôle, et vérifie `ouverts + arbitrés = détectés` directement sur l'API. Les 5 specs monétaires existantes sont retargetées.
- `npm run build` (`tsc -b`) et `npm run lint` propres.

Doc : `docs/MODULES/money.md` (nouvelle fiche), sections « Argent » de `CLAUDE.md` et du README des modules.