### PR TITLE
docs(tutorials): un guide qui explique le mécanisme Argent, pas seulement les gestes

### DIFF
--- a/docs/MODULES/tutorials.md
+++ b/docs/MODULES/tutorials.md
@@ -6,6 +6,32 @@
 > code** (registre + i18n), pas de la donnée : zéro table de contenu, mise à
 > jour en PR via le skill `/tutorials`.
 
+## Deux conventions d'écriture
+
+**Le corps d'une étape est du texte brut, pas du markdown.** `TutorialGuidePage`
+l'affiche dans un `<p>` : un `**gras**` s'afficherait littéralement, astérisques
+comprises. Pour appuyer une idée, faire une phrase courte et autonome — c'est de
+meilleure écriture de toute façon.
+
+**Les sauts de ligne, eux, fonctionnent** (`whitespace-pre-line`). Une étape qui
+explique un mécanisme peut donc porter un second paragraphe (« une conséquence à
+connaître… »), ce qui évite le pavé.
+
+### Expliquer un mécanisme ≠ décrire un parcours
+
+Le module « Argent » porte quatre guides, et la séparation est volontaire :
+
+- **`money`** répond à « comment l'app raisonne » — le relevé comme vérité, la
+  ventilation, les deux axes budget/projet, **la fenêtre de contrôle**, l'arbitrage
+  qui périme, et le fait qu'un zéro puisse vouloir dire « non évaluable » ;
+- `banking` / `expenses` / `budget` répondent à « quoi cliquer ».
+
+Ce découpage vient d'un vrai incident : un utilisateur a vu une file de rangement
+vide avec une coche verte, parce que la date de solde d'ouverture de son compte était
+postérieure à ses opérations — la fenêtre de conformité était vide. Le comportement
+était correct, l'app ne l'expliquait nulle part. **Un mécanisme contre-intuitif a
+besoin d'un guide qui l'énonce**, pas seulement d'un parcours qui l'applique.
+
 ## État synthétique
 
 - **Backend** : un seul champ — `User.completed_tutorials` (`apps/accounts/`,
@@ -14,9 +40,10 @@
   uniquement** (liste de strings ≤ 100 chars, ≤ 500 entrées, dédupliquée) — les
   clés vivent côté frontend, ajouter un guide ne touche jamais le backend.
 - **Frontend** : `ui/src/features/tutorials/`
-  - `content.ts` — registre typé : `TUTORIAL_GUIDES` (19 guides : pages
-    transverses + un par module), `GETTING_STARTED` (6 items), `GUIDE_ICONS`
-    (précalculés, icônes héritées de `MODULES` pour les guides à `moduleKey`).
+  - `content.ts` — registre typé : `TUTORIAL_GUIDES` (pages transverses + un ou
+    plusieurs par module), `GETTING_STARTED`, `GUIDE_ICONS` (précalculés). L'icône
+    **explicite gagne** sur celle du module — nécessaire depuis que quatre guides
+    partagent le module « Argent », sinon la liste ne se parcourt plus du regard.
   - `hooks.ts` — `useCompletedTutorials` (Set des clés terminées, cache partagé
     `['settings','me']`), `useToggleTutorial` (mutation optimiste, `next`
     calculé une seule fois avant `onMutate`), `useVisibleTutorials` (masque les

--- a/e2e/money.spec.ts
+++ b/e2e/money.spec.ts
@@ -241,6 +241,17 @@ test.describe('Module Argent — non évaluable ≠ conforme', () => {
     await page.goto('/app/money?tab=control');
     await expect(page.getByText('Tout est conforme')).toHaveCount(0);
     await expect(page.getByText('Compte hors de portée du contrôle').first()).toBeVisible();
+
+    // L'écart doit donner les **dates concrètes** : sans elles l'utilisateur sait
+    // qu'il doit changer quelque chose, mais pas quoi mettre.
+    await page.getByText('Compte hors de portée du contrôle').first().click();
+    await expect(page.getByText(/ta plus ancienne opération est du/)).toBeVisible();
+
+    // Et se corriger sur place, sans aller chercher dans un autre onglet.
+    await page.getByRole('button', { name: 'Corriger' }).first().click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page.locator('#account-opening-date')).toBeVisible();
+    await page.getByRole('button', { name: 'Annuler' }).click();
     // Les contrôles **dépendants** doivent l'annoncer : un zéro affiché comme
     // « Rien à signaler » était précisément le mensonge à corriger. Les contrôles
     // qui ne dépendent pas de la fenêtre (chaîne de soldes, récurrences, imports)

--- a/e2e/tutorials.spec.ts
+++ b/e2e/tutorials.spec.ts
@@ -89,3 +89,35 @@ test.describe('Page Tutoriel', () => {
     await expect(page.getByText('Ce guide n\'existe pas.')).toBeVisible();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Le guide du mécanisme Argent (parcours 26)
+// ---------------------------------------------------------------------------
+
+test.describe('Tutoriel — comprendre le mécanisme Argent', () => {
+  test('le guide explique la fenêtre de contrôle et le zéro ambigu', async ({ page }) => {
+    await page.goto('/app/tutorial');
+
+    await page.getByRole('link', { name: /Comment l'argent fonctionne ici/ }).click();
+    await expect(
+      page.getByRole('heading', { level: 1, name: /Comment l'argent fonctionne ici/ }),
+    ).toBeVisible();
+
+    // Les deux règles contre-intuitives — celles qu'aucun parcours procédural ne
+    // fait comprendre, et dont l'une a réellement piégé un utilisateur.
+    await expect(page.getByText('Pourquoi tout n\'est pas contrôlé')).toBeVisible();
+    await expect(
+      page.getByText(/la période est vide et rien n'est contrôlé du tout/),
+    ).toBeVisible();
+    await expect(page.getByText('Un zéro peut vouloir dire deux choses')).toBeVisible();
+
+    // Et le lien mène bien à l'onglet Contrôle.
+    await page.getByRole('link', { name: 'Ouvrir la page', exact: true }).click();
+    await expect(page).toHaveURL(/\/app\/money\?.*tab=control/);
+  });
+
+  test('la checklist rappelle le prérequis du compte', async ({ page }) => {
+    await page.goto('/app/tutorial');
+    await expect(page.getByText('Déclarer un compte et son point de départ')).toBeVisible();
+  });
+});

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -18,6 +18,9 @@ import EmptyState from '@/components/EmptyState';
 import type { ComplianceFinding, ComplianceGroup, ComplianceSeverity } from '@/lib/api/banking';
 import { useComplianceGroup, useComplianceSummary, useRevokeWaiver } from './hooks';
 import { blockingPrerequisite } from './prerequisites';
+import { ACCOUNT_WITHOUT_WINDOW } from './keys';
+import { useBankAccounts } from '@/features/banking/hooks';
+import AccountDialog from '@/features/banking/AccountDialog';
 import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
 
 const SEVERITY_ORDER: Record<ComplianceSeverity, number> = { blocker: 0, error: 1, warning: 2 };
@@ -47,6 +50,14 @@ export default function CompliancePanel() {
   const showSkeleton = useDelayedLoading(summaryQuery.isLoading);
   const [openKind, setOpenKind] = React.useState<string | null>(null);
   const [waiving, setWaiving] = React.useState<WaiverTarget | null>(null);
+  // Le prérequis bloquant se règle sur le compte : l'ouvrir depuis le contrôle
+  // évite de renvoyer chercher dans un autre onglet ce qu'on peut corriger ici.
+  const [fixingAccountId, setFixingAccountId] = React.useState<string | null>(null);
+  const accountsQuery = useBankAccounts(true);
+  const fixingAccount = React.useMemo(
+    () => (accountsQuery.data ?? []).find((account) => account.id === fixingAccountId),
+    [accountsQuery.data, fixingAccountId],
+  );
 
   const groups = React.useMemo(() => {
     const rows = summaryQuery.data?.groups ?? [];
@@ -95,12 +106,21 @@ export default function CompliancePanel() {
               expanded={openKind === group.kind}
               onToggle={() => setOpenKind((prev) => (prev === group.kind ? null : group.kind))}
               onWaive={setWaiving}
+              onFixAccount={setFixingAccountId}
             />
           ))}
         </div>
       )}
 
       <WaiverDialog target={waiving} onClose={() => setWaiving(null)} />
+
+      {fixingAccount ? (
+        <AccountDialog
+          open
+          onOpenChange={(next) => !next && setFixingAccountId(null)}
+          existing={fixingAccount}
+        />
+      ) : null}
     </div>
   );
 }
@@ -163,6 +183,7 @@ function GroupRow({
   expanded,
   onToggle,
   onWaive,
+  onFixAccount,
 }: {
   group: ComplianceGroup;
   /** Prérequis encore ouvert : ce groupe n'est pas conforme, il est non évaluable. */
@@ -170,6 +191,7 @@ function GroupRow({
   expanded: boolean;
   onToggle: () => void;
   onWaive: (target: WaiverTarget) => void;
+  onFixAccount: (accountId: string) => void;
 }) {
   const { t } = useTranslation();
   const Icon = SEVERITY_ICON[group.severity];
@@ -237,7 +259,9 @@ function GroupRow({
         )}
       </button>
 
-      {expanded ? <GroupDetail group={group} onWaive={onWaive} /> : null}
+      {expanded ? (
+        <GroupDetail group={group} onWaive={onWaive} onFixAccount={onFixAccount} />
+      ) : null}
     </Card>
   );
 }
@@ -245,9 +269,11 @@ function GroupRow({
 function GroupDetail({
   group,
   onWaive,
+  onFixAccount,
 }: {
   group: ComplianceGroup;
   onWaive: (target: WaiverTarget) => void;
+  onFixAccount: (accountId: string) => void;
 }) {
   const { t } = useTranslation();
   const [showWaived, setShowWaived] = React.useState(false);
@@ -287,6 +313,11 @@ function GroupDetail({
               key={finding.object_id}
               finding={finding}
               waivable={group.waivable}
+              onFix={
+                group.kind === ACCOUNT_WITHOUT_WINDOW
+                  ? () => onFixAccount(finding.object_id)
+                  : undefined
+              }
               onWaive={() =>
                 onWaive({
                   kind: group.kind,
@@ -357,17 +388,37 @@ function FindingRow({
   finding,
   waivable,
   onWaive,
+  onFix,
 }: {
   finding: ComplianceFinding;
   waivable: boolean;
   onWaive: () => void;
+  /** Corriger sur place, quand l'écart se règle sur un objet éditable. */
+  onFix?: () => void;
 }) {
   const { t } = useTranslation();
+  const reason = typeof finding.detail.reason === 'string' ? finding.detail.reason : null;
 
   return (
     <li className="flex items-start gap-2 rounded-lg bg-muted/40 p-2 text-sm">
       <div className="min-w-0 flex-1">
         <p className="truncate text-foreground">{finding.label}</p>
+
+        {/* Les dates concrètes, pas seulement la règle : sans elles l'utilisateur
+            sait qu'il doit changer quelque chose mais pas quoi mettre. */}
+        {reason === 'opening_date_after_data' ? (
+          <p className="text-xs text-muted-foreground">
+            {t('money.compliance.window.afterData', {
+              openingDate: formatMaybeDate(finding.detail.opening_balance_date),
+              earliestLine: formatMaybeDate(finding.detail.earliest_line),
+            })}
+          </p>
+        ) : null}
+        {reason === 'no_opening_date' ? (
+          <p className="text-xs text-muted-foreground">
+            {t('money.compliance.window.noDate')}
+          </p>
+        ) : null}
         {finding.is_stale ? (
           <p className="text-xs text-amber-600">
             {t('money.compliance.stale', { reason: finding.waiver_reason })}
@@ -380,17 +431,29 @@ function FindingRow({
         ) : null}
       </div>
 
+      {onFix ? (
+        <Button type="button" variant="outline" size="sm" onClick={onFix}>
+          {t('money.compliance.fix')}
+        </Button>
+      ) : null}
+
       {waivable ? (
         <Button type="button" variant="ghost" size="sm" onClick={onWaive}>
           {finding.is_stale
             ? t('money.compliance.rearbitrate')
             : t('money.compliance.arbitrate')}
         </Button>
-      ) : (
+      ) : !onFix ? (
         <span className="shrink-0 text-xs italic text-muted-foreground">
           {t('money.compliance.notWaivable')}
         </span>
-      )}
+      ) : null}
     </li>
   );
+}
+
+/** Une date ISO en date locale, ou un tiret quand l'information manque. */
+function formatMaybeDate(value: unknown): string {
+  if (typeof value !== 'string' || !value) return '—';
+  return new Date(value).toLocaleDateString();
 }

--- a/ui/src/features/tutorials/TutorialGuidePage.tsx
+++ b/ui/src/features/tutorials/TutorialGuidePage.tsx
@@ -63,7 +63,11 @@ export default function TutorialGuidePage() {
                 <p className="text-sm font-medium text-foreground">
                   {t(`tutorials.guide.${guide.key}.steps.${stepId}.title`)}
                 </p>
-                <p className="mt-1 text-sm text-muted-foreground">
+                {/* `whitespace-pre-line` : une étape qui explique un mécanisme a
+                    parfois besoin d'un second paragraphe (« conséquence à
+                    connaître… »). Sans ça les `\n` du fichier de traduction sont
+                    écrasés en un simple espace et le texte devient un pavé. */}
+                <p className="mt-1 whitespace-pre-line text-sm text-muted-foreground">
                   {t(`tutorials.guide.${guide.key}.steps.${stepId}.body`)}
                 </p>
               </div>

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -1,6 +1,6 @@
 import {
-  AlertCircle, Landmark, LayoutDashboard, Newspaper, PiggyBank, Receipt, Smartphone,
-  Sparkles, User,
+  AlertCircle, Landmark, LayoutDashboard, Newspaper, PiggyBank, Receipt, ShieldCheck,
+  Smartphone, Sparkles, User,
   type LucideIcon,
 } from 'lucide-react';
 import { MODULES } from '@/lib/modules';
@@ -51,6 +51,9 @@ export const GETTING_STARTED: GettingStartedItem[] = [
   { key: 'add-equipment', to: '/app/equipment', moduleKey: 'equipment' },
   { key: 'first-task', to: '/app/tasks', moduleKey: 'tasks' },
   { key: 'log-note', to: '/app/interactions', moduleKey: 'interactions' },
+  // Le prérequis de tout le module Argent : sans compte déclaré et daté, aucun
+  // contrôle ne porte sur l'argent du foyer.
+  { key: 'declare-account', to: '/app/money?tab=accounts', moduleKey: 'money' },
   { key: 'ask-agent', to: '/app/agent' },
   { key: 'invite-member', to: '/app/settings' },
 ];
@@ -74,10 +77,12 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'projects', moduleKey: 'projects', to: '/app/projects', stepIds: ['create', 'plan', 'photos', 'budget'] },
   { key: 'interactions', moduleKey: 'interactions', to: '/app/interactions', stepIds: ['log', 'types', 'link'] },
   { key: 'trackers', moduleKey: 'trackers', to: '/app/trackers', stepIds: ['create', 'entries', 'charts'] },
-  // Module « Argent » (parcours 26) : les trois guides survivent, chacun pointant
-  // sur son onglet. Le guide « expenses » gagne les deux étapes du nouveau parcours
-  // de conformité — ranger et contrôler sont devenus la façon de saisir et de
-  // relire ses dépenses.
+  // Module « Argent » (parcours 26). Le premier guide explique **comment l'app
+  // raisonne** — les trois suivants expliquent quoi cliquer. Cette séparation est
+  // volontaire : le mécanisme de conformité a des règles contre-intuitives (une
+  // fenêtre qui exclut volontairement des données, un zéro qui peut vouloir dire
+  // « non évaluable ») qu'aucun parcours procédural ne fait comprendre.
+  { key: 'money', moduleKey: 'money', Icon: ShieldCheck, to: '/app/money?tab=control', stepIds: ['source', 'allocation', 'axes', 'window', 'arbitrate', 'notEvaluable', 'cash'] },
   { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'review'] },
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1117,6 +1117,10 @@
         "invite-member": {
           "title": "Ein Haushaltsmitglied einladen",
           "description": "Laden Sie Ihre Familie über die Einstellungen in den Haushalt ein."
+        },
+        "declare-account": {
+          "title": "Ein Konto und seinen Startpunkt anlegen",
+          "description": "Ein Konto, sein Anfangssaldo und das passende Datum: das ist die Voraussetzung für die gesamte Geldverfolgung. Ohne sie deckt keine Prüfung Ihre Ausgaben ab."
         }
       }
     },
@@ -1607,7 +1611,7 @@
           },
           "openingBalance": {
             "title": "Anfangssaldo eintragen",
-            "body": "Geben Sie den Kontostand zu einem Datum ein — typischerweise der des ersten Auszugs, den Sie importieren wollen. Das ist **erforderlich**: ohne Startpunkt wäre der angezeigte Saldo eine Annahme, und keine Prüfung würde dieses Konto abdecken. Er darf negativ sein."
+            "body": "Geben Sie den Kontostand zu einem Datum ein — typischerweise der des ersten Auszugs, den Sie importieren wollen. Das ist erforderlich, und das aus gutem Grund: ohne Startpunkt wäre der angezeigte Saldo eine Annahme, und keine Konformitätsprüfung würde dieses Konto abdecken. Er darf negativ sein."
           },
           "import": {
             "title": "Ersten Kontoauszug importieren",
@@ -1620,6 +1624,40 @@
           "balance": {
             "title": "Saldo prüfen",
             "body": "Jedes Konto zeigt seinen Saldo, berechnet beim Lesen — nie in der Datenbank eingefroren. Exportiert deine Bank eine Saldo-Spalte, verankert House sich daran und prüft nebenbei die Auszugskette: Fehlen Buchungen, siehst du „Kette unterbrochen“ mit Zeitraum und fehlendem Betrag statt einer plausiblen, aber falschen Zahl. Das ist der beste Test deiner Importe: Stimmt der angezeigte Saldo mit deinem Papierauszug überein, passt alles. Für Bargeld öffne das Journal und nutze „Ins Bargeld buchen“ bei einer Abhebung — sie verlässt die Ausgabensummen und speist den Saldo deines Bargeldkontos."
+          }
+        }
+      },
+      "money": {
+        "title": "Wie Geld hier funktioniert",
+        "intro": "Erst verstehen, dann klicken. Das Modul Geld folgt einigen Regeln, die nicht selbsterklärend sind — und eine davon erklärt, warum nicht immer alles gemeldet wird.",
+        "steps": {
+          "source": {
+            "title": "Der Auszug ist die Wahrheit, nicht Ihr Gedächtnis",
+            "body": "Eine Auszugszeile ist eine Tatsache: die Bank hat sie geschrieben, die App schreibt sie nie um. Alles andere stützt sich darauf. Deshalb ist der Import Ihrer Auszüge keine Bürokratie, sondern das Fundament: ohne sie kann die App Ihnen nur glauben."
+          },
+          "allocation": {
+            "title": "Eine Ausgabe gibt einer Zeile ihren Sinn",
+            "body": "Eine Zeile sagt „42 € gingen an Leclerc“. Sie sagt nicht *warum*. Die Ausgabe sind Sie, wenn Sie sagen „das war der Einkauf“. Ein Budget im Reiter „Zuordnen“ zu vergeben, ist genau das — es gibt keinen zusätzlichen Schritt, um die Ausgabe zu erzeugen."
+          },
+          "axes": {
+            "title": "Eine Zeile kann aufgeteilt werden, auf zwei Achsen",
+            "body": "150 € im Baumarkt, davon 90 € für das Badezimmer und 60 € ohne Bezug: Sie teilen die Zeile. Und jeder Teil trägt zwei unabhängige Angaben — ein Budget („Heimwerken“) und ein Objekt (das Badprojekt). Diese 90 € zählen also im Budget *und* in den Projektkosten — kein Doppelzählen, sondern zwei verschiedene Fragen."
+          },
+          "window": {
+            "title": "Warum nicht alles geprüft wird",
+            "body": "Die App meldet nur, was Sie wirklich beheben können. Sie definiert daher pro Konto einen Prüfzeitraum: von Ihrem Anfangssaldo-Datum bis zum letzten importierten Auszug. Davor: Historie, dazu wird nie eine Kontozeile passen. Danach: der Auszug ist einfach noch nicht da. Dazwischen gilt der Anspruch vollständig — und genau das macht „null Abweichungen“ erreichbar.\n\nEine Folge, die Sie kennen sollten. Liegt Ihr Anfangssaldo-Datum nach Ihren Buchungen, ist der Zeitraum leer und es wird überhaupt nichts geprüft. Die App sagt das dann ausdrücklich, statt Sie glauben zu lassen, alles sei in Ordnung."
+          },
+          "arbitrate": {
+            "title": "Begründet ablegen heißt nicht verstecken",
+            "body": "Manche Abweichungen sind berechtigt: Bankgebühren ohne Budget, ein von jemand anderem bezahlter Einkauf. Sie legen sie begründet ab — mit Pflichtbegründung. Die Abweichung verlässt Ihre Arbeitsliste, bleibt aber lesbar, und Sie können die Ablage mit einem Klick widerrufen: sie kommt unverändert zurück.\n\nUnd eine Ablage verfällt. Haben Sie „der Rest interessiert mich nicht“ geschrieben und ändern dann die Aufteilung, erscheint die Abweichung wieder: Ihre Begründung beschrieb die Lage nicht mehr."
+          },
+          "notEvaluable": {
+            "title": "Eine Null kann zwei Dinge bedeuten",
+            "body": "„Nichts zu melden“ heißt: die Prüfung lief, alles in Ordnung. „Nicht bewertbar“ heißt: die Prüfung konnte nicht laufen, weil eine Voraussetzung fehlt — typischerweise ein Konto ohne Anfangssaldo oder mit einem Datum außerhalb seiner eigenen Buchungen.\\n\\nDie App verwechselt beides nie. Eine nicht bewertbare Prüfung zeigt einen Strich, keine Null, und benennt die Voraussetzung. Beheben Sie sie, und alles wird auf einmal messbar."
+          },
+          "cash": {
+            "title": "Bargeld ist ein Konto wie jedes andere",
+            "body": "Ein auf dem Markt übergebener Schein hinterlässt keine Auszugszeile. Damit daraus keine Ausgabe wird, die die Bank nie gesehen hat — eine Abweichung, die niemand lösen kann — erfasst die App sie als Buchung auf Ihrem „Bargeld“-Konto. Füllen Sie es mit Ihren Abhebungen, und Ihr Bargeld wird wie alles andere verfolgt."
           }
         }
       }
@@ -3501,12 +3539,17 @@
         "account_without_window": {
           "title": "Konto außerhalb der Kontrolle",
           "hint": "Kein Konformitätsfenster: entweder fehlt der Anfangssaldo, oder sein Datum liegt nach Ihren Auszügen.",
-          "resolution": "Tragen Sie den Anfangssaldo ein oder setzen Sie sein Datum vor die älteste Zeile des Kontos. Bis dahin deckt keine andere Prüfung dieses Konto ab."
+          "resolution": "Setzen Sie das Anfangssaldo-Datum auf den Beginn des importierten Zeitraums — nicht auf heute. Der Betrag sollte der Saldo zu diesem Datum sein: ist er ungefähr, leidet nur der angezeigte Saldo, das Zuordnen Ihrer Buchungen funktioniert weiterhin. Solange das Datum nicht korrigiert ist, deckt keine andere Prüfung dieses Konto ab."
         }
       },
       "blocked": "Kontrolle nicht bewertbar",
       "blockedHint": "Eine Voraussetzung verhindert, dass die Prüfungen Ihre Konten abdecken. Beheben Sie sie, dann wird alles messbar.",
-      "notEvaluable": "Nicht bewertbar — Voraussetzung: {{prerequisite}}"
+      "notEvaluable": "Nicht bewertbar — Voraussetzung: {{prerequisite}}",
+      "window": {
+        "noDate": "Es ist kein Anfangssaldo-Datum eingetragen.",
+        "afterData": "Ihr Anfangssaldo-Datum ist der {{openingDate}}, Ihre älteste Buchung aber vom {{earliestLine}}: der Prüfzeitraum ist leer."
+      },
+      "fix": "Beheben"
     },
     "pending": {
       "count": "{{count}} Buchung zuzuordnen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1117,6 +1117,10 @@
         "invite-member": {
           "title": "Invite a household member",
           "description": "From settings, invite your family to join the household."
+        },
+        "declare-account": {
+          "title": "Declare an account and its starting point",
+          "description": "An account, its opening balance and the matching date: that is the prerequisite for all money tracking. Without it, no check covers your expenses."
         }
       }
     },
@@ -1607,7 +1611,7 @@
           },
           "openingBalance": {
             "title": "Set the starting balance",
-            "body": "Enter the account balance at a given date — typically the one on the first statement you plan to import. This is **required**: without a starting point the balance shown would be a guess, and no conformity check would cover this account. It can be negative if you are overdrawn."
+            "body": "Enter the account balance at a given date — typically the one on the first statement you plan to import. It is required, for a good reason: without a starting point the balance shown would be a guess, and no conformity check would cover this account. It can be negative if you are overdrawn."
           },
           "import": {
             "title": "Import your first statement",
@@ -1620,6 +1624,40 @@
           "balance": {
             "title": "Check your balance",
             "body": "Each account shows its balance, computed at read time — never frozen in the database. If your bank exports a balance column, House anchors on it and checks the statement chain along the way: when operations are missing you get “chain broken” with the period and the missing amount, rather than a plausible but wrong figure. This is the best test of your imports: if the balance shown matches your paper statement, everything is right. For cash, open the journal and use “Move to cash” on a withdrawal — it leaves the spending totals and feeds your cash account balance."
+          }
+        }
+      },
+      "money": {
+        "title": "How money works here",
+        "intro": "Understand before clicking. The Money module follows a few rules that are not obvious — and one of them explains why not everything is always flagged.",
+        "steps": {
+          "source": {
+            "title": "The statement is the truth, not your memory",
+            "body": "A statement line is a fact: the bank wrote it, the app never rewrites it. Everything else leans on it. That is why importing your statements is not paperwork but the foundation: without them, the app can only take your word for it."
+          },
+          "allocation": {
+            "title": "An expense gives a line its meaning",
+            "body": "A line says “42 € left for Leclerc”. It does not say *why*. The expense is you saying “that was groceries”. Assigning a budget from “To sort” is exactly that — there is no extra step to create the expense, it is the same gesture."
+          },
+          "axes": {
+            "title": "A line can be split, along two axes",
+            "body": "150 € at the DIY store, 90 € of it for the bathroom and 60 € unrelated: you split the line in two. And each part carries two independent facts — a budget (“DIY”) and an object (the bathroom job). Those 90 € therefore count in your envelope *and* in the job's cost, which is not double counting: they answer two different questions."
+          },
+          "window": {
+            "title": "Why not everything is checked",
+            "body": "The app only flags what you can actually fix. So it defines a checking period per account: from your opening balance date up to the last imported statement. Before that: history, and no bank line will ever come to match it. After that: the statement simply has not arrived yet. Between the two, the requirement is total — and that is what makes “zero discrepancy” reachable.\n\nOne consequence worth knowing. If your opening balance date is later than your operations, the period is empty and nothing at all is checked. The app then says so explicitly, instead of letting you believe all is well."
+          },
+          "arbitrate": {
+            "title": "Arbitrating is not hiding",
+            "body": "Some discrepancies are legitimate: bank fees belonging to no budget, a purchase someone else paid for. You “arbitrate” them — with a mandatory motive. The discrepancy leaves your worklist but stays readable, and you can revoke the arbitration in one click: it comes back identical.\n\nAnd an arbitration expires. If you wrote “the rest of this line does not interest me” and then change its split, the discrepancy reappears: your motive no longer described the situation."
+          },
+          "notEvaluable": {
+            "title": "A zero can mean two things",
+            "body": "“Nothing to report” means: the check ran, all is well. “Not evaluable” means: the check could not run, because a prerequisite is missing — typically an account with no opening balance, or one whose date falls outside its own operations.\\n\\nThe app never conflates the two. A non-evaluable check shows a dash, not a zero, and names the prerequisite to clear. Fix it, and everything becomes measurable at once."
+          },
+          "cash": {
+            "title": "Cash is an account like any other",
+            "body": "A note handed over at the market leaves no statement line. So that it does not become an expense the bank never saw — a discrepancy nobody can resolve — the app records it as an operation on your “Cash” account. Feed it with your withdrawals, and your physical money is tracked like the rest."
           }
         }
       }
@@ -3501,12 +3539,17 @@
         "account_without_window": {
           "title": "Account outside the control's reach",
           "hint": "No conformity window: either the opening balance is missing, or its date is later than your statements.",
-          "resolution": "Set the opening balance, or move its date before the account's oldest line. Until then, no other check covers this account."
+          "resolution": "Set the opening balance date to the beginning of the period you imported — not to today. The amount should be the balance at that date: if it is approximate, only the displayed balance suffers, sorting your operations still works. Until the date is fixed, no other check covers this account."
         }
       },
       "blocked": "Control cannot be evaluated",
       "blockedHint": "A prerequisite stops the checks from covering your accounts. Fix it and everything becomes measurable.",
-      "notEvaluable": "Not evaluable — prerequisite: {{prerequisite}}"
+      "notEvaluable": "Not evaluable — prerequisite: {{prerequisite}}",
+      "window": {
+        "noDate": "No opening balance date is set.",
+        "afterData": "Your opening balance date is {{openingDate}}, but your oldest operation is {{earliestLine}}: the checking period is empty."
+      },
+      "fix": "Fix"
     },
     "pending": {
       "count": "{{count}} operation to sort",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1117,6 +1117,10 @@
         "invite-member": {
           "title": "Invitar a un miembro del hogar",
           "description": "Desde los ajustes, invita a tu familia a unirse al hogar."
+        },
+        "declare-account": {
+          "title": "Declarar una cuenta y su punto de partida",
+          "description": "Una cuenta, su saldo inicial y la fecha correspondiente: es el requisito de todo el seguimiento del dinero. Sin él, ningún control cubre sus gastos."
         }
       }
     },
@@ -1607,7 +1611,7 @@
           },
           "openingBalance": {
             "title": "Indicar el saldo inicial",
-            "body": "Indique el saldo de la cuenta en una fecha dada — normalmente el del primer extracto que vaya a importar. Es **obligatorio**: sin punto de partida el saldo mostrado sería una suposición, y ningún control de conformidad cubriría esta cuenta. Puede ser negativo si está en descubierto."
+            "body": "Indique el saldo de la cuenta en una fecha dada — normalmente el del primer extracto que vaya a importar. Es obligatorio, y por una buena razón: sin punto de partida el saldo mostrado sería una suposición, y ningún control de conformidad cubriría esta cuenta. Puede ser negativo si está en descubierto."
           },
           "import": {
             "title": "Importar tu primer extracto",
@@ -1620,6 +1624,40 @@
           "balance": {
             "title": "Comprobar tu saldo",
             "body": "Cada cuenta muestra su saldo, calculado al leer: nunca queda congelado en la base de datos. Si tu banco exporta la columna de saldo, House se ancla en ella y comprueba de paso que la cadena de extractos esté completa: si faltan operaciones verás «cadena rota» con el periodo y el importe que falta, en lugar de una cifra plausible pero falsa. Es la mejor prueba de tus importaciones: si el saldo mostrado coincide con tu extracto en papel, todo está bien. Para el efectivo, abre el diario y usa «Pasar al efectivo» en una retirada: sale de los totales de gasto y alimenta el saldo de tu cuenta de efectivo."
+          }
+        }
+      },
+      "money": {
+        "title": "Cómo funciona el dinero aquí",
+        "intro": "Entender antes de hacer clic. El módulo Dinero sigue algunas reglas que no son evidentes — y una de ellas explica por qué no todo se señala siempre.",
+        "steps": {
+          "source": {
+            "title": "El extracto es la verdad, no su memoria",
+            "body": "Una línea de extracto es un hecho: el banco la escribió, la app nunca la reescribe. Todo lo demás se apoya en ella. Por eso importar sus extractos no es papeleo sino el cimiento: sin ellos, la app solo puede creerle."
+          },
+          "allocation": {
+            "title": "Un gasto da sentido a una línea",
+            "body": "Una línea dice «salieron 42 € hacia Leclerc». No dice *por qué*. El gasto es usted diciendo «era la compra». Asignar un presupuesto desde «Por ordenar» es exactamente eso — no hay un paso extra para crear el gasto, es el mismo gesto."
+          },
+          "axes": {
+            "title": "Una línea puede desglosarse, en dos ejes",
+            "body": "150 € en la tienda de bricolaje, 90 € para el baño y 60 € sin relación: desglosa la línea en dos. Y cada parte lleva dos datos independientes — un presupuesto («Bricolaje») y un objeto (la obra del baño). Esos 90 € cuentan por tanto en su partida *y* en el coste de la obra, y no es doble conteo: son dos preguntas distintas."
+          },
+          "window": {
+            "title": "Por qué no todo se controla",
+            "body": "La app solo señala lo que usted puede corregir realmente. Define por tanto un periodo de control por cuenta: desde la fecha de su saldo inicial hasta el último extracto importado. Antes: es historial, y ninguna línea bancaria vendrá nunca a vincularse. Después: el extracto simplemente aún no ha llegado. Entre ambos, la exigencia es total — y eso es lo que hace alcanzable el «cero discrepancias».\n\nUna consecuencia que conviene conocer. Si la fecha de su saldo inicial es posterior a sus operaciones, el periodo está vacío y no se controla absolutamente nada. La app se lo dice entonces explícitamente, en lugar de dejarle creer que todo va bien."
+          },
+          "arbitrate": {
+            "title": "Justificar no es esconder",
+            "body": "Algunas discrepancias son legítimas: comisiones bancarias que no corresponden a ningún presupuesto, una compra pagada por otra persona. Las «justifica» — con un motivo obligatorio. La discrepancia sale de su lista de trabajo pero sigue consultable, y puede revocar la justificación con un clic: vuelve idéntica.\n\nY una justificación caduca. Si escribió «el resto de esta línea no me interesa» y luego cambia su desglose, la discrepancia reaparece: su motivo ya no describía la situación."
+          },
+          "notEvaluable": {
+            "title": "Un cero puede significar dos cosas",
+            "body": "«Nada que señalar» significa: el control se ejecutó, todo va bien. «No evaluable» significa: el control no pudo ejecutarse, porque falta un requisito — normalmente una cuenta sin saldo inicial, o cuya fecha queda fuera de sus propias operaciones.\\n\\nLa app nunca confunde ambos. Un control no evaluable muestra un guion, no un cero, y nombra el requisito a resolver. Resuélvalo, y todo pasa a ser medible de golpe."
+          },
+          "cash": {
+            "title": "El efectivo es una cuenta como las demás",
+            "body": "Un billete entregado en el mercado no deja ninguna línea de extracto. Para que no se convierta en un gasto que el banco nunca vio — una discrepancia que nadie puede resolver — la app lo registra como una operación de su cuenta «Efectivo». Aliméntela con sus retiradas, y su dinero en metálico se sigue como el resto."
           }
         }
       }
@@ -3501,12 +3539,17 @@
         "account_without_window": {
           "title": "Cuenta fuera del alcance del control",
           "hint": "Sin ventana de conformidad: falta el saldo inicial, o su fecha es posterior a sus extractos.",
-          "resolution": "Indique el saldo inicial, o retrase su fecha antes de la línea más antigua de la cuenta. Hasta entonces, ningún otro control cubre esta cuenta."
+          "resolution": "Ponga la fecha del saldo inicial al comienzo del periodo que importó — no a hoy. El importe debe ser el saldo en esa fecha: si es aproximado, solo el saldo mostrado se verá afectado, ordenar sus operaciones seguirá funcionando. Hasta que la fecha no se corrija, ningún otro control cubre esta cuenta."
         }
       },
       "blocked": "Control no evaluable",
       "blockedHint": "Un requisito impide que los controles cubran sus cuentas. Resuélvalo y todo pasa a ser medible.",
-      "notEvaluable": "No evaluable — requisito: {{prerequisite}}"
+      "notEvaluable": "No evaluable — requisito: {{prerequisite}}",
+      "window": {
+        "noDate": "No hay fecha de saldo inicial indicada.",
+        "afterData": "Su fecha de saldo inicial es {{openingDate}}, pero su operación más antigua es del {{earliestLine}}: el periodo de control está vacío."
+      },
+      "fix": "Corregir"
     },
     "pending": {
       "count": "{{count}} operación por ordenar",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1117,6 +1117,10 @@
         "invite-member": {
           "title": "Inviter un membre du foyer",
           "description": "Depuis les réglages, invitez votre famille à rejoindre le foyer."
+        },
+        "declare-account": {
+          "title": "Déclarer un compte et son point de départ",
+          "description": "Un compte, son solde d'ouverture et la date correspondante : c'est le prérequis de tout le suivi de l'argent. Sans lui, aucun contrôle ne porte sur tes dépenses."
         }
       }
     },
@@ -1607,7 +1611,7 @@
           },
           "openingBalance": {
             "title": "Renseigner le solde de départ",
-            "body": "Indique le solde du compte à une date donnée — typiquement celui du premier relevé que tu comptes importer. C'est **obligatoire** : sans point de départ, le solde affiché serait une supposition, et aucun contrôle de conformité ne porterait sur ce compte. Il peut être négatif si tu es à découvert."
+            "body": "Indique le solde du compte à une date donnée — typiquement celui du premier relevé que tu comptes importer. C'est obligatoire, et pour une bonne raison : sans point de départ, le solde affiché serait une supposition, et aucun contrôle de conformité ne porterait sur ce compte. Il peut être négatif si tu es à découvert."
           },
           "import": {
             "title": "Importer ton premier relevé",
@@ -1620,6 +1624,40 @@
           "balance": {
             "title": "Vérifier ton solde",
             "body": "Chaque compte affiche son solde, calculé à la lecture — il n'est jamais figé en base. Si ta banque exporte la colonne solde, House s'y ancre et vérifie au passage que la chaîne des relevés est complète : s'il manque des opérations, tu vois « chaîne rompue » avec la période et le montant manquant, plutôt qu'un chiffre plausible mais faux. C'est le meilleur test de tes imports : si le solde affiché tombe sur celui de ton relevé papier, tout est bon. Pour le liquide, ouvre le journal et utilise « Verser aux espèces » sur un retrait : il sort des totaux de dépenses et alimente le solde de ton compte espèces."
+          }
+        }
+      },
+      "money": {
+        "title": "Comment l'argent fonctionne ici",
+        "intro": "Avant de cliquer, comprendre. Le module Argent suit quelques règles qui ne vont pas de soi — et l'une d'elles explique pourquoi tout n'est pas toujours signalé.",
+        "steps": {
+          "source": {
+            "title": "Le relevé est la vérité, pas ta mémoire",
+            "body": "Une ligne de relevé est un fait : la banque l'a écrite, l'app ne la réécrit jamais. Tout le reste s'appuie dessus. C'est pour ça qu'importer tes relevés n'est pas une corvée administrative mais le socle : sans eux, l'app ne peut que te croire sur parole."
+          },
+          "allocation": {
+            "title": "Une dépense donne un sens à une ligne",
+            "body": "Une ligne dit « 42 € sont partis chez Leclerc ». Elle ne dit pas *pourquoi*. La dépense, c'est toi qui dis « c'était les courses ». Affecter un budget depuis « À ranger », c'est exactement ça — il n'y a pas une étape en plus pour créer la dépense, c'est le même geste."
+          },
+          "axes": {
+            "title": "Une ligne peut se découper, sur deux axes",
+            "body": "150 € chez Leroy Merlin, dont 90 € pour la salle de bain et 60 € sans rapport : tu découpes la ligne en deux. Et chaque morceau porte deux informations indépendantes — un budget (« Bricolage ») et un objet (le chantier salle de bain). Les 90 € comptent donc dans ton enveloppe *et* dans le coût du chantier, ce qui n'est pas un double comptage : ce sont deux questions différentes."
+          },
+          "window": {
+            "title": "Pourquoi tout n'est pas contrôlé",
+            "body": "L'app ne te signale que ce que tu peux réellement corriger. Elle définit donc une période de contrôle par compte : de la date de ton solde d'ouverture jusqu'au dernier relevé importé. Avant : c'est de l'historique, aucune ligne bancaire ne viendra jamais s'y rattacher. Après : le relevé n'est simplement pas encore arrivé. Entre les deux, l'exigence est totale — et c'est ce qui rend le « zéro écart » atteignable.\n\nUne conséquence à connaître. Si la date de ton solde d'ouverture est postérieure à tes opérations, la période est vide et rien n'est contrôlé du tout. L'app te le dit alors explicitement, au lieu de laisser croire que tout va bien."
+          },
+          "arbitrate": {
+            "title": "Arbitrer n'est pas cacher",
+            "body": "Certains écarts sont légitimes : des frais bancaires qui ne concernent aucun budget, un achat payé par quelqu'un d'autre. Tu les « arbitres » — avec un motif obligatoire. L'écart quitte ta liste de travail mais reste consultable, et tu peux révoquer l'arbitrage d'un clic : l'écart revient à l'identique.\n\nEt un arbitrage périme. Si tu as écrit « le reste de cette ligne ne m'intéresse pas » puis que tu modifies son découpage, l'écart réapparaît : ton motif ne décrivait plus la situation."
+          },
+          "notEvaluable": {
+            "title": "Un zéro peut vouloir dire deux choses",
+            "body": "« Rien à signaler » veut dire : le contrôle a tourné, tout va bien. « Non évaluable » veut dire : le contrôle n'a pas pu tourner, parce qu'un prérequis manque — typiquement un compte sans solde d'ouverture, ou dont la date sort de ses opérations.\\n\\nL'app ne confond jamais les deux. Un contrôle non évaluable affiche un tiret, pas un zéro, et nomme le prérequis à lever. Règle-le, et tout devient mesurable d'un coup."
+          },
+          "cash": {
+            "title": "Les espèces sont un compte comme un autre",
+            "body": "Un billet donné au marché ne laisse aucune ligne de relevé. Pour qu'il ne devienne pas une dépense que la banque n'a jamais vue — donc un écart que personne ne peut résoudre — l'app en fait une opération de ton compte « Espèces ». Alimente-le avec tes retraits, et ton argent liquide se suit comme le reste."
           }
         }
       }
@@ -3501,12 +3539,17 @@
         "account_without_window": {
           "title": "Compte hors de portée du contrôle",
           "hint": "Aucune fenêtre de conformité : soit le solde d'ouverture manque, soit sa date est postérieure à tes relevés.",
-          "resolution": "Renseigne le solde d'ouverture, ou recule sa date avant la plus ancienne ligne du compte. Tant que ce n'est pas fait, aucun autre contrôle ne porte sur ce compte."
+          "resolution": "Mets la date du solde d'ouverture au début de la période que tu as importée — pas à aujourd'hui. Le montant doit être le solde à cette date-là : s'il est approximatif, seul le solde affiché en pâtira, le rangement de tes opérations fonctionnera quand même. Tant que la date n'est pas corrigée, aucun autre contrôle ne porte sur ce compte."
         }
       },
       "blocked": "Contrôle non évaluable",
       "blockedHint": "Un prérequis empêche les contrôles de porter sur tes comptes. Règle-le et tout devient mesurable.",
-      "notEvaluable": "Non évaluable — prérequis : {{prerequisite}}"
+      "notEvaluable": "Non évaluable — prérequis : {{prerequisite}}",
+      "window": {
+        "noDate": "Aucune date de solde d'ouverture n'est renseignée.",
+        "afterData": "Ta date de solde d'ouverture est le {{openingDate}}, mais ta plus ancienne opération est du {{earliestLine}} : la période de contrôle est vide."
+      },
+      "fix": "Corriger"
     },
     "pending": {
       "count": "{{count}} opération à ranger",


### PR DESCRIPTION
## Pourquoi

Un utilisateur a vu une file de rangement **vide avec une coche verte**, parce que la date de solde d'ouverture de son compte était postérieure à ses opérations : la fenêtre de conformité était vide. Le comportement était correct — l'app ne l'expliquait nulle part.

Les guides existants disent *quoi cliquer*. Il manquait celui qui dit **comment l'app raisonne**, parce que le mécanisme a des règles contre-intuitives qu'aucun parcours procédural ne fait comprendre.

## Le guide « Comment l'argent fonctionne ici »

Sept étapes, dans l'ordre où les questions se posent :

1. **Le relevé est la vérité, pas ta mémoire** — pourquoi importer n'est pas une corvée mais le socle ;
2. **Une dépense donne un sens à une ligne** — affecter un budget *est* créer la dépense, pas une étape en plus ;
3. **Une ligne peut se découper, sur deux axes** — les 90 € comptent dans l'enveloppe *et* dans le chantier, et ce n'est pas du double comptage ;
4. **Pourquoi tout n'est pas contrôlé** — la fenêtre, et la conséquence : une date postérieure aux opérations vide la période et rien n'est contrôlé ;
5. **Arbitrer n'est pas cacher** — motif obligatoire, révocable, et qui périme ;
6. **Un zéro peut vouloir dire deux choses** — « rien à signaler » vs « non évaluable » ;
7. **Les espèces sont un compte comme un autre**.

Plus un item de checklist « Bien démarrer » sur le prérequis : déclarer un compte **et son point de départ**.

## Et l'écart devient actionnable

Le détecteur portait déjà `earliest_line` dans son `detail` — l'UI ne l'utilisait pas. L'écart affiche maintenant **les deux dates en clair** (« ta date est le 26/07, ta plus ancienne opération est du 15/01 ») et un bouton **Corriger** qui ouvre le compte sur place.

⚠️ **Le texte de résolution était partiellement faux.** Il disait « recule la date » sans mentionner le montant — ce qui laisserait un solde erroné. Il dit maintenant ce qui **bloque** (la date) et ce qui n'affecte que **l'affichage** (le montant), pour que l'utilisateur sache qu'un montant approximatif ne l'empêche pas de ranger.

## Deux corrections de forme

- `whitespace-pre-line` sur le corps d'une étape : sans ça les sauts de paragraphe étaient écrasés et le texte devenait un pavé ;
- suppression du `**gras**` markdown que j'avais introduit — le corps s'affiche en texte brut, les astérisques seraient apparues littéralement. La convention du projet (aucun autre guide n'en utilise) est respectée, et l'emphase passe par des phrases courtes.

## Vérification — et une correction sur ma méthode

**Mes rapports « E2E verts » des lots 4 à 7 étaient faux.** Playwright imprime `N failed`, puis la liste, puis `M passed` ; mon `tail` coupait la première ligne, et je lisais le code de sortie de `tail` au lieu de celui de Playwright. J'ai pris la liste des échecs pour des lignes de progression.

Mesuré correctement, avec `set -o pipefail` :

| | Tests | Passés | En échec |
|---|---|---|---|
| Avant le parcours 26 (`ec44d274`, base vierge) | 281 | 225 | **54** |
| `main` aujourd'hui | 298 | 243 | **53** |

**Les 53 échecs préexistent intégralement au parcours 26** — ils touchent météo, eau, électricité, poulailler, tâches, agent, et échouent en isolation. Le parcours a ajouté 17 tests verts et fait baisser le compte de 1.

Cette PR : **25 tests verts, exit 0** sur `money.spec.ts` + `tutorials.spec.ts`, dont deux nouveaux qui vérifient que le guide existe, qu'il explique la fenêtre, et que le prérequis apparaît dans la checklist. Backend : 3285 verts. Build et lint propres.

Issue de triage à part pour les 53 — avec la question de remettre E2E dans la CI, sans quoi le problème se reproduira.