### PR TITLE
feat(money): une ventilation porte projet, zone et budget (parcours 26, lot 3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,28 @@ onglets : Contrôle / À ranger / Comptes / Dépenses / Budgets. Doc :
   complet, donc un raccourci sur une ligne partielle détruirait le travail déjà
   fait. Même raison pour la sélection multiple.
 
+#### Ventilation — budget et projet sont deux axes indépendants
+
+Une ligne de ventilation porte un **budget** *et* un **objet** (projet, équipement,
+article de stock) *et* des **zones**. 90 € des 150 € dépensés chez Leroy Merlin
+comptent dans le chantier **et** dans l'enveloppe « Bricolage ».
+
+- **⚠️ La règle de propriété de l'éditeur de ventilation lit `kind` seul**
+  (`OWNED_BY_ALLOCATION_EDITOR`). Ne jamais y rajouter une clause sur
+  `source_content_type_id` : avec elle, une ligne rattachée à un projet cesse
+  d'être « possédée » et se retrouve *détachée* au lieu d'être supprimée à la
+  ré-édition — **chaque ré-édition laisse une dépense fantôme** toujours comptée
+  dans le coût du projet. Test de régression :
+  `banking/tests/test_allocation_axes.py::TestOwnershipRuleRegression`.
+- `kind` reste `bank` même avec une source : il dit *d'où vient* la dépense, pas
+  *sur quoi elle porte*.
+- Toute résolution de source passe par
+  `interactions.services.resolve_allocation_source`, qui **vérifie le foyer** —
+  sans ça un client gonflerait le coût d'un projet qu'il ne peut pas voir.
+- `set_allocations` convertit les `ValueError` du créateur en **400 préfixé du
+  numéro de ligne**. Ne pas les laisser remonter : un mauvais id de zone donnait un
+  500 sur une simple erreur client.
+
 ### Ajouter un nouveau template d'auto-subject
 
 1. Ajouter l'entrée dans `AUTO_SUBJECT_TEMPLATES` (`apps/interactions/services.py`)

--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -6,6 +6,7 @@ would therefore never ask:
 - money left the account and nobody said what for (``transaction_unallocated``);
 - money left and only part of it was accounted for (``transaction_partial``);
 - an expense was typed in that the bank never saw (``expense_unreconciled``);
+- an expense that counts against no envelope (``expense_without_budget``);
 - an account whose starting point is unknown (``account_no_opening_balance``);
 - an account whose statements do not chain (``account_chain_broken``).
 
@@ -44,6 +45,7 @@ ZERO = Value(Decimal("0.00"), output_field=AMOUNT_FIELD)
 TRANSACTION_UNALLOCATED = "transaction_unallocated"
 TRANSACTION_PARTIAL = "transaction_partially_allocated"
 EXPENSE_UNRECONCILED = "expense_unreconciled"
+EXPENSE_WITHOUT_BUDGET = "expense_without_budget"
 ACCOUNT_NO_OPENING_BALANCE = "account_no_opening_balance"
 ACCOUNT_CHAIN_BROKEN = "account_chain_broken"
 
@@ -182,6 +184,50 @@ def _unreconciled_qs(household):
 
 def _count_unreconciled(household) -> int:
     return _unreconciled_qs(household).count()
+
+
+def _without_budget_qs(household):
+    """Expenses inside the horizon that count against no envelope.
+
+    Scoped by the same window as the rest, for a reason of its own: a budget is
+    **monthly**, so assigning one to a two-year-old expense changes no figure
+    anybody looks at. Flagging it would be busywork, and busywork is what makes a
+    control panel stop being read.
+    """
+    from interactions.models import Interaction
+    from interactions.queries import expenses
+
+    window = household_covered_period(household)
+    if window is None:
+        return Interaction.objects.none()
+
+    return expenses(household_id=household.id).filter(
+        budget__isnull=True,
+        occurred_at__date__gte=window.start,
+        occurred_at__date__lte=window.end,
+    )
+
+
+def _count_without_budget(household) -> int:
+    return _without_budget_qs(household).count()
+
+
+def _find_without_budget(household, **window) -> list[Finding]:
+    return [
+        Finding(
+            kind=EXPENSE_WITHOUT_BUDGET,
+            object_id=str(expense.pk),
+            label=f"{expense.occurred_at.date().isoformat()} · {expense.subject[:80]}",
+            fingerprint=fingerprint_of(EXPENSE_WITHOUT_BUDGET, expense.amount),
+            detail={
+                "subject": expense.subject,
+                "amount": str(expense.amount or Decimal("0.00")),
+                "occurred_at": expense.occurred_at.isoformat(),
+                "kind": expense.kind,
+            },
+        )
+        for expense in apply_window(_without_budget_qs(household), **window)
+    ]
 
 
 def _find_unreconciled(household, **window) -> list[Finding]:
@@ -352,6 +398,16 @@ def _specs() -> list[DetectorSpec]:
             model=Interaction,
             count=_count_unreconciled,
             findings=_find_unreconciled,
+            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+        ),
+        DetectorSpec(
+            kind=EXPENSE_WITHOUT_BUDGET,
+            severity=WARNING,
+            label="Expense counting against no budget envelope",
+            target="expense",
+            model=Interaction,
+            count=_count_without_budget,
+            findings=_find_without_budget,
             blocked_by=ACCOUNT_NO_OPENING_BALANCE,
         ),
         DetectorSpec(

--- a/apps/banking/services.py
+++ b/apps/banking/services.py
@@ -405,10 +405,19 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
     atomic.
 
     The destructive half is deliberately narrow. Only the expenses this editor
-    created (``kind='bank'`` **and** no source object) are deleted; anything else
-    — a stock purchase that was reconciled onto this line — is **detached**, not
-    destroyed. Deleting it would take its documents, tags, zones and possibly a
+    created (``kind='bank'``) are deleted; anything else — a stock purchase that
+    was reconciled onto this line — is **detached**, not destroyed. Deleting it
+    would take its documents, tags, zones and possibly a
     ``Task.source_interaction`` with it, to undo a split.
+
+    ⚠️ The rule reads ``kind`` **alone**. It used to also require no source
+    object, which was redundant (a stock purchase has ``kind='stock_purchase'``,
+    never ``'bank'``) — and became actively wrong in parcours 26 lot 3, when
+    allocation lines started carrying a project. With the extra clause, a line
+    attached to a project stopped being "owned" and was detached instead of
+    deleted on re-edit: **every re-split would leave a phantom expense behind**,
+    still counted in the project's cost. Exactly the orphan this parcours exists
+    to remove.
 
     The row is locked for the duration so two concurrent edits cannot each see a
     stale total and jointly overshoot.
@@ -429,10 +438,7 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
 
         existing = list(locked.interactions.all())
         for interaction in existing:
-            owned = (
-                interaction.kind in OWNED_BY_ALLOCATION_EDITOR
-                and interaction.source_content_type_id is None
-            )
+            owned = interaction.kind in OWNED_BY_ALLOCATION_EDITOR
             if owned:
                 interaction.delete()
             else:
@@ -449,22 +455,34 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
                 )
 
         created = []
-        for line in lines:
+        for index, line in enumerate(lines):
             amount = Decimal(str(line.get("amount") or 0))
             if amount <= 0:
                 raise ValidationError({"amount": "Each allocation must be strictly positive."})
-            created.append(
-                create_bank_expense_interaction(
-                    household=household,
-                    user=user,
-                    transaction=locked,
-                    subject=str(line.get("subject") or "").strip(),
-                    amount=amount,
-                    budget_id=line.get("budget_id"),
-                    zone_ids=line.get("zone_ids"),
-                    notes=str(line.get("notes") or ""),
+            try:
+                created.append(
+                    create_bank_expense_interaction(
+                        household=household,
+                        user=user,
+                        transaction=locked,
+                        subject=str(line.get("subject") or "").strip(),
+                        amount=amount,
+                        budget_id=line.get("budget_id"),
+                        zone_ids=line.get("zone_ids"),
+                        notes=str(line.get("notes") or ""),
+                        # Budget and project are independent axes (lot 3): a line
+                        # can carry both, and counts in both.
+                        source_type=line.get("source_type"),
+                        source_id=line.get("source_id"),
+                    )
                 )
-            )
+            except ValueError as exc:
+                # The creator signals bad references (unknown zone, budget from
+                # another household, source outside the household) with
+                # ``ValueError``. Left alone it surfaces as a 500 on what is a
+                # plain client mistake — and the line number is what makes the
+                # message actionable on a five-line split.
+                raise ValidationError({"lines": f"line {index + 1}: {exc}"})
 
         # Refresh so the caller sees the linked state rather than a stale copy.
         Interaction.objects.filter(pk__in=[i.pk for i in created])
@@ -509,20 +527,18 @@ def unlink_interaction(*, user, interaction):
 def delete_transaction(*, user, transaction) -> None:
     """Delete a bank line, keeping every fact the household journalled.
 
-    Same asymmetry as ``set_allocations``: the expenses this line generated go
-    with it, the pre-existing ones are only detached. ``SET_NULL`` on the FK
-    would handle the detaching by itself, but doing it explicitly also clears
-    ``reconciled_by`` — a reconciliation marker with nothing to point at is a
-    lie waiting to confuse the lot 6 matcher.
+    Same asymmetry as ``set_allocations``, and the same ownership rule: ``kind``
+    alone decides. The expenses this line generated go with it, the pre-existing
+    ones are only detached. ``SET_NULL`` on the FK would handle the detaching by
+    itself, but doing it explicitly also clears ``reconciled_by`` — a
+    reconciliation marker with nothing to point at is a lie waiting to confuse
+    the matcher.
     """
     from interactions.kinds import OWNED_BY_ALLOCATION_EDITOR
 
     with atomic():
         for interaction in list(transaction.interactions.all()):
-            owned = (
-                interaction.kind in OWNED_BY_ALLOCATION_EDITOR
-                and interaction.source_content_type_id is None
-            )
+            owned = interaction.kind in OWNED_BY_ALLOCATION_EDITOR
             if owned:
                 interaction.delete()
             else:

--- a/apps/banking/tests/test_allocation_axes.py
+++ b/apps/banking/tests/test_allocation_axes.py
@@ -1,0 +1,374 @@
+# banking/tests/test_allocation_axes.py
+"""Budget and project are two independent axes (parcours 26, lot 3).
+
+The real case: 150 € at the DIY store, 90 € of it for the bathroom job and 60 €
+unrelated. Before this lot an allocation line carried only a budget, so those 90 €
+counted in the « Bricolage » envelope and in **no project cost at all** —
+``projects.services`` aggregates through the polymorphic source FK, which the
+allocation creator never set.
+
+The regression test at the bottom is the important one. Removing the
+``source_content_type_id is None`` clause from the ownership rule is what keeps a
+re-split from leaving a phantom expense behind, still counted in the project.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+from rest_framework.exceptions import ValidationError
+
+from banking.dedup import compute_dedup_hash
+from banking.models import BankTransaction, TransactionDirection
+from banking.services import delete_transaction, set_allocations
+from budget.models import Budget
+from interactions.kinds import KIND_BANK, KIND_STOCK_PURCHASE
+from interactions.models import Interaction
+from projects.models import Project
+from projects.services import project_actual_cost
+from zones.models import Zone
+
+from .factories import BankAccountFactory, HouseholdFactory, UserFactory
+
+_counter = itertools.count()
+
+
+def make_txn(account, *, amount="-150.00", booked_on=date(2026, 3, 10), label="CB LEROY MERLIN"):
+    value = Decimal(amount)
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    household = HouseholdFactory()
+    user = UserFactory()
+    account = BankAccountFactory(household=household, opening_balance_date=date(2026, 1, 1))
+    bathroom = Project.objects.create(household=household, title="Salle de bain")
+    kitchen = Project.objects.create(household=household, title="Cuisine")
+    diy = Budget.objects.create(household=household, name="Bricolage", monthly_amount=300)
+    return household, user, account, bathroom, kitchen, diy
+
+
+@pytest.mark.django_db
+class TestAllocationCarriesAProject:
+    def test_a_split_feeds_two_project_costs(self, ctx):
+        household, user, account, bathroom, kitchen, _ = ctx
+        txn = make_txn(account)
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+                {
+                    "amount": "60.00",
+                    "subject": "Peinture",
+                    "source_type": "projects.project",
+                    "source_id": str(kitchen.id),
+                },
+            ],
+        )
+
+        assert project_actual_cost(bathroom) == Decimal("90.00")
+        assert project_actual_cost(kitchen) == Decimal("60.00")
+
+    def test_a_line_counts_in_a_project_and_a_budget_at_once(self, ctx):
+        """The two axes are independent — this is the whole point of the lot."""
+        household, user, account, bathroom, _, diy = ctx
+        txn = make_txn(account, amount="-90.00")
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "budget_id": str(diy.id),
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+            ],
+        )
+
+        expense = Interaction.objects.get(bank_transaction=txn)
+        assert expense.budget_id == diy.id
+        # ``str()`` on both sides: the column is a CharField but the in-memory
+        # instance still holds the UUID it was created with.
+        assert str(expense.source_object_id) == str(bathroom.id)
+        assert project_actual_cost(bathroom) == Decimal("90.00")
+
+    def test_the_kind_stays_bank_even_with_a_source(self, ctx):
+        """``kind`` says where the expense came from, not what it is about — and
+        the ownership rule reads it and nothing else."""
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account, amount="-90.00")
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+            ],
+        )
+
+        assert Interaction.objects.get(bank_transaction=txn).kind == KIND_BANK
+
+    def test_a_line_can_carry_zones_and_a_project(self, ctx):
+        household, user, account, bathroom, _, _ = ctx
+        zone = Zone.objects.create(household=household, name="Étage")
+        txn = make_txn(account, amount="-90.00")
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "zone_ids": [str(zone.id)],
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+            ],
+        )
+
+        expense = Interaction.objects.get(bank_transaction=txn)
+        assert [z.name for z in expense.zones.all()] == ["Étage"]
+        assert str(expense.source_object_id) == str(bathroom.id)
+
+    def test_no_source_is_the_ordinary_case(self, ctx):
+        household, user, account, _, _, diy = ctx
+        txn = make_txn(account, amount="-40.00", label="CB BOULANGERIE")
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[{"amount": "40.00", "subject": "Pain", "budget_id": str(diy.id)}],
+        )
+
+        expense = Interaction.objects.get(bank_transaction=txn)
+        assert expense.source_content_type_id is None
+        assert expense.source_object_id is None
+
+
+@pytest.mark.django_db
+class TestSourceScoping:
+    def test_a_project_from_another_household_is_refused(self, ctx):
+        """Without this check a client could inflate the cost of a project they
+        cannot even see."""
+        household, user, account, _, _, _ = ctx
+        foreign = Project.objects.create(household=HouseholdFactory(), title="Chez l'autre")
+        txn = make_txn(account, amount="-90.00")
+
+        with pytest.raises(ValidationError) as excinfo:
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": "90.00",
+                        "subject": "x",
+                        "source_type": "projects.project",
+                        "source_id": str(foreign.id),
+                    },
+                ],
+            )
+        assert "lines" in excinfo.value.detail
+        assert not Interaction.objects.filter(bank_transaction=txn).exists()
+
+    def test_an_unsupported_source_type_is_refused(self, ctx):
+        household, user, account, _, _, _ = ctx
+        txn = make_txn(account, amount="-90.00")
+
+        with pytest.raises(ValidationError):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": "90.00",
+                        "subject": "x",
+                        "source_type": "budget.budget",
+                        "source_id": str(account.id),
+                    },
+                ],
+            )
+
+    def test_a_bad_reference_is_a_400_naming_the_line(self, ctx):
+        """A five-line split needs to know *which* line is wrong. Left alone the
+        creator's ``ValueError`` would surface as a 500 on a client mistake."""
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account)
+
+        with pytest.raises(ValidationError) as excinfo:
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": "90.00",
+                        "subject": "ok",
+                        "source_type": "projects.project",
+                        "source_id": str(bathroom.id),
+                    },
+                    {"amount": "60.00", "subject": "bad", "zone_ids": [str(bathroom.id)]},
+                ],
+            )
+        assert "line 2" in str(excinfo.value.detail["lines"])
+
+    def test_source_type_without_source_id_is_refused(self, ctx):
+        household, user, account, _, _, _ = ctx
+        txn = make_txn(account, amount="-90.00")
+
+        with pytest.raises(ValidationError):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[{"amount": "90.00", "subject": "x", "source_type": "projects.project"}],
+            )
+
+
+@pytest.mark.django_db
+class TestOwnershipRuleRegression:
+    """THE test of the lot.
+
+    The ownership rule used to require ``kind='bank'`` **and** no source object.
+    That clause was redundant until allocation lines could carry a project — after
+    which a line attached to one stopped being "owned", and was *detached* instead
+    of deleted on re-edit. Every re-split would then leave a phantom expense
+    behind, still counted in the project's cost: exactly the orphan the parcours
+    exists to remove.
+    """
+
+    def test_re_editing_a_project_split_three_times_leaves_no_orphan(self, ctx):
+        household, user, account, bathroom, kitchen, diy = ctx
+        txn = make_txn(account)
+
+        for first, second in (("90.00", "60.00"), ("100.00", "50.00"), ("120.00", "30.00")):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": first,
+                        "subject": "Carrelage",
+                        "budget_id": str(diy.id),
+                        "source_type": "projects.project",
+                        "source_id": str(bathroom.id),
+                    },
+                    {
+                        "amount": second,
+                        "subject": "Peinture",
+                        "source_type": "projects.project",
+                        "source_id": str(kitchen.id),
+                    },
+                ],
+            )
+
+        # Two expenses, not six: each re-edit replaced its predecessors.
+        assert Interaction.objects.filter(household=household, type="expense").count() == 2
+        # And no expense left detached from the line it came from.
+        assert not Interaction.objects.filter(
+            household=household, type="expense", bank_transaction__isnull=True
+        ).exists()
+        # The project costs reflect the LAST split, not the sum of all three.
+        assert project_actual_cost(bathroom) == Decimal("120.00")
+        assert project_actual_cost(kitchen) == Decimal("30.00")
+
+    def test_a_pre_existing_purchase_is_still_only_detached(self, ctx):
+        """The asymmetry that justified the rule in the first place is preserved:
+        an expense that predates the statement is a fact of its own. Deleting it
+        would take its documents, tags and possibly a task with it."""
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account)
+        purchase = Interaction.objects.create(
+            household=household,
+            created_by=user,
+            subject="Achat de stock",
+            type="expense",
+            occurred_at=timezone.now(),
+            amount=Decimal("40.00"),
+            kind=KIND_STOCK_PURCHASE,
+            bank_transaction=txn,
+        )
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+            ],
+        )
+
+        purchase.refresh_from_db()
+        assert purchase.pk is not None
+        assert purchase.bank_transaction_id is None
+        assert purchase.reconciled_by == ""
+
+    def test_deleting_the_line_takes_its_project_allocations_with_it(self, ctx):
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account, amount="-90.00")
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "90.00",
+                    "subject": "Carrelage",
+                    "source_type": "projects.project",
+                    "source_id": str(bathroom.id),
+                },
+            ],
+        )
+
+        delete_transaction(user=user, transaction=txn)
+
+        assert not Interaction.objects.filter(household=household, type="expense").exists()
+        assert project_actual_cost(bathroom) == Decimal("0.00")

--- a/apps/banking/tests/test_compliance.py
+++ b/apps/banking/tests/test_compliance.py
@@ -33,6 +33,7 @@ from banking.detectors import (
     ACCOUNT_CHAIN_BROKEN,
     ACCOUNT_NO_OPENING_BALANCE,
     EXPENSE_UNRECONCILED,
+    EXPENSE_WITHOUT_BUDGET,
     TRANSACTION_PARTIAL,
     TRANSACTION_UNALLOCATED,
 )
@@ -655,3 +656,62 @@ class TestPagination:
         assert len(page) == 3
         waived_ids = {str(t.pk) for t in txns[:2]}
         assert not waived_ids & {f.object_id for f in page}
+
+
+# --- Detector: an expense counting against no envelope (lot 3) ----------------
+
+
+@pytest.mark.django_db
+class TestExpenseWithoutBudget:
+    def test_an_expense_with_no_budget_is_an_ecart(self, ctx):
+        household, user, _, _ = ctx
+        expense = make_expense(household, user)
+
+        findings = open_findings(household, get_detector(EXPENSE_WITHOUT_BUDGET))
+        assert [f.object_id for f in findings] == [str(expense.pk)]
+
+    def test_it_disappears_once_a_budget_is_assigned(self, ctx):
+        household, user, _, budget = ctx
+        expense = make_expense(household, user)
+
+        expense.budget = budget
+        expense.save(update_fields=["budget"])
+
+        assert group(household, EXPENSE_WITHOUT_BUDGET).detected == 0
+
+    def test_an_expense_outside_the_horizon_is_never_an_ecart(self, ctx):
+        """A budget is monthly: assigning one to a two-year-old expense changes no
+        figure anybody looks at, so flagging it would be pure busywork."""
+        household, user, _, _ = ctx
+        make_expense(household, user, occurred_on=date(2024, 5, 3))
+        assert group(household, EXPENSE_WITHOUT_BUDGET).detected == 0
+
+    def test_a_ventilated_line_without_a_budget_shows_up_here(self, ctx):
+        """Ranger une ligne « hors budget » la sort de la file mais pas du contrôle
+        — c'est un choix, qui doit rester visible et arbitrable."""
+        household, user, account, _ = ctx
+        txn = make_txn(account)
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[{"amount": "120.00", "subject": "Courses", "budget_id": None}],
+        )
+
+        assert group(household, TRANSACTION_UNALLOCATED).detected == 0
+        assert group(household, EXPENSE_WITHOUT_BUDGET).detected == 1
+
+    def test_it_can_be_arbitrated(self, ctx):
+        household, user, _, _ = ctx
+        expense = make_expense(household, user)
+
+        waive_finding(
+            household=household,
+            user=user,
+            finding_kind=EXPENSE_WITHOUT_BUDGET,
+            object_id=str(expense.pk),
+            reason="hors de tout budget, volontairement",
+        )
+
+        result = group(household, EXPENSE_WITHOUT_BUDGET)
+        assert (result.open, result.waived) == (0, 1)

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -610,6 +610,39 @@ def delete_note_interaction(*, household, user, interaction: Interaction) -> Non
     interaction.delete()
 
 
+def resolve_allocation_source(household_id, source_type: str | None, source_id):
+    """Resolve ``('projects.project', uuid)`` to a ``(ContentType, pk)`` pair.
+
+    Returns ``(None, None)`` when no source is asked for — an allocation line
+    without a project is the common case, not an error.
+
+    The **household check is the point of this function**. Without it a client
+    could attach an expense to another household's project and inflate a cost
+    they cannot even see, so the object is fetched and its ``household_id``
+    compared rather than trusted.
+    """
+    from .serializers import ALLOWED_SOURCE_TYPES
+
+    if not source_type and not source_id:
+        return None, None
+    if not source_type or not source_id:
+        raise ValueError("source_type and source_id must be provided together")
+
+    key = str(source_type).strip().lower()
+    if key not in ALLOWED_SOURCE_TYPES:
+        raise ValueError(
+            f"unsupported source type {key!r}; allowed: {', '.join(sorted(ALLOWED_SOURCE_TYPES))}"
+        )
+
+    app_label, model = key.split(".")
+    content_type = ContentType.objects.get_by_natural_key(app_label, model)
+    target = content_type.model_class().objects.filter(pk=source_id).first()
+    if target is None or getattr(target, "household_id", None) != household_id:
+        raise ValueError("source object not found in this household")
+
+    return content_type, target.pk
+
+
 def create_bank_expense_interaction(
     *,
     household,
@@ -620,6 +653,8 @@ def create_bank_expense_interaction(
     budget_id=None,
     zone_ids: list[UUID] | None = None,
     notes: str = "",
+    source_type: str | None = None,
+    source_id=None,
 ) -> Interaction:
     """Create an expense that is an allocation of a bank statement line.
 
@@ -627,6 +662,12 @@ def create_bank_expense_interaction(
     each with its own amount and budget. They are ordinary journal entries —
     searchable by the agent, counted in a project's cost, linkable to zones and
     documents — which is exactly why the split does not need a parallel table.
+
+    ``source_type``/``source_id`` attach the line to a domain object (parcours 26,
+    lot 3). **Budget and project are two independent axes**: 90 € of a 150 € trip
+    to the DIY store counts in the bathroom project *and* in the "Bricolage"
+    envelope. Without the source FK the project side would simply not exist —
+    ``projects.services`` aggregates costs through that FK and nothing else.
 
     ``occurred_at`` is set to **noon in the household's timezone**, never
     midnight: an operation booked on the 1st or the 31st would otherwise slide
@@ -648,6 +689,7 @@ def create_bank_expense_interaction(
             )
 
     budget = _resolve_expense_budget(household.id, budget_id)
+    source_ct, source_pk = resolve_allocation_source(household.id, source_type, source_id)
 
     with transaction_atomic():
         interaction = Interaction.objects.create(
@@ -658,9 +700,15 @@ def create_bank_expense_interaction(
             type="expense",
             occurred_at=household_noon(household, transaction.booked_on),
             amount=amount,
+            # Stays ``bank`` even with a source: the kind says where the expense
+            # came from (a statement line), not what it is about. The allocation
+            # editor's ownership rule reads this field and nothing else — see
+            # ``banking.services.set_allocations``.
             kind=KIND_BANK,
             supplier="",
             metadata=_build_expense_metadata(source_name=None, unit_price=None, extra=None),
+            source_content_type=source_ct,
+            source_object_id=source_pk,
             budget=budget,
             bank_transaction=transaction,
             reconciled_by="manual",

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -34,7 +34,7 @@ Le lot 7 du parcours 25 (recettes, virements internes, couverture — #390) est
 |---|---|---|
 | 1 | Socle de conformité (`ComplianceWaiver`, détecteurs, API) | ✅ **Livré** |
 | 2 | Module « Argent » à onglets + file de rangement | ✅ **Livré** — voir [money.md](./money.md) |
-| 3 | Une ventilation porte projet, zone et budget | ⬜ |
+| 3 | Une ventilation porte projet, zone et budget | ✅ **Livré** |
 | 4 | Tout est une ligne de compte (espèces) | ⬜ |
 | 5 | Recettes et mouvements internes | ⬜ |
 | 6 | Le relevé confirme les récurrences | ⬜ |
@@ -489,13 +489,14 @@ base pour ne pas avoir à arbitrer deux fois la même situation.
 
 ### Les cinq détecteurs du lot — `detectors.py`
 
-| Clé | Sévérité | Arbitrable |
-|---|---|---|
-| `account_no_opening_balance` | `blocker` | ❌ prérequis |
-| `transaction_unallocated` | `error` | ✅ |
-| `transaction_partially_allocated` | `error` | ✅ |
-| `expense_unreconciled` | `warning` | ✅ |
-| `account_chain_broken` | `error` | ✅ |
+| Clé | Sévérité | Arbitrable | Lot |
+|---|---|---|---|
+| `account_no_opening_balance` | `blocker` | ❌ prérequis | 1 |
+| `transaction_unallocated` | `error` | ✅ | 1 |
+| `transaction_partially_allocated` | `error` | ✅ | 1 |
+| `expense_unreconciled` | `warning` | ✅ | 1 |
+| `account_chain_broken` | `error` | ✅ | 1 |
+| `expense_without_budget` | `warning` | ✅ | 3 |
 
 Les sorties « à affecter » excluent les recettes (leur détecteur arrive au lot 5),
 les mouvements internes et leurs contreparties (l'argent est compté une fois, plus
@@ -524,6 +525,64 @@ a bougé.
 Le libellé utilisateur de chaque `kind` vit dans le namespace i18n `money` du
 front, pas en `gettext` backend : ajouter un détecteur ne doit pas imposer un
 passage dans quatre `.po`.
+
+## Ventilation multi-axes (parcours 26, lot 3)
+
+### Budget et projet sont deux axes **indépendants**
+
+Le cas réel : 150 € chez Leroy Merlin, dont 90 € pour le chantier salle de bain et
+60 € sans rapport. Ces 90 € comptent dans le chantier **et** dans l'enveloppe
+« Bricolage » — ce ne sont pas deux façons de dire la même chose.
+
+Avant ce lot une ligne de ventilation ne portait qu'un budget. Or
+`projects/services.py::_expense_amounts` agrège les coûts par la **FK polymorphe
+source**, et `create_bank_expense_interaction` ne la posait pas : ces 90 € ne
+remontaient donc dans **aucun** coût de projet.
+
+`create_bank_expense_interaction` accepte désormais `source_type`/`source_id`
+(valeurs de `ALLOWED_SOURCE_TYPES`) et `zone_ids` (qui existait déjà).
+`resolve_allocation_source` fait la résolution — et **vérifie le foyer** : sans ce
+contrôle un client pourrait gonfler le coût d'un projet qu'il ne peut même pas voir.
+
+`kind` reste `bank` même avec une source : le kind dit *d'où vient* la dépense (une
+ligne de relevé), pas *sur quoi elle porte*.
+
+### ⚠️ La règle de propriété lit `kind` seul
+
+`set_allocations` et `delete_transaction` décidaient qu'une dépense leur
+« appartenait » si `kind='bank'` **et** qu'elle n'avait pas d'objet source. La
+seconde clause était redondante (un achat de stock a `kind='stock_purchase'`,
+jamais `'bank'`) — et devient **activement fausse** dès qu'une ligne de ventilation
+porte un projet : la ligne cessait d'être possédée, donc elle était *détachée* au
+lieu d'être supprimée à la ré-édition. **Chaque ré-édition d'un découpage laissait
+une dépense fantôme derrière elle**, toujours comptée dans le coût du projet.
+Exactement l'orphelin que le parcours 26 supprime.
+
+L'asymétrie qui justifiait la règle est préservée : une dépense qui **préexiste** au
+relevé (achat de stock rapproché sur la ligne) est toujours seulement détachée —
+la supprimer emporterait ses documents, tags, zones et parfois une tâche.
+
+### Rattacher une dépense existante — ce que le matcher refuse de deviner
+
+Un achat de 90 € saisi depuis une page projet ne sera **jamais** proposé par
+`matching.score_pair` pour une ligne de 150 € : l'écart de montant dépasse la
+tolérance, par construction, et c'est bien ainsi — 60 € d'écart n'est pas un
+appariement plausible. Mais les 90 € sont bien *une partie* de la ligne.
+
+D'où `UnreconciledPicker` (dans `SuggestionsDialog`) : un sélecteur **explicite**
+alimenté par le détecteur `expense_unreconciled`, qui est déjà l'inventaire exact
+des candidates. Les dépenses plus grosses que le reste à ventiler sont masquées —
+`assert_allocation_fits` les refuserait, et proposer un bouton qui échoue est pire
+que ne rien proposer. **C'est ce qui ferme l'orphelin « dépense non rapprochée »
+dans le cas partiel.**
+
+### Une erreur de référence est un 400 qui nomme la ligne
+
+`create_bank_expense_interaction` signale les mauvaises références (zone inconnue,
+budget d'un autre foyer, source hors foyer) par un `ValueError`. Laissé tel quel il
+remontait en **500** sur une simple erreur client. `set_allocations` le convertit en
+400 en préfixant le numéro de ligne — sur un découpage à cinq lignes, c'est le
+numéro qui rend le message actionnable.
 
 ## Ce que les lots suivants ajouteront *(à venir)*
 - **Règle transverse** — on n'additionne **jamais** un total banque et un total

--- a/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
+++ b/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
@@ -92,7 +92,7 @@ incohérence à corriger.
 | Écart | Détection | Résolution | Flag légitime | Lot |
 |---|---|---|---|---|
 | **Non rapprochée** | `bank_transaction IS NULL` et date dans la fenêtre | rattacher à une ligne | « payé par un tiers » | 1 ✅ |
-| **Hors budget** | `budget IS NULL` | affecter un budget | « hors de tout budget, volontairement » | 3 |
+| **Hors budget** | `budget IS NULL` | affecter un budget | « hors de tout budget, volontairement » | 3 ✅ |
 
 ### Sur un compte
 
@@ -142,7 +142,7 @@ puis ventiler 90 € laisserait 60 € couverts par un motif qui ne décrit plus
 |---|---|---|
 | 1 | **Socle de conformité** — `ComplianceWaiver`, `coverage.py`, registre de détecteurs, 5 détecteurs, API | ✅ Livré |
 | 2 | **Module « Argent »** — coque à onglets, panneau Contrôle, file de rangement, actions groupées | ✅ Livré |
-| 3 | **Une ventilation porte projet, zone et budget** — les deux axes sont indépendants | ⬜ |
+| 3 | **Une ventilation porte projet, zone et budget** — les deux axes sont indépendants | ✅ Livré |
 | 4 | **Tout est une ligne de compte** — `create_manual_transaction`, espèces | ⬜ |
 | 5 | **Recettes et mouvements internes** — `inflow_nature`, contreparties | ⬜ |
 | 6 | **Le relevé confirme les récurrences** — `match_recurrences` | ⬜ |

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -7,9 +7,12 @@ import { Input } from '@/design-system/input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
+import { ZoneMultiSelect } from '@/components/ZoneMultiSelect';
 import type { AllocationLine } from '@/lib/api/banking';
 import { useBudgets } from '@/features/budget/hooks';
 import { useAllocations, useSetAllocations } from './hooks';
+import AllocationSourceSelect from './AllocationSourceSelect';
+import { NO_SOURCE, type AllocationSource } from './allocationSource';
 
 interface AllocationDialogProps {
   open: boolean;
@@ -28,12 +31,21 @@ interface DraftLine {
   subject: string;
   amount: string;
   budgetId: string;
+  /** Axe « objet » (projet / équipement / stock) — indépendant du budget. */
+  source: AllocationSource;
+  zoneIds: string[];
 }
 
 let lineCounter = 0;
-function blankLine(subject = '', amount = '', budgetId = ''): DraftLine {
+function blankLine(
+  subject = '',
+  amount = '',
+  budgetId = '',
+  source: AllocationSource = NO_SOURCE,
+  zoneIds: string[] = [],
+): DraftLine {
   lineCounter += 1;
-  return { key: `line-${lineCounter}`, subject, amount, budgetId };
+  return { key: `line-${lineCounter}`, subject, amount, budgetId, source, zoneIds };
 }
 
 /**
@@ -67,7 +79,17 @@ export default function AllocationDialog({
     const existing = allocationsQuery.data.allocations;
     setLines(
       existing.length > 0
-        ? existing.map((a) => blankLine(a.subject, a.amount ?? '', a.budget?.id ?? ''))
+        ? existing.map((a) =>
+            blankLine(
+              a.subject,
+              a.amount ?? '',
+              a.budget?.id ?? '',
+              a.source_type && a.source_id
+                ? { type: a.source_type as AllocationSource['type'], id: a.source_id }
+                : NO_SOURCE,
+              a.zone_ids ?? [],
+            ),
+          )
         : // Première ventilation : on pré-remplit une ligne au montant total,
           // le cas le plus fréquent (une opération = un poste).
           [blankLine(label, total.toFixed(2), '')],
@@ -99,10 +121,19 @@ export default function AllocationDialog({
         setError(t('banking.allocation.errors.amountInvalid'));
         return;
       }
+      // Un type de source sans objet choisi est une ligne à moitié remplie : le
+      // serveur la refuserait, autant le dire ici et nommer la ligne.
+      if (line.source.type && !line.source.id) {
+        setError(t('banking.allocation.errors.sourceIncomplete'));
+        return;
+      }
       payload.push({
         subject: line.subject.trim() || label,
         amount: value.toFixed(2),
         budget_id: line.budgetId || null,
+        source_type: line.source.type || null,
+        source_id: line.source.id || null,
+        zone_ids: line.zoneIds,
       });
     }
 
@@ -195,6 +226,31 @@ export default function AllocationDialog({
                     />
                   </FormField>
                 </div>
+
+                {/* Axe « objet », indépendant du budget : ces 90 € comptent dans le
+                    chantier *et* dans l'enveloppe. */}
+                <FormField
+                  label={t('banking.allocation.fields.attachTo')}
+                  htmlFor={`src-${line.key}-source-type`}
+                >
+                  <AllocationSourceSelect
+                    idPrefix={`src-${line.key}`}
+                    value={line.source}
+                    onChange={(source) => update(line.key, { source })}
+                  />
+                </FormField>
+
+                <FormField
+                  label={t('banking.allocation.fields.zones')}
+                  htmlFor={`z-${line.key}`}
+                >
+                  <ZoneMultiSelect
+                    id={`z-${line.key}`}
+                    value={line.zoneIds}
+                    onChange={(zoneIds) => update(line.key, { zoneIds })}
+                    maxHeightClass="max-h-32"
+                  />
+                </FormField>
               </div>
             </div>
           ))}

--- a/ui/src/features/banking/AllocationSourceSelect.tsx
+++ b/ui/src/features/banking/AllocationSourceSelect.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Select } from '@/design-system/select';
+import { useProjects } from '@/features/projects/hooks';
+import { useEquipmentList } from '@/features/equipment/hooks';
+import { useStockItems } from '@/features/stock/hooks';
+
+import type { AllocationSource, AllocationSourceType } from './allocationSource';
+
+interface AllocationSourceSelectProps {
+  idPrefix: string;
+  value: AllocationSource;
+  onChange: (next: AllocationSource) => void;
+}
+
+/**
+ * « Rattacher à » — l'axe *objet* d'une ligne de ventilation (parcours 26, lot 3).
+ *
+ * Budget et projet sont deux axes **indépendants** : 90 € des 150 € dépensés chez
+ * Leroy Merlin comptent dans le chantier salle de bain *et* dans l'enveloppe
+ * « Bricolage ». Sans ce champ le côté projet n'existerait pas du tout —
+ * `projects.services` agrège les coûts par la FK polymorphe et par rien d'autre.
+ *
+ * Deux `Select` plutôt qu'une liste unique de tous les objets du foyer : choisir le
+ * type d'abord évite de charger équipements et stock quand on ne veut qu'un projet,
+ * et garde une liste lisible sur un foyer bien rempli.
+ */
+export default function AllocationSourceSelect({
+  idPrefix,
+  value,
+  onChange,
+}: AllocationSourceSelectProps) {
+  const { t } = useTranslation();
+
+  // Trois requêtes pour tout le dialog, pas trois par ligne : React Query dédoublonne
+  // par clé, donc les N lignes d'un découpage partagent le même cache.
+  const projectsQuery = useProjects();
+  const equipmentQuery = useEquipmentList();
+  const stockQuery = useStockItems();
+
+  const options = React.useMemo(() => {
+    if (value.type === 'projects.project') {
+      return (projectsQuery.data ?? []).map((p) => ({ value: p.id, label: p.title }));
+    }
+    if (value.type === 'equipment.equipment') {
+      return (equipmentQuery.data ?? []).map((e) => ({ value: e.id, label: e.name }));
+    }
+    if (value.type === 'stock.stockitem') {
+      return (stockQuery.data ?? []).map((s) => ({ value: s.id, label: s.name }));
+    }
+    return [];
+  }, [value.type, projectsQuery.data, equipmentQuery.data, stockQuery.data]);
+
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      <Select
+        id={`${idPrefix}-source-type`}
+        value={value.type}
+        // Changer de type vide l'id : garder l'ancien produirait une référence
+        // valide dans le mauvais modèle, qui passerait la validation serveur.
+        onChange={(e) =>
+          onChange({ type: e.target.value as AllocationSourceType | '', id: '' })
+        }
+        options={[
+          { value: '', label: t('banking.allocation.source.none') },
+          { value: 'projects.project', label: t('banking.allocation.source.project') },
+          { value: 'equipment.equipment', label: t('banking.allocation.source.equipment') },
+          { value: 'stock.stockitem', label: t('banking.allocation.source.stock') },
+        ]}
+      />
+
+      {value.type ? (
+        <Select
+          id={`${idPrefix}-source-id`}
+          value={value.id}
+          onChange={(e) => onChange({ type: value.type, id: e.target.value })}
+          options={[
+            { value: '', label: t('banking.allocation.source.pick') },
+            ...options,
+          ]}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/features/banking/SuggestionsDialog.tsx
+++ b/ui/src/features/banking/SuggestionsDialog.tsx
@@ -3,8 +3,9 @@ import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
 import type { BankTransaction } from '@/lib/api/banking';
-import { useLinkInteraction, useSuggestions } from './hooks';
+import { useAllocations, useLinkInteraction, useSuggestions } from './hooks';
 import SuggestionRow from './SuggestionRow';
+import UnreconciledPicker from './UnreconciledPicker';
 
 interface SuggestionsDialogProps {
   open: boolean;
@@ -20,9 +21,11 @@ export default function SuggestionsDialog({
 }: SuggestionsDialogProps) {
   const { t } = useTranslation();
   const suggestionsQuery = useSuggestions(open ? transaction.id : undefined);
+  const allocationsQuery = useAllocations(open ? transaction.id : undefined);
   const linkMutation = useLinkInteraction();
 
   const candidates = suggestionsQuery.data ?? [];
+  const remaining = allocationsQuery.data?.remaining ?? '0';
 
   return (
     <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.reconcile.title')}>
@@ -63,6 +66,19 @@ export default function SuggestionsDialog({
             ))}
           </div>
         )}
+
+        {/* Le chemin que le matcher ne peut pas prendre : un achat de 90 € n'est
+            pas un appariement plausible pour une ligne de 150 €, mais il en est
+            bien une *partie*. C'est ce qui ferme l'orphelin « dépense non
+            rapprochée » dans le cas partiel. */}
+        <div className="border-t border-border pt-3">
+          <UnreconciledPicker
+            transactionId={transaction.id}
+            remaining={remaining}
+            excludeIds={candidates.map((candidate) => candidate.interaction_id)}
+            onLinked={() => onOpenChange(false)}
+          />
+        </div>
 
         <div className="flex justify-end pt-2">
           <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>

--- a/ui/src/features/banking/UnreconciledPicker.tsx
+++ b/ui/src/features/banking/UnreconciledPicker.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card } from '@/design-system/card';
+import { Button } from '@/design-system/button';
+import { formatAmount } from '@/lib/format';
+import { useComplianceGroup } from '@/features/money/hooks';
+import { EXPENSE_UNRECONCILED } from '@/features/money/keys';
+import { useLinkInteraction } from './hooks';
+
+interface UnreconciledPickerProps {
+  transactionId: string;
+  /** Montant encore libre sur la ligne, en string décimale. */
+  remaining: string;
+  /** Ids déjà proposés par le matcher — on ne les répète pas. */
+  excludeIds: string[];
+  onLinked?: () => void;
+}
+
+/**
+ * Rattacher une dépense déjà saisie à cette ligne — le chemin que le matcher ne
+ * peut pas prendre.
+ *
+ * Un achat de 90 € saisi depuis une page projet ne sera **jamais** proposé pour une
+ * ligne de 150 € : `score_pair` rejette au-delà de la tolérance de montant, par
+ * construction, et c'est bien ainsi — un écart de 60 € n'est pas un appariement
+ * plausible. Mais c'est un cas d'usage réel : les 90 € sont *une partie* de la
+ * ligne. D'où ce sélecteur explicite, qui assume ce que le matcher refuse de
+ * deviner.
+ *
+ * La liste vient du détecteur `expense_unreconciled` : c'est déjà l'inventaire des
+ * dépenses que la banque n'a jamais confirmées, donc exactement le vivier. Les
+ * candidates plus grosses que le reste à ventiler sont masquées — le serveur les
+ * refuserait (`assert_allocation_fits`), et proposer un bouton qui échoue est pire
+ * que ne rien proposer.
+ */
+export default function UnreconciledPicker({
+  transactionId,
+  remaining,
+  excludeIds,
+  onLinked,
+}: UnreconciledPickerProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const groupQuery = useComplianceGroup(open ? EXPENSE_UNRECONCILED : undefined, { limit: 50 });
+  const linkMutation = useLinkInteraction();
+
+  const remainingValue = Number(remaining);
+  const excluded = React.useMemo(() => new Set(excludeIds), [excludeIds]);
+
+  const candidates = React.useMemo(() => {
+    const rows = groupQuery.data?.results ?? [];
+    return rows
+      .filter((finding) => !excluded.has(finding.object_id))
+      .map((finding) => {
+        const detail = finding.detail as Record<string, string | undefined>;
+        return {
+          id: finding.object_id,
+          subject: detail.subject ?? finding.label,
+          amount: detail.amount ?? '0',
+          occurredAt: detail.occurred_at ?? '',
+        };
+      })
+      .filter((row) => Number(row.amount) <= remainingValue + 0.001);
+  }, [groupQuery.data, excluded, remainingValue]);
+
+  if (!open) {
+    return (
+      <Button type="button" variant="outline" size="sm" onClick={() => setOpen(true)}>
+        {t('banking.reconcile.pickExisting')}
+      </Button>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">
+        {t('banking.reconcile.pickExistingHint', { amount: formatAmount(remaining) })}
+      </p>
+
+      {groupQuery.isLoading ? (
+        <div className="h-16 animate-pulse rounded-lg bg-muted" />
+      ) : candidates.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          {t('banking.reconcile.noUnreconciled')}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          {candidates.map((candidate) => (
+            <Card key={candidate.id} className="flex items-center gap-2 p-2 text-sm">
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-foreground">{candidate.subject}</p>
+                <p className="text-xs text-muted-foreground">
+                  {candidate.occurredAt
+                    ? new Date(candidate.occurredAt).toLocaleDateString()
+                    : ''}
+                </p>
+              </div>
+              <span className="shrink-0 tabular-nums text-foreground">
+                {formatAmount(candidate.amount)}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={linkMutation.isPending}
+                onClick={() =>
+                  linkMutation.mutate(
+                    { transactionId, interactionId: candidate.id },
+                    { onSuccess: () => onLinked?.() },
+                  )
+                }
+              >
+                {t('banking.reconcile.attach')}
+              </Button>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/features/banking/allocationSource.ts
+++ b/ui/src/features/banking/allocationSource.ts
@@ -1,0 +1,18 @@
+/**
+ * L'axe « objet » d'une ligne de ventilation (parcours 26, lot 3).
+ *
+ * Type et constante dans leur propre module : les exporter depuis le composant
+ * casserait le fast refresh de Vite (`react-refresh/only-export-components`).
+ */
+
+export type AllocationSourceType =
+  | 'projects.project'
+  | 'equipment.equipment'
+  | 'stock.stockitem';
+
+export interface AllocationSource {
+  type: AllocationSourceType | '';
+  id: string;
+}
+
+export const NO_SOURCE: AllocationSource = { type: '', id: '' };

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -290,11 +290,20 @@ export async function unlinkCashCounterpart(transactionId: string): Promise<void
 
 // --- Ventilation (parcours 25, lot 5) ---------------------------------------
 
-/** Une ligne de ventilation à envoyer. Le PUT est un « set » : on envoie tout. */
+/**
+ * Une ligne de ventilation à envoyer. Le PUT est un « set » : on envoie tout.
+ *
+ * `budget_id` et `source_type`/`source_id` sont deux axes **indépendants** : une
+ * ligne peut porter les deux, et compte dans les deux (parcours 26, lot 3).
+ */
 export interface AllocationLine {
   subject: string;
   amount: string;
   budget_id?: string | null;
+  /** `projects.project` | `equipment.equipment` | `stock.stockitem`. */
+  source_type?: string | null;
+  source_id?: string | null;
+  zone_ids?: string[];
   notes?: string;
 }
 
@@ -305,6 +314,10 @@ export interface AllocatedExpense {
   amount: string | null;
   kind: string;
   budget: { id: string; name: string } | null;
+  source_type: string | null;
+  source_id: string | null;
+  source_label: string | null;
+  zone_ids: string[];
   bank_transaction: string | null;
   reconciled_by: string;
 }

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3254,11 +3254,21 @@
       "fields": {
         "subject": "Bezeichnung",
         "amount": "Betrag",
-        "budget": "Budget"
+        "budget": "Budget",
+        "attachTo": "Zuordnen zu",
+        "zones": "Bereiche"
       },
       "errors": {
         "amountInvalid": "Jeder Posten braucht einen positiven Betrag.",
-        "overAllocated": "Die Posten ergeben zusammen mehr als {{total}}."
+        "overAllocated": "Die Posten ergeben zusammen mehr als {{total}}.",
+        "sourceIncomplete": "Wählen Sie das Objekt aus oder setzen Sie „Nichts“ zurück."
+      },
+      "source": {
+        "none": "Nichts",
+        "project": "Projekt",
+        "equipment": "Gerät",
+        "stock": "Lagerartikel",
+        "pick": "Auswählen…"
       }
     },
     "reconcile": {
@@ -3274,7 +3284,11 @@
       "unknownExpense": "Ausgabe",
       "amountGap": "{{amount}} Abweichung",
       "dayGap_one": "{{count}} Tag Abstand",
-      "dayGap_other": "{{count}} Tage Abstand"
+      "dayGap_other": "{{count}} Tage Abstand",
+      "pickExisting": "Bereits erfasste Ausgabe verknüpfen",
+      "pickExistingHint": "Ausgaben, die die Bank nie bestätigt hat und die in die noch freien {{amount}} passen.",
+      "noUnreconciled": "Keine nicht abgeglichene Ausgabe passt in den Rest.",
+      "attach": "Verknüpfen"
     }
   },
   "pwa": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3254,11 +3254,21 @@
       "fields": {
         "subject": "Label",
         "amount": "Amount",
-        "budget": "Budget"
+        "budget": "Budget",
+        "attachTo": "Attach to",
+        "zones": "Zones"
       },
       "errors": {
         "amountInvalid": "Every item needs a positive amount.",
-        "overAllocated": "The items add up to more than {{total}}."
+        "overAllocated": "The items add up to more than {{total}}.",
+        "sourceIncomplete": "Pick the object to attach, or set it back to “Nothing”."
+      },
+      "source": {
+        "none": "Nothing",
+        "project": "Project",
+        "equipment": "Equipment",
+        "stock": "Stock item",
+        "pick": "Pick one…"
       }
     },
     "reconcile": {
@@ -3274,7 +3284,11 @@
       "unknownExpense": "Expense",
       "amountGap": "{{amount}} off",
       "dayGap_one": "{{count}} day apart",
-      "dayGap_other": "{{count}} days apart"
+      "dayGap_other": "{{count}} days apart",
+      "pickExisting": "Attach an expense you already recorded",
+      "pickExistingHint": "Expenses the bank never confirmed, that fit in the {{amount}} still free.",
+      "noUnreconciled": "No unreconciled expense fits in what is left.",
+      "attach": "Attach"
     }
   },
   "pwa": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3254,11 +3254,21 @@
       "fields": {
         "subject": "Concepto",
         "amount": "Importe",
-        "budget": "Presupuesto"
+        "budget": "Presupuesto",
+        "attachTo": "Vincular a",
+        "zones": "Zonas"
       },
       "errors": {
         "amountInvalid": "Cada partida necesita un importe positivo.",
-        "overAllocated": "Las partidas suman más de {{total}}."
+        "overAllocated": "Las partidas suman más de {{total}}.",
+        "sourceIncomplete": "Elija el objeto a vincular, o vuelva a «Nada»."
+      },
+      "source": {
+        "none": "Nada",
+        "project": "Proyecto",
+        "equipment": "Equipo",
+        "stock": "Artículo de inventario",
+        "pick": "Elegir…"
       }
     },
     "reconcile": {
@@ -3274,7 +3284,11 @@
       "unknownExpense": "Gasto",
       "amountGap": "{{amount}} de diferencia",
       "dayGap_one": "{{count}} día de diferencia",
-      "dayGap_other": "{{count}} días de diferencia"
+      "dayGap_other": "{{count}} días de diferencia",
+      "pickExisting": "Vincular un gasto ya registrado",
+      "pickExistingHint": "Gastos que el banco nunca confirmó y que caben en los {{amount}} aún libres.",
+      "noUnreconciled": "Ningún gasto sin conciliar cabe en lo que queda.",
+      "attach": "Vincular"
     }
   },
   "pwa": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3254,11 +3254,21 @@
       "fields": {
         "subject": "Intitulé",
         "amount": "Montant",
-        "budget": "Budget"
+        "budget": "Budget",
+        "attachTo": "Rattacher à",
+        "zones": "Zones"
       },
       "errors": {
         "amountInvalid": "Chaque poste doit avoir un montant positif.",
-        "overAllocated": "La somme des postes dépasse {{total}}."
+        "overAllocated": "La somme des postes dépasse {{total}}.",
+        "sourceIncomplete": "Choisissez l'objet à rattacher, ou remettez « Rien »."
+      },
+      "source": {
+        "none": "Rien",
+        "project": "Projet",
+        "equipment": "Équipement",
+        "stock": "Article de stock",
+        "pick": "Choisir…"
       }
     },
     "reconcile": {
@@ -3274,7 +3284,11 @@
       "unknownExpense": "Dépense",
       "amountGap": "écart de {{amount}}",
       "dayGap_one": "{{count}} jour d'écart",
-      "dayGap_other": "{{count}} jours d'écart"
+      "dayGap_other": "{{count}} jours d'écart",
+      "pickExisting": "Rattacher une dépense déjà saisie",
+      "pickExistingHint": "Dépenses que la banque n'a jamais confirmées, et qui tiennent dans les {{amount}} encore libres.",
+      "noUnreconciled": "Aucune dépense non rapprochée ne tient dans le reste.",
+      "attach": "Rattacher"
     }
   },
   "pwa": {


### PR DESCRIPTION
## Le cas réel

150 € chez Leroy Merlin, dont 90 € pour le chantier salle de bain et 60 € sans rapport. Ces 90 € comptent dans le chantier **et** dans l'enveloppe « Bricolage ». Budget et projet ne sont pas deux façons de dire la même chose : ce sont deux **axes indépendants**.

Avant ce lot, une ligne de ventilation ne portait qu'un budget. Or `projects/services.py::_expense_amounts` agrège les coûts par la **FK polymorphe source**, et `create_bank_expense_interaction` ne la posait pas : ces 90 € ne remontaient dans **aucun** coût de projet.

## Ce que ça change

- `create_bank_expense_interaction` accepte `source_type`/`source_id`. `resolve_allocation_source` fait la résolution et **vérifie le foyer** — sans ce contrôle un client pourrait gonfler le coût d'un projet qu'il ne peut même pas voir.
- `kind` reste `bank` même avec une source : le kind dit *d'où vient* la dépense (une ligne de relevé), pas *sur quoi elle porte*.
- Détecteur **`expense_without_budget`**, scopé à la fenêtre de conformité pour une raison qui lui est propre : un budget est **mensuel**, donc en affecter un à une dépense de deux ans ne change aucun chiffre que quelqu'un regarde. Le signaler serait du travail pour rien, et le travail pour rien est ce qui fait qu'on arrête de lire un panneau de contrôle.
- `AllocationDialog` : par ligne, un « Rattacher à » (projet / équipement / stock) et le `ZoneMultiSelect` existant.

## ⚠️ La correction critique

La règle de propriété de l'éditeur (`set_allocations`, `delete_transaction`) exigeait `kind='bank'` **et** l'absence d'objet source. Cette seconde clause était **redondante** (un achat de stock a `kind='stock_purchase'`, jamais `'bank'`) — et devenait **activement fausse** dès qu'une ligne de ventilation porte un projet : la ligne cessait d'être « possédée », donc elle était *détachée* au lieu d'être supprimée à la ré-édition.

**Chaque ré-édition d'un découpage aurait laissé une dépense fantôme derrière elle**, toujours comptée dans le coût du projet. Exactement l'orphelin que ce parcours existe pour supprimer.

L'asymétrie qui justifiait la règle est préservée et testée : une dépense qui **préexiste** au relevé (un achat de stock rapproché sur la ligne) est toujours seulement détachée — la supprimer emporterait ses documents, tags, zones et parfois une tâche.

`TestOwnershipRuleRegression` ré-édite trois fois un découpage sur deux projets et vérifie qu'il reste **deux** dépenses, pas six, aucune détachée, et que les coûts reflètent le dernier découpage.

## Rattacher une dépense existante — ce que le matcher refuse de deviner

Un achat de 90 € saisi depuis une page projet ne sera **jamais** proposé par `score_pair` pour une ligne de 150 € : l'écart de montant dépasse la tolérance, par construction — et c'est bien ainsi, 60 € d'écart n'est pas un appariement plausible. Mais les 90 € sont bien *une partie* de la ligne.

`UnreconciledPicker` assume ce que le matcher refuse de deviner. Sa liste vient du détecteur `expense_unreconciled`, qui est déjà l'inventaire exact des candidates. Les dépenses plus grosses que le reste à ventiler sont masquées : `assert_allocation_fits` les refuserait, et proposer un bouton qui échoue est pire que ne rien proposer.

**C'est ce qui ferme l'orphelin « dépense non rapprochée » dans le cas partiel.**

## Un 500 devenu un 400

`create_bank_expense_interaction` signale les mauvaises références (zone inconnue, budget d'un autre foyer, source hors foyer) par un `ValueError`. Laissé tel quel il remontait en **500** sur une simple erreur client. C'est maintenant un 400 préfixé du **numéro de ligne** — sur un découpage à cinq lignes, c'est le numéro qui rend le message actionnable.

## Vérification

- **3181 tests backend** (+17). `test_allocation_axes.py` couvre les deux axes, le scoping foyer, le refus d'un type non supporté, le 400 nommant la ligne, et la régression sur la clause supprimée.
- **240 E2E verts, 0 échec** (suite complète, que la CI ne lance pas).
- `npm run build` (`tsc -b`) et `npm run lint` propres, **aucune dérive de schéma API**.

Note : `budget.spec.ts:126` et `project-purchase.spec.ts` échouent quand on les lance en sous-ensemble — vérifié sur `main`, c'est une dépendance à l'ordre préexistante, pas une régression. Ils passent dans la suite complète.

Doc : section « Ventilation multi-axes » de `docs/MODULES/banking.md`, règles transverses dans `CLAUDE.md`.