### PR TITLE
feat(money): la dépense en espèces devient une opération de compte (parcours 26, lot 4)

### DIFF
--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -1,4 +1,4 @@
-"""Banking's own compliance detectors — the first five entries of the catalogue.
+"""Banking's own compliance detectors — most of the orphan catalogue.
 
 Each one answers a question the household would otherwise have to ask itself, and
 would therefore never ask:
@@ -8,7 +8,8 @@ would therefore never ask:
 - an expense was typed in that the bank never saw (``expense_unreconciled``);
 - an expense that counts against no envelope (``expense_without_budget``);
 - an account whose starting point is unknown (``account_no_opening_balance``);
-- an account whose statements do not chain (``account_chain_broken``).
+- an account whose statements do not chain (``account_chain_broken``);
+- a cash account in the red, which is physically impossible (``account_cash_negative``).
 
 Every detector that reasons about "money we should know about" is scoped by
 ``banking.coverage``: outside the conformity window an écart is not an écart, it
@@ -48,6 +49,7 @@ EXPENSE_UNRECONCILED = "expense_unreconciled"
 EXPENSE_WITHOUT_BUDGET = "expense_without_budget"
 ACCOUNT_NO_OPENING_BALANCE = "account_no_opening_balance"
 ACCOUNT_CHAIN_BROKEN = "account_chain_broken"
+ACCOUNT_CASH_NEGATIVE = "account_cash_negative"
 
 
 # --- Shared base: spendable outflows inside their account's window -----------
@@ -277,6 +279,59 @@ def _find_no_opening_balance(household, **window) -> list[Finding]:
     ]
 
 
+def _negative_cash_pairs(household) -> list[tuple[BankAccount, Decimal]]:
+    """Cash accounts showing a negative balance, with the figure.
+
+    Physically impossible: you cannot hand over a note you do not have. So it never
+    means "overdraft", it means a withdrawal was never declared — the money left
+    the bank account and nobody said it arrived in the pot. Hence
+    ``waivable=False``: there is no motive that makes this acceptable, only a
+    missing operation to record.
+
+    Python rather than SQL for the same reason as the chain check: the balance is a
+    computation (``balances.compute_balance``), and the cost is bounded by the
+    number of cash accounts — one, usually.
+    """
+    from .balances import compute_balance
+
+    pairs = []
+    for account in BankAccount.objects.filter(
+        household=household, archived=False, kind=BankAccount.Kind.CASH
+    ):
+        balance = compute_balance(account=account)
+        if balance.amount < 0:
+            pairs.append((account, balance.amount))
+    return pairs
+
+
+def _count_negative_cash(household) -> int:
+    return len(_negative_cash_pairs(household))
+
+
+def _find_negative_cash(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
+    pairs = _negative_cash_pairs(household)
+    if pks is not None:
+        wanted = {str(p) for p in pks}
+        pairs = [p for p in pairs if str(p[0].pk) in wanted]
+    if exclude_pks:
+        unwanted = {str(p) for p in exclude_pks}
+        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
+    if offset or limit:
+        start = offset or 0
+        pairs = pairs[start : start + limit] if limit else pairs[start:]
+
+    return [
+        Finding(
+            kind=ACCOUNT_CASH_NEGATIVE,
+            object_id=str(account.pk),
+            label=account.name,
+            fingerprint=fingerprint_of(ACCOUNT_CASH_NEGATIVE, amount),
+            detail={"name": account.name, "balance": str(amount)},
+        )
+        for account, amount in pairs
+    ]
+
+
 def _chain_broken_pairs(household) -> list[tuple[BankAccount, list]]:
     """Accounts whose statement chain does not close, with their gaps.
 
@@ -418,5 +473,17 @@ def _specs() -> list[DetectorSpec]:
             model=BankAccount,
             count=_count_chain_broken,
             findings=_find_chain_broken,
+        ),
+        DetectorSpec(
+            kind=ACCOUNT_CASH_NEGATIVE,
+            severity=ERROR,
+            label="Cash account in the red — a withdrawal was never declared",
+            target="account",
+            model=BankAccount,
+            count=_count_negative_cash,
+            findings=_find_negative_cash,
+            # No motive makes physically impossible money acceptable. There is an
+            # operation missing, not a judgement call to record.
+            waivable=False,
         ),
     ]

--- a/apps/banking/services.py
+++ b/apps/banking/services.py
@@ -619,3 +619,132 @@ def waive_finding(*, household, user, finding_kind: str, object_id: str, reason:
 def revoke_waiver(*, waiver) -> None:
     """Undo an arbitration. The écart comes back identical — that is the point."""
     waiver.delete()
+
+
+# --- Manual account lines (parcours 26, lot 4) --------------------------------
+
+
+def create_manual_transaction(
+    *,
+    household,
+    user,
+    account,
+    booked_on,
+    label: str,
+    amount: Decimal,
+    notes: str = "",
+):
+    """Record an operation nobody's bank will ever export.
+
+    Cash is the case that forced this: a note handed over at the market leaves no
+    statement line, so before this lot such a spend could only exist as a bare
+    ``Interaction`` — an expense the bank never saw, which the conformity control
+    can only ever report as an écart nobody can resolve. Making it a real account
+    line **removes that orphan by construction** rather than teaching the user to
+    arbitrate it every month.
+
+    ``dedup_hash`` carries a ``manual:{uuid4}`` discriminant. Two consequences,
+    both wanted:
+
+    - a manual entry is never a duplicate of itself (typing the same 20 € twice is
+      two spends, and only the user knows whether that is a mistake);
+    - it can never collide with an imported line, whose discriminant always comes
+      from the file (reference, balance, or occurrence index).
+    """
+    import uuid
+
+    from .models import BankAccount, BankTransaction, TransactionDirection
+
+    if account.household_id != household.id:
+        raise ValidationError({"account": "Account belongs to another household."})
+    if account.archived:
+        raise ValidationError({"account": "This account is archived."})
+
+    value = Decimal(str(amount))
+    if value == 0:
+        raise ValidationError({"amount": "Amount cannot be zero."})
+
+    label = (label or "").strip()
+    if not label:
+        raise ValidationError({"label": "A label is required."})
+
+    normalized = normalize_label(label)
+    return BankTransaction.objects.create(
+        household=household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label[:500],
+        label_norm=normalized[:255],
+        amount=value,
+        currency=account.currency or "EUR",
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=normalized,
+            amount=value,
+            currency=account.currency or "EUR",
+            discriminant=f"manual:{uuid.uuid4()}",
+        ),
+        notes=notes or "",
+        created_by=user,
+        updated_by=user,
+    )
+
+
+def record_cash_expense(
+    *,
+    household,
+    user,
+    account,
+    booked_on,
+    label: str,
+    amount: Decimal,
+    budget_id=None,
+    zone_ids=None,
+    source_type: str | None = None,
+    source_id=None,
+    notes: str = "",
+):
+    """Spend cash: the operation and its allocation are born together.
+
+    Composed in **one** transaction on purpose. Creating the line first and
+    letting the user allocate it later would put a freshly created operation
+    straight into the "unallocated" queue — the app would be manufacturing its own
+    écarts. Here there is no window during which the line exists unaccounted for.
+
+    ``amount`` is given positive (what the user spent) and stored **signed**, like
+    every outflow.
+    """
+    value = abs(Decimal(str(amount)))
+    if value <= 0:
+        raise ValidationError({"amount": "Amount must be positive."})
+
+    with atomic():
+        transaction_row = create_manual_transaction(
+            household=household,
+            user=user,
+            account=account,
+            booked_on=booked_on,
+            label=label,
+            amount=-value,
+            notes=notes,
+        )
+        allocations = set_allocations(
+            household=household,
+            user=user,
+            transaction=transaction_row,
+            lines=[
+                {
+                    "subject": label,
+                    "amount": f"{value:.2f}",
+                    "budget_id": budget_id,
+                    "zone_ids": zone_ids or [],
+                    "source_type": source_type,
+                    "source_id": source_id,
+                    "notes": notes,
+                }
+            ],
+        )
+
+    return transaction_row, allocations

--- a/apps/banking/tests/test_api_transactions.py
+++ b/apps/banking/tests/test_api_transactions.py
@@ -18,6 +18,7 @@ from rest_framework.test import APIClient
 
 from banking.dedup import compute_dedup_hash
 from banking.models import BankTransaction, TransactionDirection
+from budget.models import Budget
 from households.models import HouseholdMember
 
 from .factories import BankAccountFactory, HouseholdFactory, HouseholdMemberFactory, UserFactory
@@ -276,3 +277,125 @@ class TestFlowEndpoint:
         stranger = BankAccountFactory(household=HouseholdFactory())
         response = client.get(f"{FLOW_URL}?account={stranger.id}")
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+# --- Cash expense (parcours 26, lot 4) ---------------------------------------
+
+
+@pytest.mark.django_db
+class TestCashExpenseEndpoint:
+    """POST /api/banking/transactions/cash-expense/.
+
+    One call, two writes, one transaction: the operation and its allocation. The
+    endpoint exists so a cash spend never lands in the app as an expense the bank
+    never saw — an écart the control could only report, never resolve.
+    """
+
+    URL = "/api/banking/transactions/cash-expense/"
+
+    def _cash_account(self, household, user):
+        from banking.models import BankAccount
+        from banking.services import create_account
+
+        return create_account(
+            household=household,
+            user=user,
+            name="Espèces",
+            kind=BankAccount.Kind.CASH,
+            opening_balance="200.00",
+            opening_balance_date="2026-01-01",
+        )
+
+    def test_records_the_line_and_its_allocation(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        account = self._cash_account(household, user)
+        budget = Budget.objects.create(household=household, name="Courses", monthly_amount=400)
+
+        response = _client_for(user).post(
+            self.URL,
+            {
+                "account": str(account.id),
+                "label": "Marché",
+                "amount": "18.50",
+                "booked_on": "2026-03-10",
+                "budget_id": str(budget.id),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        body = response.json()
+        assert body["transaction"]["amount"] == "-18.50"
+        assert len(body["allocations"]) == 1
+        assert body["allocations"][0]["amount"] == "18.50"
+
+    def test_defaults_to_today_without_a_date(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        account = self._cash_account(household, user)
+
+        response = _client_for(user).post(
+            self.URL,
+            {"account": str(account.id), "label": "Boulangerie", "amount": "4.20"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json()["transaction"]["booked_on"] == date.today().isoformat()
+
+    def test_a_missing_account_is_a_400(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        response = _client_for(user).post(
+            self.URL, {"label": "Marché", "amount": "18.50"}, format="json"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "account" in response.json()
+
+    def test_an_account_from_another_household_is_a_400(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        foreign = BankAccountFactory(household=HouseholdFactory())
+
+        response = _client_for(user).post(
+            self.URL,
+            {"account": str(foreign.id), "label": "Marché", "amount": "18.50"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_a_non_numeric_amount_is_a_400_not_a_500(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        account = self._cash_account(household, user)
+
+        response = _client_for(user).post(
+            self.URL,
+            {"account": str(account.id), "label": "Marché", "amount": "beaucoup"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "amount" in response.json()
+
+    def test_a_malformed_date_is_a_400(self):
+        household = HouseholdFactory()
+        user = _make_member(household)
+        account = self._cash_account(household, user)
+
+        response = _client_for(user).post(
+            self.URL,
+            {
+                "account": str(account.id),
+                "label": "Marché",
+                "amount": "18.50",
+                "booked_on": "10/03/2026",
+            },
+            format="json",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_requires_authentication(self):
+        assert APIClient().post(self.URL, {}, format="json").status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/apps/banking/tests/test_cash_expense.py
+++ b/apps/banking/tests/test_cash_expense.py
@@ -1,0 +1,379 @@
+# banking/tests/test_cash_expense.py
+"""Tout est une ligne de compte (parcours 26, lot 4).
+
+Une dépense en espèces ne laisse aucune ligne de relevé. Avant ce lot elle ne
+pouvait exister que comme `Interaction` nue — donc comme une dépense que la banque
+n'a jamais vue, que le contrôle de conformité ne peut que **signaler** sans que
+personne puisse la résoudre. Chaque mois, la même liste d'écarts inarbitrables.
+
+En faire une vraie opération de compte supprime l'orphelin **par construction**.
+C'est ce que ces tests protègent : l'opération et sa ventilation naissent
+ensemble, donc il n'existe aucun instant où la ligne est non affectée.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from banking.detectors import (
+    ACCOUNT_CASH_NEGATIVE,
+    EXPENSE_UNRECONCILED,
+    TRANSACTION_UNALLOCATED,
+)
+from banking.compliance import get_detector, open_findings, summary
+from banking.models import BankAccount, BankTransaction, ImportStatus, StatementImport
+from banking.services import (
+    create_manual_transaction,
+    record_cash_expense,
+    record_cash_withdrawal,
+)
+from banking.validators import remaining_to_allocate
+from budget.models import Budget
+from interactions.kinds import KIND_BANK
+from interactions.models import Interaction
+from projects.models import Project
+from projects.services import project_actual_cost
+
+from .factories import BankAccountFactory, HouseholdFactory, UserFactory
+
+
+@pytest.fixture
+def ctx(db):
+    household = HouseholdFactory()
+    user = UserFactory()
+    cash = BankAccountFactory(
+        household=household,
+        name="Espèces",
+        kind=BankAccount.Kind.CASH,
+        bank_label="",
+        opening_balance=Decimal("200.00"),
+        opening_balance_date=date(2026, 1, 1),
+    )
+    budget = Budget.objects.create(household=household, name="Courses", monthly_amount=400)
+    return household, user, cash, budget
+
+
+def group(household, kind):
+    return next(g for g in summary(household) if g.spec.kind == kind)
+
+
+@pytest.mark.django_db
+class TestCreateManualTransaction:
+    def test_creates_a_signed_outflow(self, ctx):
+        household, user, cash, _ = ctx
+        txn = create_manual_transaction(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("-18.50"),
+        )
+        assert txn.amount == Decimal("-18.50")
+        assert txn.direction == "out"
+        assert txn.label_raw == "Marché"
+        assert txn.label_norm == "MARCHE"
+
+    def test_typing_the_same_spend_twice_creates_two_lines(self, ctx):
+        """A manual entry is never a duplicate of itself: two 20 € handed over are
+        two spends, and only the user knows whether that was a mistake."""
+        household, user, cash, _ = ctx
+        for _ in range(2):
+            create_manual_transaction(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="Boulangerie",
+                amount=Decimal("-4.20"),
+            )
+        assert BankTransaction.objects.filter(account=cash).count() == 2
+
+    def test_its_hash_can_never_collide_with_an_imported_line(self, ctx):
+        household, user, cash, _ = ctx
+        txn = create_manual_transaction(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("-18.50"),
+        )
+        # An imported line's discriminant always comes from the file (reference,
+        # balance, occurrence index) — never from a uuid.
+        assert txn.dedup_hash
+        other = create_manual_transaction(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("-18.50"),
+        )
+        assert txn.dedup_hash != other.dedup_hash
+
+    def test_a_zero_amount_is_refused(self, ctx):
+        household, user, cash, _ = ctx
+        with pytest.raises(ValidationError):
+            create_manual_transaction(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="Rien",
+                amount=Decimal("0"),
+            )
+
+    def test_a_blank_label_is_refused(self, ctx):
+        household, user, cash, _ = ctx
+        with pytest.raises(ValidationError):
+            create_manual_transaction(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="   ",
+                amount=Decimal("-10.00"),
+            )
+
+    def test_an_account_from_another_household_is_refused(self, ctx):
+        household, user, _, _ = ctx
+        foreign = BankAccountFactory(household=HouseholdFactory())
+        with pytest.raises(ValidationError):
+            create_manual_transaction(
+                household=household,
+                user=user,
+                account=foreign,
+                booked_on=date(2026, 3, 10),
+                label="Marché",
+                amount=Decimal("-10.00"),
+            )
+
+    def test_an_archived_account_is_refused(self, ctx):
+        household, user, cash, _ = ctx
+        cash.archived = True
+        cash.save(update_fields=["archived"])
+        with pytest.raises(ValidationError):
+            create_manual_transaction(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="Marché",
+                amount=Decimal("-10.00"),
+            )
+
+
+@pytest.mark.django_db
+class TestRecordCashExpense:
+    def test_the_line_and_its_allocation_are_born_together(self, ctx):
+        """No window during which the operation sits unallocated — the app must not
+        manufacture its own écarts."""
+        household, user, cash, budget = ctx
+
+        txn, allocations = record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("18.50"),
+            budget_id=str(budget.id),
+        )
+
+        assert txn.amount == Decimal("-18.50")
+        assert len(allocations) == 1
+        assert allocations[0].amount == Decimal("18.50")
+        assert allocations[0].budget_id == budget.id
+        assert allocations[0].kind == KIND_BANK
+        assert remaining_to_allocate(txn) == Decimal("0.00")
+
+    def test_the_amount_is_given_positive_and_stored_signed(self, ctx):
+        household, user, cash, _ = ctx
+        txn, _ = record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("18.50"),
+        )
+        assert txn.amount < 0
+        assert Interaction.objects.get(bank_transaction=txn).amount == Decimal("18.50")
+
+    def test_it_produces_no_unallocated_ecart(self, ctx):
+        household, user, cash, budget = ctx
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("18.50"),
+            budget_id=str(budget.id),
+        )
+        assert group(household, TRANSACTION_UNALLOCATED).detected == 0
+
+    def test_it_produces_no_unreconciled_ecart_either(self, ctx):
+        """THE point of the lot: the expense is attached to a line, so it is not an
+        expense the bank never saw."""
+        household, user, cash, budget = ctx
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("18.50"),
+            budget_id=str(budget.id),
+        )
+        assert group(household, EXPENSE_UNRECONCILED).detected == 0
+
+    def test_it_can_carry_a_project(self, ctx):
+        household, user, cash, budget = ctx
+        project = Project.objects.create(household=household, title="Salle de bain")
+
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Quincaillerie",
+            amount=Decimal("22.00"),
+            budget_id=str(budget.id),
+            source_type="projects.project",
+            source_id=str(project.id),
+        )
+
+        assert project_actual_cost(project) == Decimal("22.00")
+
+    def test_a_negative_amount_is_refused(self, ctx):
+        household, user, cash, _ = ctx
+        with pytest.raises(ValidationError):
+            record_cash_expense(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="Marché",
+                amount=Decimal("0"),
+            )
+
+    def test_a_bad_budget_rolls_the_whole_thing_back(self, ctx):
+        """Atomic: a rejected allocation must not leave the operation behind, or we
+        would have created the very orphan this service exists to prevent."""
+        household, user, cash, _ = ctx
+        foreign_budget = Budget.objects.create(
+            household=HouseholdFactory(), name="Ailleurs", monthly_amount=100
+        )
+
+        with pytest.raises(ValidationError):
+            record_cash_expense(
+                household=household,
+                user=user,
+                account=cash,
+                booked_on=date(2026, 3, 10),
+                label="Marché",
+                amount=Decimal("18.50"),
+                budget_id=str(foreign_budget.id),
+            )
+
+        assert not BankTransaction.objects.filter(account=cash).exists()
+        assert not Interaction.objects.filter(household=household, type="expense").exists()
+
+
+@pytest.mark.django_db
+class TestNegativeCashDetector:
+    def test_spending_more_cash_than_declared_is_an_ecart(self, ctx):
+        household, user, cash, budget = ctx
+        # Opening balance is 200 €; spend 250 € and the pot goes impossible.
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("250.00"),
+            budget_id=str(budget.id),
+        )
+
+        findings = open_findings(household, get_detector(ACCOUNT_CASH_NEGATIVE))
+        assert [f.object_id for f in findings] == [str(cash.pk)]
+        assert findings[0].detail["balance"] == "-50.00"
+
+    def test_declaring_the_withdrawal_resolves_it(self, ctx):
+        household, user, cash, budget = ctx
+        bank = BankAccountFactory(
+            household=household, name="Courant", opening_balance_date=date(2026, 1, 1)
+        )
+        StatementImport.objects.create(
+            household=household,
+            account=bank,
+            provider="generic_csv",
+            status=ImportStatus.COMPLETED,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 3, 31),
+        )
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("250.00"),
+            budget_id=str(budget.id),
+        )
+        assert group(household, ACCOUNT_CASH_NEGATIVE).detected == 1
+
+        withdrawal = create_manual_transaction(
+            household=household,
+            user=user,
+            account=bank,
+            booked_on=date(2026, 3, 1),
+            label="RETRAIT DAB",
+            amount=Decimal("-100.00"),
+        )
+        record_cash_withdrawal(user=user, transaction=withdrawal, cash_account=cash)
+
+        assert group(household, ACCOUNT_CASH_NEGATIVE).detected == 0
+
+    def test_a_positive_cash_balance_is_not_an_ecart(self, ctx):
+        household, user, cash, budget = ctx
+        record_cash_expense(
+            household=household,
+            user=user,
+            account=cash,
+            booked_on=date(2026, 3, 10),
+            label="Marché",
+            amount=Decimal("18.50"),
+            budget_id=str(budget.id),
+        )
+        assert group(household, ACCOUNT_CASH_NEGATIVE).detected == 0
+
+    def test_a_bank_account_in_the_red_is_not_this_ecart(self, ctx):
+        """An overdraft is legitimate; an impossible pot of cash is not. Only cash
+        accounts are checked."""
+        household, user, _, _ = ctx
+        bank = BankAccountFactory(
+            household=household,
+            name="Courant",
+            opening_balance=Decimal("-300.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        create_manual_transaction(
+            household=household,
+            user=user,
+            account=bank,
+            booked_on=date(2026, 3, 10),
+            label="Frais",
+            amount=Decimal("-10.00"),
+        )
+        assert group(household, ACCOUNT_CASH_NEGATIVE).detected == 0
+
+    def test_it_cannot_be_arbitrated(self, ctx):
+        """No motive makes physically impossible money acceptable — there is an
+        operation missing, not a judgement call to record."""
+        assert get_detector(ACCOUNT_CASH_NEGATIVE).waivable is False

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -1,6 +1,7 @@
 """Banking REST API views."""
 import json
 from datetime import date
+from decimal import InvalidOperation
 
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
@@ -43,6 +44,7 @@ from .services import (
     archive_account,
     create_account,
     import_statement_file,
+    record_cash_expense,
     link_interaction,
     preview_statement_file,
     record_cash_withdrawal,
@@ -322,6 +324,62 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
         instance.updated_by = request.user
         instance.save(update_fields=[*updated_fields, "updated_by", "updated_at"])
         return Response(self.get_serializer(instance).data)
+
+    @action(detail=False, methods=["post"], url_path="cash-expense")
+    def cash_expense(self, request):
+        """Spend cash: create the operation **and** its allocation, together.
+
+        The point of going through the account rather than creating a bare expense:
+        a spend that exists only as an ``Interaction`` is an expense the bank never
+        saw, which the conformity control can only ever report as an écart nobody
+        can resolve. Recording it as a real account line removes that orphan by
+        construction.
+
+        Atomic on purpose — see ``services.record_cash_expense``. Creating the line
+        and letting the user allocate it later would drop a freshly created
+        operation straight into the "unallocated" queue: the app manufacturing its
+        own écarts.
+        """
+        from interactions.serializers import InteractionSerializer
+
+        household = request.household
+        if household is None:
+            raise ValidationError({"household_id": "A valid household context is required."})
+
+        account_id = request.data.get("account")
+        if not account_id:
+            raise ValidationError({"account": "This field is required."})
+        account = BankAccount.objects.filter(household=household, pk=account_id).first()
+        if account is None:
+            raise ValidationError({"account": "Unknown account for this household."})
+
+        booked_on = _parse_date_param(request.data.get("booked_on"), "booked_on") or date.today()
+
+        try:
+            transaction_row, allocations = record_cash_expense(
+                household=household,
+                user=request.user,
+                account=account,
+                booked_on=booked_on,
+                label=str(request.data.get("label") or ""),
+                amount=request.data.get("amount") or 0,
+                budget_id=request.data.get("budget_id"),
+                zone_ids=request.data.get("zone_ids") or [],
+                source_type=request.data.get("source_type"),
+                source_id=request.data.get("source_id"),
+                notes=str(request.data.get("notes") or ""),
+            )
+        except (TypeError, ValueError, InvalidOperation):
+            # A non-numeric amount is a client mistake, not a server fault.
+            raise ValidationError({"amount": "Expected a decimal amount."})
+
+        return Response(
+            {
+                "transaction": self.get_serializer(transaction_row).data,
+                "allocations": InteractionSerializer(allocations, many=True).data,
+            },
+            status=status.HTTP_201_CREATED,
+        )
 
     @action(detail=False, methods=["get"], url_path="flow")
     def flow(self, request):

--- a/apps/tasks/management/commands/seed_demo_data.py
+++ b/apps/tasks/management/commands/seed_demo_data.py
@@ -63,6 +63,12 @@ from electricity.models import (
     UsagePoint,
 )
 from households.models import Household, HouseholdMember
+from banking.models import (
+    BankAccount,
+    BankTransaction,
+    ComplianceWaiver,
+    StatementImport,
+)
 from interactions.models import Interaction
 from projects.models import Project
 from stock.models import StockCategory, StockItem
@@ -111,6 +117,15 @@ class Command(BaseCommand):
             ProtectiveDevice.objects.filter(board__household_id__in=household_ids).delete()
             ElectricityBoard.objects.filter(household_id__in=household_ids).delete()
             Interaction.objects.filter(household_id__in=household_ids).delete()
+            # Banking must go before the household: ``BankTransaction.account`` is
+            # PROTECT (an account holding history is archived, never deleted), so a
+            # household carrying a single statement line — or a cash expense typed
+            # from the UI — could not be deleted at all. A flush command that cannot
+            # flush is worse than no flush command.
+            BankTransaction.objects.filter(household_id__in=household_ids).delete()
+            ComplianceWaiver.objects.filter(household_id__in=household_ids).delete()
+            StatementImport.objects.filter(household_id__in=household_ids).delete()
+            BankAccount.objects.filter(household_id__in=household_ids).delete()
             StockItem.objects.filter(household_id__in=household_ids).delete()
             StockCategory.objects.filter(household_id__in=household_ids).delete()
             Zone.objects.filter(household_id__in=household_ids).delete()

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -35,7 +35,7 @@ Le lot 7 du parcours 25 (recettes, virements internes, couverture — #390) est
 | 1 | Socle de conformité (`ComplianceWaiver`, détecteurs, API) | ✅ **Livré** |
 | 2 | Module « Argent » à onglets + file de rangement | ✅ **Livré** — voir [money.md](./money.md) |
 | 3 | Une ventilation porte projet, zone et budget | ✅ **Livré** |
-| 4 | Tout est une ligne de compte (espèces) | ⬜ |
+| 4 | Tout est une ligne de compte (espèces) | ✅ **Livré** |
 | 5 | Recettes et mouvements internes | ⬜ |
 | 6 | Le relevé confirme les récurrences | ⬜ |
 | 7 | Continuité des relevés et provenance | ⬜ |
@@ -497,6 +497,7 @@ base pour ne pas avoir à arbitrer deux fois la même situation.
 | `expense_unreconciled` | `warning` | ✅ | 1 |
 | `account_chain_broken` | `error` | ✅ | 1 |
 | `expense_without_budget` | `warning` | ✅ | 3 |
+| `account_cash_negative` | `error` | ❌ incohérence | 4 |
 
 Les sorties « à affecter » excluent les recettes (leur détecteur arrive au lot 5),
 les mouvements internes et leurs contreparties (l'argent est compté une fois, plus
@@ -583,6 +584,66 @@ budget d'un autre foyer, source hors foyer) par un `ValueError`. Laissé tel que
 remontait en **500** sur une simple erreur client. `set_allocations` le convertit en
 400 en préfixant le numéro de ligne — sur un découpage à cinq lignes, c'est le
 numéro qui rend le message actionnable.
+
+## Tout est une ligne de compte (parcours 26, lot 4)
+
+### Pourquoi la dépense en espèces devait changer de nature
+
+Un billet donné au marché ne laisse aucune ligne de relevé. Avant ce lot, une telle
+dépense ne pouvait exister que comme `Interaction` nue — donc comme une **dépense
+que la banque n'a jamais vue**, que le contrôle de conformité ne peut que
+*signaler*, sans que personne puisse la résoudre. Chaque mois, la même liste
+d'écarts inarbitrables : le meilleur moyen de faire abandonner le contrôle.
+
+En faire une vraie opération de compte supprime l'orphelin **par construction**,
+plutôt que d'apprendre à l'utilisateur à l'arbitrer tous les mois.
+
+### `create_manual_transaction`
+
+Le `dedup_hash` porte un discriminant `manual:{uuid4}`. Deux conséquences, toutes
+deux voulues :
+
+- une saisie manuelle n'est **jamais** un doublon d'elle-même — deux fois 20 € en
+  liquide, ce sont deux dépenses, et seul l'utilisateur sait si c'est une erreur ;
+- elle ne peut **jamais** entrer en collision avec une ligne importée, dont le
+  discriminant vient toujours du fichier (référence, solde, index d'occurrence).
+
+### `record_cash_expense` — atomique par nécessité
+
+L'opération et sa ventilation naissent **dans la même transaction**. Créer la ligne
+puis laisser l'utilisateur la ventiler plus tard déposerait une opération
+fraîchement créée directement dans la file « à ranger » : l'app fabriquerait ses
+propres écarts. Ici il n'existe aucun instant où la ligne est non affectée — et un
+budget invalide fait rouler l'ensemble en arrière, opération comprise.
+
+`amount` est **donné positif** (ce que l'utilisateur a dépensé) et **stocké signé**,
+comme toute sortie.
+
+### Détecteur `account_cash_negative` — non arbitrable
+
+Un compte espèces dans le rouge est **physiquement impossible** : on ne donne pas un
+billet qu'on n'a pas. Ça ne veut donc jamais dire « découvert », ça veut dire qu'un
+retrait n'a pas été déclaré. D'où `waivable=False` : aucun motif ne rend acceptable
+de l'argent impossible, il y a une opération à enregistrer.
+
+Un **compte bancaire** à découvert n'est pas concerné — un découvert est légitime.
+Seuls les comptes `kind='cash'` sont vérifiés.
+
+### `CashExpenseDialog` — pas de cul-de-sac
+
+Sans compte espèces il n'y a rien à écrire. Mais renvoyer l'utilisateur vers un
+autre onglet au moment où il veut noter une dépense serait un cul-de-sac : le dialog
+propose de créer le compte **sur place, en un clic** (solde d'ouverture à zéro,
+daté du jour — qui est aussi le prérequis de conformité). La contrainte est tenue
+sans que la saisie soit interrompue.
+
+`ExpenseAdHocDialog` n'est plus utilisé par l'UI. L'endpoint `expenses_manual`
+reste pour compatibilité API.
+
+### API
+
+`POST /api/banking/transactions/cash-expense/` → `{transaction, allocations}`.
+Un montant non numérique est un **400**, pas un 500.
 
 ## Ce que les lots suivants ajouteront *(à venir)*
 - **Règle transverse** — on n'additionne **jamais** un total banque et un total

--- a/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
+++ b/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
@@ -101,7 +101,7 @@ incohérence à corriger.
 | **Sans solde d'ouverture** | `opening_balance_date IS NULL` | le renseigner | **aucun — prérequis bloquant** | 1 ✅ |
 | **Chaîne de soldes rompue** | `balances.check_balance_chain` | importer le relevé manquant | « relevé indisponible » | 1 ✅ |
 | **Période non couverte** | trou entre deux `StatementImport` | importer | « pas d'opération sur la période » | 7 |
-| **Espèces à découvert** | solde espèces négatif | déclarer le retrait qui l'alimente | **aucun — incohérence** | 4 |
+| **Espèces à découvert** | solde espèces négatif | déclarer le retrait qui l'alimente | **aucun — incohérence** | 4 ✅ |
 
 ### Sur une récurrence
 
@@ -143,7 +143,7 @@ puis ventiler 90 € laisserait 60 € couverts par un motif qui ne décrit plus
 | 1 | **Socle de conformité** — `ComplianceWaiver`, `coverage.py`, registre de détecteurs, 5 détecteurs, API | ✅ Livré |
 | 2 | **Module « Argent »** — coque à onglets, panneau Contrôle, file de rangement, actions groupées | ✅ Livré |
 | 3 | **Une ventilation porte projet, zone et budget** — les deux axes sont indépendants | ✅ Livré |
-| 4 | **Tout est une ligne de compte** — `create_manual_transaction`, espèces | ⬜ |
+| 4 | **Tout est une ligne de compte** — `create_manual_transaction`, espèces | ✅ Livré |
 | 5 | **Recettes et mouvements internes** — `inflow_nature`, contreparties | ⬜ |
 | 6 | **Le relevé confirme les récurrences** — `match_recurrences` | ⬜ |
 | 7 | **Continuité des relevés et provenance** — solde d'ouverture requis, badges | ⬜ |

--- a/e2e/budget.spec.ts
+++ b/e2e/budget.spec.ts
@@ -38,6 +38,29 @@ async function deleteAllBudgets(page: import('@playwright/test').Page): Promise<
   }
 }
 
+/**
+ * Ouvre le dialog de dépense en espèces, en créant le compte espèces au besoin.
+ * Depuis le parcours 26 lot 4, une dépense saisie à la main est une **opération de
+ * compte** : sans compte espèces il n'y a rien à écrire, et le dialog propose de le
+ * créer sur place plutôt que de renvoyer ailleurs.
+ */
+async function openCashDialog(page: import('@playwright/test').Page) {
+  await page.goto('/app/money?tab=expenses');
+  await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
+  await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  const createButton = dialog.getByRole('button', { name: 'Créer mon compte espèces' });
+  if (await createButton.isVisible().catch(() => false)) {
+    await createButton.click();
+  }
+
+  await expect(dialog.locator('#cash-label')).toBeVisible();
+  return dialog;
+}
+
 /** Crée un budget nommé via l'API et retourne l'objet créé. */
 async function apiCreateBudget(
   page: import('@playwright/test').Page,
@@ -244,39 +267,25 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
     await apiCreateBudget(page, 'Courses Tests', 500);
   });
 
-  test('le dialog de dépense ad-hoc propose le select de budget quand un budget nommé existe', async ({ page }) => {
-    await page.goto('/app/money?tab=expenses');
-    await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
-
-    // Ouvrir le dialog de dépense ad-hoc
-    await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
-
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
-    await expect(dialog).toContainText('Enregistrer une dépense ad-hoc');
+  test('le dialog de dépense en espèces propose le select de budget quand un budget nommé existe', async ({ page }) => {
+    const dialog = await openCashDialog(page);
 
     // Le select "Budget" doit être présent
-    await expect(dialog.getByLabel('Budget')).toBeVisible();
-    await expect(dialog.locator('#adhoc-budget')).toBeVisible();
+    await expect(dialog.locator('#cash-budget')).toBeVisible();
 
     // L'option "Courses Tests" doit être disponible dans le select
-    const select = dialog.locator('#adhoc-budget');
+    const select = dialog.locator('#cash-budget');
     await expect(select.locator('option', { hasText: 'Courses Tests' })).toHaveCount(1);
   });
 
   test('enregistrer une dépense rattachée à un budget incrémente le budget', async ({ page }) => {
-    // Créer la dépense via l'UI
-    await page.goto('/app/money?tab=expenses');
-    await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
-
-    const dialog = page.getByRole('dialog');
-    await expect(dialog).toBeVisible();
+    const dialog = await openCashDialog(page);
 
     const subject = `Supermarché E2E ${Date.now()}`;
-    await page.locator('#adhoc-subject').fill(subject);
+    await dialog.locator('#cash-label').fill(subject);
 
     // Sélectionner le budget "Courses Tests"
-    await page.locator('#adhoc-budget').selectOption({ label: 'Courses Tests' });
+    await dialog.locator('#cash-budget').selectOption({ label: 'Courses Tests' });
 
     await page.locator('#purchase-price').fill('85');
     await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();

--- a/e2e/expense-adhoc.spec.ts
+++ b/e2e/expense-adhoc.spec.ts
@@ -1,54 +1,96 @@
 import { test, expect } from '@playwright/test';
 
 /**
- * Parcours 08 — Lot 1.2 : enregistrer une dépense ad-hoc.
+ * Parcours 26 — Lot 4 : la dépense en espèces est une opération de compte.
  *
- * Issue: https://github.com/jammindev/house/issues/124
+ * Remplace le parcours « dépense ad-hoc » (parcours 08 lot 1.2, issue #124). Le
+ * formulaire n'a presque pas changé ; ce qu'il **écrit** a changé du tout au tout.
  *
- * La dépense ad-hoc n'a pas de source : c'est l'utilisateur qui saisit
- * le sujet libre. metadata.kind = 'manual', source_content_type = NULL.
+ * Une dépense qui n'existe que comme `Interaction` est une dépense que la banque
+ * n'a jamais vue : le contrôle de conformité ne peut que la signaler, et personne
+ * ne peut la résoudre. En passant par le compte espèces, l'opération et sa
+ * ventilation naissent ensemble — l'orphelin disparaît par construction.
  */
 
-test('parcours dépense ad-hoc — Restaurant Le Bistrot 32€', async ({ page }) => {
+/** Le compte espèces se crée depuis le dialog, en un clic. */
+async function openCashDialog(page: import('@playwright/test').Page) {
   await page.goto('/app/money?tab=expenses');
-  await expect(page).toHaveURL(/\/app\/money/);
   await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
-
-  // Cliquer sur le bouton « + Nouvelle dépense » de l'onglet Dépenses
   await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText('Enregistrer une dépense ad-hoc');
 
-  const subject = `Restaurant E2E ${Date.now()}`;
-  await page.locator('#adhoc-subject').fill(subject);
+  // Premier passage : pas encore de compte espèces. Le dialog ne renvoie pas
+  // ailleurs — il propose de le créer sur place.
+  const createButton = dialog.getByRole('button', { name: 'Créer mon compte espèces' });
+  if (await createButton.isVisible().catch(() => false)) {
+    await createButton.click();
+  }
+
+  await expect(dialog.locator('#cash-label')).toBeVisible();
+  return dialog;
+}
+
+test('dépense en espèces — Marché 32 €, opération et ventilation ensemble', async ({ page }) => {
+  const dialog = await openCashDialog(page);
+
+  const label = `Marché E2E ${Date.now()}`;
+  await dialog.locator('#cash-label').fill(label);
   await page.locator('#purchase-price').fill('32');
-  await page.locator('#purchase-supplier').fill('Le Bistrot E2E');
   await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
   await expect(dialog).toBeHidden();
 
-  // Vérifier que la dépense apparaît dans la vue dépense (le subject est
-  // saisi tel-quel — pas de template gettext)
-  await expect(page.getByText(subject).first()).toBeVisible();
+  // La dépense apparaît dans l'onglet Dépenses — le libellé est saisi tel quel.
+  await expect(page.getByText(label).first()).toBeVisible();
 
-  // Vérifier qu'elle apparaît aussi dans /app/interactions
+  // Et dans le journal du foyer, comme toute dépense.
   await page.goto('/app/interactions');
-  await expect(page.getByText(subject).first()).toBeVisible();
+  await expect(page.getByText(label).first()).toBeVisible();
 });
 
-test('parcours dépense ad-hoc — sujet vide refusé', async ({ page }) => {
-  await page.goto('/app/money?tab=expenses');
-  await page.getByRole('button', { name: 'Nouvelle dépense' }).first().click();
+test('dépense en espèces — la ligne apparaît dans le journal bancaire', async ({ page }) => {
+  const dialog = await openCashDialog(page);
 
-  const dialog = page.getByRole('dialog');
-  await expect(dialog).toBeVisible();
+  const label = `Boulangerie E2E ${Date.now()}`;
+  await dialog.locator('#cash-label').fill(label);
+  await page.locator('#purchase-price').fill('4.20');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+  await expect(dialog).toBeHidden();
 
-  // Tenter de soumettre sans sujet
+  // C'est **une opération de compte**, pas seulement une dépense : elle doit se
+  // voir dans le journal bancaire.
+  await page.goto('/app/money/transactions');
+  await expect(page.getByText(label).first()).toBeVisible();
+});
+
+test('dépense en espèces — libellé vide refusé', async ({ page }) => {
+  const dialog = await openCashDialog(page);
+
   await page.locator('#purchase-price').fill('10');
   await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
 
-  // Le dialog reste ouvert (validation côté front)
+  // Le dialog reste ouvert : validation côté front avant tout appel réseau.
   await expect(dialog).toBeVisible();
-  await expect(dialog).toContainText('Un sujet est requis');
+  await expect(dialog).toContainText('Le libellé est obligatoire');
+});
+
+test('dépense en espèces — elle ne produit aucun écart de conformité', async ({ page }) => {
+  const dialog = await openCashDialog(page);
+
+  const label = `Sans écart E2E ${Date.now()}`;
+  await dialog.locator('#cash-label').fill(label);
+  await page.locator('#purchase-price').fill('7.50');
+  await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();
+  await expect(dialog).toBeHidden();
+
+  // C'est LE point du lot : l'opération naît ventilée, donc ni « sortie non
+  // affectée » ni « dépense non rapprochée » pour cette ligne.
+  const token = await page.evaluate(() => localStorage.getItem('access_token') ?? '');
+  const resp = await page.request.get('/api/banking/compliance/', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const body = (await resp.json()) as { groups: Array<{ kind: string; open: number }> };
+  const byKind = new Map(body.groups.map((g) => [g.kind, g.open]));
+  expect(byKind.get('transaction_unallocated')).toBe(0);
 });

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -15,6 +15,7 @@ import {
   previewStatementFile,
   qualifyTransaction,
   reconcileTransactions,
+  recordCashExpense,
   restoreBankAccount,
   setAllocations,
   unlinkCashCounterpart,
@@ -22,6 +23,7 @@ import {
   withdrawToCash,
   type AllocationLine,
   type BankAccountPayload,
+  type CashExpensePayload,
   type StatementMapping,
   type TransactionFilters,
 } from '@/lib/api/banking';
@@ -290,6 +292,27 @@ export function useLinkInteraction() {
       invalidate();
       void qc.invalidateQueries({ queryKey: ['interactions'] });
       toast({ description: t('banking.reconcile.linked'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useRecordCashExpense() {
+  const invalidate = useInvalidateBanking();
+  const qc = useQueryClient();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: CashExpensePayload) => recordCashExpense(payload),
+    onSuccess: () => {
+      invalidate();
+      // L'opération crée aussi une Interaction : dépenses, budgets et conformité
+      // doivent se rafraîchir, sinon la dépense qu'on vient de saisir n'apparaît
+      // nulle part avant un reload.
+      void qc.invalidateQueries({ queryKey: ['interactions'] });
+      void qc.invalidateQueries({ queryKey: ['expenses'] });
+      void qc.invalidateQueries({ queryKey: ['budget'] });
+      void qc.invalidateQueries({ queryKey: complianceKeys.all });
+      toast({ description: t('banking.cash.recorded'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });

--- a/ui/src/features/money/CashExpenseDialog.tsx
+++ b/ui/src/features/money/CashExpenseDialog.tsx
@@ -1,0 +1,201 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Landmark } from 'lucide-react';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { Button } from '@/design-system/button';
+import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
+import { useBudgets } from '@/features/budget/hooks';
+import {
+  useBankAccounts,
+  useCreateBankAccount,
+  useRecordCashExpense,
+} from '@/features/banking/hooks';
+
+interface CashExpenseDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Dépense en espèces — l'ancienne « dépense ad hoc », devenue une opération de
+ * compte (parcours 26, lot 4).
+ *
+ * Ce qui change n'est pas le formulaire, c'est ce qu'il écrit. Une dépense qui
+ * n'existe que comme `Interaction` est une dépense que la banque n'a jamais vue :
+ * le contrôle de conformité ne peut que la signaler, et personne ne peut la
+ * résoudre. En passant par le compte espèces, l'orphelin disparaît **par
+ * construction** — au lieu d'apprendre à l'utilisateur à l'arbitrer chaque mois.
+ *
+ * Sans compte espèces déclaré il n'y a rien à écrire — mais renvoyer l'utilisateur
+ * vers un autre onglet au moment où il veut noter une dépense serait un cul-de-sac.
+ * Le dialog propose donc de créer le compte **sur place, en un clic** : la
+ * contrainte est tenue sans que la saisie soit interrompue.
+ */
+export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDialogProps) {
+  const { t } = useTranslation();
+  const accountsQuery = useBankAccounts();
+  const { data: budgets } = useBudgets();
+  const mutation = useRecordCashExpense();
+  const createAccount = useCreateBankAccount();
+
+  const [label, setLabel] = React.useState('');
+  const [accountId, setAccountId] = React.useState('');
+  const [budgetId, setBudgetId] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const cashAccounts = React.useMemo(
+    () => (accountsQuery.data ?? []).filter((a) => a.kind === 'cash'),
+    [accountsQuery.data],
+  );
+
+  const budgetOptions = React.useMemo(
+    () => (budgets ?? []).filter((b) => !b.is_global).map((b) => ({ value: b.id, label: b.name })),
+    [budgets],
+  );
+
+  React.useEffect(() => {
+    if (!open) {
+      setLabel('');
+      setBudgetId('');
+      setError(null);
+      return;
+    }
+    // Un seul compte espèces est le cas normal : le pré-sélectionner épargne un
+    // champ à remplir sur la saisie la plus fréquente de l'app.
+    setAccountId((prev) => prev || cashAccounts[0]?.id || '');
+  }, [open, cashAccounts]);
+
+  async function handleSubmit(payload: PurchaseFormPayload) {
+    setError(null);
+    if (!label.trim()) {
+      setError(t('banking.cash.labelRequired'));
+      return;
+    }
+    if (!accountId) {
+      setError(t('banking.cash.accountRequired'));
+      return;
+    }
+    if (!payload.amount || Number(payload.amount) <= 0) {
+      setError(t('banking.cash.amountRequired'));
+      return;
+    }
+
+    try {
+      await mutation.mutateAsync({
+        account: accountId,
+        label: label.trim(),
+        // `PurchaseForm` renvoie un `number` ; l'API attend une décimale en
+        // string, comme partout ailleurs sur les montants.
+        amount: payload.amount.toFixed(2),
+        // `occurred_at` du form est un datetime ; l'opération de compte est datée
+        // au jour, comme toute ligne de relevé.
+        booked_on: payload.occurred_at ? payload.occurred_at.slice(0, 10) : undefined,
+        budget_id: budgetId || null,
+        notes: payload.notes,
+      });
+      onOpenChange(false);
+    } catch {
+      setError(t('purchase.errors.save_failed'));
+    }
+  }
+
+  async function createCashAccount() {
+    setError(null);
+    try {
+      const created = await createAccount.mutateAsync({
+        name: t('banking.cash.defaultAccountName'),
+        kind: 'cash',
+        // Un compte espèces qui démarre à zéro aujourd'hui est le point de départ
+        // honnête : c'est aussi le prérequis de conformité (sans date d'ouverture,
+        // aucun contrôle ne porte sur ce compte).
+        opening_balance: '0',
+        opening_balance_date: new Date().toISOString().slice(0, 10),
+      });
+      setAccountId(created.id);
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  const hasCashAccount = cashAccounts.length > 0;
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.cash.title')}>
+      {!hasCashAccount ? (
+        <div className="mt-4 space-y-4">
+          <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 p-3">
+            <Landmark className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+            <div className="min-w-0 text-sm">
+              <p className="font-medium text-foreground">{t('banking.cash.noAccount')}</p>
+              <p className="text-muted-foreground">{t('banking.cash.noAccountHint')}</p>
+            </div>
+          </div>
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              onClick={createCashAccount}
+              disabled={createAccount.isPending}
+            >
+              {t('banking.cash.createAccount')}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <FormField label={`${t('banking.cash.label')} *`} htmlFor="cash-label">
+            <Input
+              id="cash-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t('banking.cash.labelPlaceholder')}
+              autoFocus
+              required
+            />
+          </FormField>
+
+          {cashAccounts.length > 1 ? (
+            <FormField label={t('banking.cash.account')} htmlFor="cash-account">
+              <Select
+                id="cash-account"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                options={cashAccounts.map((a) => ({ value: a.id, label: a.name }))}
+              />
+            </FormField>
+          ) : null}
+
+          {budgetOptions.length > 0 ? (
+            <FormField label={t('banking.cash.budget')} htmlFor="cash-budget">
+              <Select
+                id="cash-budget"
+                value={budgetId}
+                onChange={(e) => setBudgetId(e.target.value)}
+                placeholder={t('banking.cash.budgetNone')}
+                options={budgetOptions}
+              />
+            </FormField>
+          ) : null}
+
+          <PurchaseForm
+            isPending={mutation.isPending}
+            onSubmit={handleSubmit}
+            onCancel={() => onOpenChange(false)}
+            externalError={error}
+          />
+        </>
+      )}
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/money/ExpensesPanel.tsx
+++ b/ui/src/features/money/ExpensesPanel.tsx
@@ -13,7 +13,7 @@ import ExpenseSummaryCards from '@/features/expenses/ExpenseSummaryCards';
 import ExpenseFilters from '@/features/expenses/ExpenseFilters';
 import { resolvePeriod, type PeriodRange } from '@/features/expenses/period';
 import ExpenseList from '@/features/expenses/ExpenseList';
-import ExpenseAdHocDialog from '@/features/expenses/ExpenseAdHocDialog';
+import CashExpenseDialog from './CashExpenseDialog';
 
 /**
  * Onglet « Dépenses » du module Argent (parcours 26, lot 2).
@@ -129,7 +129,7 @@ export default function ExpensesPanel() {
         ) : null}
       </div>
 
-      <ExpenseAdHocDialog open={adhocOpen} onOpenChange={setAdhocOpen} />
+      <CashExpenseDialog open={adhocOpen} onOpenChange={setAdhocOpen} />
     </>
   );
 }

--- a/ui/src/gen/api/services/BankingService.ts
+++ b/ui/src/gen/api/services/BankingService.ts
@@ -531,6 +531,33 @@ export class BankingService {
         });
     }
     /**
+     * Spend cash: create the operation **and** its allocation, together.
+     *
+     * The point of going through the account rather than creating a bare expense:
+     * a spend that exists only as an ``Interaction`` is an expense the bank never
+     * saw, which the conformity control can only ever report as an écart nobody
+     * can resolve. Recording it as a real account line removes that orphan by
+     * construction.
+     *
+     * Atomic on purpose — see ``services.record_cash_expense``. Creating the line
+     * and letting the user allocate it later would drop a freshly created
+     * operation straight into the "unallocated" queue: the app manufacturing its
+     * own écarts.
+     * @param requestBody
+     * @returns BankTransaction
+     * @throws ApiError
+     */
+    public static bankingTransactionsCashExpenseCreate(
+        requestBody?: BankTransaction,
+    ): CancelablePromise<BankTransaction> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/banking/transactions/cash-expense/',
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * Money in / out over a period, internal movements excluded.
      *
      * Never add this to a budget or expense total — see the module docstring of

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -497,3 +497,40 @@ export async function createWaiver(payload: {
 export async function deleteWaiver(id: string): Promise<void> {
   await api.delete(`/banking/waivers/${id}/`);
 }
+
+// --- Dépense en espèces (parcours 26, lot 4) --------------------------------
+
+export interface CashExpensePayload {
+  account: string;
+  label: string;
+  /** Positif — ce que l'utilisateur a dépensé. Stocké signé côté serveur. */
+  amount: string;
+  booked_on?: string;
+  budget_id?: string | null;
+  zone_ids?: string[];
+  source_type?: string | null;
+  source_id?: string | null;
+  notes?: string;
+}
+
+export interface CashExpenseResult {
+  transaction: BankTransaction;
+  allocations: AllocatedExpense[];
+}
+
+/**
+ * Dépense en espèces : l'opération **et** sa ventilation naissent ensemble.
+ *
+ * Passer par le compte plutôt que créer une dépense nue supprime par construction
+ * l'orphelin « dépense que la banque n'a jamais vue » — un écart que le contrôle
+ * ne pourrait que signaler sans que personne puisse le résoudre.
+ */
+export async function recordCashExpense(
+  payload: CashExpensePayload,
+): Promise<CashExpenseResult> {
+  const { data } = await api.post<CashExpenseResult>(
+    '/banking/transactions/cash-expense/',
+    payload,
+  );
+  return data;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3223,23 +3223,20 @@
       }
     },
     "cash": {
-      "title": "Diese Abhebung ins Bargeld buchen",
-      "action": "Ins Bargeld buchen",
-      "intro": "Eine Abhebung ist keine Ausgabe, sondern Bargeld, das die Tasche wechselt. Buchst du sie auf dein Bargeldkonto, fällt sie hier aus den Summen heraus und wird nur einmal gezählt — wenn du das Geld tatsächlich ausgibst.",
-      "unlink": "Bargeld-Verknüpfung lösen",
-      "linked": "Abhebung ins Bargeld gebucht",
-      "unlinked": "Bargeld-Verknüpfung gelöst",
-      "linkedBadge": "Ins Bargeld gebucht",
-      "noCashAccount": "Lege zuerst auf der Konten-Seite ein Konto vom Typ „Bargeld“ an.",
-      "fields": {
-        "account": "Bargeldkonto",
-        "amount": "Gebuchter Betrag",
-        "amountHint": "Nicht jede Abhebung landet in der gemeinsamen Kasse — passe den Betrag bei Bedarf an."
-      },
-      "errors": {
-        "accountRequired": "Wähle ein Bargeldkonto.",
-        "amountInvalid": "Gib einen positiven Betrag ein, höchstens {{max}}."
-      }
+      "title": "Barausgabe",
+      "label": "Bezeichnung",
+      "labelPlaceholder": "z. B. Markt, Bäckerei",
+      "labelRequired": "Eine Bezeichnung ist erforderlich.",
+      "account": "Barkonto",
+      "accountRequired": "Wählen Sie ein Barkonto.",
+      "amountRequired": "Geben Sie einen positiven Betrag ein.",
+      "budget": "Budget",
+      "budgetNone": "Ohne Budget",
+      "recorded": "Ausgabe auf dem Barkonto erfasst.",
+      "noAccount": "Kein Barkonto",
+      "noAccountHint": "Legen Sie im Reiter Konten ein Konto „Bargeld“ an: eine Barausgabe wird dann eine Kontobuchung wie jede andere.",
+      "createAccount": "Barkonto anlegen",
+      "defaultAccountName": "Bargeld"
     },
     "allocation": {
       "title": "Diese Buchung aufteilen",
@@ -3437,6 +3434,16 @@
           "title": "Saldenkette unterbrochen",
           "hint": "Die Salden des Auszugs passen nicht zusammen: Buchungen fehlen.",
           "resolution": "Importieren Sie den fehlenden Auszug. Bis dahin bleibt der Saldo als unzuverlässig markiert."
+        },
+        "account_cash_negative": {
+          "title": "Barkonto im Minus",
+          "hint": "Physisch unmöglich: eine Abhebung wurde nicht erfasst.",
+          "resolution": "Erfassen Sie die Abhebung, die dieses Konto füllt, im Bankjournal („Bargeld auffüllen“ auf der Abhebungszeile)."
+        },
+        "expense_without_budget": {
+          "title": "Ausgaben ohne Budget",
+          "hint": "Sie zählen auf kein Budget.",
+          "resolution": "Weisen Sie ein Budget zu oder legen Sie es begründet ab, wenn es Absicht ist."
         }
       }
     },

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3223,23 +3223,20 @@
       }
     },
     "cash": {
-      "title": "Move this withdrawal to cash",
-      "action": "Move to cash",
-      "intro": "A withdrawal is not spending: it is cash changing pocket. Moving it to your cash account takes it out of the totals here, so the money is counted once — when you actually spend it.",
-      "unlink": "Remove the cash link",
-      "linked": "Withdrawal moved to cash",
-      "unlinked": "Cash link removed",
-      "linkedBadge": "Moved to cash",
-      "noCashAccount": "Create a “Cash” account first, from the Accounts page.",
-      "fields": {
-        "account": "Cash account",
-        "amount": "Amount moved",
-        "amountHint": "Not every withdrawal ends up in the common pot — adjust if needed."
-      },
-      "errors": {
-        "accountRequired": "Pick a cash account.",
-        "amountInvalid": "Enter a positive amount, at most {{max}}."
-      }
+      "title": "Cash expense",
+      "label": "Label",
+      "labelPlaceholder": "E.g. market, bakery",
+      "labelRequired": "A label is required.",
+      "account": "Cash account",
+      "accountRequired": "Pick a cash account.",
+      "amountRequired": "Enter a positive amount.",
+      "budget": "Budget",
+      "budgetNone": "No budget",
+      "recorded": "Expense recorded on the cash account.",
+      "noAccount": "No cash account",
+      "noAccountHint": "Declare a “Cash” account in the Accounts tab: a cash spend then becomes an account operation, like every other.",
+      "createAccount": "Create my cash account",
+      "defaultAccountName": "Cash"
     },
     "allocation": {
       "title": "Split this operation",
@@ -3437,6 +3434,16 @@
           "title": "Broken balance chain",
           "hint": "The statement balances do not chain: operations are missing.",
           "resolution": "Import the missing statement. Until then the balance stays flagged as unreliable."
+        },
+        "account_cash_negative": {
+          "title": "Cash account in the red",
+          "hint": "Physically impossible: a withdrawal was never declared.",
+          "resolution": "Declare the withdrawal that feeds this account, from the bank journal (“Feed cash” on the withdrawal line)."
+        },
+        "expense_without_budget": {
+          "title": "Expenses outside any budget",
+          "hint": "They count against no envelope.",
+          "resolution": "Assign a budget, or arbitrate if it is deliberate."
         }
       }
     },

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3223,23 +3223,20 @@
       }
     },
     "cash": {
-      "title": "Pasar esta retirada al efectivo",
-      "action": "Pasar al efectivo",
-      "intro": "Una retirada no es un gasto: es dinero que cambia de bolsillo. Al pasarla a tu cuenta de efectivo sale de los totales de aquí, y se contará una sola vez, cuando gastes ese dinero.",
-      "unlink": "Quitar el vínculo con efectivo",
-      "linked": "Retirada pasada al efectivo",
-      "unlinked": "Vínculo con efectivo eliminado",
-      "linkedBadge": "Pasada al efectivo",
-      "noCashAccount": "Crea antes una cuenta de tipo «Efectivo» desde la página Cuentas.",
-      "fields": {
-        "account": "Cuenta de efectivo",
-        "amount": "Importe pasado",
-        "amountHint": "No toda la retirada acaba en el fondo común: ajústalo si hace falta."
-      },
-      "errors": {
-        "accountRequired": "Elige una cuenta de efectivo.",
-        "amountInvalid": "Introduce un importe positivo, como máximo {{max}}."
-      }
+      "title": "Gasto en efectivo",
+      "label": "Concepto",
+      "labelPlaceholder": "Ej.: mercado, panadería",
+      "labelRequired": "El concepto es obligatorio.",
+      "account": "Cuenta de efectivo",
+      "accountRequired": "Elija una cuenta de efectivo.",
+      "amountRequired": "Indique un importe positivo.",
+      "budget": "Presupuesto",
+      "budgetNone": "Sin presupuesto",
+      "recorded": "Gasto registrado en la cuenta de efectivo.",
+      "noAccount": "Sin cuenta de efectivo",
+      "noAccountHint": "Declare una cuenta «Efectivo» en la pestaña Cuentas: un gasto en metálico pasa entonces a ser una operación de cuenta, como las demás.",
+      "createAccount": "Crear mi cuenta de efectivo",
+      "defaultAccountName": "Efectivo"
     },
     "allocation": {
       "title": "Desglosar esta operación",
@@ -3437,6 +3434,16 @@
           "title": "Cadena de saldos rota",
           "hint": "Los saldos del extracto no encadenan: faltan operaciones.",
           "resolution": "Importe el extracto que falta. Hasta entonces el saldo queda marcado como no fiable."
+        },
+        "account_cash_negative": {
+          "title": "Efectivo en negativo",
+          "hint": "Físicamente imposible: no se declaró una retirada.",
+          "resolution": "Declare la retirada que alimenta esta cuenta, desde el diario bancario («Alimentar el efectivo» en la línea de retirada)."
+        },
+        "expense_without_budget": {
+          "title": "Gastos sin presupuesto",
+          "hint": "No cuentan en ninguna partida.",
+          "resolution": "Asigne un presupuesto, o justifíquelo si es deliberado."
         }
       }
     },

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3223,23 +3223,20 @@
       }
     },
     "cash": {
-      "title": "Verser ce retrait aux espèces",
-      "action": "Verser aux espèces",
-      "intro": "Un retrait n'est pas une dépense : c'est du liquide qui change de poche. En le versant sur ton compte espèces, il sort des totaux ici et sera compté une seule fois, quand tu dépenseras cet argent.",
-      "unlink": "Retirer le lien espèces",
-      "linked": "Retrait versé aux espèces",
-      "unlinked": "Lien espèces retiré",
-      "linkedBadge": "Versé aux espèces",
-      "noCashAccount": "Crée d'abord un compte de type « Espèces » depuis la page Comptes.",
-      "fields": {
-        "account": "Compte espèces",
-        "amount": "Montant versé",
-        "amountHint": "Tout le retrait ne finit pas forcément dans le pot commun — ajuste si besoin."
-      },
-      "errors": {
-        "accountRequired": "Choisis un compte espèces.",
-        "amountInvalid": "Saisis un montant positif, au plus {{max}}."
-      }
+      "title": "Dépense en espèces",
+      "label": "Libellé",
+      "labelPlaceholder": "Ex. : marché, boulangerie",
+      "labelRequired": "Le libellé est obligatoire.",
+      "account": "Compte espèces",
+      "accountRequired": "Choisissez un compte espèces.",
+      "amountRequired": "Indiquez un montant positif.",
+      "budget": "Budget",
+      "budgetNone": "Hors budget",
+      "recorded": "Dépense enregistrée sur le compte espèces.",
+      "noAccount": "Aucun compte espèces",
+      "noAccountHint": "Déclarez un compte « Espèces » dans l'onglet Comptes : une dépense en liquide devient alors une opération de compte, comme les autres.",
+      "createAccount": "Créer mon compte espèces",
+      "defaultAccountName": "Espèces"
     },
     "allocation": {
       "title": "Ventiler cette opération",
@@ -3437,6 +3434,16 @@
           "title": "Chaîne de soldes rompue",
           "hint": "Les soldes du relevé ne s'enchaînent pas : des opérations manquent.",
           "resolution": "Importez le relevé manquant. Le solde affiché reste marqué comme non fiable d'ici là."
+        },
+        "account_cash_negative": {
+          "title": "Espèces à découvert",
+          "hint": "Impossible physiquement : un retrait n'a pas été déclaré.",
+          "resolution": "Déclarez le retrait qui alimente ce compte, depuis le journal bancaire (« Alimenter les espèces » sur la ligne de retrait)."
+        },
+        "expense_without_budget": {
+          "title": "Dépenses hors budget",
+          "hint": "Elles ne comptent dans aucune enveloppe.",
+          "resolution": "Affectez un budget, ou arbitrez si c'est volontaire."
         }
       }
     },


### PR DESCRIPTION
## Pourquoi

Un billet donné au marché ne laisse aucune ligne de relevé. Avant ce lot, une telle dépense ne pouvait exister que comme `Interaction` nue — donc comme une **dépense que la banque n'a jamais vue**, que le contrôle de conformité ne peut que *signaler*, sans que personne puisse la résoudre.

Chaque mois, la même liste d'écarts inarbitrables. C'est le meilleur moyen de faire abandonner le contrôle.

En faire une vraie opération de compte supprime l'orphelin **par construction**, au lieu d'apprendre à l'utilisateur à l'arbitrer tous les mois.

## `create_manual_transaction`

Le `dedup_hash` porte un discriminant `manual:{uuid4}`. Deux conséquences, toutes deux voulues :

- une saisie manuelle n'est **jamais** un doublon d'elle-même — deux fois 20 € en liquide, ce sont deux dépenses, et seul l'utilisateur sait si c'est une erreur ;
- elle ne peut **jamais** collisionner avec une ligne importée, dont le discriminant vient toujours du fichier (référence, solde, index d'occurrence).

## `record_cash_expense` — atomique par nécessité

L'opération et sa ventilation naissent dans la **même** transaction. Créer la ligne puis laisser l'utilisateur la ventiler plus tard déposerait une opération fraîchement créée directement dans la file « à ranger » : l'app fabriquerait ses propres écarts.

Et un budget invalide fait rouler l'ensemble en arrière, opération comprise — sinon on créerait précisément l'orphelin que ce service existe pour empêcher.

## Détecteur `account_cash_negative` — non arbitrable

Un compte espèces dans le rouge est **physiquement impossible** : on ne donne pas un billet qu'on n'a pas. Ça ne veut donc jamais dire « découvert », ça veut dire qu'un **retrait n'a pas été déclaré**. D'où `waivable=False` : aucun motif ne rend acceptable de l'argent impossible, il y a une opération à enregistrer.

Un **compte bancaire** à découvert n'est pas concerné — un découvert est légitime. Seuls les comptes `kind='cash'` sont vérifiés.

## Pas de cul-de-sac dans l'UI

Sans compte espèces il n'y a rien à écrire. Ma première version renvoyait vers l'onglet Comptes — un cul-de-sac au moment précis où l'utilisateur veut noter une dépense. Le dialog propose maintenant de créer le compte **sur place, en un clic** (solde d'ouverture à zéro, daté du jour, ce qui est aussi le prérequis de conformité). La contrainte est tenue sans interrompre la saisie.

## Un bug que les nouveaux tests ont exposé

`seed_demo_data --flush` ne pouvait plus supprimer un foyer dès qu'il portait une ligne bancaire : `BankTransaction.account` est `PROTECT` (un compte qui porte de l'historique s'archive, il ne se supprime pas).

Le trou existe **depuis le parcours 25**. Il ne s'était jamais vu parce que l'E2E ne créait aucune opération bancaire — mes tests de dépense en espèces en créent, et la suite s'est arrêtée au setup. Le flush nettoie maintenant les tables banking avant le foyer : une commande de flush qui ne peut pas flusher est pire que pas de commande.

## Vérification

- **3207 tests backend** (+26). `test_cash_expense.py` couvre le service, l'atomicité (un budget invalide ne laisse aucune opération derrière), le détecteur, et le fait qu'une dépense en espèces ne produise **aucun** écart — ni « non affectée » ni « non rapprochée ».
- **238 E2E verts, 0 échec.** `expense-adhoc.spec.ts` est réécrit autour du nouveau parcours, y compris la création du compte en un clic et une vérification directe de l'API de conformité.
- `npm run build` + `npm run lint` propres, types API régénérés.

Doc : section « Tout est une ligne de compte » de `docs/MODULES/banking.md`.