### PR TITLE
feat(banking): dire sur chaque ligne du journal où en est son rangement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -259,6 +259,13 @@ Doc : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` + section « Conformité 
 - Le libellé utilisateur d'un `kind` vit dans le namespace i18n **`money`** du
   front, pas en `gettext` backend : ajouter un détecteur ne doit pas imposer un
   passage dans quatre `.po`.
+- **Un écart ne se dit jamais deux fois avec deux voix.** Le marqueur du journal
+  (`allocation_state`, servi par le serializer) et le compteur du Contrôle lisent
+  la **même** fonction `banking.queries.allocation_state` / `with_allocation`. Ne
+  jamais recalculer un état de traitement côté client à partir d'un montant : le
+  verdict dépend de la fenêtre de conformité, et une ligne verte dans un écran
+  face à un écart dans l'autre fait perdre leur crédit aux deux. Régression :
+  `banking/tests/test_journal_marker.py::TestTheMarkerAgreesWithTheControl`.
 
 #### Le module « Argent » — une seule clé, cinq onglets
 

--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -30,8 +30,7 @@ from __future__ import annotations
 from datetime import date
 from decimal import Decimal
 
-from django.db.models import Case, DecimalField, F, Q, Sum, Value, When
-from django.db.models.functions import Coalesce
+from django.db.models import F, Q
 
 from .balances import check_balance_chain
 from .compliance import (
@@ -47,9 +46,7 @@ from .compliance import (
 )
 from .coverage import accounts_with_window, household_covered_period, period_gaps
 from .models import BankAccount, BankTransaction, ImportStatus
-
-AMOUNT_FIELD = DecimalField(max_digits=14, decimal_places=2)
-ZERO = Value(Decimal("0.00"), output_field=AMOUNT_FIELD)
+from .queries import with_allocation
 
 #: Kind keys — imported by tests and by the services layer, never retyped.
 TRANSACTION_UNALLOCATED = "transaction_unallocated"
@@ -94,28 +91,13 @@ def _allocatable_outflows(household):
     for account, window in pairs:
         scope |= Q(account=account, booked_on__gte=window.start, booked_on__lte=window.end)
 
-    return (
+    # ``with_allocation`` is shared with the journal badge on purpose: the count
+    # on the Contrôle tab and the marker on the line must be the same judgement.
+    return with_allocation(
         BankTransaction.objects.filter(household=household)
         .filter(scope)
         .filter(amount__lt=0, is_internal=False, transfer_counterpart__isnull=True)
-        .annotate(
-            allocated=Coalesce(
-                Sum(
-                    "interactions__amount",
-                    filter=Q(interactions__type="expense"),
-                ),
-                ZERO,
-            ),
-            # NOT ``outflow``: that name is already a property on the model, and
-            # an annotation cannot be assigned onto a property without a setter.
-            outflow_value=Case(
-                When(amount__lt=0, then=-1 * F("amount")),
-                default=ZERO,
-                output_field=AMOUNT_FIELD,
-            ),
-        )
-        .select_related("account")
-    )
+    ).select_related("account")
 
 
 def _unallocated_qs(household):

--- a/apps/banking/queries.py
+++ b/apps/banking/queries.py
@@ -64,6 +64,68 @@ def inflow_expr():
     )
 
 
+def allocated_expr():
+    """Sum of the expenses this line has been split into.
+
+    There is no ``Allocation`` table: a line split 80/40 carries two
+    ``Interaction(type='expense')``. Summing them **is** reading how much of the
+    line has been accounted for.
+    """
+    return Coalesce(
+        Sum("interactions__amount", filter=Q(interactions__type="expense")),
+        ZERO,
+    )
+
+
+def with_allocation(qs: QuerySet) -> QuerySet:
+    """Annotate ``allocated`` and ``outflow_value`` on a transaction queryset.
+
+    One definition for two readers that must never disagree: the Contrôle tab
+    counts the écarts, the journal badges each line. Two copies of the same
+    ``Sum`` would eventually differ by a filter, and the user would be told a line
+    is fine in one screen and orphaned in the other.
+
+    ``outflow_value``, not ``outflow``: the latter is already a property on the
+    model, and an annotation cannot be assigned onto a property with no setter.
+    """
+    return qs.annotate(allocated=allocated_expr(), outflow_value=outflow_expr())
+
+
+#: Nothing to allocate — a receipt, an internal movement, a cash counterpart.
+#: Not a state of progress: an empty string renders no badge at all.
+NOT_ALLOCATABLE = ""
+#: Money out that nobody has said anything about.
+UNALLOCATED = "unallocated"
+#: Part of the line is accounted for, the rest is not.
+PARTIAL = "partial"
+#: Fully accounted for.
+ALLOCATED = "allocated"
+#: Outside the account's conformity window — House cannot require anything here,
+#: so the line is *not* reported as untreated. Distinguishing this from
+#: ``unallocated`` is the same rule as ``coverage.window_status``: a blank counter
+#: means either "nothing to report" or "nothing evaluable", never both.
+OUT_OF_SCOPE = "out_of_scope"
+
+
+def allocation_state(txn, *, allocated: Decimal, window) -> str:
+    """How far ``txn`` has been accounted for, from the reader's point of view.
+
+    Mirrors the two detectors ``transaction_unallocated`` and
+    ``transaction_partially_allocated`` exactly, window included — with one
+    deliberate difference: a **fully** allocated line reads « ventilée » even
+    outside the window. Being done is a fact; being required is a scope.
+    """
+    if txn.amount >= 0 or txn.is_internal or txn.transfer_counterpart_id:
+        return NOT_ALLOCATABLE
+
+    outflow = -txn.amount
+    if allocated >= outflow:
+        return ALLOCATED
+    if window is None or not window.contains(txn.booked_on):
+        return OUT_OF_SCOPE
+    return PARTIAL if allocated > 0 else UNALLOCATED
+
+
 def sum_outflow(qs: QuerySet) -> Decimal:
     """Total money out over ``qs``, as a positive number."""
     return qs.aggregate(total=Coalesce(Sum(outflow_expr()), ZERO))["total"] or Decimal("0.00")

--- a/apps/banking/serializers.py
+++ b/apps/banking/serializers.py
@@ -1,7 +1,14 @@
 """Banking serializers — account CRUD + statement import API."""
+from decimal import Decimal
+
+from django.db.models import Sum
 from rest_framework import serializers
 
+from . import queries
+from .coverage import covered_period
 from .models import BankAccount, BankTransaction, ComplianceWaiver, StatementImport
+
+ZERO = Decimal("0.00")
 
 
 class BankAccountSerializer(serializers.ModelSerializer):
@@ -160,7 +167,17 @@ class BankTransactionSerializer(serializers.ModelSerializer):
     ``label_raw``, ``amount``, ``direction`` and ``dedup_hash`` are immutable:
     this is what the bank says. Only the qualification fields (``is_internal``,
     ``notes``) are writable — and only through the lot 3 ``qualify`` action.
+
+    **Où en est cette ligne** (``allocation_state``) is computed here rather than
+    in the client: the answer depends on the account's conformity window, which
+    the journal has no business re-deriving, and it has to agree — line by line —
+    with what the Contrôle tab counts. Both read
+    :func:`banking.queries.allocation_state`.
     """
+
+    allocated_amount = serializers.SerializerMethodField()
+    remaining_amount = serializers.SerializerMethodField()
+    allocation_state = serializers.SerializerMethodField()
 
     class Meta:
         model = BankTransaction
@@ -180,6 +197,9 @@ class BankTransactionSerializer(serializers.ModelSerializer):
             "notes",
             "source_import",
             "transfer_counterpart",
+            "allocated_amount",
+            "remaining_amount",
+            "allocation_state",
             "created_at",
         ]
         read_only_fields = [
@@ -197,6 +217,51 @@ class BankTransactionSerializer(serializers.ModelSerializer):
             "transfer_counterpart",
             "created_at",
         ]
+
+    def get_allocated_amount(self, obj) -> str:
+        return str(self._allocated(obj))
+
+    def get_remaining_amount(self, obj) -> str:
+        """What is still owed an explanation, never negative.
+
+        Over-allocating is already impossible (``assert_allocation_fits``); if a
+        legacy row ever went past, showing « reste −5 € » would invite someone to
+        fix it by adding more.
+        """
+        if obj.amount >= 0:
+            return str(ZERO)
+        return str(max(-obj.amount - self._allocated(obj), ZERO))
+
+    def get_allocation_state(self, obj) -> str:
+        return queries.allocation_state(
+            obj, allocated=self._allocated(obj), window=self._window(obj)
+        )
+
+    def _allocated(self, obj) -> Decimal:
+        """Prefer the queryset annotation; fall back to a query for lone objects.
+
+        The journal annotates via ``queries.with_allocation`` — without it, fifty
+        rows would mean fifty extra queries. But single-object responses (the
+        ``qualify`` action, the cash counterpart) serialize an unannotated
+        instance, and answering « 0 » there would badge a fully sorted line as
+        untreated.
+        """
+        annotated = getattr(obj, "allocated", None)
+        if annotated is not None:
+            return annotated
+        total = obj.interactions.filter(type="expense").aggregate(t=Sum("amount"))["t"]
+        return total or ZERO
+
+    def _window(self, obj):
+        """Conformity window of the line's account, memoized per response.
+
+        ``covered_period`` costs two aggregates; a household has a handful of
+        accounts and a page has fifty lines.
+        """
+        cache = self.context.setdefault("_allocation_windows", {})
+        if obj.account_id not in cache:
+            cache[obj.account_id] = covered_period(obj.account)
+        return cache[obj.account_id]
 
 
 class ComplianceWaiverSerializer(serializers.ModelSerializer):

--- a/apps/banking/tests/test_journal_marker.py
+++ b/apps/banking/tests/test_journal_marker.py
@@ -1,0 +1,253 @@
+# banking/tests/test_journal_marker.py
+"""Le marqueur « traitée / partiellement / pas du tout » du journal bancaire.
+
+Un journal qui n'affiche que des libellés et des montants oblige à ouvrir chaque
+ligne pour savoir s'il reste quelque chose à en dire. Le marqueur répond à ça —
+mais il ne vaut que s'il dit **exactement** ce que compte l'onglet Contrôle : une
+ligne verte ici et un écart là-bas, et plus personne ne croit ni l'un ni l'autre.
+D'où la classe de régression du bas de fichier, qui compare les deux lectures.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from rest_framework.test import APIClient
+
+from banking.dedup import compute_dedup_hash
+from banking.detectors import TRANSACTION_PARTIAL, TRANSACTION_UNALLOCATED
+from banking.models import BankTransaction, ImportStatus, StatementImport, TransactionDirection
+from budget.models import Budget
+from households.models import HouseholdMember
+from interactions.services import create_bank_expense_interaction
+
+from .factories import BankAccountFactory, HouseholdFactory, HouseholdMemberFactory, UserFactory
+
+LIST_URL = "/api/banking/transactions/"
+TX_URL = "/api/banking/transactions/"
+_counter = itertools.count()
+
+
+def make_txn(account, *, amount, booked_on=date(2026, 3, 10), internal=False, label="CB LECLERC"):
+    value = Decimal(amount)
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        is_internal=internal,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    """Un foyer dont le compte a une fenêtre de conformité sur janvier→mars 2026."""
+    household = HouseholdFactory()
+    user = UserFactory()
+    HouseholdMemberFactory(household=household, user=user, role=HouseholdMember.Role.MEMBER)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    account = BankAccountFactory(
+        household=household,
+        name="Courant",
+        opening_balance=Decimal("1000.00"),
+        opening_balance_date=date(2026, 1, 1),
+    )
+    StatementImport.objects.create(
+        household=household,
+        account=account,
+        provider="generic_csv",
+        status=ImportStatus.COMPLETED,
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),
+    )
+    budget = Budget.objects.create(household=household, name="Courses", monthly_amount=400)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return household, user, account, budget, client
+
+
+def allocate(household, user, txn, budget, amount):
+    return create_bank_expense_interaction(
+        household=household,
+        user=user,
+        transaction=txn,
+        subject="Courses",
+        amount=Decimal(amount),
+        budget_id=budget.id,
+    )
+
+
+def row_for(client, txn):
+    body = client.get(f"{LIST_URL}?account={txn.account_id}").json()
+    return next(r for r in body["results"] if r["id"] == str(txn.pk))
+
+
+@pytest.mark.django_db
+class TestTheThreeStates:
+    def test_an_untouched_outflow_says_so(self, ctx):
+        household, _, account, _, client = ctx
+        txn = make_txn(account, amount="-120.00")
+
+        row = row_for(client, txn)
+
+        assert row["allocation_state"] == "unallocated"
+        assert row["allocated_amount"] == "0.00"
+        assert row["remaining_amount"] == "120.00"
+
+    def test_a_half_sorted_line_carries_what_is_left(self, ctx):
+        """C'est le reste qui est l'information utile, pas le pourcentage fait."""
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-150.00")
+        allocate(household, user, txn, budget, "90.00")
+
+        row = row_for(client, txn)
+
+        assert row["allocation_state"] == "partial"
+        assert row["allocated_amount"] == "90.00"
+        assert row["remaining_amount"] == "60.00"
+
+    def test_a_fully_split_line_is_done(self, ctx):
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-150.00")
+        allocate(household, user, txn, budget, "90.00")
+        allocate(household, user, txn, budget, "60.00")
+
+        row = row_for(client, txn)
+
+        assert row["allocation_state"] == "allocated"
+        assert row["remaining_amount"] == "0.00"
+
+
+@pytest.mark.django_db
+class TestWhatCarriesNoMarkerAtAll:
+    """Un marqueur sur une ligne qui n'a rien à ventiler est un faux reproche."""
+
+    def test_an_inflow_has_no_state(self, ctx):
+        _, _, account, _, client = ctx
+        txn = make_txn(account, amount="2100.00", label="VIR SALAIRE")
+
+        row = row_for(client, txn)
+
+        assert row["allocation_state"] == ""
+        assert row["remaining_amount"] == "0.00"
+
+    def test_an_internal_movement_has_no_state(self, ctx):
+        """L'argent est compté une fois, quand le liquide qu'il alimente est dépensé."""
+        _, _, account, _, client = ctx
+        txn = make_txn(account, amount="-100.00", internal=True, label="RETRAIT DAB")
+
+        assert row_for(client, txn)["allocation_state"] == ""
+
+    def test_a_line_with_a_cash_counterpart_has_no_state(self, ctx):
+        _, _, account, _, client = ctx
+        withdrawal = make_txn(account, amount="-100.00", label="RETRAIT DAB")
+        mirror = make_txn(account, amount="100.00", label="ALIM ESPECES")
+        withdrawal.transfer_counterpart = mirror
+        withdrawal.is_internal = True
+        withdrawal.save(update_fields=["transfer_counterpart", "is_internal"])
+
+        assert row_for(client, withdrawal)["allocation_state"] == ""
+
+
+@pytest.mark.django_db
+class TestOutsideTheWindow:
+    """Un zéro a deux sens, et le marqueur doit les distinguer comme le contrôle.
+
+    Une ligne antérieure au solde d'ouverture ne peut pas être exigée : la
+    badger « non ventilée » fabriquerait une tâche que l'utilisateur ne peut pas
+    résoudre — exactement le bruit que la fenêtre de conformité existe pour éviter.
+    """
+
+    def test_a_line_before_the_opening_date_is_out_of_scope_not_untreated(self, ctx):
+        _, _, account, _, client = ctx
+        txn = make_txn(account, amount="-80.00", booked_on=date(2025, 11, 4))
+
+        assert row_for(client, txn)["allocation_state"] == "out_of_scope"
+
+    def test_an_account_without_a_window_never_reads_untreated(self, ctx):
+        _, _, account, _, client = ctx
+        account.opening_balance_date = None
+        account.save(update_fields=["opening_balance_date"])
+        txn = make_txn(account, amount="-80.00")
+
+        assert row_for(client, txn)["allocation_state"] == "out_of_scope"
+
+    def test_but_being_done_is_a_fact_not_a_scope(self, ctx):
+        """Hors fenêtre, House n'exige rien — mais une ligne ventilée l'est."""
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-80.00", booked_on=date(2025, 11, 4))
+        allocate(household, user, txn, budget, "80.00")
+
+        assert row_for(client, txn)["allocation_state"] == "allocated"
+
+
+@pytest.mark.django_db
+class TestTheMarkerAgreesWithTheControl:
+    """Le journal et l'onglet Contrôle lisent la même fonction — preuve par les nombres."""
+
+    def test_same_verdict_line_by_line(self, ctx):
+        from banking.compliance import summary
+
+        household, user, account, budget, client = ctx
+        make_txn(account, amount="-10.00")  # rien
+        make_txn(account, amount="-20.00")  # rien
+        partial = make_txn(account, amount="-100.00")
+        allocate(household, user, partial, budget, "40.00")
+        full = make_txn(account, amount="-30.00")
+        allocate(household, user, full, budget, "30.00")
+        make_txn(account, amount="-50.00", booked_on=date(2025, 11, 4))  # hors fenêtre
+        make_txn(account, amount="900.00", label="VIR SALAIRE")  # recette
+
+        rows = client.get(LIST_URL).json()["results"]
+        states = [r["allocation_state"] for r in rows]
+        groups = {g.spec.kind: g.open for g in summary(household)}
+
+        assert states.count("unallocated") == groups[TRANSACTION_UNALLOCATED] == 2
+        assert states.count("partial") == groups[TRANSACTION_PARTIAL] == 1
+        assert states.count("allocated") == 1
+        assert states.count("out_of_scope") == 1
+        assert states.count("") == 1
+
+
+@pytest.mark.django_db
+class TestItStaysCheapAndFresh:
+    def test_the_page_does_not_query_once_per_line(self, ctx, django_assert_max_num_queries):
+        """Le marqueur est une annotation, jamais une boucle : 50 lignes/page."""
+        household, user, account, budget, client = ctx
+        for i in range(25):
+            txn = make_txn(account, amount=f"-{i + 1}.00")
+            if i % 2:
+                allocate(household, user, txn, budget, "1.00")
+
+        # Cinq en réalité (session, user, count, page, fenêtre du compte) ; la
+        # marge laisse passer une requête de plomberie, jamais une par ligne.
+        with django_assert_max_num_queries(8):
+            client.get(LIST_URL)
+
+    def test_writing_a_split_returns_the_new_state_not_the_old_one(self, ctx):
+        """``refresh_from_db`` ne rafraîchit pas une annotation — la réponse mentait."""
+        _, _, account, budget, client = ctx
+        txn = make_txn(account, amount="-150.00")
+
+        body = client.put(
+            f"{TX_URL}{txn.id}/allocations/",
+            {"lines": [{"amount": "150.00", "budget": str(budget.id), "subject": "Courses"}]},
+            format="json",
+        ).json()
+
+        assert body["transaction"]["allocation_state"] == "allocated"
+        assert body["transaction"]["remaining_amount"] == "0.00"

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -45,6 +45,7 @@ from .models import (
     StatementImport,
     TransactionDirection,
 )
+from . import queries
 from .queries import search
 from .validators import allocated_total, remaining_to_allocate
 from .serializers import (
@@ -344,8 +345,19 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        qs = BankTransaction.objects.for_user_households(self.request.user).select_related(
-            "account"
+        # ``with_allocation`` so the serializer can badge « ventilée / partielle /
+        # non ventilée » without one query per line.
+        #
+        # ⚠️ The explicit ``order_by`` is not decoration: since Django 3.1 a
+        # ``GROUP BY`` query **ignores** ``Meta.ordering``, so annotating silently
+        # served the journal in insertion order — oldest first. Same tuple as
+        # ``BankTransaction.Meta.ordering``.
+        qs = (
+            queries.with_allocation(
+                BankTransaction.objects.for_user_households(self.request.user)
+            )
+            .select_related("account")
+            .order_by("-booked_on", "-line_no", "-created_at")
         )
         if self.request.household:
             qs = qs.filter(household=self.request.household)
@@ -558,8 +570,10 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
         set_allocations(
             household=household, user=request.user, transaction=instance, lines=lines
         )
-        instance.refresh_from_db()
-        return Response(self._allocation_payload(instance))
+        # Re-read through the annotated queryset rather than ``refresh_from_db``:
+        # the latter reloads columns but leaves the stale ``allocated`` annotation
+        # in place, so the response would badge the line with its pre-write state.
+        return Response(self._allocation_payload(self.get_object()))
 
     def _allocation_payload(self, instance) -> dict:
         from interactions.serializers import InteractionSerializer

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -233,6 +233,39 @@ mixte compenserait les entrées avec les sorties et sous-estimerait les deux.
 - `search(qs, term)` — recherche sur `label_norm`, insensible à la casse **et aux
   accents** sans appel à `unaccent` : le libellé est déjà normalisé à l'import,
   c'est précisément la raison d'être de la colonne.
+- `with_allocation(qs)` / `allocation_state(txn, …)` — où en est une ligne
+  (voir juste en dessous)
+
+### Le marqueur « où en est cette ligne »
+
+Chaque ligne du journal porte son état de traitement : **ventilée**, **reste
+X €**, **non ventilée**, ou **hors période contrôlée**. Sans lui, savoir s'il
+restait quelque chose à dire d'une opération demandait de l'ouvrir — sur 116
+lignes, personne ne le fait, et le relevé redevient une liste morte.
+
+Trois règles tiennent ce marqueur :
+
+- **Le verdict est calculé par le serveur, jamais par le client.** Il dépend de
+  la fenêtre de conformité du compte, que le journal n'a pas à re-dériver.
+- **Le journal et l'onglet Contrôle lisent la même fonction**
+  (`queries.allocation_state`, adossée à `queries.with_allocation`). Une ligne
+  verte ici et un écart là-bas, et les deux écrans perdent leur crédit — d'où le
+  test `test_journal_marker.py::TestTheMarkerAgreesWithTheControl`, qui compare
+  les deux lectures nombre par nombre.
+- **Hors fenêtre, le marqueur est gris, pas rouge** (`out_of_scope`) : House
+  n'exige rien là où elle ne peut rien exiger. Même raison que
+  `coverage.window_status` — un reproche irrésoluble est ce qui fait abandonner
+  le contrôle. Exception assumée : une ligne **entièrement** ventilée lit
+  « ventilée » même hors fenêtre. Être fait est un fait ; être exigé est un
+  périmètre.
+
+Une recette, un mouvement interne et une contrepartie espèces n'ont **pas** de
+marqueur (état `""`) : il n'y a rien à ventiler, et un badge y serait un faux
+reproche.
+
+⚠️ `refresh_from_db()` ne rafraîchit **pas** une annotation. Après un
+`PUT allocations/`, la réponse se relit par `get_object()` sur le queryset
+annoté, sinon elle renvoie l'état d'avant l'écriture.
 
 ### `aggregations.py` — la vue « banque »
 
@@ -265,8 +298,8 @@ ignoré : une liste filtrée à tort est pire qu'une erreur.
 
 Sous-page `/app/banking/transactions` (`TransactionsPage`) : `FlowSummaryCards` en
 tête, `TransactionFilters` (recherche, compte, période, pills direction/interne),
-`TransactionList` + `TransactionRow` avec les deux actions de qualification. Les
-filtres sont persistés en session.
+`TransactionList` + `TransactionRow` avec les deux actions de qualification et la
+pastille d'état (`AllocationBadge`). Les filtres sont persistés en session.
 
 ## Soldes, continuité & espèces (lot 4)
 

--- a/ui/src/features/banking/TransactionRow.tsx
+++ b/ui/src/features/banking/TransactionRow.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from 'react-i18next';
 import {
   Banknote,
+  Check,
+  CircleDashed,
   Link2Off,
   PieChart,
   Repeat,
@@ -103,6 +105,8 @@ export default function TransactionRow({
               : ''}
           </p>
 
+          <AllocationBadge transaction={transaction} />
+
           {transaction.is_internal ? (
             <span className="mt-1.5 inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
               {hasCounterpart ? (
@@ -139,5 +143,51 @@ export default function TransactionRow({
         <CardActions actions={actions} />
       </div>
     </Card>
+  );
+}
+
+/**
+ * Où en est la ligne : traitée, à moitié, pas du tout.
+ *
+ * Sans ce marqueur, savoir s'il reste quelque chose à dire d'une opération
+ * demandait de l'ouvrir — sur un relevé de 116 lignes, personne ne le fait.
+ *
+ * ⚠️ L'état vient du serveur (`allocation_state`), il n'est **pas** recalculé
+ * à partir de `allocated_amount` : le verdict dépend de la fenêtre de conformité
+ * du compte, et il doit rester le même que celui compté par l'onglet Contrôle.
+ * Une ligne verte ici et un écart là-bas, et les deux écrans perdent leur
+ * crédit.
+ */
+function AllocationBadge({ transaction }: { transaction: BankTransaction }) {
+  const { t } = useTranslation();
+  const state = transaction.allocation_state;
+
+  if (state === '') return null;
+
+  // Hors fenêtre, House n'exige rien : le dire en gris, jamais en rouge — un
+  // reproche qu'on ne peut pas résoudre est ce qui fait abandonner le contrôle.
+  const style =
+    state === 'allocated'
+      ? 'bg-primary/10 text-primary'
+      : state === 'out_of_scope'
+        ? 'bg-muted text-muted-foreground'
+        : 'bg-destructive/10 text-destructive';
+
+  const Icon = state === 'allocated' ? Check : state === 'out_of_scope' ? CircleDashed : PieChart;
+
+  const label =
+    state === 'partial'
+      ? t('banking.journal.allocation.partial', {
+          amount: formatAmount(transaction.remaining_amount),
+        })
+      : t(`banking.journal.allocation.${state}`);
+
+  return (
+    <span
+      className={`mt-1.5 inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs ${style}`}
+    >
+      <Icon className="h-3 w-3" aria-hidden />
+      {label}
+    </span>
   );
 }

--- a/ui/src/gen/api/models/BankTransaction.ts
+++ b/ui/src/gen/api/models/BankTransaction.ts
@@ -11,6 +11,12 @@ import type { InflowNatureEnum } from './InflowNatureEnum';
  * ``label_raw``, ``amount``, ``direction`` and ``dedup_hash`` are immutable:
  * this is what the bank says. Only the qualification fields (``is_internal``,
  * ``notes``) are writable — and only through the lot 3 ``qualify`` action.
+ *
+ * **Où en est cette ligne** (``allocation_state``) is computed here rather than
+ * in the client: the answer depends on the account's conformity window, which
+ * the journal has no business re-deriving, and it has to agree — line by line —
+ * with what the Contrôle tab counts. Both read
+ * :func:`banking.queries.allocation_state`.
  */
 export type BankTransaction = {
     readonly id: string;
@@ -66,6 +72,16 @@ export type BankTransaction = {
      * The other leg of an internal movement — typically an ATM withdrawal and the matching credit on the cash account. SET_NULL so deleting one leg never leaves the other pointing at nothing.
      */
     readonly transfer_counterpart: string | null;
+    readonly allocated_amount: string;
+    /**
+     * What is still owed an explanation, never negative.
+     *
+     * Over-allocating is already impossible (``assert_allocation_fits``); if a
+     * legacy row ever went past, showing « reste −5 € » would invite someone to
+     * fix it by adding more.
+     */
+    readonly remaining_amount: string;
+    readonly allocation_state: string;
     readonly created_at: string;
 };
 

--- a/ui/src/gen/api/models/PatchedBankTransaction.ts
+++ b/ui/src/gen/api/models/PatchedBankTransaction.ts
@@ -11,6 +11,12 @@ import type { InflowNatureEnum } from './InflowNatureEnum';
  * ``label_raw``, ``amount``, ``direction`` and ``dedup_hash`` are immutable:
  * this is what the bank says. Only the qualification fields (``is_internal``,
  * ``notes``) are writable — and only through the lot 3 ``qualify`` action.
+ *
+ * **Où en est cette ligne** (``allocation_state``) is computed here rather than
+ * in the client: the answer depends on the account's conformity window, which
+ * the journal has no business re-deriving, and it has to agree — line by line —
+ * with what the Contrôle tab counts. Both read
+ * :func:`banking.queries.allocation_state`.
  */
 export type PatchedBankTransaction = {
     readonly id?: string;
@@ -66,6 +72,16 @@ export type PatchedBankTransaction = {
      * The other leg of an internal movement — typically an ATM withdrawal and the matching credit on the cash account. SET_NULL so deleting one leg never leaves the other pointing at nothing.
      */
     readonly transfer_counterpart?: string | null;
+    readonly allocated_amount?: string;
+    /**
+     * What is still owed an explanation, never negative.
+     *
+     * Over-allocating is already impossible (``assert_allocation_fits``); if a
+     * legacy row ever went past, showing « reste −5 € » would invite someone to
+     * fix it by adding more.
+     */
+    readonly remaining_amount?: string;
+    readonly allocation_state?: string;
     readonly created_at?: string;
 };
 

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -244,8 +244,24 @@ export interface BankTransaction {
   source_import: string | null;
   /** Autre jambe d'un mouvement interne (retrait ↔ crédit espèces), si liée. */
   transfer_counterpart: string | null;
+  /** Somme des dépenses ventilées sur la ligne — positive. */
+  allocated_amount: string;
+  /** Ce qui reste à expliquer, jamais négatif. */
+  remaining_amount: string;
+  allocation_state: AllocationProgress;
   created_at: string;
 }
+
+/**
+ * Où en est une ligne — calculé par le serveur, jamais dérivé ici.
+ *
+ * Le verdict dépend de la fenêtre de conformité du compte, et il doit dire
+ * **exactement** ce que compte l'onglet Contrôle : le refaire côté client
+ * garantirait qu'un jour les deux divergent. `''` = rien à ventiler (recette,
+ * mouvement interne) ; `out_of_scope` = hors fenêtre, House n'exige rien —
+ * ce n'est pas la même chose que « pas encore traitée ».
+ */
+export type AllocationProgress = '' | 'unallocated' | 'partial' | 'allocated' | 'out_of_scope';
 
 export interface TransactionFilters {
   account?: string;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3246,6 +3246,12 @@
       "inflow": "Eingänge",
       "net": "Saldo des Zeitraums",
       "internal": "Interne Umbuchung",
+      "allocation": {
+        "unallocated": "Nicht zugeordnet",
+        "partial": "Rest {{amount}}",
+        "allocated": "Zugeordnet",
+        "out_of_scope": "Außerhalb des geprüften Zeitraums"
+      },
       "internalExcluded_one": "{{count}} interne Umbuchung ausgeschlossen",
       "internalExcluded_other": "{{count}} interne Umbuchungen ausgeschlossen",
       "markInternal": "Als interne Umbuchung markieren",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3246,6 +3246,12 @@
       "inflow": "Money in",
       "net": "Period net",
       "internal": "Internal movement",
+      "allocation": {
+        "unallocated": "Not allocated",
+        "partial": "{{amount}} left",
+        "allocated": "Allocated",
+        "out_of_scope": "Outside the checked period"
+      },
       "internalExcluded_one": "{{count}} internal movement excluded",
       "internalExcluded_other": "{{count}} internal movements excluded",
       "markInternal": "Mark as internal movement",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3246,6 +3246,12 @@
       "inflow": "Entradas",
       "net": "Saldo del periodo",
       "internal": "Movimiento interno",
+      "allocation": {
+        "unallocated": "Sin asignar",
+        "partial": "Quedan {{amount}}",
+        "allocated": "Asignada",
+        "out_of_scope": "Fuera del periodo controlado"
+      },
       "internalExcluded_one": "{{count}} movimiento interno excluido",
       "internalExcluded_other": "{{count}} movimientos internos excluidos",
       "markInternal": "Marcar como movimiento interno",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3246,6 +3246,12 @@
       "inflow": "Entrées",
       "net": "Solde de la période",
       "internal": "Mouvement interne",
+      "allocation": {
+        "unallocated": "Non ventilée",
+        "partial": "Reste {{amount}}",
+        "allocated": "Ventilée",
+        "out_of_scope": "Hors période contrôlée"
+      },
       "internalExcluded_one": "{{count}} mouvement interne exclu",
       "internalExcluded_other": "{{count}} mouvements internes exclus",
       "markInternal": "Marquer comme mouvement interne",


### PR DESCRIPTION
## Le problème

Une ligne de relevé n'affiche qu'un libellé et un montant. Savoir s'il reste quelque chose à en dire demande de l'ouvrir — sur 116 lignes, personne ne le fait.

## Ce que ça change

Chaque ligne du journal porte son état de traitement :

| État | Rendu |
|---|---|
| Ventilée | ✓ vert |
| Partiellement | « Reste 60,00 € » en rouge |
| Non ventilée | rouge |
| Hors période contrôlée | gris |
| Recette / interne / contrepartie | aucune pastille |

## Trois choix à garder

- **Le verdict vient du serveur, et les deux écrans lisent la même fonction.** `queries.allocation_state` / `with_allocation` — que les détecteurs consomment désormais aussi, à la place de leur copie du `Sum`. Une ligne verte ici et un écart dans le Contrôle, et les deux écrans perdent leur crédit. Test : `TestTheMarkerAgreesWithTheControl` compare les deux lectures nombre par nombre.
- **Hors fenêtre, gris et pas rouge.** Un reproche irrésoluble est ce qui fait abandonner le contrôle (même règle que `coverage.window_status`). Exception assumée : une ligne **entièrement** ventilée lit « ventilée » même hors fenêtre — être fait est un fait, être exigé est un périmètre.
- **Pas de pastille là où il n'y a rien à ventiler.** Un badge sur une recette serait un faux reproche.

## Deux bugs trouvés en route

- `refresh_from_db()` ne rafraîchit **pas** une annotation : après un `PUT allocations/`, la réponse renvoyait l'état d'avant l'écriture.
- Depuis Django 3.1 une requête `GROUP BY` **ignore** `Meta.ordering` : annoter servait le journal du plus ancien au plus récent. Attrapé par un test existant, `order_by` explicite ajouté avec la raison en commentaire.

## Vérification

- `pytest` : **3327 passed, 2 skipped** (dont 12 nouveaux dans `test_journal_marker.py`)
- Coût : 5 requêtes pour une page de 25 lignes, borné par `django_assert_max_num_queries(8)` — le marqueur est une annotation, jamais une boucle
- `npm run build` + `npm run lint` propres, types API régénérés, i18n ×4
- `docs/MODULES/banking.md` et la règle correspondante dans `CLAUDE.md`