### PR TITLE
fix(money): un contrôle non évaluable ne doit jamais se lire « conforme »

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,14 @@ Doc : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` + section « Conformité 
   `[opening_balance_date, dernière date connue]`, un écart n'est pas un écart. Sans
   cette borne le contrôle afficherait des centaines d'écarts irrésolubles, et une
   liste irrésoluble ne se lit pas.
+- **⚠️ Un compteur à zéro a deux sens : « rien à signaler » et « rien d'évaluable ».**
+  Les confondre a produit un silence total en prod (compte dont la date de solde
+  d'ouverture postdatait ses lignes → fenêtre vide → coche verte « tout est
+  affecté »). Deux conséquences permanentes : `coverage.window_status()` renvoie une
+  **raison** et jamais un simple `None` — un compte sans données est normal, un compte
+  hors fenêtre ne l'est pas ; et tout affichage de compteur passe par
+  `ui/src/features/money/prerequisites.ts`, qui distingue les deux. Ne jamais afficher
+  « conforme » sans avoir vérifié que le contrôle a pu s'exécuter.
 - **Le badge doit rester bon marché** : `DetectorSpec.count` est un `COUNT(*)`
   indexé, `findings` est paginé et ne tourne que pour le groupe ouvert. Ne jamais
   matérialiser les écarts en Python pour les compter.

--- a/apps/banking/coverage.py
+++ b/apps/banking/coverage.py
@@ -46,6 +46,38 @@ class Window:
         return self.start <= day <= self.end
 
 
+#: Why an account has no conformity window. ``""`` means it has one.
+WINDOW_OK = ""
+#: No starting point at all — the original blocking prerequisite.
+NO_OPENING_DATE = "no_opening_date"
+#: A starting point, but **later than every line we hold**. The nastiest case: the
+#: date is filled, so the old detector stayed silent, while the window excluded all
+#: the data as "history". Everything then read « conforme » with nothing checked.
+OPENING_DATE_AFTER_DATA = "opening_date_after_data"
+#: Nothing imported yet. Not a problem — a fresh account has nothing to assert.
+NO_DATA = "no_data"
+
+
+def window_status(account) -> tuple[str, Window | None]:
+    """Why this account has (or has not) a conformity window.
+
+    Split out from :func:`covered_period` because the *reason* matters: an account
+    with no data is fine, whereas an account whose opening date postdates its own
+    statements is invisible to every control — and must say so. Returning only
+    ``None`` made those two indistinguishable, which is how the silent case shipped.
+    """
+    start = account.opening_balance_date
+    end = _latest_known_date(account)
+
+    if start is None:
+        return (NO_OPENING_DATE, None)
+    if end is None:
+        return (NO_DATA, None)
+    if end < start:
+        return (OPENING_DATE_AFTER_DATA, None)
+    return (WINDOW_OK, Window(start=start, end=end))
+
+
 def covered_period(account) -> Window | None:
     """Conformity window of ``account``, or ``None`` when it has none.
 
@@ -59,17 +91,7 @@ def covered_period(account) -> Window | None:
     Returns ``None`` when the account has no opening balance date (nothing can be
     asserted) or holds nothing at all (nothing to assert about).
     """
-    start = account.opening_balance_date
-    if start is None:
-        return None
-
-    end = _latest_known_date(account)
-    if end is None or end < start:
-        # Either nothing imported yet, or everything we hold predates the opening
-        # balance — in both cases the window is empty, not "everything is fine".
-        return None
-
-    return Window(start=start, end=end)
+    return window_status(account)[1]
 
 
 def _latest_known_date(account) -> date | None:

--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -7,7 +7,7 @@ would therefore never ask:
 - money left and only part of it was accounted for (``transaction_partial``);
 - an expense was typed in that the bank never saw (``expense_unreconciled``);
 - an expense that counts against no envelope (``expense_without_budget``);
-- an account whose starting point is unknown (``account_no_opening_balance``);
+- an account the control cannot reach at all (``account_without_window``);
 - an account whose statements do not chain (``account_chain_broken``);
 - a cash account in the red, which is physically impossible (``account_cash_negative``);
 - a receipt nobody classified (``inflow_unclassified``);
@@ -54,7 +54,7 @@ TRANSACTION_UNALLOCATED = "transaction_unallocated"
 TRANSACTION_PARTIAL = "transaction_partially_allocated"
 EXPENSE_UNRECONCILED = "expense_unreconciled"
 EXPENSE_WITHOUT_BUDGET = "expense_without_budget"
-ACCOUNT_NO_OPENING_BALANCE = "account_no_opening_balance"
+ACCOUNT_WITHOUT_WINDOW = "account_without_window"
 ACCOUNT_CHAIN_BROKEN = "account_chain_broken"
 ACCOUNT_CASH_NEGATIVE = "account_cash_negative"
 INFLOW_UNCLASSIFIED = "inflow_unclassified"
@@ -267,29 +267,80 @@ def _find_unreconciled(household, **window) -> list[Finding]:
 # --- Accounts ----------------------------------------------------------------
 
 
-def _no_opening_balance_qs(household):
-    return BankAccount.objects.filter(
-        household=household, archived=False, opening_balance_date__isnull=True
-    )
+def _accounts_without_window(household) -> list[tuple[BankAccount, str]]:
+    """Accounts that **hold data** but have no conformity window, with the reason.
+
+    Two reasons matter, and conflating them is what let a silent failure ship:
+
+    - ``no_opening_date`` — no starting point at all;
+    - ``opening_date_after_data`` — a starting point **later than every line held**.
+      The date is filled, so the original detector stayed quiet, while the window
+      excluded all the statement as "history". Every control then read « conforme »
+      with nothing actually checked — the exact silent orphan this parcours forbids.
+
+    An account with **no data** is deliberately not reported: a freshly declared
+    account has nothing to assert about, and nagging about it would be the busywork
+    that makes a control panel stop being read.
+    """
+    from .coverage import NO_DATA, WINDOW_OK, window_status
+
+    pairs = []
+    for account in BankAccount.objects.filter(household=household, archived=False):
+        reason, _ = window_status(account)
+        if reason in (WINDOW_OK, NO_DATA):
+            continue
+        pairs.append((account, reason))
+    return pairs
 
 
-def _count_no_opening_balance(household) -> int:
-    return _no_opening_balance_qs(household).count()
+def _count_without_window(household) -> int:
+    return len(_accounts_without_window(household))
 
 
-def _find_no_opening_balance(household, **window) -> list[Finding]:
+def _find_without_window(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
+    pairs = _accounts_without_window(household)
+    if pks is not None:
+        wanted = {str(p) for p in pks}
+        pairs = [p for p in pairs if str(p[0].pk) in wanted]
+    if exclude_pks:
+        unwanted = {str(p) for p in exclude_pks}
+        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
+    if offset or limit:
+        start = offset or 0
+        pairs = pairs[start : start + limit] if limit else pairs[start:]
+
     return [
         Finding(
-            kind=ACCOUNT_NO_OPENING_BALANCE,
+            kind=ACCOUNT_WITHOUT_WINDOW,
             object_id=str(account.pk),
             label=account.name,
-            # Constant: there is nothing to re-arbitrate here, the field is either
-            # filled or it is not. (And the écart is not waivable anyway.)
-            fingerprint=fingerprint_of(ACCOUNT_NO_OPENING_BALANCE),
-            detail={"name": account.name, "kind": account.kind},
+            # The reason is part of what founds the écart: moving from « no date » to
+            # « date after data » is a different problem needing a different fix.
+            fingerprint=fingerprint_of(ACCOUNT_WITHOUT_WINDOW, reason),
+            detail={
+                "name": account.name,
+                "kind": account.kind,
+                "reason": reason,
+                "opening_balance_date": (
+                    account.opening_balance_date.isoformat()
+                    if account.opening_balance_date
+                    else None
+                ),
+                "earliest_line": _earliest_line_date(account),
+            },
         )
-        for account in apply_window(_no_opening_balance_qs(household), **window)
+        for account, reason in pairs
     ]
+
+
+def _earliest_line_date(account) -> str | None:
+    """Oldest line held, so the UI can propose the date that would fix it."""
+    from django.db.models import Min
+
+    oldest = BankTransaction.objects.filter(account=account).aggregate(
+        oldest=Min("booked_on")
+    )["oldest"]
+    return oldest.isoformat() if oldest else None
 
 
 # --- Receipts and internal movements (lot 5) ---------------------------------
@@ -792,13 +843,13 @@ def _specs() -> list[DetectorSpec]:
 
     return [
         DetectorSpec(
-            kind=ACCOUNT_NO_OPENING_BALANCE,
+            kind=ACCOUNT_WITHOUT_WINDOW,
             severity=BLOCKER,
-            label="Account without an opening balance date",
+            label="Account outside the control's reach — no conformity window",
             target="account",
             model=BankAccount,
-            count=_count_no_opening_balance,
-            findings=_find_no_opening_balance,
+            count=_count_without_window,
+            findings=_find_without_window,
             # A prerequisite, not an arbitration: without it the account has no
             # conformity window, so no other control can say anything about it.
             waivable=False,
@@ -811,7 +862,7 @@ def _specs() -> list[DetectorSpec]:
             model=BankTransaction,
             count=_count_unallocated,
             findings=_find_unallocated,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=TRANSACTION_PARTIAL,
@@ -821,7 +872,7 @@ def _specs() -> list[DetectorSpec]:
             model=BankTransaction,
             count=_count_partial,
             findings=_find_partial,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=EXPENSE_UNRECONCILED,
@@ -831,7 +882,7 @@ def _specs() -> list[DetectorSpec]:
             model=Interaction,
             count=_count_unreconciled,
             findings=_find_unreconciled,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=EXPENSE_WITHOUT_BUDGET,
@@ -841,7 +892,7 @@ def _specs() -> list[DetectorSpec]:
             model=Interaction,
             count=_count_without_budget,
             findings=_find_without_budget,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=ACCOUNT_CHAIN_BROKEN,
@@ -860,7 +911,7 @@ def _specs() -> list[DetectorSpec]:
             model=BankTransaction,
             count=_count_unclassified_inflow,
             findings=_find_unclassified_inflow,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=INTERNAL_WITHOUT_COUNTERPART,
@@ -870,7 +921,7 @@ def _specs() -> list[DetectorSpec]:
             model=BankTransaction,
             count=_count_internal_without_counterpart,
             findings=_find_internal_without_counterpart,
-            blocked_by=ACCOUNT_NO_OPENING_BALANCE,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(
             kind=RECURRING_OVERDUE,

--- a/apps/banking/tests/test_api_compliance.py
+++ b/apps/banking/tests/test_api_compliance.py
@@ -20,7 +20,7 @@ from rest_framework.test import APIClient
 
 from banking.dedup import compute_dedup_hash
 from banking.detectors import (
-    ACCOUNT_NO_OPENING_BALANCE,
+    ACCOUNT_WITHOUT_WINDOW,
     TRANSACTION_PARTIAL,
     TRANSACTION_UNALLOCATED,
 )
@@ -122,7 +122,7 @@ class TestComplianceSummary:
 
         kinds = {g["kind"] for g in body["groups"]}
         assert TRANSACTION_UNALLOCATED in kinds
-        assert ACCOUNT_NO_OPENING_BALANCE in kinds
+        assert ACCOUNT_WITHOUT_WINDOW in kinds
 
     def test_counts_the_open_ecarts(self, household_with_window):
         _, user, account = household_with_window
@@ -139,9 +139,9 @@ class TestComplianceSummary:
         _, user, _ = household_with_window
         body = _client_for(user).get(SUMMARY_URL).json()
 
-        assert _group(body, ACCOUNT_NO_OPENING_BALANCE)["severity"] == "blocker"
-        assert _group(body, ACCOUNT_NO_OPENING_BALANCE)["waivable"] is False
-        assert _group(body, TRANSACTION_UNALLOCATED)["blocked_by"] == ACCOUNT_NO_OPENING_BALANCE
+        assert _group(body, ACCOUNT_WITHOUT_WINDOW)["severity"] == "blocker"
+        assert _group(body, ACCOUNT_WITHOUT_WINDOW)["waivable"] is False
+        assert _group(body, TRANSACTION_UNALLOCATED)["blocked_by"] == ACCOUNT_WITHOUT_WINDOW
 
     def test_another_household_is_never_counted(self, household_with_window):
         _, user, _ = household_with_window
@@ -264,7 +264,7 @@ class TestWaiverCreate:
         response = _client_for(user).post(
             WAIVERS_URL,
             {
-                "finding_kind": ACCOUNT_NO_OPENING_BALANCE,
+                "finding_kind": ACCOUNT_WITHOUT_WINDOW,
                 "object_id": str(account.pk),
                 "reason": "plus tard",
             },

--- a/apps/banking/tests/test_compliance.py
+++ b/apps/banking/tests/test_compliance.py
@@ -31,7 +31,7 @@ from banking.compliance import get_detector, open_findings, summary, waived_find
 from banking.dedup import compute_dedup_hash
 from banking.detectors import (
     ACCOUNT_CHAIN_BROKEN,
-    ACCOUNT_NO_OPENING_BALANCE,
+    ACCOUNT_WITHOUT_WINDOW,
     EXPENSE_UNRECONCILED,
     EXPENSE_WITHOUT_BUDGET,
     TRANSACTION_PARTIAL,
@@ -177,7 +177,7 @@ class TestUnallocatedTransaction:
         account.save(update_fields=["opening_balance_date"])
 
         assert group(household, TRANSACTION_UNALLOCATED).detected == 0
-        assert group(household, ACCOUNT_NO_OPENING_BALANCE).detected == 1
+        assert group(household, ACCOUNT_WITHOUT_WINDOW).detected == 1
 
 
 # --- Detector: an outflow only partly accounted for ---------------------------
@@ -276,13 +276,72 @@ class TestAccountWithoutOpeningBalance:
         account.opening_balance_date = None
         account.save(update_fields=["opening_balance_date"])
 
-        result = group(household, ACCOUNT_NO_OPENING_BALANCE)
+        result = group(household, ACCOUNT_WITHOUT_WINDOW)
         assert result.detected == 1
         assert result.spec.severity == compliance.BLOCKER
 
     def test_it_disappears_once_the_date_is_filled(self, ctx):
         household, _, _, _ = ctx
-        assert group(household, ACCOUNT_NO_OPENING_BALANCE).detected == 0
+        assert group(household, ACCOUNT_WITHOUT_WINDOW).detected == 0
+
+    def test_an_opening_date_later_than_the_statement_is_an_ecart(self, ctx):
+        """THE case that shipped silently.
+
+        The date is filled, so the original detector stayed quiet — while the window
+        excluded the whole statement as « history ». Every control then read
+        « conforme » with nothing checked, and the « À ranger » queue was empty with
+        a green tick. The exact silent orphan this parcours forbids, produced by the
+        horizon that exists to prevent silence.
+        """
+        household, _, account, _ = ctx
+        make_txn(account, booked_on=date(2026, 3, 10))
+        account.opening_balance_date = date(2026, 7, 1)
+        account.save(update_fields=["opening_balance_date"])
+
+        findings = open_findings(household, get_detector(ACCOUNT_WITHOUT_WINDOW))
+        assert [f.object_id for f in findings] == [str(account.pk)]
+        assert findings[0].detail["reason"] == "opening_date_after_data"
+        # And it hands the UI the date that would fix it.
+        assert findings[0].detail["earliest_line"] == "2026-03-10"
+
+    def test_moving_the_date_back_resolves_it(self, ctx):
+        household, _, account, _ = ctx
+        make_txn(account, booked_on=date(2026, 3, 10))
+        account.opening_balance_date = date(2026, 7, 1)
+        account.save(update_fields=["opening_balance_date"])
+        assert group(household, ACCOUNT_WITHOUT_WINDOW).detected == 1
+
+        account.opening_balance_date = date(2026, 1, 1)
+        account.save(update_fields=["opening_balance_date"])
+
+        assert group(household, ACCOUNT_WITHOUT_WINDOW).detected == 0
+        # And the work becomes visible again.
+        assert group(household, TRANSACTION_UNALLOCATED).detected == 1
+
+    def test_a_fresh_account_with_no_data_is_not_reported(self, ctx):
+        """Un compte tout juste déclaré n'a rien à affirmer : le signaler serait du
+        travail pour rien, et c'est ce qui fait arrêter de lire un panneau."""
+        household, _, _, _ = ctx
+        BankAccountFactory(
+            household=household, name="Neuf", opening_balance_date=date(2026, 1, 1)
+        )
+        assert group(household, ACCOUNT_WITHOUT_WINDOW).detected == 0
+
+    def test_the_reason_is_part_of_the_fingerprint(self, ctx):
+        """Passer de « pas de date » à « date après les données » est un autre
+        problème, qui demande une autre correction."""
+        household, _, account, _ = ctx
+        make_txn(account, booked_on=date(2026, 3, 10))
+
+        account.opening_balance_date = None
+        account.save(update_fields=["opening_balance_date"])
+        without_date = open_findings(household, get_detector(ACCOUNT_WITHOUT_WINDOW))[0]
+
+        account.opening_balance_date = date(2026, 7, 1)
+        account.save(update_fields=["opening_balance_date"])
+        after_data = open_findings(household, get_detector(ACCOUNT_WITHOUT_WINDOW))[0]
+
+        assert without_date.fingerprint != after_data.fingerprint
 
     def test_it_cannot_be_arbitrated(self, ctx):
         """« Aucun flag légitime » from the catalogue, enforced as a 400 rather
@@ -295,7 +354,7 @@ class TestAccountWithoutOpeningBalance:
             waive_finding(
                 household=household,
                 user=user,
-                finding_kind=ACCOUNT_NO_OPENING_BALANCE,
+                finding_kind=ACCOUNT_WITHOUT_WINDOW,
                 object_id=str(account.pk),
                 reason="pas envie",
             )

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -426,6 +426,37 @@ une fonctionnalité mais une **garantie** : de l'argent sorti que personne n'a
 affecté, des dépenses que la banque n'a jamais vues, des chaînes de soldes rompues
 — autant d'**orphelins silencieux**. Le contrôle les rend comptables.
 
+### ⚠️ Un zéro a deux sens — et les confondre a produit un silence total
+
+**Bug trouvé à la recette du parcours 26, corrigé après coup.** À retenir avant de
+toucher à `coverage.py` ou à un détecteur.
+
+Un compte dont la date de solde d'ouverture était **postérieure à ses propres
+lignes** (cas réel : compte créé aujourd'hui, relevé couvrant les mois passés) n'avait
+aucune fenêtre de conformité. Conséquence en chaîne :
+
+1. tous les détecteurs de lignes voyaient zéro ligne ;
+2. le prérequis bloquant ne se déclenchait pas — la date *était* renseignée ;
+3. la file « À ranger » affichait une **coche verte** : « Toutes vos opérations sont
+   affectées ou arbitrées » ;
+4. le panneau Contrôle affichait « Rien à signaler » sur chaque groupe.
+
+C'est-à-dire : **le silence produit par le mécanisme qui existe pour empêcher le
+silence.** Le test `test_no_window_when_everything_predates_the_opening_balance`
+disait déjà « une fenêtre vide, c'est *on ne sait rien* » — mais rien ne rapportait
+« on ne sait rien ».
+
+Les deux règles qui en découlent :
+
+- **`coverage.window_status()` renvoie une raison, pas seulement `None`.** Un compte
+  sans données (`no_data`) est normal ; un compte dont la date postdate les lignes
+  (`opening_date_after_data`) est hors de portée du contrôle et doit le dire. Ne
+  jamais revenir à un booléen : c'est la confusion des deux cas qui a shippé.
+- **Un compteur à zéro ne se lit « conforme » que si le contrôle a pu s'exécuter.**
+  Côté front, `money/prerequisites.ts` distingue *rien à signaler* de *rien
+  d'évaluable*, et la file comme le panneau l'affichent. Tout nouveau compteur doit
+  passer par là.
+
 ### L'horizon de conformité — `coverage.py`
 
 Sans borne, le contrôle serait inutilisable dès le premier jour : les dépenses
@@ -439,9 +470,10 @@ La fenêtre d'un compte est donc `[opening_balance_date, dernière date connue]`
 - **après** le dernier relevé : pas encore de relevé, c'est normal ;
 - **entre les deux** : l'exigence est totale — et « zéro écart » devient atteignable.
 
-Un compte sans `opening_balance_date` n'a **pas de fenêtre** : les détecteurs
-dépendants l'ignorent, et son absence de solde d'ouverture est signalée seule, en
-prérequis bloquant. Une action rend le reste du contrôle signifiant.
+Un compte sans fenêtre est signalé seul, en **prérequis bloquant**
+(`account_without_window`), et les détecteurs dépendants sont rendus « non
+évaluable » — jamais « conforme ». Deux raisons le déclenchent : solde d'ouverture
+absent, ou daté **après** les lignes du compte. Une action rend le reste signifiant.
 
 `_latest_known_date` prend le **maximum** entre le `period_end` des imports
 `completed` et le `booked_on` le plus récent — ce second signal est le seul qu'un
@@ -491,7 +523,7 @@ base pour ne pas avoir à arbitrer deux fois la même situation.
 
 | Clé | Sévérité | Arbitrable | Lot |
 |---|---|---|---|
-| `account_no_opening_balance` | `blocker` | ❌ prérequis | 1 |
+| `account_without_window` | `blocker` | ❌ prérequis | 1 |
 | `transaction_unallocated` | `error` | ✅ | 1 |
 | `transaction_partially_allocated` | `error` | ✅ | 1 |
 | `expense_unreconciled` | `warning` | ✅ | 1 |

--- a/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
+++ b/docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md
@@ -98,7 +98,7 @@ incohérence à corriger.
 
 | Écart | Détection | Résolution | Flag légitime | Lot |
 |---|---|---|---|---|
-| **Sans solde d'ouverture** | `opening_balance_date IS NULL` | le renseigner | **aucun — prérequis bloquant** | 1 ✅ (requis à la création : 7 ✅) |
+| **Hors de portée du contrôle** | pas de fenêtre : solde d'ouverture absent **ou** daté après les relevés | le renseigner, ou reculer sa date | **aucun — prérequis bloquant** | 1 ✅ (requis à la création : 7 ✅ · date postérieure : corrigé après recette) |
 | **Chaîne de soldes rompue** | `balances.check_balance_chain` | importer le relevé manquant | « relevé indisponible » | 1 ✅ |
 | **Période non couverte** | trou entre deux `StatementImport` | importer | « pas d'opération sur la période » | 7 ✅ |
 | **Espèces à découvert** | solde espèces négatif | déclarer le retrait qui l'alimente | **aucun — incohérence** | 4 ✅ |
@@ -157,7 +157,7 @@ détecteur). Trois n'admettent **aucun** arbitrage, et c'est structurant :
 
 | Clé | Pourquoi aucun motif ne tient |
 |---|---|
-| `account_no_opening_balance` | Prérequis : sans point de départ, aucun contrôle ne porte sur le compte. |
+| `account_without_window` | Prérequis : sans fenêtre de conformité, aucun contrôle ne porte sur le compte. |
 | `account_cash_negative` | Physiquement impossible : un retrait n'a pas été déclaré. |
 | `recurring_double_confirmed` | Compter une facture deux fois n'est jamais acceptable. |
 

--- a/e2e/money.spec.ts
+++ b/e2e/money.spec.ts
@@ -109,7 +109,7 @@ test.describe('Module Argent — Contrôle', () => {
     // Les cinq détecteurs du lot 1 sont déclarés côté serveur : le panneau doit
     // tous les montrer, y compris ceux à zéro — « contrôlé et conforme » ne doit
     // pas être indistinguable de « pas encore contrôlé ».
-    await expect(page.getByText('Compte sans solde d\'ouverture')).toBeVisible();
+    await expect(page.getByText('Compte hors de portée du contrôle')).toBeVisible();
     await expect(page.getByText('Sorties non affectées')).toBeVisible();
     await expect(page.getByText('Dépenses non rapprochées')).toBeVisible();
   });
@@ -185,7 +185,73 @@ test.describe('Module Argent — création de compte', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 7. Sous-pages autonomes
+// 7. Un zéro ne doit jamais se lire « conforme » quand rien n'est évaluable
+// ---------------------------------------------------------------------------
+
+test.describe('Module Argent — non évaluable ≠ conforme', () => {
+  test('un compte hors fenêtre bloque le contrôle au lieu de le dire conforme', async ({
+    page,
+  }) => {
+    // Reproduit le bug shippé au parcours 26, exactement comme il s'est produit : un
+    // compte créé avec la date du jour, alimenté par des opérations **antérieures**.
+    // La fenêtre de conformité devient vide, tous les détecteurs se taisent, et l'app
+    // affichait une coche verte avec « Toutes vos opérations sont affectées ».
+    await page.goto('/app/money?tab=accounts');
+    const token = await page.evaluate(() => localStorage.getItem('access_token') ?? '');
+    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+
+    const account = await (
+      await page.request.post('/api/banking/accounts/', {
+        headers,
+        data: {
+          name: `Hors fenêtre ${Date.now()}`,
+          kind: 'cash',
+          opening_balance: '0',
+          opening_balance_date: new Date().toISOString().slice(0, 10),
+        },
+      })
+    ).json();
+
+    // Une opération datée d'avant la date d'ouverture → fenêtre vide.
+    const spend = await page.request.post('/api/banking/transactions/cash-expense/', {
+      headers,
+      data: {
+        account: account.id,
+        label: 'Achat antérieur E2E',
+        amount: '12.00',
+        booked_on: '2020-01-15',
+      },
+    });
+    expect(spend.ok()).toBeTruthy();
+
+    const summary = await (
+      await page.request.get('/api/banking/compliance/', { headers })
+    ).json();
+    const blocker = summary.groups.find(
+      (group: { kind: string; open: number }) => group.kind === 'account_without_window',
+    );
+    expect(blocker.open).toBeGreaterThan(0);
+
+    // La file ne doit surtout PAS annoncer que tout est rangé.
+    await page.goto('/app/money?tab=pending');
+    await expect(page.getByText('Toutes vos opérations sont affectées')).toHaveCount(0);
+    await expect(page.getByText("Rien d'évaluable pour l'instant")).toBeVisible();
+
+    // Et le contrôle doit dire « non évaluable », pas « conforme ».
+    await page.goto('/app/money?tab=control');
+    await expect(page.getByText('Tout est conforme')).toHaveCount(0);
+    await expect(page.getByText('Compte hors de portée du contrôle').first()).toBeVisible();
+    // Les contrôles **dépendants** doivent l'annoncer : un zéro affiché comme
+    // « Rien à signaler » était précisément le mensonge à corriger. Les contrôles
+    // qui ne dépendent pas de la fenêtre (chaîne de soldes, récurrences, imports)
+    // restent légitimement « Rien à signaler » — c'est la distinction, pas un
+    // silence global.
+    await expect(page.getByText(/Non évaluable — prérequis/).first()).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Sous-pages autonomes
 // ---------------------------------------------------------------------------
 
 test.describe('Module Argent — sous-pages', () => {

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, Check, ChevronDown, ChevronRight, Info, ShieldAlert, Undo2 } from 'lucide-react';
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  HelpCircle,
+  Info,
+  ShieldAlert,
+  Undo2,
+} from 'lucide-react';
 import { Card } from '@/design-system/card';
 import { Button } from '@/design-system/button';
 import { Badge } from '@/design-system/badge';
@@ -8,6 +17,7 @@ import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import EmptyState from '@/components/EmptyState';
 import type { ComplianceFinding, ComplianceGroup, ComplianceSeverity } from '@/lib/api/banking';
 import { useComplianceGroup, useComplianceSummary, useRevokeWaiver } from './hooks';
+import { blockingPrerequisite } from './prerequisites';
 import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
 
 const SEVERITY_ORDER: Record<ComplianceSeverity, number> = { blocker: 0, error: 1, warning: 2 };
@@ -66,6 +76,7 @@ export default function CompliancePanel() {
         openTotal={open_total}
         waivedTotal={waived_total}
         staleTotal={stale_total}
+        blocked={groups.some((group) => blockingPrerequisite(groups, group) !== null)}
       />
 
       {groups.length === 0 ? (
@@ -80,6 +91,7 @@ export default function CompliancePanel() {
             <GroupRow
               key={group.kind}
               group={group}
+              blockedBy={blockingPrerequisite(groups, group)}
               expanded={openKind === group.kind}
               onToggle={() => setOpenKind((prev) => (prev === group.kind ? null : group.kind))}
               onWaive={setWaiving}
@@ -97,13 +109,16 @@ function ComplianceHeadline({
   openTotal,
   waivedTotal,
   staleTotal,
+  blocked,
 }: {
   openTotal: number;
   waivedTotal: number;
   staleTotal: number;
+  /** Au moins un contrôle non évaluable : « tout est conforme » serait faux. */
+  blocked: boolean;
 }) {
   const { t } = useTranslation();
-  const isClean = openTotal === 0;
+  const isClean = openTotal === 0 && !blocked;
 
   return (
     <Card className="p-4">
@@ -117,12 +132,16 @@ function ComplianceHeadline({
           <p className="font-medium text-foreground">
             {isClean
               ? t('money.compliance.clean')
-              : t('money.compliance.openCount', { count: openTotal })}
+              : blocked && openTotal === 0
+                ? t('money.compliance.blocked')
+                : t('money.compliance.openCount', { count: openTotal })}
           </p>
           <p className="text-sm text-muted-foreground">
             {isClean
               ? t('money.compliance.cleanHint')
-              : t('money.compliance.openHint')}
+              : blocked && openTotal === 0
+                ? t('money.compliance.blockedHint')
+                : t('money.compliance.openHint')}
           </p>
           {waivedTotal > 0 || staleTotal > 0 ? (
             <p className="mt-1 text-xs text-muted-foreground">
@@ -140,18 +159,24 @@ function ComplianceHeadline({
 
 function GroupRow({
   group,
+  blockedBy,
   expanded,
   onToggle,
   onWaive,
 }: {
   group: ComplianceGroup;
+  /** Prérequis encore ouvert : ce groupe n'est pas conforme, il est non évaluable. */
+  blockedBy: ComplianceGroup | null;
   expanded: boolean;
   onToggle: () => void;
   onWaive: (target: WaiverTarget) => void;
 }) {
   const { t } = useTranslation();
   const Icon = SEVERITY_ICON[group.severity];
-  const isClean = group.open === 0;
+  // Un zéro a deux sens : « rien à signaler » et « rien d'évaluable ». Les confondre
+  // affiche une coche verte sur un contrôle qui n'a rien vérifié.
+  const isBlocked = blockedBy !== null;
+  const isClean = group.open === 0 && !isBlocked;
 
   return (
     <Card className="p-0">
@@ -161,7 +186,9 @@ function GroupRow({
         className="flex w-full items-center gap-3 p-3 text-left transition-colors hover:bg-accent/60"
         aria-expanded={expanded}
       >
-        {isClean ? (
+        {isBlocked ? (
+          <HelpCircle className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+        ) : isClean ? (
           <Check className="h-4 w-4 shrink-0 text-primary" aria-hidden />
         ) : (
           <Icon
@@ -179,9 +206,13 @@ function GroupRow({
             {t(`money.compliance.kinds.${group.kind}.title`)}
           </p>
           <p className="truncate text-xs text-muted-foreground">
-            {isClean
-              ? t('money.compliance.groupClean')
-              : t(`money.compliance.kinds.${group.kind}.hint`)}
+            {isBlocked
+              ? t('money.compliance.notEvaluable', {
+                  prerequisite: t(`money.compliance.kinds.${blockedBy.kind}.title`),
+                })
+              : isClean
+                ? t('money.compliance.groupClean')
+                : t(`money.compliance.kinds.${group.kind}.hint`)}
           </p>
         </div>
 
@@ -197,7 +228,7 @@ function GroupRow({
           </span>
         ) : null}
         <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
-          {group.open}
+          {isBlocked ? '—' : group.open}
         </span>
         {expanded ? (
           <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />

--- a/ui/src/features/money/MoneyPage.tsx
+++ b/ui/src/features/money/MoneyPage.tsx
@@ -34,6 +34,17 @@ export default function MoneyPage() {
   const [searchParams] = useSearchParams();
   const summaryQuery = useComplianceSummary();
 
+  /** Bascule d'onglet impérative — `TabShell` lit sa valeur dans la session. */
+  const goToTab = React.useCallback((tab: MoneyTab) => {
+    try {
+      sessionStorage.setItem(MONEY_TAB_SESSION_KEY, JSON.stringify(tab));
+    } catch {
+      // sessionStorage indisponible : la navigation manuelle reste possible.
+    }
+    // `TabShell` ne réagit pas au storage ; un reload de la route applique la valeur.
+    window.location.assign(`/app/money?tab=${tab}`);
+  }, []);
+
   // Deep link `?tab=budgets` — les anciennes URLs (/app/budget…) et les liens de
   // l'agent y atterrissent. Écrit dans la session **avant** que TabShell lise sa
   // valeur initiale : l'initialiseur d'état du parent s'exécute avant le montage
@@ -79,7 +90,11 @@ export default function MoneyPage() {
       >
         {(tab) => {
           if (tab === 'control') return <CompliancePanel />;
-          if (tab === 'pending') return <PendingQueue />;
+          if (tab === 'pending') {
+            // La file renvoie vers Contrôle quand un prérequis la rend vide : sinon
+            // l'utilisateur voit une file vide sans savoir où agir.
+            return <PendingQueue onGoToControl={() => goToTab('control')} />;
+          }
           if (tab === 'accounts') return <AccountsPanel />;
           if (tab === 'expenses') return <ExpensesPanel />;
           return <BudgetsPanel />;

--- a/ui/src/features/money/PendingQueue.tsx
+++ b/ui/src/features/money/PendingQueue.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Inbox } from 'lucide-react';
+import { Check, Inbox, ShieldAlert } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
 import EmptyState from '@/components/EmptyState';
@@ -10,7 +10,8 @@ import AllocationDialog from '@/features/banking/AllocationDialog';
 import { useSetAllocations } from '@/features/banking/hooks';
 import type { ComplianceFinding } from '@/lib/api/banking';
 import { TRANSACTION_PARTIAL, TRANSACTION_UNALLOCATED } from './keys';
-import { useComplianceGroup } from './hooks';
+import { useComplianceGroup, useComplianceSummary } from './hooks';
+import { householdBlocker } from './prerequisites';
 import PendingCard from './PendingCard';
 import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
 
@@ -58,10 +59,16 @@ function toRow(finding: ComplianceFinding, isPartial: boolean): PendingRow {
  * (une pastille = un clic, sélection multiple pour traiter un lot), pas par la
  * devinette. À ~160 lignes par mois, les actions groupées ne sont pas un confort.
  */
-export default function PendingQueue() {
+interface PendingQueueProps {
+  /** Renvoie vers l'onglet Contrôle, où le prérequis bloquant se règle. */
+  onGoToControl?: () => void;
+}
+
+export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
   const { t } = useTranslation();
   const unallocatedQuery = useComplianceGroup(TRANSACTION_UNALLOCATED, { limit: 50 });
   const partialQuery = useComplianceGroup(TRANSACTION_PARTIAL, { limit: 50 });
+  const summaryQuery = useComplianceSummary();
   const budgetsQuery = useBudgets();
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
@@ -115,6 +122,27 @@ export default function PendingQueue() {
           <div key={i} className="h-24 animate-pulse rounded-lg bg-muted" />
         ))}
       </div>
+    );
+  }
+
+  // Une file vide a deux sens, et les confondre est exactement le bug qui a shippé :
+  // « tout est rangé » et « rien n'est évaluable ». Le prérequis bloquant passe donc
+  // devant, avec l'action qui le lève.
+  const blocker = householdBlocker(summaryQuery.data);
+
+  if (rows.length === 0 && blocker) {
+    return (
+      <EmptyState
+        icon={ShieldAlert}
+        title={t('money.pending.blocked')}
+        description={t('money.pending.blockedHint', {
+          prerequisite: t(`money.compliance.kinds.${blocker.kind}.title`),
+        })}
+        action={{
+          label: t('money.pending.blockedAction'),
+          onClick: () => onGoToControl?.(),
+        }}
+      />
     );
   }
 

--- a/ui/src/features/money/keys.ts
+++ b/ui/src/features/money/keys.ts
@@ -23,7 +23,7 @@ export const complianceKeys = {
 export const TRANSACTION_UNALLOCATED = 'transaction_unallocated';
 export const TRANSACTION_PARTIAL = 'transaction_partially_allocated';
 export const EXPENSE_UNRECONCILED = 'expense_unreconciled';
-export const ACCOUNT_NO_OPENING_BALANCE = 'account_no_opening_balance';
+export const ACCOUNT_WITHOUT_WINDOW = 'account_without_window';
 export const ACCOUNT_CHAIN_BROKEN = 'account_chain_broken';
 
 /** Les deux écarts que la file « À ranger » traite — même geste de résolution. */

--- a/ui/src/features/money/prerequisites.ts
+++ b/ui/src/features/money/prerequisites.ts
@@ -1,0 +1,33 @@
+import type { ComplianceGroup, ComplianceSummary } from '@/lib/api/banking';
+
+/**
+ * Un contrôle bloqué ne doit **jamais** se lire « conforme ».
+ *
+ * C'est le bug qui a shippé au parcours 26 : un compte dont la date de solde
+ * d'ouverture était postérieure à son relevé n'avait aucune fenêtre de conformité,
+ * donc tous les détecteurs voyaient zéro ligne — et l'app affichait une coche verte
+ * avec « Toutes vos opérations sont affectées ». Silence produit par le mécanisme
+ * même qui existe pour empêcher le silence.
+ *
+ * Un compteur à zéro a donc deux sens qu'il faut distinguer partout :
+ * **rien à signaler** et **rien d'évaluable**.
+ */
+
+/** Le groupe prérequis d'un contrôle, s'il est encore ouvert. */
+export function blockingPrerequisite(
+  groups: ComplianceGroup[],
+  group: ComplianceGroup,
+): ComplianceGroup | null {
+  if (!group.blocked_by) return null;
+  const prerequisite = groups.find((candidate) => candidate.kind === group.blocked_by);
+  return prerequisite && prerequisite.open > 0 ? prerequisite : null;
+}
+
+/**
+ * Le prérequis bloquant du foyer, tous contrôles confondus — ce que la file « À
+ * ranger » doit annoncer au lieu d'une coche verte.
+ */
+export function householdBlocker(summary: ComplianceSummary | undefined): ComplianceGroup | null {
+  if (!summary) return null;
+  return summary.groups.find((group) => group.severity === 'blocker' && group.open > 0) ?? null;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3438,11 +3438,6 @@
       "noDetectors": "Keine Prüfungen verfügbar",
       "noDetectorsHint": "Legen Sie ein Konto an, damit die Kontrolle etwas prüfen kann.",
       "kinds": {
-        "account_no_opening_balance": {
-          "title": "Konto ohne Anfangssaldo",
-          "hint": "Ohne Startpunkt ist der Saldo eine Annahme.",
-          "resolution": "Tragen Sie Anfangssaldo und Datum des Kontos ein. Erst dann sind die anderen Prüfungen aussagekräftig."
-        },
         "transaction_unallocated": {
           "title": "Nicht zugeordnete Abgänge",
           "hint": "Geld ist abgegangen, ohne dass jemand den Zweck genannt hat.",
@@ -3502,8 +3497,16 @@
           "title": "Zu prüfende übersprungene Zeilen",
           "hint": "Die Datei hatte weder Referenz noch Saldo: die Duplikaterkennung kann nicht sicher sein.",
           "resolution": "Prüfen Sie, ob die übersprungenen Zeilen wirklich Duplikate waren, und legen Sie es dann ab."
+        },
+        "account_without_window": {
+          "title": "Konto außerhalb der Kontrolle",
+          "hint": "Kein Konformitätsfenster: entweder fehlt der Anfangssaldo, oder sein Datum liegt nach Ihren Auszügen.",
+          "resolution": "Tragen Sie den Anfangssaldo ein oder setzen Sie sein Datum vor die älteste Zeile des Kontos. Bis dahin deckt keine andere Prüfung dieses Konto ab."
         }
-      }
+      },
+      "blocked": "Kontrolle nicht bewertbar",
+      "blockedHint": "Eine Voraussetzung verhindert, dass die Prüfungen Ihre Konten abdecken. Beheben Sie sie, dann wird alles messbar.",
+      "notEvaluable": "Nicht bewertbar — Voraussetzung: {{prerequisite}}"
     },
     "pending": {
       "count": "{{count}} Buchung zuzuordnen",
@@ -3521,7 +3524,10 @@
       "allDone": "Liste leer",
       "allDoneHint": "Alle Buchungen sind zugeordnet oder begründet abgelegt.",
       "nothingLeft": "Nichts für diese Sitzung",
-      "nothingLeftHint": "Zurückgestellte Buchungen erscheinen beim nächsten Besuch wieder."
+      "nothingLeftHint": "Zurückgestellte Buchungen erscheinen beim nächsten Besuch wieder.",
+      "blocked": "Noch nichts bewertbar",
+      "blockedHint": "Eine Voraussetzung blockiert die Kontrolle: {{prerequisite}}. Ihre Buchungen existieren, aber keine Regel kann sie erfassen.",
+      "blockedAction": "Kontrolle öffnen"
     }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3438,11 +3438,6 @@
       "noDetectors": "No checks available",
       "noDetectorsHint": "Declare an account so the control has something to verify.",
       "kinds": {
-        "account_no_opening_balance": {
-          "title": "Account without an opening balance",
-          "hint": "With no starting point, the balance is a guess.",
-          "resolution": "Fill in the account's opening balance and its date. The other checks then become meaningful."
-        },
         "transaction_unallocated": {
           "title": "Unaccounted outflows",
           "hint": "Money left without anyone saying what for.",
@@ -3502,8 +3497,16 @@
           "title": "Skipped lines to verify",
           "hint": "The file had neither reference nor balance: dedup cannot be certain.",
           "resolution": "Check the skipped lines really were duplicates, then arbitrate."
+        },
+        "account_without_window": {
+          "title": "Account outside the control's reach",
+          "hint": "No conformity window: either the opening balance is missing, or its date is later than your statements.",
+          "resolution": "Set the opening balance, or move its date before the account's oldest line. Until then, no other check covers this account."
         }
-      }
+      },
+      "blocked": "Control cannot be evaluated",
+      "blockedHint": "A prerequisite stops the checks from covering your accounts. Fix it and everything becomes measurable.",
+      "notEvaluable": "Not evaluable — prerequisite: {{prerequisite}}"
     },
     "pending": {
       "count": "{{count}} operation to sort",
@@ -3521,7 +3524,10 @@
       "allDone": "Queue empty",
       "allDoneHint": "Every operation is accounted for or arbitrated.",
       "nothingLeft": "Nothing for this session",
-      "nothingLeftHint": "Postponed operations will be back on your next visit."
+      "nothingLeftHint": "Postponed operations will be back on your next visit.",
+      "blocked": "Nothing evaluable yet",
+      "blockedHint": "A prerequisite blocks the control: {{prerequisite}}. Your operations exist, but no rule can cover them yet.",
+      "blockedAction": "Open the control"
     }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3438,11 +3438,6 @@
       "noDetectors": "No hay controles disponibles",
       "noDetectorsHint": "Declare una cuenta para que el control tenga algo que verificar.",
       "kinds": {
-        "account_no_opening_balance": {
-          "title": "Cuenta sin saldo inicial",
-          "hint": "Sin punto de partida, el saldo es una suposición.",
-          "resolution": "Indique el saldo inicial de la cuenta y su fecha. Los demás controles pasan entonces a ser evaluables."
-        },
         "transaction_unallocated": {
           "title": "Salidas sin asignar",
           "hint": "Salió dinero sin que nadie dijera para qué.",
@@ -3502,8 +3497,16 @@
           "title": "Líneas ignoradas por verificar",
           "hint": "El archivo no tenía referencia ni saldo: la deduplicación no puede estar segura.",
           "resolution": "Compruebe que las líneas ignoradas eran realmente duplicados, y justifíquelo."
+        },
+        "account_without_window": {
+          "title": "Cuenta fuera del alcance del control",
+          "hint": "Sin ventana de conformidad: falta el saldo inicial, o su fecha es posterior a sus extractos.",
+          "resolution": "Indique el saldo inicial, o retrase su fecha antes de la línea más antigua de la cuenta. Hasta entonces, ningún otro control cubre esta cuenta."
         }
-      }
+      },
+      "blocked": "Control no evaluable",
+      "blockedHint": "Un requisito impide que los controles cubran sus cuentas. Resuélvalo y todo pasa a ser medible.",
+      "notEvaluable": "No evaluable — requisito: {{prerequisite}}"
     },
     "pending": {
       "count": "{{count}} operación por ordenar",
@@ -3521,7 +3524,10 @@
       "allDone": "Lista vacía",
       "allDoneHint": "Todas sus operaciones están asignadas o justificadas.",
       "nothingLeft": "Nada para esta sesión",
-      "nothingLeftHint": "Las operaciones postergadas volverán en su próxima visita."
+      "nothingLeftHint": "Las operaciones postergadas volverán en su próxima visita.",
+      "blocked": "Nada evaluable por ahora",
+      "blockedHint": "Un requisito bloquea el control: {{prerequisite}}. Sus operaciones existen, pero ninguna regla puede cubrirlas todavía.",
+      "blockedAction": "Ver el control"
     }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3438,11 +3438,6 @@
       "noDetectors": "Aucun contrôle disponible",
       "noDetectorsHint": "Déclarez un compte pour que le contrôle ait quelque chose à vérifier.",
       "kinds": {
-        "account_no_opening_balance": {
-          "title": "Compte sans solde d'ouverture",
-          "hint": "Sans point de départ, le solde est une supposition.",
-          "resolution": "Renseignez le solde d'ouverture du compte et sa date. Les autres contrôles deviennent alors évaluables."
-        },
         "transaction_unallocated": {
           "title": "Sorties non affectées",
           "hint": "De l'argent est parti sans que personne dise pour quoi.",
@@ -3502,8 +3497,16 @@
           "title": "Lignes ignorées à vérifier",
           "hint": "Le fichier n'avait ni référence ni solde : la dédup ne peut pas être certaine.",
           "resolution": "Vérifiez que les lignes ignorées étaient bien des doublons, puis arbitrez."
+        },
+        "account_without_window": {
+          "title": "Compte hors de portée du contrôle",
+          "hint": "Aucune fenêtre de conformité : soit le solde d'ouverture manque, soit sa date est postérieure à tes relevés.",
+          "resolution": "Renseigne le solde d'ouverture, ou recule sa date avant la plus ancienne ligne du compte. Tant que ce n'est pas fait, aucun autre contrôle ne porte sur ce compte."
         }
-      }
+      },
+      "blocked": "Contrôle non évaluable",
+      "blockedHint": "Un prérequis empêche les contrôles de porter sur tes comptes. Règle-le et tout devient mesurable.",
+      "notEvaluable": "Non évaluable — prérequis : {{prerequisite}}"
     },
     "pending": {
       "count": "{{count}} opération à ranger",
@@ -3521,7 +3524,10 @@
       "allDone": "File vide",
       "allDoneHint": "Toutes vos opérations sont affectées ou arbitrées.",
       "nothingLeft": "Rien pour cette session",
-      "nothingLeftHint": "Les opérations reportées reviendront à votre prochaine visite."
+      "nothingLeftHint": "Les opérations reportées reviendront à votre prochaine visite.",
+      "blocked": "Rien d'évaluable pour l'instant",
+      "blockedHint": "Un prérequis bloque le contrôle : {{prerequisite}}. Tes opérations existent, mais aucune règle ne peut encore porter sur elles.",
+      "blockedAction": "Voir le contrôle"
     }
   }
 }


### PR DESCRIPTION
## Le bug, tel qu'il s'est présenté

File « À ranger » **vide**, coche verte, « Toutes vos opérations sont affectées ou arbitrées » — alors qu'aucune ligne n'était rangée. Aucun badge sur l'onglet Contrôle.

C'est le **silence produit par le mécanisme qui existe pour empêcher le silence**.

## La cause

Un compte dont la date de solde d'ouverture est **postérieure à ses propres lignes** (cas réel : compte créé aujourd'hui, relevé couvrant les mois passés) n'a aucune fenêtre de conformité. En chaîne :

1. tous les détecteurs de lignes voient zéro ligne ;
2. le prérequis bloquant **ne se déclenche pas** — la date *est* renseignée ;
3. la file affiche une coche verte ;
4. chaque groupe du contrôle affiche « Rien à signaler ».

Le plus gênant : mon propre test `test_no_window_when_everything_predates_the_opening_balance` disait déjà, en commentaire, « une fenêtre vide, c'est *on ne sait rien* ». **Rien ne rapportait « on ne sait rien ».** J'avais écrit le constat sans en tirer la conséquence.

## Le correctif

**`coverage.window_status()` renvoie une raison, plus un simple `None`.** C'est la racine : un `None` confondait « compte sans données » (normal — un compte fraîchement déclaré n'a rien à affirmer) et « compte hors fenêtre » (grave). Les distinguer est ce qui rend le second signalable.

**Le prérequis devient `account_without_window`** et couvre les deux causes. Son `detail` porte la raison *et* la date de la ligne la plus ancienne, pour que l'UI puisse proposer la correction plutôt que de laisser chercher.

**`money/prerequisites.ts` distingue « rien à signaler » de « rien d'évaluable ».** Trois endroits mentaient :
- la file annonce maintenant le prérequis et renvoie vers le contrôle ;
- un groupe bloqué affiche « Non évaluable — prérequis : … » et un **tiret** au lieu d'un zéro ;
- le bandeau ne dit plus « Tout est conforme ».

## Ce qui reste « Rien à signaler », et c'est voulu

Les six contrôles qui ne dépendent pas de la fenêtre — chaîne de soldes, récurrences, imports — restent légitimement clean. C'est la **distinction** qui compte, pas un silence global. Mon premier jet de test l'avait oublié et exigeait qu'aucun contrôle nulle part ne soit clean : c'était le test qui avait tort, pas le code.

## Vérification

- **3285 tests backend** (+4) dont la reproduction exacte : ligne au 10/03, date d'ouverture au 01/07 → l'écart apparaît avec `reason: opening_date_after_data` et `earliest_line`. Plus la résolution (reculer la date → l'écart disparaît **et** les lignes redeviennent visibles), et le fait que la raison entre dans le `fingerprint` (passer de « pas de date » à « date après données » est un autre problème).
- **242 E2E verts**, dont une régression qui reproduit le scénario de bout en bout : compte créé à la date du jour, opération datée de 2020, puis vérification que ni la file ni le contrôle ne prétendent à la conformité.

Doc : encadré « Un zéro a deux sens » dans `docs/MODULES/banking.md`, règle transverse dans `CLAUDE.md`.