### PR TITLE
feat(money): continuité des relevés et provenance des dépenses (parcours 26, lot 7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,20 @@ comptent dans le chantier **et** dans l'enveloppe « Bricolage ».
   (`interactions__isnull=True`), jamais un `exists()` par ligne : la version naïve
   coûtait 160 allers-retours sur un relevé réel.
 
+#### Continuité et provenance
+
+- **`opening_balance_date` est requise à la création** d'un compte, jamais à
+  l'édition. Sans elle le compte n'a pas de fenêtre de conformité ; mais l'exiger à
+  chaque PATCH rendrait un simple renommage impossible — le détecteur du lot 1 traite
+  l'existant.
+- `statement_period_gap` et `account_chain_broken` sont **complémentaires** : le
+  second attrape les opérations manquantes *dans* une période importée par
+  l'arithmétique, le premier une période jamais importée, qui ne laisse aucune trace
+  arithmétique. Ne pas fusionner.
+- `skipped_count > 0` n'est un écart que sur un fichier **sans référence ni solde** —
+  ailleurs c'est la signature normale d'un ré-import. La présence de ces colonnes est
+  dérivée des lignes créées, pas stockée.
+
 ### Ajouter un nouveau template d'auto-subject
 
 1. Ajouter l'entrée dans `AUTO_SUBJECT_TEMPLATES` (`apps/interactions/services.py`)

--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -13,7 +13,9 @@ would therefore never ask:
 - a receipt nobody classified (``inflow_unclassified``);
 - an internal movement whose other leg is missing (``internal_without_counterpart``);
 - a recurrence past due with nothing recorded (``recurring_overdue``);
-- a recurrence confirmed twice for the same day (``recurring_double_confirmed``).
+- a recurrence confirmed twice for the same day (``recurring_double_confirmed``);
+- a period nobody ever imported (``statement_period_gap``);
+- lines skipped where the dedup recipe cannot be trusted (``import_skipped_lines``).
 
 Every detector that reasons about "money we should know about" is scoped by
 ``banking.coverage``: outside the conformity window an écart is not an écart, it
@@ -23,7 +25,7 @@ Registered from ``banking.apps.BankingConfig.ready()``.
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 
 from django.db.models import Case, DecimalField, F, Q, Sum, Value, When
@@ -42,7 +44,7 @@ from .compliance import (
     register,
 )
 from .coverage import accounts_with_window, household_covered_period
-from .models import BankAccount, BankTransaction
+from .models import BankAccount, BankTransaction, ImportStatus
 
 AMOUNT_FIELD = DecimalField(max_digits=14, decimal_places=2)
 ZERO = Value(Decimal("0.00"), output_field=AMOUNT_FIELD)
@@ -59,6 +61,8 @@ INFLOW_UNCLASSIFIED = "inflow_unclassified"
 INTERNAL_WITHOUT_COUNTERPART = "internal_without_counterpart"
 RECURRING_OVERDUE = "recurring_overdue"
 RECURRING_DOUBLE_CONFIRMED = "recurring_double_confirmed"
+STATEMENT_PERIOD_GAP = "statement_period_gap"
+IMPORT_SKIPPED_LINES = "import_skipped_lines"
 
 
 # --- Shared base: spendable outflows inside their account's window -----------
@@ -377,6 +381,154 @@ def _find_internal_without_counterpart(household, **window) -> list[Finding]:
     ]
 
 
+# --- Statement continuity and provenance (lot 7) ------------------------------
+
+
+def _period_gap_pairs(household) -> list[tuple[BankAccount, list[dict]]]:
+    """Accounts with a hole between two consecutive imported periods.
+
+    The balance chain check catches missing operations *inside* an imported period,
+    by arithmetic. This catches the other half: a period nobody ever imported. The
+    two are complementary and neither sees the other's blind spot — a February
+    that was never dropped in leaves no arithmetic trace at all, only a gap in the
+    calendar.
+
+    Only ``completed`` imports count: a failed one wrote nothing, so claiming its
+    period would be a lie. Overlapping periods are fine (re-importing a month is
+    the normal way to catch up) — only a **strictly positive** gap is reported.
+    """
+    from .models import StatementImport
+
+    pairs = []
+    for account in BankAccount.objects.filter(household=household, archived=False):
+        periods = list(
+            StatementImport.objects.filter(
+                account=account,
+                status=ImportStatus.COMPLETED,
+                period_start__isnull=False,
+                period_end__isnull=False,
+            )
+            .order_by("period_start")
+            .values_list("period_start", "period_end")
+        )
+        if len(periods) < 2:
+            continue
+
+        gaps = []
+        covered_to = periods[0][1]
+        for start, end in periods[1:]:
+            if start > covered_to + timedelta(days=1):
+                gaps.append(
+                    {
+                        "gap_start": (covered_to + timedelta(days=1)).isoformat(),
+                        "gap_end": (start - timedelta(days=1)).isoformat(),
+                        "days": (start - covered_to).days - 1,
+                    }
+                )
+            covered_to = max(covered_to, end)
+
+        if gaps:
+            pairs.append((account, gaps))
+    return pairs
+
+
+def _count_period_gaps(household) -> int:
+    return len(_period_gap_pairs(household))
+
+
+def _find_period_gaps(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
+    pairs = _period_gap_pairs(household)
+    if pks is not None:
+        wanted = {str(p) for p in pks}
+        pairs = [p for p in pairs if str(p[0].pk) in wanted]
+    if exclude_pks:
+        unwanted = {str(p) for p in exclude_pks}
+        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
+    if offset or limit:
+        start = offset or 0
+        pairs = pairs[start : start + limit] if limit else pairs[start:]
+
+    return [
+        Finding(
+            kind=STATEMENT_PERIOD_GAP,
+            object_id=str(account.pk),
+            label=account.name,
+            # The missing days found the écart: importing part of the hole must
+            # invalidate an arbitration that accepted the whole of it.
+            fingerprint=fingerprint_of(
+                STATEMENT_PERIOD_GAP, sorted(g["gap_start"] for g in gaps)
+            ),
+            detail={
+                "name": account.name,
+                "gap_count": len(gaps),
+                "missing_days": sum(g["days"] for g in gaps),
+                "gaps": gaps,
+            },
+        )
+        for account, gaps in pairs
+    ]
+
+
+def _skipped_lines_qs(household):
+    """Imports that skipped lines on a file with neither reference nor balance.
+
+    ``skipped_count > 0`` is normally the good news — it is what a re-import looks
+    like. It becomes a warning **only** on a file carrying neither a bank reference
+    nor a running balance, because that is exactly the documented limit of the
+    dedup recipe (``docs/fiches/IMPORT_ET_RAPPROCHEMENT.md`` §3.2): the discriminant
+    falls back to an in-file occurrence index, so a later *partial* export of an
+    identical line can be skipped as a duplicate when it is genuinely new.
+
+    Whether the file had those columns is derived from the rows it created rather
+    than stored: a column that produced no value on any line was, for dedup
+    purposes, absent — which is the property that actually matters here.
+    """
+    from django.db.models import Count, Q as _Q
+
+    from .models import StatementImport
+
+    return (
+        StatementImport.objects.filter(
+            household=household, status=ImportStatus.COMPLETED, skipped_count__gt=0
+        )
+        .annotate(
+            with_reference=Count(
+                "transactions", filter=~_Q(transactions__external_id=""), distinct=True
+            ),
+            with_balance=Count(
+                "transactions",
+                filter=_Q(transactions__balance_after__isnull=False),
+                distinct=True,
+            ),
+        )
+        .filter(with_reference=0, with_balance=0)
+        .select_related("account")
+    )
+
+
+def _count_skipped_lines(household) -> int:
+    return _skipped_lines_qs(household).count()
+
+
+def _find_skipped_lines(household, **window) -> list[Finding]:
+    return [
+        Finding(
+            kind=IMPORT_SKIPPED_LINES,
+            object_id=str(imported.pk),
+            label=f"{imported.filename or imported.provider} · {imported.account.name}",
+            fingerprint=fingerprint_of(IMPORT_SKIPPED_LINES, imported.skipped_count),
+            detail={
+                "filename": imported.filename,
+                "account_name": imported.account.name,
+                "skipped_count": imported.skipped_count,
+                "created_count": imported.created_count,
+                "created_at": imported.created_at.isoformat(),
+            },
+        )
+        for imported in apply_window(_skipped_lines_qs(household), **window)
+    ]
+
+
 # --- Recurrences (lot 6) ------------------------------------------------------
 
 
@@ -627,6 +779,12 @@ def _recurring_model():
     return RecurringExpense
 
 
+def _statement_import_model():
+    from .models import StatementImport
+
+    return StatementImport
+
+
 def _specs() -> list[DetectorSpec]:
     """Declared in the order the control panel should read them: the blocking
     prerequisite first, because it is what makes the others meaningful."""
@@ -733,6 +891,24 @@ def _specs() -> list[DetectorSpec]:
             findings=_find_double_confirmed,
             # Counting one bill twice is never acceptable — one of the two has to go.
             waivable=False,
+        ),
+        DetectorSpec(
+            kind=STATEMENT_PERIOD_GAP,
+            severity=ERROR,
+            label="A period nobody ever imported",
+            target="account",
+            model=BankAccount,
+            count=_count_period_gaps,
+            findings=_find_period_gaps,
+        ),
+        DetectorSpec(
+            kind=IMPORT_SKIPPED_LINES,
+            severity=WARNING,
+            label="Lines skipped on a file with neither reference nor balance",
+            target="import",
+            model=_statement_import_model(),
+            count=_count_skipped_lines,
+            findings=_find_skipped_lines,
         ),
         DetectorSpec(
             kind=ACCOUNT_CASH_NEGATIVE,

--- a/apps/banking/serializers.py
+++ b/apps/banking/serializers.py
@@ -69,11 +69,33 @@ class BankAccountSerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, attrs):
-        """A cash account has no bank behind it: keep its bank fields empty."""
+        """A cash account has no bank behind it: keep its bank fields empty.
+
+        And **on creation, the opening balance date is required** (parcours 26,
+        lot 7). Without it the account has no conformity window: its balance is a
+        guess, and no other control can assert anything about it — the lot 1
+        detector reports exactly that, as a blocking prerequisite. Closing the door
+        at creation is cheaper than asking the user to come back and fix it.
+
+        Only on creation: an existing account without one is handled by the
+        detector, and forcing the field on every PATCH would make an unrelated
+        rename impossible until the user fills it in.
+        """
         kind = attrs.get("kind", getattr(self.instance, "kind", BankAccount.Kind.BANK))
         if kind == BankAccount.Kind.CASH:
             attrs["bank_label"] = ""
             attrs["iban_last4"] = ""
+
+        if self.instance is None and attrs.get("opening_balance_date") is None:
+            raise serializers.ValidationError(
+                {
+                    "opening_balance_date": (
+                        "Required: without a starting point the balance is a guess, "
+                        "and no conformity check can cover this account."
+                    )
+                }
+            )
+
         return attrs
 
 

--- a/apps/banking/tests/test_api_accounts.py
+++ b/apps/banking/tests/test_api_accounts.py
@@ -10,6 +10,7 @@ Coverage per section:
 """
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 
 import pytest
@@ -46,8 +47,27 @@ def _results(response) -> list:
     return body["results"] if isinstance(body, dict) else body
 
 
+def _make_account(household, user, **fields):
+    """Crée un compte via le service, en injectant la date de solde d'ouverture.
+
+    Requise depuis le parcours 26 lot 7 ; chaque test n'énonce ainsi que ce qu'il
+    teste. La règle elle-même est couverte par
+    ``test_services_account.py::TestOpeningBalanceDateRequired``.
+    """
+    fields.setdefault("opening_balance_date", date(2026, 1, 1))
+    return create_account(household=household, user=user, **fields)
+
+
 def _payload(**overrides) -> dict:
-    payload = {"name": "Compte joint", "bank_label": "LCL", "kind": "bank", "currency": "EUR"}
+    payload = {
+        "name": "Compte joint",
+        "bank_label": "LCL",
+        "kind": "bank",
+        "currency": "EUR",
+        # Requis depuis le parcours 26 lot 7 : sans point de départ le solde est une
+        # supposition, et aucun contrôle de conformité ne porte sur le compte.
+        "opening_balance_date": "2026-01-01",
+    }
     payload.update(overrides)
     return payload
 
@@ -57,7 +77,7 @@ class TestAccountList:
     def test_lists_own_household_accounts(self):
         household = HouseholdFactory()
         user = _make_member(household)
-        create_account(household=household, user=user, name="Compte joint")
+        _make_account(household, user, name="Compte joint")
 
         response = _client_for(user).get(LIST_URL)
 
@@ -68,7 +88,7 @@ class TestAccountList:
         mine, theirs = HouseholdFactory(), HouseholdFactory()
         user = _make_member(mine)
         other_user = _make_member(theirs)
-        create_account(household=theirs, user=other_user, name="Leur compte")
+        _make_account(theirs, other_user, name="Leur compte")
 
         response = _client_for(user).get(LIST_URL)
 
@@ -77,8 +97,8 @@ class TestAccountList:
     def test_archived_hidden_by_default_and_visible_on_demand(self):
         household = HouseholdFactory()
         user = _make_member(household)
-        create_account(household=household, user=user, name="Actif")
-        create_account(household=household, user=user, name="Fermé", archived=True)
+        _make_account(household, user, name="Actif")
+        _make_account(household, user, name="Fermé", archived=True)
         client = _client_for(user)
 
         assert [a["name"] for a in _results(client.get(LIST_URL))] == ["Actif"]
@@ -113,7 +133,12 @@ class TestAccountCreate:
         user = _make_member(household)
 
         response = _client_for(user).post(
-            LIST_URL, {"name": "Espèces", "kind": "cash"}, format="json"
+            LIST_URL,
+            # La date de solde d'ouverture est requise pour un compte espèces aussi :
+            # sans fenêtre de conformité, la détection du solde négatif ne porterait
+            # sur rien.
+            {"name": "Espèces", "kind": "cash", "opening_balance_date": "2026-01-01"},
+            format="json",
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -179,7 +204,7 @@ class TestAccountUpdate:
     def test_member_can_patch(self):
         household = HouseholdFactory()
         user = _make_member(household)
-        account = create_account(household=household, user=user, name="Old")
+        account = _make_account(household, user, name="Old")
 
         response = _client_for(user).patch(
             f"{LIST_URL}{account.id}/", {"name": "New"}, format="json"
@@ -193,7 +218,7 @@ class TestAccountUpdate:
         mine, theirs = HouseholdFactory(), HouseholdFactory()
         user = _make_member(mine)
         other_user = _make_member(theirs)
-        account = create_account(household=theirs, user=other_user, name="Leur compte")
+        account = _make_account(theirs, other_user, name="Leur compte")
 
         response = _client_for(user).patch(
             f"{LIST_URL}{account.id}/", {"name": "Hacked"}, format="json"
@@ -206,7 +231,7 @@ class TestAccountUpdate:
     def test_import_options_are_read_only(self):
         household = HouseholdFactory()
         user = _make_member(household)
-        account = create_account(household=household, user=user, name="Compte joint")
+        account = _make_account(household, user, name="Compte joint")
 
         response = _client_for(user).patch(
             f"{LIST_URL}{account.id}/",
@@ -225,7 +250,7 @@ class TestAccountDelete:
     def test_delete_archives_instead_of_destroying(self):
         household = HouseholdFactory()
         user = _make_member(household)
-        account = create_account(household=household, user=user, name="Compte joint")
+        account = _make_account(household, user, name="Compte joint")
 
         response = _client_for(user).delete(f"{LIST_URL}{account.id}/")
 
@@ -237,7 +262,7 @@ class TestAccountDelete:
         """Backs the "rouvrir" action on the archived list — archiving is reversible."""
         household = HouseholdFactory()
         user = _make_member(household)
-        account = create_account(household=household, user=user, name="Compte joint")
+        account = _make_account(household, user, name="Compte joint")
         client = _client_for(user)
         client.delete(f"{LIST_URL}{account.id}/")
 
@@ -253,7 +278,7 @@ class TestAccountDelete:
         mine, theirs = HouseholdFactory(), HouseholdFactory()
         user = _make_member(mine)
         other_user = _make_member(theirs)
-        account = create_account(household=theirs, user=other_user, name="Leur compte")
+        account = _make_account(theirs, other_user, name="Leur compte")
 
         response = _client_for(user).delete(f"{LIST_URL}{account.id}/")
 

--- a/apps/banking/tests/test_continuity.py
+++ b/apps/banking/tests/test_continuity.py
@@ -1,0 +1,255 @@
+# banking/tests/test_continuity.py
+"""Continuité des relevés (parcours 26, lot 7).
+
+Deux angles morts que rien d'autre ne voit :
+
+- **une période que personne n'a jamais importée.** Le contrôle de chaîne attrape
+  les opérations manquantes *à l'intérieur* d'une période importée, par
+  l'arithmétique des soldes. Un février jamais déposé, lui, ne laisse aucune trace
+  arithmétique — seulement un trou dans le calendrier ;
+- **des lignes ignorées là où la recette de dédup ne peut pas être crue.**
+  `skipped_count > 0` est normalement la bonne nouvelle (c'est à quoi ressemble un
+  ré-import). Ça devient un avertissement **seulement** sur un fichier sans
+  référence ni solde, parce que c'est exactement la limite documentée du
+  `dedup_hash` : le discriminant retombe sur l'index d'occurrence dans le fichier.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from banking.compliance import get_detector, open_findings, summary
+from banking.dedup import compute_dedup_hash
+from banking.detectors import IMPORT_SKIPPED_LINES, STATEMENT_PERIOD_GAP
+from banking.models import (
+    BankTransaction,
+    ImportStatus,
+    StatementImport,
+    TransactionDirection,
+)
+
+from .factories import BankAccountFactory, HouseholdFactory, UserFactory
+
+_counter = itertools.count()
+
+
+def make_import(account, *, start, end, status=ImportStatus.COMPLETED, skipped=0, filename="r.csv"):
+    return StatementImport.objects.create(
+        household=account.household,
+        account=account,
+        provider="generic_csv",
+        filename=filename,
+        status=status,
+        period_start=start,
+        period_end=end,
+        skipped_count=skipped,
+    )
+
+
+def make_txn(account, *, imported=None, booked_on=date(2026, 1, 5), **extra):
+    label = extra.pop("label", "CB TEST")
+    value = Decimal(extra.pop("amount", "-10.00"))
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+        source_import=imported,
+        **extra,
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    household = HouseholdFactory()
+    account = BankAccountFactory(
+        household=household, name="Courant", opening_balance_date=date(2026, 1, 1)
+    )
+    return household, UserFactory(), account
+
+
+def group(household, kind):
+    return next(g for g in summary(household) if g.spec.kind == kind)
+
+
+@pytest.mark.django_db
+class TestPeriodGap:
+    def test_a_missing_month_is_an_ecart(self, ctx):
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+
+        findings = open_findings(household, get_detector(STATEMENT_PERIOD_GAP))
+        assert [f.object_id for f in findings] == [str(account.pk)]
+        assert findings[0].detail["gaps"][0]["gap_start"] == "2026-02-01"
+        assert findings[0].detail["gaps"][0]["gap_end"] == "2026-02-28"
+
+    def test_contiguous_periods_are_fine(self, ctx):
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 2, 1), end=date(2026, 2, 28))
+
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 0
+
+    def test_overlapping_periods_are_fine(self, ctx):
+        """Ré-importer un mois est la façon normale de rattraper — seul un trou
+        strictement positif est signalé."""
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 2, 15))
+        make_import(account, start=date(2026, 2, 1), end=date(2026, 3, 31))
+
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 0
+
+    def test_a_single_import_cannot_have_a_gap(self, ctx):
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 0
+
+    def test_a_failed_import_does_not_bridge_a_gap(self, ctx):
+        """Un import échoué n'a rien écrit ; prétendre couvrir sa période serait un
+        mensonge."""
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(
+            account, start=date(2026, 2, 1), end=date(2026, 2, 28), status=ImportStatus.FAILED
+        )
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 1
+
+    def test_importing_the_hole_resolves_it(self, ctx):
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 1
+
+        make_import(account, start=date(2026, 2, 1), end=date(2026, 2, 28))
+
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 0
+
+    def test_an_archived_account_is_not_checked(self, ctx):
+        household, _, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+        account.archived = True
+        account.save(update_fields=["archived"])
+
+        assert group(household, STATEMENT_PERIOD_GAP).detected == 0
+
+    def test_it_can_be_arbitrated(self, ctx):
+        from banking.services import waive_finding
+
+        household, user, account = ctx
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+
+        waive_finding(
+            household=household,
+            user=user,
+            finding_kind=STATEMENT_PERIOD_GAP,
+            object_id=str(account.pk),
+            reason="pas d'opération sur la période",
+        )
+
+        result = group(household, STATEMENT_PERIOD_GAP)
+        assert (result.open, result.waived) == (0, 1)
+
+
+@pytest.mark.django_db
+class TestSkippedLines:
+    def test_skipped_lines_on_a_bare_file_is_an_ecart(self, ctx):
+        household, _, account = ctx
+        imported = make_import(
+            account, start=date(2026, 1, 1), end=date(2026, 1, 31), skipped=3
+        )
+        make_txn(account, imported=imported)
+
+        findings = open_findings(household, get_detector(IMPORT_SKIPPED_LINES))
+        assert [f.object_id for f in findings] == [str(imported.pk)]
+        assert findings[0].detail["skipped_count"] == 3
+
+    def test_no_skipped_lines_is_not_an_ecart(self, ctx):
+        household, _, account = ctx
+        imported = make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_txn(account, imported=imported)
+
+        assert group(household, IMPORT_SKIPPED_LINES).detected == 0
+
+    def test_a_file_with_references_is_trusted(self, ctx):
+        """Une référence bancaire est un discriminant parfait : `skipped_count` y est
+        la bonne nouvelle d'un ré-import, pas un doute."""
+        household, _, account = ctx
+        imported = make_import(
+            account, start=date(2026, 1, 1), end=date(2026, 1, 31), skipped=3
+        )
+        make_txn(account, imported=imported, external_id="REF123")
+
+        assert group(household, IMPORT_SKIPPED_LINES).detected == 0
+
+    def test_a_file_with_balances_is_trusted(self, ctx):
+        """Deux opérations identiques le même jour laissent forcément des soldes
+        différents — c'est le truc qui résout le cas difficile."""
+        household, _, account = ctx
+        imported = make_import(
+            account, start=date(2026, 1, 1), end=date(2026, 1, 31), skipped=3
+        )
+        make_txn(account, imported=imported, balance_after=Decimal("900.00"))
+
+        assert group(household, IMPORT_SKIPPED_LINES).detected == 0
+
+    def test_a_mixed_file_is_trusted(self, ctx):
+        """Une seule ligne portant une référence suffit : la colonne existe."""
+        household, _, account = ctx
+        imported = make_import(
+            account, start=date(2026, 1, 1), end=date(2026, 1, 31), skipped=3
+        )
+        make_txn(account, imported=imported, label="SANS REF")
+        make_txn(account, imported=imported, label="AVEC REF", external_id="REF9")
+
+        assert group(household, IMPORT_SKIPPED_LINES).detected == 0
+
+    def test_a_failed_import_is_not_reported(self, ctx):
+        household, _, account = ctx
+        make_import(
+            account,
+            start=date(2026, 1, 1),
+            end=date(2026, 1, 31),
+            skipped=3,
+            status=ImportStatus.FAILED,
+        )
+
+        assert group(household, IMPORT_SKIPPED_LINES).detected == 0
+
+    def test_it_can_be_arbitrated(self, ctx):
+        from banking.services import waive_finding
+
+        household, user, account = ctx
+        imported = make_import(
+            account, start=date(2026, 1, 1), end=date(2026, 1, 31), skipped=3
+        )
+        make_txn(account, imported=imported)
+
+        waive_finding(
+            household=household,
+            user=user,
+            finding_kind=IMPORT_SKIPPED_LINES,
+            object_id=str(imported.pk),
+            reason="doublons confirmés",
+        )
+
+        result = group(household, IMPORT_SKIPPED_LINES)
+        assert (result.open, result.waived) == (0, 1)

--- a/apps/banking/tests/test_services_account.py
+++ b/apps/banking/tests/test_services_account.py
@@ -13,13 +13,23 @@ from banking.services import archive_account, create_account, update_account
 
 from .factories import BankAccountFactory, HouseholdFactory, UserFactory
 
+#: Requis depuis le parcours 26 lot 7. Injecté par défaut ici pour que chaque test
+#: n'énonce que ce qu'il teste ; ``TestOpeningBalanceRequired`` couvre la règle
+#: elle-même.
+DEFAULT_OPENING_DATE = date(2026, 1, 1)
+
+
+def make_account(household, user, **fields):
+    fields.setdefault("opening_balance_date", DEFAULT_OPENING_DATE)
+    return create_account(household=household, user=user, **fields)
+
 
 @pytest.mark.django_db
 class TestCreateAccount:
     def test_creates_scoped_to_household(self):
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(
-            household=household, user=user, name="Compte joint", bank_label="LCL"
+        account = make_account(
+            household, user, name="Compte joint", bank_label="LCL"
         )
         assert account.household_id == household.id
         assert account.created_by_id == user.id
@@ -27,24 +37,24 @@ class TestCreateAccount:
 
     def test_strips_and_rejects_blank_name(self):
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(household=household, user=user, name="  Livret  ")
+        account = make_account(household, user, name="  Livret  ")
         assert account.name == "Livret"
 
         with pytest.raises(ValidationError) as exc:
-            create_account(household=household, user=user, name="   ")
+            make_account(household, user, name="   ")
         assert "name" in exc.value.detail
 
     def test_duplicate_name_is_a_400_not_a_500(self):
         household, user = HouseholdFactory(), UserFactory()
-        create_account(household=household, user=user, name="Compte joint")
+        make_account(household, user, name="Compte joint")
         with pytest.raises(ValidationError) as exc:
-            create_account(household=household, user=user, name="Compte joint")
+            make_account(household, user, name="Compte joint")
         assert "name" in exc.value.detail
 
     def test_cash_account_needs_no_bank_fields(self):
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(
-            household=household, user=user, name="Espèces", kind=BankAccount.Kind.CASH
+        account = make_account(
+            household, user, name="Espèces", kind=BankAccount.Kind.CASH
         )
         assert account.kind == BankAccount.Kind.CASH
         assert account.bank_label == ""
@@ -52,9 +62,9 @@ class TestCreateAccount:
 
     def test_cash_account_discards_bank_fields_if_provided(self):
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(
-            household=household,
-            user=user,
+        account = make_account(
+            household,
+            user,
             name="Espèces",
             kind=BankAccount.Kind.CASH,
             bank_label="LCL",
@@ -65,20 +75,20 @@ class TestCreateAccount:
 
     def test_currency_is_normalised_and_validated(self):
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(household=household, user=user, name="A", currency="eur")
+        account = make_account(household, user, name="A", currency="eur")
         assert account.currency == "EUR"
 
         with pytest.raises(ValidationError) as exc:
-            create_account(household=household, user=user, name="B", currency="EURO")
+            make_account(household, user, name="B", currency="EURO")
         assert "currency" in exc.value.detail
 
     def test_full_iban_is_rejected(self):
         """The "never store a full IBAN" rule is enforced at the API boundary."""
         household, user = HouseholdFactory(), UserFactory()
         with pytest.raises(ValidationError) as exc:
-            create_account(
-                household=household,
-                user=user,
+            make_account(
+                household,
+                user,
                 name="Compte joint",
                 iban_last4="FR7630006000011234567890189",
             )
@@ -99,9 +109,9 @@ class TestCreateAccount:
     def test_import_options_are_not_client_writable(self):
         """Lot 2 owns the mapping; a client must not be able to forge one."""
         household, user = HouseholdFactory(), UserFactory()
-        account = create_account(
-            household=household,
-            user=user,
+        account = make_account(
+            household,
+            user,
             name="Compte joint",
             import_options={"date_column": "hacked"},
             default_provider="hacked",
@@ -162,4 +172,52 @@ class TestArchiveAccount:
         account = BankAccountFactory(household=household, name="Compte joint")
         archive_account(account=account, user=UserFactory())
         with pytest.raises(ValidationError):
-            create_account(household=household, user=UserFactory(), name="Compte joint")
+            make_account(household, UserFactory(), name="Compte joint")
+
+
+@pytest.mark.django_db
+class TestOpeningBalanceDateRequired:
+    """Parcours 26, lot 7 — la porte fermée à l'entrée.
+
+    Sans date de solde d'ouverture un compte n'a **pas de fenêtre de conformité** :
+    son solde est une supposition, et aucun autre contrôle ne peut rien affirmer à
+    son sujet. Le détecteur du lot 1 le signale comme prérequis bloquant sur
+    l'existant ; ici on empêche d'en créer de nouveaux.
+    """
+
+    def test_creation_without_a_date_is_refused(self):
+        household, user = HouseholdFactory(), UserFactory()
+        with pytest.raises(ValidationError) as exc:
+            create_account(household=household, user=user, name="Sans date")
+        assert "opening_balance_date" in exc.value.detail
+
+    def test_creation_with_a_date_is_accepted(self):
+        household, user = HouseholdFactory(), UserFactory()
+        account = create_account(
+            household=household,
+            user=user,
+            name="Avec date",
+            opening_balance_date=date(2026, 1, 1),
+        )
+        assert account.opening_balance_date == date(2026, 1, 1)
+
+    def test_a_cash_account_needs_one_too(self):
+        """Un compte espèces a une fenêtre comme les autres — sinon la détection du
+        solde négatif ne porterait sur rien."""
+        household, user = HouseholdFactory(), UserFactory()
+        with pytest.raises(ValidationError):
+            create_account(
+                household=household, user=user, name="Espèces", kind=BankAccount.Kind.CASH
+            )
+
+    def test_updating_an_account_without_one_stays_possible(self):
+        """Sinon un simple renommage serait bloqué jusqu'à ce que l'utilisateur
+        remplisse un champ sans rapport — le détecteur est là pour ça."""
+        household = HouseholdFactory()
+        account = BankAccountFactory(household=household, opening_balance_date=None)
+
+        updated = update_account(
+            account=account, user=UserFactory(), fields={"name": "Renommé"}
+        )
+        assert updated.name == "Renommé"
+        assert updated.opening_balance_date is None

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -38,7 +38,7 @@ Le lot 7 du parcours 25 (recettes, virements internes, couverture — #390) est
 | 4 | Tout est une ligne de compte (espèces) | ✅ **Livré** |
 | 5 | Recettes et mouvements internes | ✅ **Livré** |
 | 6 | Le relevé confirme les récurrences | ✅ **Livré** |
-| 7 | Continuité des relevés et provenance | ⬜ |
+| 7 | Continuité des relevés et provenance | ✅ **Livré** |
 
 **Cette fiche décrit l'état livré.** Les sections marquées *(à venir)* annoncent le
 contrat que les lots suivants devront respecter.
@@ -502,6 +502,8 @@ base pour ne pas avoir à arbitrer deux fois la même situation.
 | `internal_without_counterpart` | `error` | ✅ | 5 |
 | `recurring_overdue` | `warning` | ✅ | 6 |
 | `recurring_double_confirmed` | `error` | ❌ bug de données | 6 |
+| `statement_period_gap` | `error` | ✅ | 7 |
+| `import_skipped_lines` | `warning` | ✅ | 7 |
 
 Les sorties « à affecter » excluent les recettes (leur détecteur arrive au lot 5),
 les mouvements internes et leurs contreparties (l'argent est compté une fois, plus
@@ -775,9 +777,68 @@ Compter une facture deux fois n'est jamais acceptable : l'une des deux doit part
 date fait sauter la récurrence), mais le détecteur reste — la confirmation manuelle
 est un autre chemin, et le contrôle ne fait pas confiance aux garde-fous, il vérifie.
 
-## Ce que les lots suivants ajouteront *(à venir)*
-- **Règle transverse** — on n'additionne **jamais** un total banque et un total
-  interactions. Le pont est un taux de couverture, pas une somme.
+## Continuité des relevés et provenance (parcours 26, lot 7)
+
+Le dernier lot. Le catalogue des orphelins est complet : **13 détecteurs**.
+
+### `statement_period_gap` — l'angle mort du contrôle de chaîne
+
+Le contrôle de chaîne attrape les opérations manquantes **à l'intérieur** d'une
+période importée, par l'arithmétique des soldes. Un février que personne n'a jamais
+déposé, lui, ne laisse **aucune trace arithmétique** — seulement un trou dans le
+calendrier. Les deux détecteurs sont complémentaires et ni l'un ni l'autre ne voit
+l'angle mort de l'autre.
+
+Seuls les imports `completed` comptent : un import échoué n'a rien écrit, prétendre
+couvrir sa période serait un mensonge. Les périodes qui se chevauchent sont normales
+(ré-importer un mois est la façon de rattraper) — seul un trou **strictement
+positif** est signalé.
+
+### `import_skipped_lines` — la limite de la dédup, rendue visible
+
+`skipped_count > 0` est normalement la **bonne** nouvelle : c'est à quoi ressemble un
+ré-import. Ça devient un avertissement **uniquement** sur un fichier sans référence
+bancaire ni solde courant, parce que c'est exactement la limite documentée de la
+recette de dédup (`docs/fiches/IMPORT_ET_RAPPROCHEMENT.md` §3.2) : le discriminant
+retombe sur l'index d'occurrence *dans le fichier*, donc un export partiel ultérieur
+d'une ligne identique peut être ignoré comme doublon alors qu'il est vraiment neuf.
+
+La présence de ces colonnes est **dérivée des lignes créées**, pas stockée : une
+colonne qui n'a produit aucune valeur était, du point de vue de la dédup, absente —
+et c'est cette propriété-là qui compte.
+
+### Le solde d'ouverture, requis à l'entrée
+
+`BankAccountSerializer` refuse une création sans `opening_balance_date`. Sans elle le
+compte n'a **pas de fenêtre de conformité** : son solde est une supposition, et aucun
+autre contrôle ne peut rien affirmer à son sujet.
+
+**Uniquement à la création.** Sur l'existant, le détecteur du lot 1 fait le travail ;
+exiger le champ à chaque PATCH rendrait un simple renommage impossible tant que
+l'utilisateur ne l'a pas rempli — une contrainte qui punit la mauvaise personne.
+
+Côté UI la date est **pré-remplie à aujourd'hui** : le cas fréquent est « je commence
+à suivre ce compte maintenant », et proposer une valeur juste vaut mieux qu'exiger
+une saisie de plus.
+
+### Provenance et couverture
+
+`ExpenseList` porte un badge de provenance — **relevé**, **espèces**, ou **en attente
+de rapprochement**. Seule la troisième appelle une action : une dépense que la banque
+n'a jamais confirmée est un écart, pas un état normal. Le dire dans la liste où on la
+lit, pas seulement dans l'onglet Contrôle.
+
+`ExpenseSummaryCards` gagne la carte **Couverture** : « X rangés sur Y sortis du
+compte ». C'est ce qui rend « 340 € dépensés » interprétable — sur combien réellement
+sorti ? Et c'est **un ratio, jamais une somme** des deux mondes.
+
+Nettoyé au passage : trois `t()` avec `defaultValue` dans les composants de dépenses,
+que CLAUDE.md interdit précisément parce qu'ils masquent les traductions manquantes.
+Les clés `bank`, `recurring` et `chickens_purchase` manquaient effectivement.
+
+## Règle transverse
+- On n'additionne **jamais** un total banque et un total interactions. Le pont est un
+  taux de couverture, pas une somme.
 
 ## Points d'attention
 

--- a/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
+++ b/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
@@ -98,9 +98,9 @@ incohérence à corriger.
 
 | Écart | Détection | Résolution | Flag légitime | Lot |
 |---|---|---|---|---|
-| **Sans solde d'ouverture** | `opening_balance_date IS NULL` | le renseigner | **aucun — prérequis bloquant** | 1 ✅ |
+| **Sans solde d'ouverture** | `opening_balance_date IS NULL` | le renseigner | **aucun — prérequis bloquant** | 1 ✅ (requis à la création : 7 ✅) |
 | **Chaîne de soldes rompue** | `balances.check_balance_chain` | importer le relevé manquant | « relevé indisponible » | 1 ✅ |
-| **Période non couverte** | trou entre deux `StatementImport` | importer | « pas d'opération sur la période » | 7 |
+| **Période non couverte** | trou entre deux `StatementImport` | importer | « pas d'opération sur la période » | 7 ✅ |
 | **Espèces à découvert** | solde espèces négatif | déclarer le retrait qui l'alimente | **aucun — incohérence** | 4 ✅ |
 
 ### Sur une récurrence
@@ -114,7 +114,7 @@ incohérence à corriger.
 
 | Écart | Détection | Résolution | Flag légitime | Lot |
 |---|---|---|---|---|
-| **Lignes ignorées** | `skipped_count > 0` sans référence ni solde | vérifier manuellement | « doublons confirmés » | 7 |
+| **Lignes ignorées** | `skipped_count > 0` sans référence ni solde | vérifier manuellement | « doublons confirmés » | 7 ✅ |
 
 ## Le mécanisme d'arbitrage
 
@@ -146,9 +146,23 @@ puis ventiler 90 € laisserait 60 € couverts par un motif qui ne décrit plus
 | 4 | **Tout est une ligne de compte** — `create_manual_transaction`, espèces | ✅ Livré |
 | 5 | **Recettes et mouvements internes** — `inflow_nature`, contreparties | ✅ Livré |
 | 6 | **Le relevé confirme les récurrences** — `match_recurrences` | ✅ Livré |
-| 7 | **Continuité des relevés et provenance** — solde d'ouverture requis, badges | ⬜ |
+| 7 | **Continuité des relevés et provenance** — solde d'ouverture requis, badges | ✅ Livré |
 
 Détail d'implémentation par lot : `docs/MODULES/banking.md`.
+
+## Le catalogue est complet
+
+**13 détecteurs**, couvrant les 16 lignes du catalogue (certaines lignes partagent un
+détecteur). Trois n'admettent **aucun** arbitrage, et c'est structurant :
+
+| Clé | Pourquoi aucun motif ne tient |
+|---|---|
+| `account_no_opening_balance` | Prérequis : sans point de départ, aucun contrôle ne porte sur le compte. |
+| `account_cash_negative` | Physiquement impossible : un retrait n'a pas été déclaré. |
+| `recurring_double_confirmed` | Compter une facture deux fois n'est jamais acceptable. |
+
+Les dix autres sont arbitrables — et chaque arbitrage **périme** si ce qu'il couvrait
+change.
 
 ## La recette qui prouve la garantie
 

--- a/e2e/money.spec.ts
+++ b/e2e/money.spec.ts
@@ -143,7 +143,49 @@ test.describe('Module Argent — Contrôle', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 6. Sous-pages autonomes
+// 6. Le solde d'ouverture, prérequis fermé à l'entrée (lot 7)
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — création de compte', () => {
+  test('la date de solde d\'ouverture est requise, et pré-remplie à aujourd\'hui', async ({
+    page,
+  }) => {
+    await page.goto('/app/money?tab=accounts');
+    await page.getByRole('button', { name: 'Nouveau compte' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    // Pré-remplie : le cas fréquent est « je commence à suivre ce compte
+    // maintenant », et proposer une valeur juste vaut mieux qu'exiger une saisie.
+    await expect(dialog.locator('#account-opening-date')).not.toHaveValue('');
+
+    // Vidée, la création est refusée côté front — sans point de départ le solde est
+    // une supposition et aucun contrôle ne porte sur le compte.
+    await dialog.locator('#account-name').fill(`Compte E2E ${Date.now()}`);
+    await dialog.locator('#account-opening-date').fill('');
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    await expect(dialog).toBeVisible();
+    await expect(dialog).toContainText("La date du solde d'ouverture est obligatoire");
+  });
+
+  test('avec une date, le compte est créé', async ({ page }) => {
+    await page.goto('/app/money?tab=accounts');
+    await page.getByRole('button', { name: 'Nouveau compte' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    const name = `Compte E2E ${Date.now()}`;
+    await dialog.locator('#account-name').fill(name);
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText(name).first()).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. Sous-pages autonomes
 // ---------------------------------------------------------------------------
 
 test.describe('Module Argent — sous-pages', () => {

--- a/ui/src/features/banking/AccountDialog.tsx
+++ b/ui/src/features/banking/AccountDialog.tsx
@@ -46,7 +46,10 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
       setBankLabel('');
       setIbanLast4('');
       setOpeningBalance('');
-      setOpeningBalanceDate('');
+      // Aujourd'hui par défaut : le cas le plus fréquent est « je commence à suivre
+      // ce compte maintenant », et proposer une valeur juste vaut mieux qu'exiger
+      // une saisie de plus.
+      setOpeningBalanceDate(new Date().toISOString().slice(0, 10));
     }
   }, [open, existing]);
 
@@ -68,6 +71,15 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
     const rawBalance = openingBalance.trim().replace(',', '.');
     if (rawBalance && !Number.isFinite(Number(rawBalance))) {
       setError(t('banking.errors.openingBalanceInvalid'));
+      return;
+    }
+
+    // Requise à la création (parcours 26, lot 7) : sans point de départ le solde est
+    // une supposition, et aucun contrôle de conformité ne porte sur le compte. Pas
+    // exigée à l'édition — un simple renommage ne doit pas être bloqué par un champ
+    // sans rapport, le détecteur est là pour ça.
+    if (!isEditing && !openingBalanceDate) {
+      setError(t('banking.errors.openingBalanceDateRequired'));
       return;
     }
 
@@ -160,13 +172,19 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
           </p>
         </FormField>
 
-        <FormField label={t('banking.fields.openingBalanceDate')} htmlFor="account-opening-date">
+        <FormField
+          label={`${t('banking.fields.openingBalanceDate')}${isEditing ? '' : ' *'}`}
+          htmlFor="account-opening-date"
+        >
           <Input
             id="account-opening-date"
             type="date"
             value={openingBalanceDate}
             onChange={(e) => setOpeningBalanceDate(e.target.value)}
           />
+          <p className="text-xs text-muted-foreground">
+            {t('banking.fields.openingBalanceDateHint')}
+          </p>
         </FormField>
 
         {error ? (

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -9,6 +9,22 @@ interface ExpenseListProps {
   items: InteractionListItem[];
 }
 
+/**
+ * D'où vient cette dépense — la question que le parcours 26 rend visible.
+ *
+ * Trois provenances, et la troisième est la seule qui appelle une action : une
+ * dépense saisie dans l'app que la banque n'a jamais confirmée est un écart, pas un
+ * état normal. Le dire ici, dans la liste où on la lit, plutôt que seulement dans
+ * l'onglet Contrôle.
+ */
+function provenanceOf(item: InteractionListItem): 'statement' | 'cash' | 'pending' {
+  if (!item.bank_transaction) return 'pending';
+  // Une dépense en espèces est née avec sa ligne (lot 4) : même provenance
+  // technique qu'un relevé, mais un sens différent pour l'utilisateur — personne
+  // n'a « rapproché » quoi que ce soit, l'opération a été saisie à la main.
+  return item.reconciled_by === '' ? 'cash' : 'statement';
+}
+
 export default function ExpenseList({ items }: ExpenseListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -29,9 +45,17 @@ export default function ExpenseList({ items }: ExpenseListProps) {
                     <CardTitle>{item.subject}</CardTitle>
                     {item.kind ? (
                       <Badge variant="outline" className="text-xs">
-                        {t(`expenses.kind.${item.kind}`, { defaultValue: item.kind })}
+                        {t(`expenses.kind.${item.kind}`)}
                       </Badge>
                     ) : null}
+                    <Badge
+                      variant={
+                        provenanceOf(item) === 'pending' ? 'destructive' : 'secondary'
+                      }
+                      className="text-xs"
+                    >
+                      {t(`expenses.provenance.${provenanceOf(item)}`)}
+                    </Badge>
                   </div>
                   <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                     <span>{formatDate(item.occurred_at)}</span>

--- a/ui/src/features/expenses/ExpenseSummaryCards.tsx
+++ b/ui/src/features/expenses/ExpenseSummaryCards.tsx
@@ -2,12 +2,15 @@ import { useTranslation } from 'react-i18next';
 import { Card } from '@/design-system/card';
 import { formatAmount } from '@/lib/format';
 import type { ExpenseSummary } from '@/lib/api/expenses';
+import type { AccountFlow } from '@/lib/api/banking';
 
 interface ExpenseSummaryCardsProps {
   summary: ExpenseSummary;
+  /** Vue « banque » de la même période, quand un compte est suivi. */
+  flow?: AccountFlow;
 }
 
-export default function ExpenseSummaryCards({ summary }: ExpenseSummaryCardsProps) {
+export default function ExpenseSummaryCards({ summary, flow }: ExpenseSummaryCardsProps) {
   const { t } = useTranslation();
   const topKinds = summary.by_kind.slice(0, 4);
   const topSuppliers = summary.by_supplier.filter((row) => row.supplier).slice(0, 3);
@@ -24,6 +27,35 @@ export default function ExpenseSummaryCards({ summary }: ExpenseSummaryCardsProp
         </p>
       </Card>
 
+      {/* Le pont banque ↔ dépenses : « rangé sur sorti », **jamais une somme** des
+          deux (règle transverse de CLAUDE.md). C'est ce qui rend « 340 € dépensés »
+          interprétable : sur combien réellement sorti du compte ? */}
+      {flow ? (
+        <Card className="p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            {t('expenses.summary.coverage')}
+          </p>
+          <p className="mt-2 text-3xl font-semibold tabular-nums">
+            {Math.round(flow.coverage_ratio * 100)}%
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {t('expenses.summary.coverageHint', {
+              sorted: formatAmount(
+                (Number(flow.outflow) - Number(flow.unallocated_outflow)).toFixed(2),
+              ),
+              outflow: formatAmount(flow.outflow),
+            })}
+          </p>
+          {Number(flow.unallocated_outflow) > 0 ? (
+            <p className="mt-1 text-xs text-destructive">
+              {t('expenses.summary.coverageRemaining', {
+                amount: formatAmount(flow.unallocated_outflow),
+              })}
+            </p>
+          ) : null}
+        </Card>
+      ) : null}
+
       <Card className="p-4">
         <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           {t('expenses.summary.byKind')}
@@ -35,7 +67,7 @@ export default function ExpenseSummaryCards({ summary }: ExpenseSummaryCardsProp
             {topKinds.map((row) => (
               <li key={row.kind || 'unknown'} className="flex items-center justify-between gap-2 text-sm">
                 <span className="truncate text-muted-foreground">
-                  {t(`expenses.kind.${row.kind}`, { defaultValue: row.kind || t('expenses.kind.unknown') })}
+                  {t(`expenses.kind.${row.kind || 'unknown'}`)}
                 </span>
                 <span className="shrink-0 tabular-nums">{formatAmount(row.total)}</span>
               </li>

--- a/ui/src/features/money/ExpensesPanel.tsx
+++ b/ui/src/features/money/ExpensesPanel.tsx
@@ -9,6 +9,7 @@ import { useSessionState } from '@/lib/useSessionState';
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
 import { interactionKeys } from '@/features/interactions/hooks';
 import { useExpenseSummary } from '@/features/expenses/hooks';
+import { useAccountFlow } from '@/features/banking/hooks';
 import ExpenseSummaryCards from '@/features/expenses/ExpenseSummaryCards';
 import ExpenseFilters from '@/features/expenses/ExpenseFilters';
 import { resolvePeriod, type PeriodRange } from '@/features/expenses/period';
@@ -38,6 +39,17 @@ export default function ExpensesPanel() {
   );
 
   const summaryQuery = useExpenseSummary(filters);
+  // La même période, vue côté banque. Sert le taux de couverture — le seul pont
+  // admis entre les deux mondes.
+  const flowQuery = useAccountFlow(
+    React.useMemo(
+      () => ({
+        ...(range.from ? { date_from: range.from } : {}),
+        ...(range.to ? { date_to: range.to } : {}),
+      }),
+      [range.from, range.to],
+    ),
+  );
 
   const listFilters = React.useMemo(
     () => ({
@@ -114,7 +126,7 @@ export default function ExpensesPanel() {
 
         {!isLoading && summary ? (
           <>
-            <ExpenseSummaryCards summary={summary} />
+            <ExpenseSummaryCards summary={summary} flow={flowQuery.data} />
             {items.length === 0 ? (
               <EmptyState
                 icon={Receipt}

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -205,6 +205,10 @@ export interface AccountFlow {
   net: string;
   transaction_count: number;
   internal_count: number;
+  /** Part des sorties qu'aucune dépense n'explique (parcours 26, lot 5). */
+  unallocated_outflow: string;
+  /** Entre 0 et 1. Le **seul** pont admis vers les totaux de dépenses — jamais une somme. */
+  coverage_ratio: number;
 }
 
 function cleanParams(filters: TransactionFilters): Record<string, string> {

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -34,6 +34,10 @@ export interface InteractionListItem {
   source_type?: string | null;
   source_id?: string | null;
   source_label?: string | null;
+  /** Ligne de relevé dont cette dépense est une ventilation (parcours 25). */
+  bank_transaction?: string | null;
+  /** `auto` | `manual` | `''` — comment le rapprochement s'est fait. */
+  reconciled_by?: string;
   contacts?: InteractionContactSummary[];
   structures?: InteractionStructureSummary[];
   equipments?: InteractionEquipmentSummary[];

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2895,14 +2895,20 @@
       "count_other": "{{count}} Ausgaben",
       "byKind": "Nach Typ",
       "bySupplier": "Nach Lieferant",
-      "empty": "—"
+      "empty": "—",
+      "coverage": "Abdeckung",
+      "coverageHint": "{{sorted}} zugeordnet von {{outflow}} abgegangen",
+      "coverageRemaining": "{{amount}} noch zuzuordnen"
     },
     "kind": {
       "stock_purchase": "Lagerkauf",
       "equipment_purchase": "Gerätekauf",
       "project_purchase": "Projektausgabe",
       "manual": "Sonstige",
-      "unknown": "Andere"
+      "unknown": "Andere",
+      "bank": "Auszug",
+      "recurring": "Wiederkehrend",
+      "chickens_purchase": "Hühner-Einkauf"
     },
     "filters": {
       "from": "Von",
@@ -2931,6 +2937,11 @@
       },
       "budget": "Budget",
       "budgetNone": "Kein Budget"
+    },
+    "provenance": {
+      "statement": "Auszug",
+      "cash": "Bargeld",
+      "pending": "Abgleich ausstehend"
     }
   },
   "aiUsage": {
@@ -3136,11 +3147,13 @@
       "ibanLast4Hint": "Um zwei Konten zu unterscheiden. Die vollständige IBAN wird nie gespeichert.",
       "openingBalance": "Anfangssaldo",
       "openingBalanceHint": "Ausgangspunkt der Saldoberechnung. Darf negativ sein (Überziehung).",
-      "openingBalanceDate": "Datum des Anfangssaldos"
+      "openingBalanceDate": "Datum des Anfangssaldos",
+      "openingBalanceDateHint": "Der Startpunkt der Erfassung: ohne ihn ist der Saldo eine Annahme, und keine Prüfung deckt dieses Konto ab."
     },
     "errors": {
       "nameRequired": "Bitte gib einen Namen ein.",
-      "openingBalanceInvalid": "Gib einen gültigen Betrag ein."
+      "openingBalanceInvalid": "Gib einen gültigen Betrag ein.",
+      "openingBalanceDateRequired": "Das Datum des Anfangssaldos ist erforderlich."
     },
     "import": {
       "title": "Kontoauszug importieren — {{account}}",
@@ -3479,6 +3492,16 @@
           "title": "Doppelt bestätigte Wiederholungen",
           "hint": "Dieselbe Rechnung am selben Tag zweimal gezählt.",
           "resolution": "Löschen Sie die doppelte Buchung im Reiter Ausgaben."
+        },
+        "statement_period_gap": {
+          "title": "Nicht abgedeckte Zeiträume",
+          "hint": "Ein Monat, den kein Auszug je abgedeckt hat — für die Saldenprüfung unsichtbar.",
+          "resolution": "Importieren Sie den fehlenden Auszug oder legen Sie es begründet ab, wenn es keine Buchung gab."
+        },
+        "import_skipped_lines": {
+          "title": "Zu prüfende übersprungene Zeilen",
+          "hint": "Die Datei hatte weder Referenz noch Saldo: die Duplikaterkennung kann nicht sicher sein.",
+          "resolution": "Prüfen Sie, ob die übersprungenen Zeilen wirklich Duplikate waren, und legen Sie es dann ab."
         }
       }
     },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1603,19 +1603,19 @@
           },
           "cash": {
             "title": "Auch Bargeld erfassen",
-            "body": "Lege ein Konto vom Typ „Bargeld“ für das Bargeld des Haushalts an. Es verhält sich wie ein Bankkonto und wird nach dem Import der Auszüge aus deinen Abhebungen gespeist."
+            "body": "Legen Sie ein Konto vom Typ „Bargeld“ an. Es verhält sich wie ein Bankkonto: Abhebungen füllen es, und eine Barausgabe wird eine Buchung darauf — also eine Ausgabe, die die Kontrolle zuordnen kann, wie jede andere."
           },
           "openingBalance": {
             "title": "Anfangssaldo eintragen",
-            "body": "Gib den Kontostand zu einem bestimmten Datum an — typischerweise den des ersten Auszugs, den du importieren willst. Davon ausgehend berechnet die App deinen Saldo. Er darf negativ sein, wenn dein Konto überzogen ist."
+            "body": "Geben Sie den Kontostand zu einem Datum ein — typischerweise der des ersten Auszugs, den Sie importieren wollen. Das ist **erforderlich**: ohne Startpunkt wäre der angezeigte Saldo eine Annahme, und keine Prüfung würde dieses Konto abdecken. Er darf negativ sein."
           },
           "import": {
             "title": "Ersten Kontoauszug importieren",
             "body": "Wähle auf der Kontokarte „Kontoauszug importieren“ und lade den CSV- oder Excel-Export deiner Bank hoch. Gib einmal an, welche Spalte Datum, Verwendungszweck und Betrag enthält — exportiert deine Bank auch den Saldo, ordne ihn zu: Er unterscheidet zwei identische Buchungen am selben Tag und zeigt einen fehlenden Auszug. Die Zuordnung wird gespeichert, beim nächsten Mal lädst du nur noch die Datei hoch. Ein erneuter Import desselben Auszugs erzeugt nie Dubletten."
           },
           "journal": {
-            "title": "Buchungen durchsehen und einordnen",
-            "body": "Öffne auf der Konten-Seite das „Kontojournal“: Dort findest du alle Buchungen, filterbar nach Konto, Zeitraum, Richtung und Verwendungszweck (die Suche ignoriert Groß-/Kleinschreibung und Akzente). Zwei nützliche Aktionen pro Zeile: eine interne Umbuchung markieren — eine Abhebung am Automaten oder eine Überweisung zwischen deinen beiden Banken ist keine Ausgabe und muss aus den Summen heraus, sonst wird das Geld doppelt gezählt — und eine Notiz hinzufügen. Verwendungszweck und Betrag lassen sich nicht ändern: Das sagt die Bank."
+            "title": "Durchsehen, markieren, einordnen",
+            "body": "Öffnen Sie im Reiter Konten das „Bankjournal“: alle Zeilen, filterbar nach Konto, Zeitraum, Richtung und Bezeichnung. Drei nützliche Handgriffe: eine interne Bewegung markieren (eine Abhebung ist keine Ausgabe), eine Einnahme einordnen (Lohn, Rückerstattung, interner Übertrag — die drei bedeuten nicht dasselbe) und eine Zeile kommentieren."
           },
           "balance": {
             "title": "Saldo prüfen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2895,14 +2895,20 @@
       "count_other": "{{count}} expenses",
       "byKind": "By type",
       "bySupplier": "By supplier",
-      "empty": "—"
+      "empty": "—",
+      "coverage": "Coverage",
+      "coverageHint": "{{sorted}} accounted for out of {{outflow}} that left the account",
+      "coverageRemaining": "{{amount}} still to account for"
     },
     "kind": {
       "stock_purchase": "Stock purchase",
       "equipment_purchase": "Equipment purchase",
       "project_purchase": "Project expense",
       "manual": "Ad-hoc",
-      "unknown": "Other"
+      "unknown": "Other",
+      "bank": "Statement",
+      "recurring": "Recurring",
+      "chickens_purchase": "Chicken purchase"
     },
     "filters": {
       "from": "From",
@@ -2931,6 +2937,11 @@
       },
       "budget": "Budget",
       "budgetNone": "No budget"
+    },
+    "provenance": {
+      "statement": "Statement",
+      "cash": "Cash",
+      "pending": "Awaiting reconciliation"
     }
   },
   "aiUsage": {
@@ -3136,11 +3147,13 @@
       "ibanLast4Hint": "To tell two accounts apart. The full IBAN is never stored.",
       "openingBalance": "Opening balance",
       "openingBalanceHint": "Starting point of the balance computation. May be negative (overdraft).",
-      "openingBalanceDate": "Opening balance date"
+      "openingBalanceDate": "Opening balance date",
+      "openingBalanceDateHint": "The starting point of tracking: without it the balance is a guess, and no check covers this account."
     },
     "errors": {
       "nameRequired": "Please enter a name.",
-      "openingBalanceInvalid": "Enter a valid amount."
+      "openingBalanceInvalid": "Enter a valid amount.",
+      "openingBalanceDateRequired": "The opening balance date is required."
     },
     "import": {
       "title": "Import a statement — {{account}}",
@@ -3479,6 +3492,16 @@
           "title": "Recurrences confirmed twice",
           "hint": "The same bill counted twice on the same day.",
           "resolution": "Delete the duplicate occurrence from the Expenses tab."
+        },
+        "statement_period_gap": {
+          "title": "Uncovered periods",
+          "hint": "A month no statement ever covered — invisible to the balance chain check.",
+          "resolution": "Import the missing statement, or arbitrate if there was no operation."
+        },
+        "import_skipped_lines": {
+          "title": "Skipped lines to verify",
+          "hint": "The file had neither reference nor balance: dedup cannot be certain.",
+          "resolution": "Check the skipped lines really were duplicates, then arbitrate."
         }
       }
     },

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1603,19 +1603,19 @@
           },
           "cash": {
             "title": "Track cash too",
-            "body": "Create a “Cash” account for the household's physical money. It behaves like a bank account, and will be topped up from your ATM withdrawals once statements are imported."
+            "body": "Create a “Cash” account for the household's physical money. It behaves like a bank account: withdrawals feed it, and a cash spend becomes an operation on it — so an expense the control can account for, like any other."
           },
           "openingBalance": {
-            "title": "Set the opening balance",
-            "body": "Enter the account balance at a given date — typically the one on the first statement you plan to import. That's the starting point the app computes your balance from. It may be negative if you're overdrawn."
+            "title": "Set the starting balance",
+            "body": "Enter the account balance at a given date — typically the one on the first statement you plan to import. This is **required**: without a starting point the balance shown would be a guess, and no conformity check would cover this account. It can be negative if you are overdrawn."
           },
           "import": {
             "title": "Import your first statement",
             "body": "On the account card, pick “Import a statement” and drop your bank's CSV or Excel export. Set once which column holds the date, the label and the amount — and if your bank also exports the running balance, map it: that's what tells two identical same-day operations apart and reveals a missing statement. The mapping is remembered, so next time you just drop the file. Re-importing the same statement never creates duplicates."
           },
           "journal": {
-            "title": "Browse and qualify your operations",
-            "body": "From the Accounts page, open “Bank journal”: every line is there, filterable by account, period, direction and label (the search ignores case and accents). Two useful gestures per line: flag an internal movement — an ATM withdrawal or a transfer between your two banks is not spending, and must leave the totals or the money gets counted twice — and add a note. The label and the amount cannot be edited: that is what the bank says."
+            "title": "Browse, qualify, classify",
+            "body": "From the Accounts tab, open “Bank journal”: every line, filterable by account, period, direction and label. Three useful gestures: flag an internal movement (a withdrawal is not spending), classify a receipt (wage, refund, internal transfer — the three do not mean the same thing), and annotate a line."
           },
           "balance": {
             "title": "Check your balance",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2895,14 +2895,20 @@
       "count_other": "{{count}} gastos",
       "byKind": "Por tipo",
       "bySupplier": "Por proveedor",
-      "empty": "—"
+      "empty": "—",
+      "coverage": "Cobertura",
+      "coverageHint": "{{sorted}} asignados de {{outflow}} salidos de la cuenta",
+      "coverageRemaining": "{{amount}} aún por asignar"
     },
     "kind": {
       "stock_purchase": "Compra de stock",
       "equipment_purchase": "Compra de equipo",
       "project_purchase": "Gasto de proyecto",
       "manual": "Suelto",
-      "unknown": "Otro"
+      "unknown": "Otro",
+      "bank": "Extracto",
+      "recurring": "Recurrente",
+      "chickens_purchase": "Compra gallinas"
     },
     "filters": {
       "from": "Desde",
@@ -2931,6 +2937,11 @@
       },
       "budget": "Presupuesto",
       "budgetNone": "Sin presupuesto"
+    },
+    "provenance": {
+      "statement": "Extracto",
+      "cash": "Efectivo",
+      "pending": "Pendiente de conciliar"
     }
   },
   "aiUsage": {
@@ -3136,11 +3147,13 @@
       "ibanLast4Hint": "Para distinguir dos cuentas. El IBAN completo nunca se guarda.",
       "openingBalance": "Saldo inicial",
       "openingBalanceHint": "Punto de partida del cálculo del saldo. Puede ser negativo (descubierto).",
-      "openingBalanceDate": "Fecha del saldo inicial"
+      "openingBalanceDate": "Fecha del saldo inicial",
+      "openingBalanceDateHint": "El punto de partida del seguimiento: sin él el saldo es una suposición, y ningún control cubre esta cuenta."
     },
     "errors": {
       "nameRequired": "Introduce un nombre.",
-      "openingBalanceInvalid": "Introduce un importe válido."
+      "openingBalanceInvalid": "Introduce un importe válido.",
+      "openingBalanceDateRequired": "La fecha del saldo inicial es obligatoria."
     },
     "import": {
       "title": "Importar un extracto — {{account}}",
@@ -3479,6 +3492,16 @@
           "title": "Recurrencias confirmadas dos veces",
           "hint": "La misma factura contada dos veces el mismo día.",
           "resolution": "Elimine la ocurrencia duplicada desde la pestaña Gastos."
+        },
+        "statement_period_gap": {
+          "title": "Periodos no cubiertos",
+          "hint": "Un mes que ningún extracto cubrió nunca — invisible para el control de cadena.",
+          "resolution": "Importe el extracto que falta, o justifíquelo si no hubo ninguna operación."
+        },
+        "import_skipped_lines": {
+          "title": "Líneas ignoradas por verificar",
+          "hint": "El archivo no tenía referencia ni saldo: la deduplicación no puede estar segura.",
+          "resolution": "Compruebe que las líneas ignoradas eran realmente duplicados, y justifíquelo."
         }
       }
     },

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1602,20 +1602,20 @@
             "body": "Toca «Nueva cuenta» y crea una por banco. El nombre es lo que te permitirá distinguirlas; añade el banco y los 4 últimos caracteres del IBAN si tienes dos cuentas en la misma entidad. El IBAN completo nunca se guarda."
           },
           "cash": {
-            "title": "Controlar también el efectivo",
-            "body": "Crea una cuenta de tipo «Efectivo» para el dinero en metálico del hogar. Funciona como una cuenta bancaria y se alimentará de tus retiradas una vez importados los extractos."
+            "title": "Seguir también el efectivo",
+            "body": "Cree una cuenta de tipo «Efectivo» para el dinero en metálico del hogar. Funciona como una cuenta bancaria: sus retiradas la alimentan, y un gasto en metálico pasa a ser una operación de esa cuenta — por tanto un gasto que el control sabe vincular, como los demás."
           },
           "openingBalance": {
             "title": "Indicar el saldo inicial",
-            "body": "Introduce el saldo de la cuenta en una fecha dada, normalmente el del primer extracto que vayas a importar. Es el punto de partida desde el que la app calcula tu saldo. Puede ser negativo si estás en descubierto."
+            "body": "Indique el saldo de la cuenta en una fecha dada — normalmente el del primer extracto que vaya a importar. Es **obligatorio**: sin punto de partida el saldo mostrado sería una suposición, y ningún control de conformidad cubriría esta cuenta. Puede ser negativo si está en descubierto."
           },
           "import": {
             "title": "Importar tu primer extracto",
             "body": "En la tarjeta de la cuenta, elige «Importar un extracto» y sube el archivo CSV o Excel de tu banco. Indica una vez qué columna contiene la fecha, el concepto y el importe; si tu banco exporta también el saldo, asígnalo: es lo que distingue dos operaciones idénticas del mismo día y revela si falta un extracto. La asignación se guarda, así que la próxima vez solo tendrás que subir el archivo. Reimportar el mismo extracto nunca crea duplicados."
           },
           "journal": {
-            "title": "Revisar y clasificar tus operaciones",
-            "body": "Desde la página Cuentas, abre «Diario bancario»: ahí están todas tus líneas, filtrables por cuenta, periodo, sentido y concepto (la búsqueda ignora mayúsculas y acentos). Dos gestos útiles en cada línea: marcar un movimiento interno —una retirada en el cajero o una transferencia entre tus dos bancos no es un gasto, y debe salir de los totales o el dinero se contaría dos veces— y añadir una nota. El concepto y el importe no se modifican: es lo que dice el banco."
+            "title": "Revisar, marcar, clasificar",
+            "body": "Desde la pestaña Cuentas, abra «Diario bancario»: todas sus líneas, filtrables por cuenta, periodo, sentido y concepto. Tres gestos útiles: marcar un movimiento interno (una retirada no es un gasto), clasificar un ingreso (sueldo, reembolso, transferencia interna — los tres no significan lo mismo) y anotar una línea."
           },
           "balance": {
             "title": "Comprobar tu saldo",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2895,14 +2895,20 @@
       "count_other": "{{count}} dépenses",
       "byKind": "Par type",
       "bySupplier": "Par fournisseur",
-      "empty": "—"
+      "empty": "—",
+      "coverage": "Couverture",
+      "coverageHint": "{{sorted}} rangés sur {{outflow}} sortis du compte",
+      "coverageRemaining": "{{amount}} encore à affecter"
     },
     "kind": {
       "stock_purchase": "Achat de stock",
       "equipment_purchase": "Achat d'équipement",
       "project_purchase": "Dépense projet",
       "manual": "Ad-hoc",
-      "unknown": "Autre"
+      "unknown": "Autre",
+      "bank": "Relevé",
+      "recurring": "Récurrent",
+      "chickens_purchase": "Achat poules"
     },
     "filters": {
       "from": "Du",
@@ -2931,6 +2937,11 @@
       },
       "budget": "Budget",
       "budgetNone": "Aucun budget"
+    },
+    "provenance": {
+      "statement": "Relevé",
+      "cash": "Espèces",
+      "pending": "En attente de rapprochement"
     }
   },
   "aiUsage": {
@@ -3136,11 +3147,13 @@
       "ibanLast4Hint": "Pour distinguer deux comptes. L'IBAN complet n'est jamais enregistré.",
       "openingBalance": "Solde de départ",
       "openingBalanceHint": "Point de départ du calcul du solde. Peut être négatif (découvert).",
-      "openingBalanceDate": "Date du solde de départ"
+      "openingBalanceDate": "Date du solde de départ",
+      "openingBalanceDateHint": "Le point de départ du suivi : sans lui le solde est une supposition, et aucun contrôle ne porte sur ce compte."
     },
     "errors": {
       "nameRequired": "Merci d'indiquer un nom.",
-      "openingBalanceInvalid": "Saisis un montant valide."
+      "openingBalanceInvalid": "Saisis un montant valide.",
+      "openingBalanceDateRequired": "La date du solde d'ouverture est obligatoire."
     },
     "import": {
       "title": "Importer un relevé — {{account}}",
@@ -3479,6 +3492,16 @@
           "title": "Récurrences confirmées deux fois",
           "hint": "Une même facture comptée deux fois le même jour.",
           "resolution": "Supprimez l'occurrence en double depuis la page Dépenses."
+        },
+        "statement_period_gap": {
+          "title": "Périodes non couvertes",
+          "hint": "Un mois qu'aucun relevé n'a jamais couvert — invisible pour le contrôle de chaîne.",
+          "resolution": "Importez le relevé manquant, ou arbitrez s'il n'y a eu aucune opération."
+        },
+        "import_skipped_lines": {
+          "title": "Lignes ignorées à vérifier",
+          "hint": "Le fichier n'avait ni référence ni solde : la dédup ne peut pas être certaine.",
+          "resolution": "Vérifiez que les lignes ignorées étaient bien des doublons, puis arbitrez."
         }
       }
     },

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1603,19 +1603,19 @@
           },
           "cash": {
             "title": "Suivre aussi les espèces",
-            "body": "Crée un compte de type « Espèces » pour l'argent liquide du foyer. Il fonctionne comme un compte bancaire, et sera alimenté par tes retraits une fois les relevés importés."
+            "body": "Crée un compte de type « Espèces » pour l'argent liquide du foyer. Il fonctionne comme un compte bancaire : tes retraits l'alimentent, et une dépense en liquide devient une opération de ce compte — donc une dépense que le contrôle sait rattacher, comme les autres."
           },
           "openingBalance": {
             "title": "Renseigner le solde de départ",
-            "body": "Indique le solde du compte à une date donnée — typiquement celui du premier relevé que tu comptes importer. C'est le point de départ à partir duquel l'app calculera ton solde. Il peut être négatif si tu es à découvert."
+            "body": "Indique le solde du compte à une date donnée — typiquement celui du premier relevé que tu comptes importer. C'est **obligatoire** : sans point de départ, le solde affiché serait une supposition, et aucun contrôle de conformité ne porterait sur ce compte. Il peut être négatif si tu es à découvert."
           },
           "import": {
             "title": "Importer ton premier relevé",
             "body": "Sur la carte du compte, choisis « Importer un relevé » et dépose l'export CSV ou Excel de ta banque. Indique une fois quelle colonne porte la date, le libellé et le montant — si ta banque exporte aussi le solde, mappe-le : c'est ce qui permet de distinguer deux opérations identiques le même jour et de repérer un relevé manquant. Le mapping est mémorisé : les fois suivantes, tu déposes le fichier et c'est tout. Réimporter le même relevé ne crée jamais de doublon."
           },
           "journal": {
-            "title": "Parcourir et qualifier tes opérations",
-            "body": "Depuis la page Comptes, ouvre « Journal bancaire » : tu y retrouves toutes tes lignes, filtrables par compte, période, sens et libellé (la recherche ignore accents et majuscules). Deux gestes utiles sur chaque ligne : marquer un mouvement interne — un retrait au distributeur ou un virement entre tes deux banques n'est pas une dépense, et doit sortir des totaux sous peine de compter l'argent deux fois — et ajouter une note. Le libellé et le montant, eux, ne se modifient pas : c'est ce que dit la banque."
+            "title": "Parcourir, qualifier, classer",
+            "body": "Depuis l'onglet Comptes, ouvre « Journal bancaire » : toutes tes lignes, filtrables par compte, période, sens et libellé. Trois gestes utiles : marquer un mouvement interne (un retrait n'est pas une dépense), classer une recette (salaire, remboursement, virement interne — les trois ne disent pas la même chose), et annoter une ligne."
           },
           "balance": {
             "title": "Vérifier ton solde",


### PR DESCRIPTION
Le dernier lot. **Le catalogue des orphelins est complet : 13 détecteurs**, dont trois qui n'admettent aucun arbitrage.

## `statement_period_gap` — l'angle mort du contrôle de chaîne

Le contrôle de chaîne attrape les opérations manquantes **à l'intérieur** d'une période importée, par l'arithmétique des soldes. Un février que personne n'a jamais déposé ne laisse **aucune trace arithmétique** — seulement un trou dans le calendrier.

Les deux détecteurs sont complémentaires, et ni l'un ni l'autre ne voit l'angle mort de l'autre. C'est pour ça qu'ils ne fusionnent pas.

Un import **échoué** ne comble pas un trou (il n'a rien écrit, prétendre couvrir sa période serait un mensonge). Les périodes qui se **chevauchent** sont normales — ré-importer un mois est la façon de rattraper — donc seul un trou strictement positif est signalé.

## `import_skipped_lines` — la limite de la dédup, rendue visible

`skipped_count > 0` est normalement la **bonne** nouvelle : c'est à quoi ressemble un ré-import. Ça devient un avertissement **uniquement** sur un fichier sans référence bancaire ni solde courant, parce que c'est exactement la limite documentée de la recette de dédup (`IMPORT_ET_RAPPROCHEMENT.md` §3.2) : le discriminant retombe sur l'index d'occurrence *dans le fichier*, donc un export partiel ultérieur d'une ligne identique peut être ignoré comme doublon alors qu'il est vraiment neuf.

La présence de ces colonnes est **dérivée des lignes créées**, pas stockée : une colonne qui n'a produit aucune valeur était, du point de vue de la dédup, absente — et c'est cette propriété-là qui compte.

## Le solde d'ouverture, requis à l'entrée

Sans `opening_balance_date`, un compte n'a **pas de fenêtre de conformité** : son solde est une supposition et aucun contrôle ne porte sur lui.

**Uniquement à la création.** Sur l'existant, le détecteur du lot 1 fait le travail ; exiger le champ à chaque PATCH rendrait un simple renommage impossible tant que l'utilisateur ne l'a pas rempli — une contrainte qui punit la mauvaise personne.

Côté UI la date est **pré-remplie à aujourd'hui** : le cas fréquent est « je commence à suivre ce compte maintenant ».

⚠️ La contrainte a cassé **19 tests** qui créaient un compte sans date. Je les ai mis à jour plutôt que d'affaiblir la règle (un helper injecte la date, chaque test n'énonce que ce qu'il teste) et ajouté `TestOpeningBalanceDateRequired` pour la règle elle-même. Exempter le service aurait été une échappatoire : `create_account` *est* le chemin unique.

## Provenance et couverture

Badge sur chaque dépense : **relevé**, **espèces**, ou **en attente de rapprochement**. Seule la troisième appelle une action — une dépense que la banque n'a jamais confirmée est un écart, pas un état normal. Le dire dans la liste où on la lit, pas seulement dans l'onglet Contrôle.

Carte **Couverture** : « X rangés sur Y sortis du compte ». C'est ce qui rend « 340 € dépensés » interprétable — sur combien réellement sorti ? Et c'est **un ratio, jamais une somme** des deux mondes.

## Nettoyage au passage

Trois `t()` avec `defaultValue` dans les composants de dépenses, que CLAUDE.md interdit **précisément** parce qu'ils masquent les traductions manquantes. Les retirer a révélé que les clés `bank`, `recurring` et `chickens_purchase` manquaient effectivement — ajoutées dans les quatre locales.

## Vérification

- **3281 tests backend** (+19) : les deux détecteurs (dont l'import échoué qui ne comble pas, les chevauchements tolérés, le fichier mixte considéré comme fiable), et la règle du solde d'ouverture y compris la non-régression sur le PATCH.
- **242 E2E verts, 0 échec**, dont deux nouveaux sur la création de compte.
- `npm run build` + `npm run lint` propres, aucune dérive de schéma API.

Doc : section « Continuité des relevés et provenance » de `docs/MODULES/banking.md`, tableau des trois détecteurs non arbitrables dans `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md`.