### PR TITLE
feat(budget): l'analyse longue des dépenses, par budget et par mois

### DIFF
--- a/apps/budget/analysis.py
+++ b/apps/budget/analysis.py
@@ -1,0 +1,253 @@
+"""
+Analyse fine des dépenses par budget — la vue « d'où ça part, et depuis quand ».
+
+Le panneau Budgets répond à une seule question : « est-ce que ce mois-ci tient
+dans l'enveloppe ? ». Utile, mais aveugle à tout le reste — une catégorie qui
+dérive de 15 % par mois passe inaperçue tant qu'elle ne franchit pas son plafond,
+et une catégorie sans plafond (le cas le plus courant depuis que le plafond est
+optionnel) n'a *aucun* signal du tout. Ce module fournit la lecture longue.
+
+Trois principes, tous hérités de règles déjà écrites ailleurs :
+
+- **On lit les ``Interaction`` et rien d'autre.** Les totaux bancaires vivent
+  dans ``banking.aggregations`` et ne s'additionnent jamais avec ceux-ci — le
+  pont entre les deux mondes est le taux de couverture, jamais une somme.
+- **Un montant sort en string décimale**, jamais en float : arrondir pour
+  l'affichage est le travail du front, pas celui de l'agrégat.
+- **Le libellé « hors budget » n'est pas produit ici.** Le backend renvoie
+  ``budget_id: null`` ; c'est le namespace i18n du front qui le nomme, sinon
+  ajouter une langue imposerait un passage par les ``.po``.
+
+Coût : quatre requêtes groupées, quel que soit le nombre de mois ou de budgets.
+Jamais une requête par mois — c'est la première chose qui dégénère sur un
+historique de deux ans.
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from django.db.models import Count, Sum
+from django.db.models.functions import Coalesce, TruncMonth
+from django.utils import timezone
+
+from interactions.queries import expenses
+
+from .models import Budget
+from .report.stats import _tz, month_bounds
+
+#: Combien de mois la vue couvre par défaut. Douze = une saisonnalité complète
+#: (chauffage, vacances, rentrée) sans écraser les barres du dernier trimestre.
+DEFAULT_MONTHS = 12
+MAX_MONTHS = 36
+
+#: Au-delà, un classement cesse d'être un classement.
+TOP_SUPPLIERS = 8
+TOP_EXPENSES = 5
+
+ZERO = Decimal("0.00")
+
+
+def _months_back(end: date, count: int) -> list[str]:
+    """Les ``count`` derniers mois en ``YYYY-MM``, du plus ancien au plus récent."""
+    year, month = end.year, end.month
+    out: list[str] = []
+    for _ in range(count):
+        out.append(f"{year:04d}-{month:02d}")
+        month -= 1
+        if month == 0:
+            year, month = year - 1, 12
+    return list(reversed(out))
+
+
+def _decimal_str(value: Decimal | None) -> str:
+    return str(value if value is not None else ZERO)
+
+
+def compute_budget_analysis(
+    *, household, months: int = DEFAULT_MONTHS, budget_id=None, today: date | None = None
+) -> dict[str, Any]:
+    """Séries mensuelles, répartition, fournisseurs et plus grosses dépenses.
+
+    ``budget_id`` restreint **tout** le calcul à une enveloppe : la série, les
+    fournisseurs et le classement. La répartition n'a alors plus qu'une ligne —
+    le front masque le camembert plutôt que d'afficher un disque plein à 100 %.
+
+    Shape::
+
+        {
+          "months": ["2025-08", …, "2026-07"],
+          "series": [{budget_id, name, monthly_amount, values: [...], total}, …],
+          "breakdown": [{budget_id, name, total, share}, …],
+          "suppliers": [{supplier, total, count}, …],
+          "biggest": [{id, subject, amount, occurred_at, budget_id, budget_name}, …],
+          "total": "…", "monthly_average": "…",
+        }
+    """
+    months = max(1, min(int(months or DEFAULT_MONTHS), MAX_MONTHS))
+    tz = _tz(household)
+    if today is None:
+        today = timezone.now().astimezone(tz).date()
+
+    labels = _months_back(today, months)
+    start, _ = month_bounds(household, labels[0])
+    _, end = month_bounds(household, labels[-1])
+
+    qs = expenses(household_id=household.id).filter(
+        occurred_at__gte=start, occurred_at__lt=end
+    )
+    if budget_id is not None:
+        qs = qs.filter(budget_id=budget_id)
+
+    grid = _monthly_grid(qs, labels, tz)
+    budgets = {
+        str(b.id): b for b in Budget.objects.filter(household_id=household.id, is_global=False)
+    }
+
+    series = _build_series(grid, labels, budgets)
+    total = sum((row["_total"] for row in series), ZERO)
+
+    return {
+        "months": labels,
+        "series": [
+            {
+                "budget_id": row["budget_id"],
+                "name": row["name"],
+                "monthly_amount": row["monthly_amount"],
+                "values": [_decimal_str(v) for v in row["values"]],
+                "total": _decimal_str(row["_total"]),
+            }
+            for row in series
+        ],
+        "breakdown": [
+            {
+                "budget_id": row["budget_id"],
+                "name": row["name"],
+                "total": _decimal_str(row["_total"]),
+                # Une part sur un total nul serait une division par zéro déguisée
+                # en « 0 % » : sans dépense il n'y a pas de répartition du tout.
+                "share": round(float(row["_total"] / total), 4) if total > 0 else 0.0,
+            }
+            for row in sorted(series, key=lambda r: r["_total"], reverse=True)
+            if row["_total"] > 0
+        ],
+        "suppliers": _top_suppliers(qs),
+        "biggest": _biggest(qs, budgets),
+        "total": _decimal_str(total),
+        # Moyenne sur la fenêtre demandée, pas sur les mois non vides : un mois à
+        # zéro est une information, l'écarter gonflerait la moyenne.
+        "monthly_average": _decimal_str(
+            (total / months).quantize(Decimal("0.01")) if months else ZERO
+        ),
+    }
+
+
+def _monthly_grid(qs, labels: list[str], tz) -> dict[tuple[str | None, str], Decimal]:
+    """``{(budget_id, 'YYYY-MM'): total}`` en **une** requête groupée."""
+    rows = (
+        qs.annotate(bucket=TruncMonth("occurred_at", tzinfo=tz))
+        .values("bucket", "budget_id")
+        .annotate(total=Coalesce(Sum("amount"), Decimal("0.00")))
+    )
+    known = set(labels)
+    grid: dict[tuple[str | None, str], Decimal] = {}
+    for row in rows:
+        bucket = row["bucket"]
+        if bucket is None:
+            continue
+        label = f"{bucket.year:04d}-{bucket.month:02d}"
+        if label not in known:  # pragma: no cover - the filter already bounds it
+            continue
+        key = (str(row["budget_id"]) if row["budget_id"] else None, label)
+        grid[key] = (grid.get(key) or ZERO) + (row["total"] or ZERO)
+    return grid
+
+
+def _build_series(grid, labels: list[str], budgets: dict[str, Budget]) -> list[dict[str, Any]]:
+    """Une ligne par budget **qui a dépensé**, plus « hors budget » s'il existe.
+
+    Un budget sans une seule dépense sur la fenêtre n'entre pas dans la légende :
+    douze entrées mortes rendraient le graphique illisible pour cacher
+    l'information qu'aucune n'a servi — que le panneau Budgets dit déjà.
+    """
+    seen: list[str | None] = []
+    for bid, _label in grid:
+        if bid not in seen:
+            seen.append(bid)
+
+    def sort_key(bid: str | None) -> tuple[int, str]:
+        # « Hors budget » ferme la marche : c'est un reste, pas une catégorie.
+        if bid is None:
+            return (1, "")
+        return (0, (budgets[bid].name if bid in budgets else "").lower())
+
+    series = []
+    for bid in sorted(seen, key=sort_key):
+        budget = budgets.get(bid) if bid else None
+        values = [grid.get((bid, label), ZERO) for label in labels]
+        series.append(
+            {
+                "budget_id": bid,
+                # ``None`` = hors budget ; le front le nomme, pas nous. Un budget
+                # supprimé laisse ses dépenses derrière (``SET_NULL``) : elles
+                # retombent naturellement dans ce même seau.
+                "name": budget.name if budget else None,
+                "monthly_amount": (
+                    None
+                    if budget is None or budget.monthly_amount is None
+                    else str(budget.monthly_amount)
+                ),
+                "values": values,
+                "_total": sum(values, ZERO),
+            }
+        )
+    return series
+
+
+def _top_suppliers(qs) -> list[dict[str, Any]]:
+    """Chez qui l'argent part, tous budgets confondus (ou dans celui filtré).
+
+    Un fournisseur vide n'est pas « inconnu à classer » — c'est une dépense qui
+    n'en a pas (une note, une régularisation). L'exclure évite une barre géante
+    « (vide) » en tête de classement, qui ne dit rien et masque les vraies.
+    """
+    rows = (
+        qs.exclude(supplier="")
+        .values("supplier")
+        .annotate(total=Coalesce(Sum("amount"), Decimal("0.00")), count=Count("id"))
+        .order_by("-total")[:TOP_SUPPLIERS]
+    )
+    return [
+        {
+            "supplier": row["supplier"],
+            "total": _decimal_str(row["total"]),
+            "count": row["count"],
+        }
+        for row in rows
+    ]
+
+
+def _biggest(qs, budgets: dict[str, Budget]) -> list[dict[str, Any]]:
+    """Les plus grosses dépenses de la fenêtre.
+
+    ``amount__isnull=False`` n'est pas défensif : sous PostgreSQL un NULL trie
+    en tête d'un ``-amount`` et volerait la première place avec un montant vide.
+    Le bilan mensuel a exactement la même clause, pour la même raison.
+    """
+    rows = qs.filter(amount__isnull=False).order_by("-amount")[:TOP_EXPENSES]
+    return [
+        {
+            "id": str(item.id),
+            "subject": item.subject,
+            "amount": _decimal_str(item.amount),
+            "occurred_at": item.occurred_at.isoformat() if item.occurred_at else None,
+            "budget_id": str(item.budget_id) if item.budget_id else None,
+            "budget_name": (
+                budgets[str(item.budget_id)].name
+                if item.budget_id and str(item.budget_id) in budgets
+                else None
+            ),
+        }
+        for item in rows
+    ]

--- a/apps/budget/tests/test_analysis.py
+++ b/apps/budget/tests/test_analysis.py
@@ -1,0 +1,348 @@
+# budget/tests/test_analysis.py
+"""L'analyse longue des dépenses par budget.
+
+Le panneau Budgets ne répond qu'à « ce mois-ci tient-il dans l'enveloppe ». Une
+catégorie qui dérive lentement, ou une catégorie **sans plafond** — le cas
+courant depuis que le plafond est optionnel — n'y produisent aucun signal. Ces
+tests fixent ce que la lecture longue doit dire, et surtout ce qu'elle ne doit
+jamais inventer : une part sur un total nul, une moyenne qui écarte les mois
+vides, un budget mort dans la légende.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.urls import reverse
+
+from budget.analysis import compute_budget_analysis
+from budget.models import Budget
+from households.models import HouseholdMember
+from interactions.services import create_manual_expense_interaction
+
+from .factories import HouseholdFactory, HouseholdMemberFactory, UserFactory
+
+TODAY = date(2026, 7, 15)
+TZ = ZoneInfo("Europe/Paris")
+
+
+def _make_owner(household):
+    user = UserFactory()
+    HouseholdMemberFactory(household=household, user=user, role=HouseholdMember.Role.OWNER)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return user
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+def _spend(household, user, amount, *, month, budget=None, supplier="", day=10):
+    year, mon = (int(p) for p in month.split("-"))
+    return create_manual_expense_interaction(
+        household=household,
+        user=user,
+        subject=f"{supplier or 'Dépense'} {amount}",
+        amount=Decimal(str(amount)),
+        supplier=supplier,
+        occurred_at=datetime(year, mon, day, 12, 0, tzinfo=TZ),
+        budget_id=budget.id if budget else None,
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    household = HouseholdFactory(timezone="Europe/Paris")
+    owner = _make_owner(household)
+    groceries = Budget.objects.create(
+        household=household, name="Courses", monthly_amount=Decimal("400")
+    )
+    gifts = Budget.objects.create(household=household, name="Cadeaux", monthly_amount=None)
+    return household, owner, groceries, gifts
+
+
+@pytest.mark.django_db
+class TestTheMonthlySeries:
+    def test_one_row_per_budget_that_actually_spent(self, ctx):
+        """Un budget sans une seule dépense n'encombre pas la légende."""
+        household, owner, groceries, gifts = ctx
+        Budget.objects.create(household=household, name="Jamais servi", monthly_amount=None)
+        _spend(household, owner, "120.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert [s["name"] for s in result["series"]] == ["Courses"]
+
+    def test_values_align_with_the_month_labels(self, ctx):
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "100.00", month="2026-05", budget=groceries)
+        _spend(household, owner, "250.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["months"][-1] == "2026-07"
+        assert result["months"][0] == "2025-08"
+        assert len(result["months"]) == 12
+        row = result["series"][0]
+        assert len(row["values"]) == 12
+        by_month = dict(zip(result["months"], row["values"]))
+        assert by_month["2026-05"] == "100.00"
+        assert by_month["2026-06"] == "0.00"
+        assert by_month["2026-07"] == "250.00"
+
+    def test_unbudgeted_is_a_row_with_no_name_and_closes_the_march(self, ctx):
+        """Le libellé « hors budget » vit dans l'i18n du front, pas ici."""
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "50.00", month="2026-07", budget=groceries)
+        _spend(household, owner, "30.00", month="2026-07")
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert [s["name"] for s in result["series"]] == ["Courses", None]
+        assert result["series"][-1]["budget_id"] is None
+
+    def test_an_uncapped_category_carries_a_null_ceiling(self, ctx):
+        household, owner, _, gifts = ctx
+        _spend(household, owner, "80.00", month="2026-07", budget=gifts)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["series"][0]["monthly_amount"] is None
+
+    def test_expenses_older_than_the_window_are_excluded(self, ctx):
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "999.00", month="2025-01", budget=groceries)
+        _spend(household, owner, "10.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=6, today=TODAY)
+
+        assert result["total"] == "10.00"
+        assert len(result["months"]) == 6
+
+
+@pytest.mark.django_db
+class TestTheTotalsItRefusesToInvent:
+    def test_no_spending_gives_no_shares_rather_than_zeroes(self, ctx):
+        """Une part sur un total nul est une division par zéro déguisée."""
+        household, _, _, _ = ctx
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["total"] == "0.00"
+        assert result["breakdown"] == []
+        assert result["monthly_average"] == "0.00"
+
+    def test_the_average_counts_the_empty_months_too(self, ctx):
+        """Écarter les mois vides gonflerait la moyenne d'un facteur arbitraire."""
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "120.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["total"] == "120.00"
+        assert result["monthly_average"] == "10.00"
+
+    def test_shares_are_computed_on_the_window_total(self, ctx):
+        household, owner, groceries, gifts = ctx
+        _spend(household, owner, "300.00", month="2026-07", budget=groceries)
+        _spend(household, owner, "100.00", month="2026-06", budget=gifts)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        shares = {row["name"]: row["share"] for row in result["breakdown"]}
+        assert shares == {"Courses": 0.75, "Cadeaux": 0.25}
+        # Trié du plus gros au plus petit — un classement se lit dans cet ordre.
+        assert [row["name"] for row in result["breakdown"]] == ["Courses", "Cadeaux"]
+
+
+@pytest.mark.django_db
+class TestSuppliersAndBiggest:
+    def test_suppliers_are_ranked_by_amount_not_by_count(self, ctx):
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "10.00", month="2026-07", budget=groceries, supplier="Tabac")
+        _spend(household, owner, "10.00", month="2026-06", budget=groceries, supplier="Tabac")
+        _spend(household, owner, "200.00", month="2026-07", budget=groceries, supplier="Leclerc")
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert [s["supplier"] for s in result["suppliers"]] == ["Leclerc", "Tabac"]
+        assert result["suppliers"][1]["count"] == 2
+
+    def test_an_expense_without_a_supplier_is_not_a_supplier(self, ctx):
+        """Sinon une barre « (vide) » trône en tête et masque les vraies."""
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "500.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["suppliers"] == []
+
+    def test_biggest_expenses_carry_their_budget(self, ctx):
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "42.00", month="2026-07", budget=groceries)
+        _spend(household, owner, "900.00", month="2026-07", budget=groceries)
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert result["biggest"][0]["amount"] == "900.00"
+        assert result["biggest"][0]["budget_name"] == "Courses"
+
+
+@pytest.mark.django_db
+class TestFilteringOnOneBudget:
+    def test_everything_narrows_together(self, ctx):
+        household, owner, groceries, gifts = ctx
+        _spend(household, owner, "300.00", month="2026-07", budget=groceries, supplier="Leclerc")
+        _spend(household, owner, "100.00", month="2026-07", budget=gifts, supplier="Fnac")
+
+        result = compute_budget_analysis(
+            household=household, months=12, budget_id=str(gifts.id), today=TODAY
+        )
+
+        assert [s["name"] for s in result["series"]] == ["Cadeaux"]
+        assert result["total"] == "100.00"
+        assert [s["supplier"] for s in result["suppliers"]] == ["Fnac"]
+        assert len(result["biggest"]) == 1
+
+
+@pytest.mark.django_db
+class TestItStaysCheap:
+    def test_the_query_count_does_not_grow_with_the_window(
+        self, ctx, django_assert_max_num_queries
+    ):
+        """Quatre requêtes groupées — jamais une par mois, ni une par budget."""
+        household, owner, groceries, gifts = ctx
+        for i in range(24):
+            month = f"2026-{((i % 12) + 1):02d}"
+            _spend(household, owner, "10.00", month=month, budget=groceries if i % 2 else gifts)
+
+        with django_assert_max_num_queries(6):
+            compute_budget_analysis(household=household, months=24, today=TODAY)
+
+
+@pytest.mark.django_db
+class TestTheEndpoint:
+    def url(self, **params):
+        base = reverse("budget-analysis")
+        if not params:
+            return base
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"{base}?{query}"
+
+    def test_it_returns_the_whole_shape(self, ctx):
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "120.00", month="2026-07", budget=groceries)
+
+        response = _client_for(owner).get(self.url())
+
+        assert response.status_code == status.HTTP_200_OK
+        assert {
+            "months", "series", "breakdown", "suppliers", "biggest",
+            "total", "monthly_average",
+        } <= set(response.data)
+
+    def test_months_is_clamped_not_trusted(self, ctx):
+        """``?months=9999`` ne doit pas balayer dix ans d'historique."""
+        _, owner, _, _ = ctx
+
+        response = _client_for(owner).get(self.url(months=9999))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data["months"]) == 36
+
+    def test_a_malformed_months_is_a_400(self, ctx):
+        _, owner, _, _ = ctx
+        assert _client_for(owner).get(self.url(months="nope")).status_code == (
+            status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_a_malformed_budget_id_is_a_400_not_a_500(self, ctx):
+        _, owner, _, _ = ctx
+        assert _client_for(owner).get(self.url(budget="not-a-uuid")).status_code == (
+            status.HTTP_400_BAD_REQUEST
+        )
+
+    def test_another_households_budget_is_refused(self, ctx):
+        """Le filtre s'applique après le scope : il ne peut jamais l'élargir."""
+        _, owner, _, _ = ctx
+        stranger = Budget.objects.create(
+            household=HouseholdFactory(), name="Chez eux", monthly_amount=Decimal("100")
+        )
+
+        response = _client_for(owner).get(self.url(budget=str(stranger.id)))
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_a_neighbours_expenses_never_appear(self, ctx):
+        household, owner, groceries, _ = ctx
+        other = HouseholdFactory(timezone="Europe/Paris")
+        other_owner = _make_owner(other)
+        _spend(other, other_owner, "9999.00", month="2026-07")
+
+        response = _client_for(owner).get(self.url())
+
+        assert response.data["total"] == "0.00"
+
+    def test_anonymous_is_rejected(self, ctx):
+        assert APIClient().get(reverse("budget-analysis")).status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+
+@pytest.mark.django_db
+class TestTheMonthBoundaryFollowsTheHousehold:
+    def test_a_late_night_expense_stays_in_its_local_month(self, ctx):
+        """31 juillet 23 h à Paris, c'est juillet — pas août en UTC."""
+        household, owner, groceries, _ = ctx
+        create_manual_expense_interaction(
+            household=household,
+            user=owner,
+            subject="Courses tardives",
+            amount=Decimal("60.00"),
+            occurred_at=datetime(2026, 7, 31, 23, 30, tzinfo=TZ),
+            budget_id=groceries.id,
+        )
+
+        result = compute_budget_analysis(
+            household=household, months=12, today=date(2026, 7, 31)
+        )
+
+        by_month = dict(zip(result["months"], result["series"][0]["values"]))
+        assert by_month["2026-07"] == "60.00"
+
+
+@pytest.mark.django_db
+class TestADeletedBudgetLeavesItsSpendingBehind:
+    def test_its_expenses_fall_into_the_unbudgeted_bucket(self, ctx):
+        """``SET_NULL`` : supprimer une enveloppe n'efface pas ce qu'on a dépensé."""
+        household, owner, groceries, _ = ctx
+        _spend(household, owner, "75.00", month="2026-07", budget=groceries)
+        groceries.delete()
+
+        result = compute_budget_analysis(household=household, months=12, today=TODAY)
+
+        assert [s["name"] for s in result["series"]] == [None]
+        assert result["total"] == "75.00"
+
+
+def test_months_back_is_ordered_oldest_first():
+    from budget.analysis import _months_back
+
+    assert _months_back(date(2026, 2, 5), 4) == ["2025-11", "2025-12", "2026-01", "2026-02"]
+
+
+def test_a_window_never_starts_in_the_future():
+    """Régression : ``timedelta`` sur les mois est un piège, on décrémente à la main."""
+    from budget.analysis import _months_back
+
+    labels = _months_back(date(2026, 1, 3), 2)
+    assert labels == ["2025-12", "2026-01"]
+    assert labels[0] < labels[-1]

--- a/apps/budget/views.py
+++ b/apps/budget/views.py
@@ -1,6 +1,7 @@
 """Budget REST API views."""
 from zoneinfo import ZoneInfo
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.decorators import action
@@ -10,6 +11,7 @@ from rest_framework.response import Response
 from core.permissions import IsHouseholdMember
 
 from .aggregations import compute_budget_overview, compute_cashflow_projection
+from .analysis import DEFAULT_MONTHS, compute_budget_analysis
 from .models import Budget, BudgetReport, RecurringExpense
 from .report.service import get_or_generate_report, last_closed_month
 from .serializers import (
@@ -109,6 +111,56 @@ class BudgetViewSet(viewsets.ModelViewSet):
                 }
             )
         return Response(compute_budget_overview(household=household))
+
+    @action(detail=False, methods=["get"])
+    def analysis(self, request):
+        """GET /api/budget/budgets/analysis/?months=12&budget=<id>
+
+        La lecture longue : séries mensuelles par budget, répartition,
+        fournisseurs, plus grosses dépenses. Le panneau Budgets ne répond qu'à
+        « ce mois-ci tient-il ? » ; une dérive lente, ou une catégorie sans
+        plafond, n'y produisent aucun signal.
+
+        ``budget`` restreint tout le calcul à une enveloppe. Un id inconnu du
+        foyer donne une fenêtre vide, jamais les données d'un autre foyer : le
+        filtre s'applique **après** le scope, il ne peut pas l'élargir.
+        """
+        household = request.household
+        if household is None:
+            return Response(
+                {
+                    "months": [],
+                    "series": [],
+                    "breakdown": [],
+                    "suppliers": [],
+                    "biggest": [],
+                    "total": "0.00",
+                    "monthly_average": "0.00",
+                }
+            )
+
+        raw_months = request.query_params.get("months")
+        try:
+            months = int(raw_months) if raw_months else DEFAULT_MONTHS
+        except (TypeError, ValueError):
+            raise ValidationError({"months": "Expected an integer number of months."})
+
+        budget_id = request.query_params.get("budget") or None
+        if budget_id:
+            try:
+                known = Budget.objects.filter(household_id=household.id, pk=budget_id).exists()
+            except (ValueError, DjangoValidationError):
+                # A malformed UUID reaches the DB driver as a crash, not a lookup:
+                # a bad query parameter is a 400, never a 500.
+                known = False
+            if not known:
+                raise ValidationError({"budget": "Unknown budget for this household."})
+
+        return Response(
+            compute_budget_analysis(
+                household=household, months=months, budget_id=budget_id
+            )
+        )
 
 
 class RecurringExpenseViewSet(viewsets.ModelViewSet):

--- a/docs/MODULES/budget.md
+++ b/docs/MODULES/budget.md
@@ -164,6 +164,46 @@ plafonnée ».
   dépassé ». ⚠️ Les snapshots **déjà figés** portent une string : `render.py`
   doit accepter les deux formes pour toujours.
 
+## Analyse fine — la lecture longue (`analysis.py`)
+
+`GET /api/budget/budgets/analysis/?months=12&budget=<id>` →
+`{months, series, breakdown, suppliers, biggest, total, monthly_average}`.
+Front : `/app/money/analysis` (`features/money/AnalysisPage`), accessible depuis
+le panneau Budgets.
+
+**Pourquoi une page à part.** Le panneau Budgets ne sait poser qu'une question :
+« ce mois-ci tient-il dans l'enveloppe ». Une catégorie qui dérive de 15 % par
+mois y reste donc invisible jusqu'au jour où elle franchit son plafond — et une
+catégorie **sans plafond** n'y produit aucun signal du tout. C'est exactement le
+trou qu'ouvre le plafond optionnel, et cette page le referme.
+
+Ce que le module refuse de faire, et qui vaut d'être retenu :
+
+- **Quatre requêtes groupées**, quelle que soit la fenêtre. Jamais une par mois :
+  c'est la première chose qui dégénère sur deux ans d'historique. Le test
+  `TestItStaysCheap` borne le compte.
+- **Pas de part sur un total nul.** `breakdown` est vide plutôt que rempli de
+  `0 %` — sans dépense il n'y a pas de répartition, pas une répartition nulle.
+- **La moyenne compte les mois vides.** Les écarter la gonflerait d'un facteur
+  arbitraire ; un mois à zéro est une information.
+- **Un budget qui n'a rien dépensé n'entre pas dans la légende.** Douze entrées
+  mortes cacheraient l'information qu'aucune n'a servi — ce que le panneau
+  Budgets dit déjà.
+- **Le libellé « hors budget » n'est pas produit ici** : le backend renvoie
+  `budget_id: null`, le front le nomme. Ajouter une langue ne doit pas imposer un
+  passage par les `.po`.
+- **`months` est borné** (36) et un `budget` inconnu du foyer est un **400** —
+  le filtre s'applique après le scope, il ne peut jamais l'élargir. Un UUID
+  malformé aussi : il crashe le driver avant d'être une requête.
+- **On lit les `Interaction`, jamais les totaux bancaires.** Règle transverse du
+  CLAUDE.md : le pont entre les deux mondes est le taux de couverture.
+
+Côté rendu : `ConsumptionBarChart` est **réutilisé** (même librairie, mêmes
+tokens de couleur, même infobulle que l'électricité), avec une prop
+`formatValue` ajoutée pour que les montants passent par `formatAmount` au lieu
+d'un `${value} €` recollé. Le classement fournisseurs est en CSS pur — huit
+`div` dont la largeur est une règle de trois ne valent pas un axe recharts.
+
 ## Décisions clés
 
 - **Budgets multiples nommés = la dimension de regroupement** (pas de taxonomie

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -33,6 +33,8 @@ ui/src/features/money/
   AccountsPanel.tsx    # ex-banking/BankingPage
   ExpensesPanel.tsx    # ex-expenses/ExpensesPage
   BudgetsPanel.tsx     # ex-budget/BudgetPage
+  AnalysisPage.tsx     # sous-page : analyse fine des dépenses par budget
+  BudgetShareChart.tsx # anneau de répartition + légende chiffrée
 ```
 
 Les trois panneaux sont les anciennes pages, **`PageHeader` en moins** : la coque
@@ -119,7 +121,12 @@ valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage
 l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
-`/app/budget/recurring`, `/app/budget/reports`.
+`/app/money/analysis`, `/app/budget/recurring`, `/app/budget/reports`.
+
+`/app/money/analysis` est la **lecture longue** des dépenses (tendance mensuelle
+par budget, répartition, fournisseurs, plus grosses dépenses) — le panneau
+Budgets ne regarde que le mois en cours. Détail du calcul et de ce qu'il refuse
+d'inventer : `docs/MODULES/budget.md`, section « Analyse fine ».
 
 ## i18n
 

--- a/ui/src/components/charts/ConsumptionBarChart.tsx
+++ b/ui/src/components/charts/ConsumptionBarChart.tsx
@@ -73,6 +73,14 @@ interface ConsumptionBarChartProps {
   unit: string;
   /** Optional line on a right-hand axis (e.g. temperature). */
   overlay?: ConsumptionChartOverlay;
+  /**
+   * Rendu d'une valeur dans l'axe et l'infobulle. Par défaut `123 kWh`.
+   *
+   * Existe pour l'argent : tout montant du projet passe par `formatAmount`
+   * (CLAUDE.md), et un `${value} €` recollé ici afficherait « 1234.5 € » là où
+   * le reste de l'app écrit « 1 234,50 € ».
+   */
+  formatValue?: (value: number) => string;
 }
 
 export default function ConsumptionBarChart({
@@ -81,6 +89,7 @@ export default function ConsumptionBarChart({
   granularity,
   unit,
   overlay,
+  formatValue,
 }: ConsumptionBarChartProps) {
   const { i18n } = useTranslation();
   const locale = i18n.language;
@@ -121,8 +130,9 @@ export default function ConsumptionBarChart({
             tick={{ fontSize: 11, fill: 'hsl(var(--muted-foreground))' }}
             tickLine={false}
             axisLine={false}
-            width={44}
-            unit={` ${unit}`}
+            width={formatValue ? 56 : 44}
+            unit={formatValue ? undefined : ` ${unit}`}
+            tickFormatter={formatValue ? (v: number) => formatValue(v) : undefined}
           />
           {overlay && (
             <YAxis
@@ -145,7 +155,11 @@ export default function ConsumptionBarChart({
             }}
             labelFormatter={(ts) => formatLabel(String(ts), granularity, locale)}
             formatter={(value, name) => {
-              const u = overlay && name === overlay.key ? overlay.unit : unit;
+              const isOverlay = Boolean(overlay && name === overlay.key);
+              if (formatValue && !isOverlay) {
+                return [formatValue(Number(value)), seriesLabel(String(name))];
+              }
+              const u = isOverlay && overlay ? overlay.unit : unit;
               return [`${String(value)} ${u}`, seriesLabel(String(name))];
             }}
           />

--- a/ui/src/features/budget/hooks.ts
+++ b/ui/src/features/budget/hooks.ts
@@ -6,6 +6,7 @@ import {
   createRecurringExpense,
   deleteBudget,
   deleteRecurringExpense,
+  fetchBudgetAnalysis,
   fetchBudgetOverview,
   fetchBudgetReports,
   fetchBudgets,
@@ -29,6 +30,8 @@ export const budgetKeys = {
   projection: () => [...budgetKeys.all, 'projection'] as const,
   reports: () => [...budgetKeys.all, 'reports'] as const,
   latestReport: () => [...budgetKeys.all, 'reports', 'latest'] as const,
+  analysis: (months: number, budget: string | null) =>
+    [...budgetKeys.all, 'analysis', months, budget] as const,
 };
 
 export function useBudgets() {
@@ -152,4 +155,21 @@ export function useBudgetReports() {
 
 export function useLatestBudgetReport() {
   return useQuery({ queryKey: budgetKeys.latestReport(), queryFn: fetchLatestBudgetReport });
+}
+
+// --- Analyse fine -----------------------------------------------------------
+
+/**
+ * La lecture longue des dépenses par budget.
+ *
+ * `staleTime` d'une minute : l'analyse porte sur des mois, elle ne bouge pas
+ * pendant qu'on change de filtre — et refaire quatre agrégats à chaque aller-
+ * retour entre deux budgets serait payé pour rien.
+ */
+export function useBudgetAnalysis(months: number, budget: string | null) {
+  return useQuery({
+    queryKey: budgetKeys.analysis(months, budget),
+    queryFn: () => fetchBudgetAnalysis({ months, budget }),
+    staleTime: 60_000,
+  });
 }

--- a/ui/src/features/money/AnalysisPage.tsx
+++ b/ui/src/features/money/AnalysisPage.tsx
@@ -1,0 +1,268 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { BarChart3, Store } from 'lucide-react';
+import PageHeader from '@/components/PageHeader';
+import BackLink from '@/components/BackLink';
+import EmptyState from '@/components/EmptyState';
+import ConsumptionBarChart, {
+  type ConsumptionChartBucket,
+  type ConsumptionChartSeries,
+} from '@/components/charts/ConsumptionBarChart';
+import { Card, CardTitle } from '@/design-system/card';
+import { FilterPill } from '@/design-system/filter-pill';
+import { Select } from '@/design-system/select';
+import { formatAmount } from '@/lib/format';
+import { chartColor, UNBUDGETED_COLOR } from '@/lib/chartColors';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useSessionState } from '@/lib/useSessionState';
+import { useBudgetAnalysis, useBudgets } from '@/features/budget/hooks';
+import BudgetShareChart from './BudgetShareChart';
+
+/** Trois fenêtres, pas un curseur : on compare des saisons, pas des jours. */
+const WINDOWS = [6, 12, 24] as const;
+
+/** `YYYY-MM` → « juil. 2026 », dans la langue du lecteur. */
+function monthLabel(month: string, locale: string): string {
+  const [y, m] = month.split('-').map(Number);
+  return new Intl.DateTimeFormat(locale, { month: 'short', year: '2-digit' }).format(
+    new Date(y, (m || 1) - 1, 1),
+  );
+}
+
+/**
+ * Analyse fine des dépenses par budget (`/app/money/analysis`).
+ *
+ * Le panneau Budgets répond à « ce mois-ci tient-il dans l'enveloppe ». C'est la
+ * seule question qu'il sache poser — donc une catégorie qui dérive de 15 % par
+ * mois y reste invisible jusqu'au jour où elle franchit son plafond, et une
+ * catégorie **sans plafond** n'y a aucun signal du tout. Cette page est la
+ * lecture longue : la tendance, la répartition, chez qui, et les plus grosses.
+ *
+ * Tout vient d'un seul appel serveur : recalculer douze mois de séries dans le
+ * navigateur imposerait de charger toutes les dépenses de l'année pour en
+ * afficher douze barres.
+ */
+export default function AnalysisPage() {
+  const { t, i18n } = useTranslation();
+  const [months, setMonths] = useSessionState<number>('money.analysis.months', 12);
+  const [budgetId, setBudgetId] = useSessionState<string>('money.analysis.budget', '');
+
+  const budgetsQuery = useBudgets();
+  const analysisQuery = useBudgetAnalysis(months, budgetId || null);
+  const showSkeleton = useDelayedLoading(analysisQuery.isLoading);
+
+  const data = analysisQuery.data;
+  const locale = i18n.language;
+
+  // Le serveur trie déjà les séries (budgets par nom, « hors budget » en
+  // dernier) : la couleur s'indexe sur cette position et reste donc stable d'un
+  // rendu à l'autre, ce qu'un index de `filter` ne garantirait pas.
+  const series: ConsumptionChartSeries[] = React.useMemo(
+    () =>
+      (data?.series ?? []).map((row, index) => ({
+        key: row.budget_id ?? 'unbudgeted',
+        label: row.name ?? t('budget.unbudgeted.label'),
+        color: row.budget_id === null ? UNBUDGETED_COLOR : chartColor(index),
+      })),
+    [data, t],
+  );
+
+  const buckets: ConsumptionChartBucket[] = React.useMemo(() => {
+    if (!data) return [];
+    return data.months.map((month, i) => ({
+      // Le graphique attend un instant ISO ; le 1er à midi évite qu'un décalage
+      // horaire ne recule l'étiquette d'un mois.
+      ts: new Date(`${month}-01T12:00:00`).toISOString(),
+      values: Object.fromEntries(
+        data.series.map((row) => [row.budget_id ?? 'unbudgeted', Number(row.values[i])]),
+      ),
+    }));
+  }, [data]);
+
+  const hasSpending = Boolean(data && Number(data.total) > 0);
+  const biggestSupplier = data?.suppliers[0];
+
+  return (
+    <>
+      <BackLink fallback="/app/money?tab=budgets" fallbackLabel={t('budget.title')} />
+      <PageHeader title={t('analysis.title')} description={t('analysis.description')} />
+
+      <div className="flex flex-wrap items-center gap-2 pb-4">
+        {WINDOWS.map((w) => (
+          <FilterPill key={w} active={months === w} onClick={() => setMonths(w)}>
+            {t('analysis.lastMonths', { count: w })}
+          </FilterPill>
+        ))}
+
+        <Select
+          className="ml-auto w-auto"
+          value={budgetId}
+          onChange={(e) => setBudgetId(e.target.value)}
+          aria-label={t('analysis.filterBudget')}
+          options={[
+            { value: '', label: t('analysis.allBudgets') },
+            ...(budgetsQuery.data ?? [])
+              .filter((b) => !b.is_global)
+              .map((b) => ({ value: b.id, label: b.name })),
+          ]}
+        />
+      </div>
+
+      {showSkeleton ? (
+        <div className="space-y-3">
+          <div className="h-72 animate-pulse rounded-lg bg-muted" />
+          <div className="h-48 animate-pulse rounded-lg bg-muted" />
+        </div>
+      ) : null}
+
+      {!analysisQuery.isLoading && data ? (
+        !hasSpending ? (
+          <EmptyState
+            icon={BarChart3}
+            title={t('analysis.empty')}
+            description={t('analysis.emptyDescription')}
+          />
+        ) : (
+          <div className="space-y-4">
+            {/* Les trois chiffres qui cadrent la lecture avant tout graphique. */}
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              <StatCard label={t('analysis.periodTotal')} value={formatAmount(data.total, { fractionDigits: 0 })} />
+              <StatCard
+                label={t('analysis.monthlyAverage')}
+                value={formatAmount(data.monthly_average, { fractionDigits: 0 })}
+              />
+              {biggestSupplier ? (
+                <StatCard
+                  label={t('analysis.topSupplier')}
+                  value={biggestSupplier.supplier}
+                  hint={formatAmount(biggestSupplier.total, { fractionDigits: 0 })}
+                />
+              ) : null}
+            </div>
+
+            <Card className="p-4">
+              <CardTitle>{t('analysis.trend.title')}</CardTitle>
+              <p className="mb-2 mt-1 text-xs text-muted-foreground">
+                {t('analysis.trend.hint')}
+              </p>
+              <ConsumptionBarChart
+                buckets={buckets}
+                series={series}
+                granularity="month"
+                unit="€"
+                formatValue={(v) => formatAmount(v, { fractionDigits: 0 })}
+              />
+            </Card>
+
+            {/* Filtré sur un budget, la répartition n'aurait qu'une part : un
+                disque plein à 100 % n'apprend rien, on le retire. */}
+            {budgetId ? null : (
+              <Card className="p-4">
+                <CardTitle>{t('analysis.share.title')}</CardTitle>
+                <p className="mb-3 mt-1 text-xs text-muted-foreground">
+                  {t('analysis.share.hint')}
+                </p>
+                <BudgetShareChart rows={data.breakdown} total={data.total} />
+              </Card>
+            )}
+
+            {data.suppliers.length > 0 ? (
+              <Card className="p-4">
+                <CardTitle>{t('analysis.suppliers.title')}</CardTitle>
+                <p className="mb-3 mt-1 text-xs text-muted-foreground">
+                  {t('analysis.suppliers.hint')}
+                </p>
+                <SupplierBars suppliers={data.suppliers} />
+              </Card>
+            ) : null}
+
+            {data.biggest.length > 0 ? (
+              <Card className="p-4">
+                <CardTitle>{t('analysis.biggest.title')}</CardTitle>
+                <ul className="mt-3 space-y-2">
+                  {data.biggest.map((expense) => (
+                    <li key={expense.id} className="flex items-baseline justify-between gap-2 text-sm">
+                      <span className="min-w-0 flex-1 truncate text-foreground">
+                        {expense.subject}
+                        {expense.budget_name ? (
+                          <span className="text-muted-foreground"> · {expense.budget_name}</span>
+                        ) : null}
+                      </span>
+                      <span className="shrink-0 tabular-nums text-foreground">
+                        {formatAmount(expense.amount)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </Card>
+            ) : null}
+
+            <p className="pt-1 text-center text-xs text-muted-foreground">
+              {t('analysis.footnote', {
+                from: monthLabel(data.months[0], locale),
+                to: monthLabel(data.months[data.months.length - 1], locale),
+              })}
+            </p>
+          </div>
+        )
+      ) : null}
+    </>
+  );
+}
+
+function StatCard({ label, value, hint }: { label: string; value: string; hint?: string }) {
+  return (
+    <Card className="p-3">
+      <p className="truncate text-xs text-muted-foreground">{label}</p>
+      <p className="mt-0.5 truncate text-lg font-semibold tabular-nums text-foreground">{value}</p>
+      {hint ? <p className="truncate text-xs text-muted-foreground">{hint}</p> : null}
+    </Card>
+  );
+}
+
+/**
+ * Classement des fournisseurs — barres en CSS, pas en recharts.
+ *
+ * Un graphique à barres horizontales de huit lignes, c'est huit `div` dont la
+ * largeur est une règle de trois. Y passer une librairie coûterait un axe, une
+ * infobulle et un conteneur responsive pour afficher la même chose.
+ */
+function SupplierBars({
+  suppliers,
+}: {
+  suppliers: { supplier: string; total: string; count: number }[];
+}) {
+  const { t } = useTranslation();
+  const max = Math.max(...suppliers.map((s) => Number(s.total)), 1);
+
+  return (
+    <ul className="space-y-2">
+      {suppliers.map((supplier, index) => (
+        <li key={supplier.supplier}>
+          <div className="flex items-baseline justify-between gap-2 text-sm">
+            <span className="min-w-0 flex-1 truncate text-foreground">
+              <Store className="mr-1 inline h-3 w-3 text-muted-foreground" aria-hidden />
+              {supplier.supplier}
+              <span className="text-muted-foreground">
+                {' · '}
+                {t('analysis.suppliers.count', { count: supplier.count })}
+              </span>
+            </span>
+            <span className="shrink-0 tabular-nums text-foreground">
+              {formatAmount(supplier.total, { fractionDigits: 0 })}
+            </span>
+          </div>
+          <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${Math.max(2, Math.round((Number(supplier.total) / max) * 100))}%`,
+                backgroundColor: chartColor(index),
+              }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/ui/src/features/money/BudgetShareChart.tsx
+++ b/ui/src/features/money/BudgetShareChart.tsx
@@ -1,0 +1,115 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from 'recharts';
+import { formatAmount } from '@/lib/format';
+import { chartColor, UNBUDGETED_COLOR } from '@/lib/chartColors';
+import type { AnalysisBreakdownRow } from '@/lib/api/budget';
+
+/** Au-delà, les parts deviennent des filets illisibles — on les regroupe. */
+const VISIBLE_SLICES = 6;
+
+interface BudgetShareChartProps {
+  rows: AnalysisBreakdownRow[];
+  total: string;
+}
+
+/**
+ * Où part l'argent sur la fenêtre — anneau + légende chiffrée.
+ *
+ * L'anneau seul ne se lit pas : sur mobile, six parts se ressemblent toutes.
+ * La légende porte le montant **et** la part, et c'est elle qu'on lit en
+ * pratique ; le disque donne l'ordre de grandeur d'un coup d'œil.
+ *
+ * Le trou du milieu affiche le total, parce que la première question devant une
+ * répartition est toujours « de combien parle-t-on ».
+ */
+export default function BudgetShareChart({ rows, total }: BudgetShareChartProps) {
+  const { t } = useTranslation();
+
+  // Regroupement au-delà de six : « Autres » agrège la traîne plutôt que de
+  // produire douze filets d'un pixel qu'aucune infobulle ne rattrape.
+  const slices = React.useMemo(() => {
+    const head = rows.slice(0, VISIBLE_SLICES);
+    const tail = rows.slice(VISIBLE_SLICES);
+    const out = head.map((row, index) => ({
+      key: row.budget_id ?? 'unbudgeted',
+      label: row.name ?? t('budget.unbudgeted.label'),
+      value: Number(row.total),
+      share: row.share,
+      color: row.budget_id === null ? UNBUDGETED_COLOR : chartColor(index),
+    }));
+    if (tail.length > 0) {
+      out.push({
+        key: 'others',
+        label: t('analysis.others', { count: tail.length }),
+        value: tail.reduce((sum, row) => sum + Number(row.total), 0),
+        share: tail.reduce((sum, row) => sum + row.share, 0),
+        color: 'hsl(var(--muted))',
+      });
+    }
+    return out;
+  }, [rows, t]);
+
+  if (slices.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+      <div className="relative h-48 w-full shrink-0 sm:w-48">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={slices}
+              dataKey="value"
+              nameKey="label"
+              innerRadius="62%"
+              outerRadius="92%"
+              paddingAngle={1}
+              stroke="hsl(var(--card))"
+              strokeWidth={2}
+            >
+              {slices.map((slice) => (
+                <Cell key={slice.key} fill={slice.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              contentStyle={{
+                backgroundColor: 'hsl(var(--card))',
+                border: '1px solid hsl(var(--border))',
+                borderRadius: 8,
+                fontSize: 12,
+              }}
+              formatter={(value, name) => [formatAmount(Number(value)), String(name)]}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+
+        {/* Centré sur l'anneau, non cliquable : c'est une étiquette, pas un contrôle. */}
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-xs text-muted-foreground">{t('analysis.periodTotal')}</span>
+          <span className="text-sm font-semibold tabular-nums text-foreground">
+            {formatAmount(total, { fractionDigits: 0 })}
+          </span>
+        </div>
+      </div>
+
+      <ul className="min-w-0 flex-1 space-y-1.5">
+        {slices.map((slice) => (
+          <li key={slice.key} className="flex items-center gap-2 text-sm">
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full"
+              style={{ backgroundColor: slice.color }}
+              aria-hidden
+            />
+            <span className="min-w-0 flex-1 truncate text-foreground">{slice.label}</span>
+            <span className="shrink-0 tabular-nums text-muted-foreground">
+              {Math.round(slice.share * 100)}%
+            </span>
+            <span className="w-20 shrink-0 text-right tabular-nums text-foreground">
+              {formatAmount(slice.value, { fractionDigits: 0 })}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/ui/src/features/money/BudgetsPanel.tsx
+++ b/ui/src/features/money/BudgetsPanel.tsx
@@ -1,5 +1,13 @@
 import * as React from 'react';
-import { Plus, PiggyBank, AlertTriangle, CalendarClock, ChevronRight, FileText } from 'lucide-react';
+import {
+  Plus,
+  PiggyBank,
+  AlertTriangle,
+  BarChart3,
+  CalendarClock,
+  ChevronRight,
+  FileText,
+} from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import EmptyState from '@/components/EmptyState';
@@ -165,11 +173,28 @@ export default function BudgetsPanel() {
         )
       ) : null}
 
+      {/* L'analyse en premier des trois accès : c'est la seule qui répond à
+          « est-ce que ça dérive », question qu'aucune carte au-dessus ne pose. */}
+      {!overviewQuery.isLoading && overview ? (
+        <Link
+          to="/app/money/analysis"
+          state={pushBack(location)}
+          className="mt-5 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
+        >
+          <BarChart3 className="h-5 w-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium text-foreground">{t('analysis.title')}</p>
+            <p className="text-xs text-muted-foreground">{t('analysis.access.hint')}</p>
+          </div>
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        </Link>
+      ) : null}
+
       {!overviewQuery.isLoading && overview ? (
         <Link
           to="/app/budget/recurring"
           state={pushBack(location)}
-          className="mt-5 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
+          className="mt-2 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
         >
           <CalendarClock className="h-5 w-5 shrink-0 text-muted-foreground" />
           <div className="min-w-0 flex-1">

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -84,7 +84,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   // « non évaluable ») qu'aucun parcours procédural ne fait comprendre.
   { key: 'money', moduleKey: 'money', Icon: ShieldCheck, to: '/app/money?tab=control', stepIds: ['source', 'allocation', 'axes', 'window', 'arbitrate', 'notEvaluable', 'cash'] },
   { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'review'] },
-  { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'recurring', 'report'] },
+  { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'analysis', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },
   { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add'] },

--- a/ui/src/gen/api/services/BudgetService.ts
+++ b/ui/src/gen/api/services/BudgetService.ts
@@ -133,6 +133,26 @@ export class BudgetService {
         });
     }
     /**
+     * GET /api/budget/budgets/analysis/?months=12&budget=<id>
+     *
+     * La lecture longue : séries mensuelles par budget, répartition,
+     * fournisseurs, plus grosses dépenses. Le panneau Budgets ne répond qu'à
+     * « ce mois-ci tient-il ? » ; une dérive lente, ou une catégorie sans
+     * plafond, n'y produisent aucun signal.
+     *
+     * ``budget`` restreint tout le calcul à une enveloppe. Un id inconnu du
+     * foyer donne une fenêtre vide, jamais les données d'un autre foyer : le
+     * filtre s'applique **après** le scope, il ne peut pas l'élargir.
+     * @returns Budget
+     * @throws ApiError
+     */
+    public static budgetBudgetsAnalysisRetrieve(): CancelablePromise<Budget> {
+        return __request(OpenAPI, {
+            method: 'GET',
+            url: '/api/budget/budgets/analysis/',
+        });
+    }
+    /**
      * GET /api/budget/budgets/overview/
      *
      * The month's budgets with spent/ceiling, the "hors budget" total and the

--- a/ui/src/lib/api/budget.ts
+++ b/ui/src/lib/api/budget.ts
@@ -46,6 +46,67 @@ export interface BudgetPayload {
   is_global?: boolean;
 }
 
+// --- Analyse fine des dépenses par budget -----------------------------------
+
+/**
+ * Une série mensuelle. `name: null` = « hors budget » — le libellé vit dans
+ * l'i18n du front, pas dans la réponse, pour qu'ajouter une langue n'impose pas
+ * un passage par les `.po` du backend.
+ */
+export interface AnalysisSeries {
+  budget_id: string | null;
+  name: string | null;
+  /** Plafond du budget, `null` quand la catégorie n'en a pas. */
+  monthly_amount: string | null;
+  /** Un montant par mois de `months`, même index, zéros compris. */
+  values: string[];
+  total: string;
+}
+
+export interface AnalysisBreakdownRow {
+  budget_id: string | null;
+  name: string | null;
+  total: string;
+  /** Part du total de la fenêtre, entre 0 et 1. `0` quand rien n'a été dépensé. */
+  share: number;
+}
+
+export interface AnalysisSupplier {
+  supplier: string;
+  total: string;
+  count: number;
+}
+
+export interface AnalysisBiggest {
+  id: string;
+  subject: string;
+  amount: string;
+  occurred_at: string | null;
+  budget_id: string | null;
+  budget_name: string | null;
+}
+
+export interface BudgetAnalysis {
+  /** `YYYY-MM`, du plus ancien au plus récent. */
+  months: string[];
+  series: AnalysisSeries[];
+  breakdown: AnalysisBreakdownRow[];
+  suppliers: AnalysisSupplier[];
+  biggest: AnalysisBiggest[];
+  total: string;
+  monthly_average: string;
+}
+
+export async function fetchBudgetAnalysis(params: {
+  months: number;
+  budget?: string | null;
+}): Promise<BudgetAnalysis> {
+  const { data } = await api.get<BudgetAnalysis>('/budget/budgets/analysis/', {
+    params: { months: params.months, ...(params.budget ? { budget: params.budget } : {}) },
+  });
+  return data;
+}
+
 export async function fetchBudgets(): Promise<Budget[]> {
   const { data } = await api.get<Budget[] | { results: Budget[] }>('/budget/budgets/');
   return Array.isArray(data) ? data : data.results;

--- a/ui/src/lib/chartColors.ts
+++ b/ui/src/lib/chartColors.ts
@@ -1,0 +1,34 @@
+/**
+ * Palette des séries de graphique — tirée des tokens, jamais de couleurs en dur.
+ *
+ * Le design-system expose cinq `--chart-*` ; au-delà on repart au début plutôt
+ * que d'inventer des teintes. Deux catégories de même couleur dans une légende
+ * de douze, c'est un désagrément ; une couleur hors thème qui reste bleu vif en
+ * mode sombre, c'est un bug visuel — et la règle « pas de hardcode » du
+ * CLAUDE.md existe exactement pour ça.
+ *
+ * L'index doit être **stable pour une même série** d'un rendu à l'autre : on
+ * l'indexe sur la position dans une liste triée côté serveur, pas sur l'ordre
+ * d'arrivée d'un `map` filtré.
+ */
+const CHART_TOKENS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+] as const;
+
+/** Couleur de la série n° `index`. */
+export function chartColor(index: number): string {
+  return CHART_TOKENS[index % CHART_TOKENS.length];
+}
+
+/**
+ * Couleur du seau « hors budget » — volontairement hors palette.
+ *
+ * Ce n'est pas une catégorie de plus : c'est ce qui n'a pas été classé. Lui
+ * donner une teinte de la palette le ferait lire comme une enveloppe légitime,
+ * alors que la barre grise dit « il reste du travail ici ».
+ */
+export const UNBUDGETED_COLOR = 'hsl(var(--muted-foreground))';

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1587,6 +1587,10 @@
             "title": "Den Monat verfolgen",
             "body": "Jedes begrenzte Budget zeigt Ausgaben vs. Obergrenze mit einem Fortschrittsbalken — orange nahe der Grenze, rot bei Überschreitung. Eine Kategorie ohne Obergrenze zeigt nur ihre Summe. Die Zähler starten jeden Monat neu."
           },
+          "analysis": {
+            "title": "Sehen, wohin es wirklich geht",
+            "body": "Öffne „Ausgabenanalyse“ auf der Budgetseite: jede Kategorie Monat für Monat, die Verteilung über 6, 12 oder 24 Monate, die gewichtigsten Anbieter und deine größten Ausgaben. Hier zeigt sich eine abdriftende Kategorie — das Budget-Panel schaut immer nur auf den laufenden Monat."
+          },
           "recurring": {
             "title": "Wiederkehrende Rechnungen planen",
             "body": "Öffne „Wiederkehrende Ausgaben“ auf der Budgetseite, um Abos, Versicherungen und Rechnungen zu erfassen. Sieh, was in den nächsten 30/90 Tagen fällig wird, und bestätige jede Fälligkeit mit einem Klick, wenn sie bezahlt ist (Betrag editierbar) — sie landet im Journal und rückt aufs nächste Datum vor."
@@ -3149,6 +3153,41 @@
     },
     "uncapped": {
       "hint": "Verfolgte Kategorie, ohne Obergrenze"
+    }
+  },
+  "analysis": {
+    "title": "Ausgabenanalyse",
+    "description": "Der lange Blick: was abdriftet, wohin das Geld geht und an wen.",
+    "access": {
+      "hint": "12-Monats-Trend, Verteilung, Anbieter."
+    },
+    "lastMonths_one": "{{count}} Monat",
+    "lastMonths_other": "{{count}} Monate",
+    "allBudgets": "Alle Budgets",
+    "filterBudget": "Nach Budget filtern",
+    "periodTotal": "Gesamt im Zeitraum",
+    "monthlyAverage": "Monatsdurchschnitt",
+    "topSupplier": "Größter Anbieter",
+    "others": "{{count}} weitere",
+    "empty": "Noch nichts zu analysieren",
+    "emptyDescription": "Ordne einige Ausgaben Budgets zu, dann erscheint hier der Trend.",
+    "footnote": "Von {{from}} bis {{to}}. Zählt nur Journalausgaben, nie Banksummen.",
+    "trend": {
+      "title": "Monatlicher Verlauf",
+      "hint": "Ein leerer Monat zählt als null – das ist eine Information, keine Lücke."
+    },
+    "share": {
+      "title": "Verteilung",
+      "hint": "Anteil jedes Budgets im Zeitraum."
+    },
+    "suppliers": {
+      "title": "Wohin es geht",
+      "hint": "Die Anbieter mit dem größten Gewicht, nach Betrag sortiert.",
+      "count_one": "{{count}} Mal",
+      "count_other": "{{count}} Mal"
+    },
+    "biggest": {
+      "title": "Größte Ausgaben"
     }
   },
   "banking": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1587,6 +1587,10 @@
             "title": "Track the month",
             "body": "Each capped budget shows spent vs ceiling with a progress bar — amber near the limit, red once over. A category with no ceiling shows its total only. Counters reset every month."
           },
+          "analysis": {
+            "title": "See where it actually goes",
+            "body": "Open “Spending analysis” from the budget page: each category month by month, the breakdown over 6, 12 or 24 months, the suppliers that weigh most and your biggest expenses. This is where a drifting category shows up — the Budgets panel only ever looks at the current month."
+          },
           "recurring": {
             "title": "Anticipate recurring bills",
             "body": "Open “Recurring expenses” from the budget page to log subscriptions, insurance and bills. See what falls due over the next 30/90 days, and confirm each occurrence in one click when paid (the amount is editable) — it lands in your journal and advances to the next date."
@@ -3149,6 +3153,41 @@
     },
     "uncapped": {
       "hint": "Tracked category, no ceiling"
+    }
+  },
+  "analysis": {
+    "title": "Spending analysis",
+    "description": "The long read: what is drifting, where the money goes, and to whom.",
+    "access": {
+      "hint": "12-month trend, breakdown, suppliers."
+    },
+    "lastMonths_one": "{{count}} month",
+    "lastMonths_other": "{{count}} months",
+    "allBudgets": "All budgets",
+    "filterBudget": "Filter by budget",
+    "periodTotal": "Period total",
+    "monthlyAverage": "Monthly average",
+    "topSupplier": "Top supplier",
+    "others": "{{count}} others",
+    "empty": "Nothing to analyse yet",
+    "emptyDescription": "Sort a few expenses into budgets and the trend will show up here.",
+    "footnote": "From {{from}} to {{to}}. Counts journal expenses only, never bank totals.",
+    "trend": {
+      "title": "Monthly trend",
+      "hint": "An empty month counts as zero: that is information, not a hole."
+    },
+    "share": {
+      "title": "Breakdown",
+      "hint": "Each budget's share over the period."
+    },
+    "suppliers": {
+      "title": "Where it goes",
+      "hint": "The suppliers that weigh most, ranked by amount.",
+      "count_one": "{{count}} time",
+      "count_other": "{{count}} times"
+    },
+    "biggest": {
+      "title": "Biggest expenses"
     }
   },
   "banking": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1587,6 +1587,10 @@
             "title": "Seguir el mes",
             "body": "Cada presupuesto con tope muestra lo gastado frente al tope con una barra de progreso — naranja cerca del límite, rojo al superarlo. Una categoría sin tope muestra solo su total. Los contadores se reinician cada mes."
           },
+          "analysis": {
+            "title": "Ver adónde va de verdad",
+            "body": "Abre «Análisis de gastos» desde la página de presupuestos: cada categoría mes a mes, el reparto en 6, 12 o 24 meses, los proveedores que más pesan y tus mayores gastos. Ahí se ve una categoría que se desvía — el panel Presupuestos solo mira el mes en curso."
+          },
           "recurring": {
             "title": "Anticipar facturas recurrentes",
             "body": "Abre «Gastos recurrentes» desde la página de presupuesto para registrar suscripciones, seguros y facturas. Mira lo que vence en los próximos 30/90 días y confirma cada vencimiento en un clic cuando lo pagues (el importe es editable) — entra en tu diario y avanza a la fecha siguiente."
@@ -3149,6 +3153,41 @@
     },
     "uncapped": {
       "hint": "Categoría seguida, sin tope"
+    }
+  },
+  "analysis": {
+    "title": "Análisis de gastos",
+    "description": "La lectura larga: qué se desvía, adónde va el dinero y a quién.",
+    "access": {
+      "hint": "Tendencia a 12 meses, reparto, proveedores."
+    },
+    "lastMonths_one": "{{count}} mes",
+    "lastMonths_other": "{{count}} meses",
+    "allBudgets": "Todos los presupuestos",
+    "filterBudget": "Filtrar por presupuesto",
+    "periodTotal": "Total del periodo",
+    "monthlyAverage": "Media mensual",
+    "topSupplier": "Primer proveedor",
+    "others": "{{count}} más",
+    "empty": "Nada que analizar todavía",
+    "emptyDescription": "Clasifica algunos gastos en presupuestos y aquí aparecerá la tendencia.",
+    "footnote": "De {{from}} a {{to}}. Solo cuenta los gastos del diario, nunca los totales bancarios.",
+    "trend": {
+      "title": "Evolución mensual",
+      "hint": "Un mes vacío cuenta como cero: es información, no un hueco."
+    },
+    "share": {
+      "title": "Reparto",
+      "hint": "Parte de cada presupuesto en el periodo."
+    },
+    "suppliers": {
+      "title": "Adónde va",
+      "hint": "Los proveedores que más pesan, ordenados por importe.",
+      "count_one": "{{count}} vez",
+      "count_other": "{{count}} veces"
+    },
+    "biggest": {
+      "title": "Mayores gastos"
     }
   },
   "banking": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1587,6 +1587,10 @@
             "title": "Suivre le mois",
             "body": "Chaque budget plafonné affiche le dépensé vs le plafond avec une barre de progression — orange près de la limite, rouge en cas de dépassement. Une catégorie sans plafond affiche seulement son total. Les compteurs repartent à zéro chaque mois."
           },
+          "analysis": {
+            "title": "Comprendre où ça part",
+            "body": "Ouvre « Analyse des dépenses » depuis la page budget : l'évolution mois par mois de chaque catégorie, la répartition sur 6, 12 ou 24 mois, les fournisseurs qui pèsent le plus et tes plus grosses dépenses. C'est là qu'une catégorie qui dérive se voit — le panneau Budgets, lui, ne regarde que le mois en cours."
+          },
           "recurring": {
             "title": "Anticiper les factures récurrentes",
             "body": "Ouvre « Dépenses récurrentes » depuis la page budget pour déclarer abonnements, assurances et factures. Vois ce qui tombe sur 30/90 jours, et confirme chaque échéance en un clic quand elle est payée (le montant est éditable) — elle rejoint ton journal et avance à la date suivante."
@@ -3149,6 +3153,41 @@
     },
     "uncapped": {
       "hint": "Catégorie suivie, sans plafond"
+    }
+  },
+  "analysis": {
+    "title": "Analyse des dépenses",
+    "description": "La lecture longue : ce qui dérive, où part l'argent, et chez qui.",
+    "access": {
+      "hint": "Tendance sur 12 mois, répartition, fournisseurs."
+    },
+    "lastMonths_one": "{{count}} mois",
+    "lastMonths_other": "{{count}} mois",
+    "allBudgets": "Tous les budgets",
+    "filterBudget": "Filtrer par budget",
+    "periodTotal": "Total période",
+    "monthlyAverage": "Moyenne / mois",
+    "topSupplier": "Premier fournisseur",
+    "others": "{{count}} autres",
+    "empty": "Rien à analyser pour l'instant",
+    "emptyDescription": "Range quelques dépenses dans des budgets, et la tendance apparaîtra ici.",
+    "footnote": "De {{from}} à {{to}}. Ne compte que les dépenses du journal, jamais les totaux bancaires.",
+    "trend": {
+      "title": "Évolution mensuelle",
+      "hint": "Un mois vide compte comme zéro : c'est une information, pas un trou."
+    },
+    "share": {
+      "title": "Répartition",
+      "hint": "Part de chaque budget sur la période."
+    },
+    "suppliers": {
+      "title": "Chez qui",
+      "hint": "Les fournisseurs qui pèsent le plus, classés par montant.",
+      "count_one": "{{count}} fois",
+      "count_other": "{{count}} fois"
+    },
+    "biggest": {
+      "title": "Plus grosses dépenses"
     }
   },
   "banking": {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -49,6 +49,7 @@ const BriefingsPage = lazyWithReload(() => import('./features/briefings/Briefing
 const MoneyPage = lazyWithReload(() => import('./features/money/MoneyPage'));
 const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPage'));
 const ReportsPage = lazyWithReload(() => import('./features/budget/ReportsPage'));
+const MoneyAnalysisPage = lazyWithReload(() => import('./features/money/AnalysisPage'));
 const BankingTransactionsPage = lazyWithReload(
   () => import('./features/banking/TransactionsPage'),
 );
@@ -85,6 +86,7 @@ export const router = createBrowserRouter([
       { path: 'interactions/:id/edit', element: <InteractionEditPage /> },
       { path: 'money', element: <MoneyPage /> },
       { path: 'money/transactions', element: <BankingTransactionsPage /> },
+      { path: 'money/analysis', element: <MoneyAnalysisPage /> },
       { path: 'budget/recurring', element: <RecurringPage /> },
       { path: 'budget/reports', element: <ReportsPage /> },
       // Anciennes URLs (parcours 26, lot 2) : les favoris, les liens de l'agent et


### PR DESCRIPTION
## Le trou

Le panneau Budgets ne sait poser qu'une question : **« ce mois-ci tient-il dans l'enveloppe ? »**. Une catégorie qui dérive de 15 % par mois y reste invisible jusqu'au jour où elle franchit son plafond — et depuis que le plafond est optionnel (#414), une catégorie sans plafond n'y produit **aucun** signal.

## `/app/money/analysis`

Accessible depuis le panneau Budgets, avec `BackLink`.

- **Évolution mensuelle** — barres empilées par budget sur 6, 12 ou 24 mois
- **Répartition** — anneau + légende chiffrée (montant *et* part), total au centre
- **Chez qui** — classement des fournisseurs par montant
- **Plus grosses dépenses** de la fenêtre
- Trois chiffres en tête : total période, moyenne mensuelle, premier fournisseur
- Filtrable sur une enveloppe : la série, les fournisseurs et le classement se restreignent ensemble ; l'anneau disparaît (un disque plein à 100 % n'apprend rien)

## Même style, même librairie

`ConsumptionBarChart` (celui de l'électricité) est **réutilisé tel quel** — mêmes tokens `--chart-*`, même grille, même infobulle. Une seule prop ajoutée, `formatValue`, pour que les montants passent par `formatAmount` au lieu du `${value} kWh` recollé : sans elle l'axe afficherait « 1234.5 € » là où le reste de l'app écrit « 1 234,50 € ».

Le classement fournisseurs est en **CSS pur** : huit `div` dont la largeur est une règle de trois ne valent pas un axe recharts, une infobulle et un conteneur responsive.

## Ce que l'agrégat refuse d'inventer

| | |
|---|---|
| Total nul | `breakdown` **vide**, pas rempli de `0 %` — sans dépense il n'y a pas de répartition |
| Mois vides | comptés dans la moyenne : les écarter la gonflerait d'un facteur arbitraire |
| Budget sans dépense | absent de la légende — douze entrées mortes cacheraient l'info qu'aucune n'a servi |
| « Hors budget » | `budget_id: null` ; le libellé vit dans l'i18n du front, pas dans les `.po` |
| Budget supprimé | ses dépenses retombent dans « hors budget » (`SET_NULL`), elles ne disparaissent pas |

## Robustesse

- **Quatre requêtes groupées**, quelle que soit la fenêtre — `TestItStaysCheap` borne le compte. Une requête par mois est ce qui dégénère sur deux ans.
- `months` **plafonné à 36** ; `?months=nope` → 400.
- Un budget d'un autre foyer → **400** : le filtre s'applique après le scope, il ne peut jamais l'élargir. Un UUID malformé aussi — il crashe le driver avant d'être une requête, donc 400 et pas 500.
- Frontière de mois dans le **fuseau du foyer** : le 31 juillet 23 h à Paris reste juillet.
- **On lit les `Interaction`, jamais les totaux bancaires** (règle CLAUDE.md).

## Vérification

- `pytest --create-db` : **3359 passed, 2 skipped** (24 nouveaux)
- `npm run build` + `npm run lint` propres, types API régénérés
- i18n ×4 (nouveau namespace `analysis`), tutoriel « Budgets » ×4
- `docs/MODULES/budget.md` (section « Analyse fine ») + `docs/MODULES/money.md`