### PR TITLE
feat(budget): ouvrir un budget sur les dépenses qui le composent

### DIFF
--- a/apps/interactions/aggregations.py
+++ b/apps/interactions/aggregations.py
@@ -17,8 +17,15 @@ from django.db.models.functions import Coalesce, TruncMonth
 from .queries import expenses
 
 
+#: Valeur de ``budget`` qui désigne le seau « hors budget ». Une chaîne plutôt
+#: qu'un ``None`` : dans une query string, l'absence de paramètre et « aucun
+#: budget » doivent rester deux demandes différentes.
+UNBUDGETED = 'none'
+
+
 def _expense_qs(household_id, from_dt: datetime | None, to_dt: datetime | None,
-                supplier: str | None = None, kind: str | None = None):
+                supplier: str | None = None, kind: str | None = None,
+                budget: str | None = None):
     qs = expenses(household_id=household_id)
     if from_dt is not None:
         qs = qs.filter(occurred_at__gte=from_dt)
@@ -28,6 +35,8 @@ def _expense_qs(household_id, from_dt: datetime | None, to_dt: datetime | None,
         qs = qs.filter(supplier=supplier)
     if kind is not None:
         qs = qs.filter(kind=kind)
+    if budget is not None:
+        qs = qs.filter(budget__isnull=True) if budget == UNBUDGETED else qs.filter(budget_id=budget)
     return qs
 
 
@@ -46,8 +55,14 @@ def compute_expense_summary(
     to_dt: datetime | None,
     supplier: str | None = None,
     kind: str | None = None,
+    budget: str | None = None,
 ) -> dict[str, Any]:
     """Return totals + breakdowns for expense interactions in the period.
+
+    ``budget`` restreint le calcul à une enveloppe, ou au seau « hors budget »
+    avec la valeur ``'none'`` — c'est ce qui permet d'ouvrir un compteur pour
+    voir de quelles dépenses il est fait, sans charger le journal entier côté
+    client pour le refiltrer.
 
     Shape:
         {
@@ -59,7 +74,7 @@ def compute_expense_summary(
           "by_month": [{"month": "2026-05", "total": "1247.83", "count": 18}, ...],
         }
     """
-    qs = _expense_qs(household_id, from_dt, to_dt, supplier=supplier, kind=kind)
+    qs = _expense_qs(household_id, from_dt, to_dt, supplier=supplier, kind=kind, budget=budget)
 
     overall = qs.aggregate(
         total=Coalesce(Sum('amount'), _zero()),

--- a/apps/interactions/tests/test_api_expense_summary.py
+++ b/apps/interactions/tests/test_api_expense_summary.py
@@ -262,3 +262,158 @@ class TestExpenseListFilters:
         assert response.status_code == status.HTTP_200_OK
         assert response.data["count"] == 1
         assert response.data["results"][0]["subject"] == "With supplier"
+
+
+@pytest.mark.django_db
+class TestFilteringByBudget:
+    """« De quoi ce compteur est-il fait ? » — ouvrir un budget sur ses dépenses.
+
+    Le panneau Budgets affiche « 340 € dépensés » ; sans ce filtre, la seule
+    façon de voir *lesquelles* était de charger le journal entier et de le
+    refiltrer dans le navigateur.
+    """
+
+    def _budget(self, household, name, amount=Decimal("400")):
+        from budget.models import Budget
+
+        return Budget.objects.create(household=household, name=name, monthly_amount=amount)
+
+    def test_list_filtered_by_budget(self, owner_client, household, owner, zone):
+        groceries = self._budget(household, "Courses")
+        inside = _create_expense(household, owner, zone, amount=Decimal("30.00"),
+                                 occurred_at=timezone.now(), subject="Dedans")
+        inside.budget = groceries
+        inside.save(update_fields=["budget"])
+        _create_expense(household, owner, zone, amount=Decimal("20.00"),
+                        occurred_at=timezone.now(), subject="Ailleurs")
+
+        response = owner_client.get(
+            reverse("interaction-list") + f"?type=expense&budget={groceries.id}"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert [r["subject"] for r in response.data["results"]] == ["Dedans"]
+
+    def test_budget_none_opens_the_unbudgeted_bucket(self, owner_client, household, owner, zone):
+        """``none`` est une valeur, pas l'absence de filtre."""
+        groceries = self._budget(household, "Courses")
+        attached = _create_expense(household, owner, zone, amount=Decimal("30.00"),
+                                   occurred_at=timezone.now(), subject="Rangée")
+        attached.budget = groceries
+        attached.save(update_fields=["budget"])
+        _create_expense(household, owner, zone, amount=Decimal("20.00"),
+                        occurred_at=timezone.now(), subject="Hors budget")
+
+        response = owner_client.get(reverse("interaction-list") + "?type=expense&budget=none")
+
+        assert [r["subject"] for r in response.data["results"]] == ["Hors budget"]
+
+    def test_a_malformed_budget_id_lists_nothing_rather_than_everything(
+        self, owner_client, household, owner, zone
+    ):
+        _create_expense(household, owner, zone, amount=Decimal("20.00"),
+                        occurred_at=timezone.now(), subject="Une dépense")
+
+        response = owner_client.get(reverse("interaction-list") + "?type=expense&budget=oops")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["count"] == 0
+
+    def test_summary_narrows_to_the_budget(self, owner_client, household, owner, zone):
+        groceries = self._budget(household, "Courses")
+        inside = _create_expense(household, owner, zone, amount=Decimal("30.00"),
+                                 occurred_at=timezone.now(), supplier="Leclerc")
+        inside.budget = groceries
+        inside.save(update_fields=["budget"])
+        _create_expense(household, owner, zone, amount=Decimal("70.00"),
+                        occurred_at=timezone.now(), supplier="Fnac")
+
+        response = owner_client.get(
+            reverse("interaction-expenses-summary") + f"?budget={groceries.id}"
+        )
+
+        assert response.data["total"] == "30.00"
+        assert response.data["count"] == 1
+        assert [r["supplier"] for r in response.data["by_supplier"]] == ["Leclerc"]
+
+    def test_summary_of_the_unbudgeted_bucket(self, owner_client, household, owner, zone):
+        groceries = self._budget(household, "Courses")
+        inside = _create_expense(household, owner, zone, amount=Decimal("30.00"),
+                                 occurred_at=timezone.now())
+        inside.budget = groceries
+        inside.save(update_fields=["budget"])
+        _create_expense(household, owner, zone, amount=Decimal("70.00"),
+                        occurred_at=timezone.now())
+
+        response = owner_client.get(reverse("interaction-expenses-summary") + "?budget=none")
+
+        assert response.data["total"] == "70.00"
+
+    def test_a_malformed_budget_id_on_the_summary_is_a_400_not_a_500(
+        self, owner_client, household
+    ):
+        response = owner_client.get(reverse("interaction-expenses-summary") + "?budget=oops")
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_another_households_budget_yields_nothing(self, owner_client, household, owner, zone):
+        """Le filtre s'applique après le scope foyer — il ne peut pas l'élargir."""
+        stranger_budget = self._budget(_create_household("Chez eux"), "Leur budget")
+        _create_expense(household, owner, zone, amount=Decimal("20.00"),
+                        occurred_at=timezone.now(), subject="La mienne")
+
+        response = owner_client.get(
+            reverse("interaction-list") + f"?type=expense&budget={stranger_budget.id}"
+        )
+
+        assert response.data["count"] == 0
+
+
+@pytest.mark.django_db
+class TestTheLastDayOfThePeriodCounts:
+    """Régression : une date de fin nue veut dire « fin de cette journée ».
+
+    Le filtre est un ``__lte`` ; lue à minuit, ``to=2026-07-31`` excluait toutes
+    les dépenses du 31. Le dernier jour de chaque période disparaissait des
+    totaux **et** de la liste, en silence — et le détail d'un budget ne tombait
+    donc pas d'accord avec le compteur du panneau juste à côté.
+    """
+
+    def _late_expense(self, household, user, zone):
+        from datetime import datetime, timezone as dt_tz
+
+        return _create_expense(
+            household, user, zone,
+            amount=Decimal("42.00"),
+            occurred_at=datetime(2026, 7, 31, 18, 30, tzinfo=dt_tz.utc),
+            subject="Le 31 au soir",
+        )
+
+    def test_the_summary_includes_it(self, owner_client, household, owner, zone):
+        self._late_expense(household, owner, zone)
+
+        response = owner_client.get(
+            reverse("interaction-expenses-summary") + "?from=2026-07-01&to=2026-07-31"
+        )
+
+        assert response.data["total"] == "42.00"
+
+    def test_the_list_includes_it(self, owner_client, household, owner, zone):
+        self._late_expense(household, owner, zone)
+
+        response = owner_client.get(
+            reverse("interaction-list")
+            + "?type=expense&start_date=2026-07-01&end_date=2026-07-31"
+        )
+
+        assert [r["subject"] for r in response.data["results"]] == ["Le 31 au soir"]
+
+    def test_an_explicit_instant_is_still_respected(self, owner_client, household, owner, zone):
+        """Qui écrit une heure sait ce qu'il demande — on ne l'étend pas."""
+        self._late_expense(household, owner, zone)
+
+        response = owner_client.get(
+            reverse("interaction-expenses-summary") + "?from=2026-07-01&to=2026-07-31T12:00:00Z"
+        )
+
+        assert response.data["total"] == "0.00"

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -18,7 +18,7 @@ from django.db.models import Q, Count
 from core.permissions import IsHouseholdMember
 from documents.models import Document, DocumentLink
 from zones.models import Zone
-from .aggregations import compute_expense_summary
+from .aggregations import UNBUDGETED, compute_expense_summary
 from .models import Interaction, InteractionZone, InteractionContact, InteractionStructure
 from .serializers import (
     InteractionSerializer,
@@ -37,17 +37,39 @@ from .services import (
 )
 
 
+def _end_of_day(value: str) -> str:
+    """``'2026-07-31'`` → ``'2026-07-31 23:59:59.999999'``, sinon la valeur telle quelle.
+
+    Un filtre ``__lte`` sur une colonne datetime lit une date nue à minuit, donc
+    exclut la journée entière qu'on croyait inclure. Un instant explicite est
+    respecté : l'appelant qui écrit une heure sait ce qu'il demande.
+    """
+    try:
+        parsed = datetime.strptime(value, '%Y-%m-%d')
+    except (TypeError, ValueError):
+        return value
+    return datetime.combine(parsed.date(), time.max).isoformat(sep=' ')
+
+
 def _parse_period(from_param: str | None, to_param: str | None):
     """Resolve from/to query params, defaulting to the current calendar month.
 
     Accepts ISO date (YYYY-MM-DD) or full datetime. Always returns aware
     datetimes (UTC for date-only inputs).
+
+    **Une date de fin nue veut dire « fin de cette journée ».** Le filtre est un
+    ``__lte`` : en la lisant à minuit, ``to=2026-07-31`` excluait toutes les
+    dépenses du 31 — le dernier jour de chaque période disparaissait des totaux,
+    en silence. C'est d'autant plus visible depuis qu'on peut ouvrir un budget
+    sur ses dépenses : le détail et le compteur du panneau ne tombaient pas
+    d'accord. Un instant explicite (``...T14:00``) est respecté tel quel.
     """
-    def _parse(value: str) -> datetime:
+    def _parse(value: str, *, end_of_day: bool = False) -> datetime:
         # Try date-only first, then full datetime.
         try:
             d = datetime.strptime(value, '%Y-%m-%d')
-            return datetime.combine(d.date(), time.min, tzinfo=dt_timezone.utc)
+            moment = time.max if end_of_day else time.min
+            return datetime.combine(d.date(), moment, tzinfo=dt_timezone.utc)
         except ValueError:
             pass
         return datetime.fromisoformat(value)
@@ -62,7 +84,7 @@ def _parse_period(from_param: str | None, to_param: str | None):
         return from_dt, next_month - timedelta(microseconds=1)
 
     from_dt = _parse(from_param) if from_param else None
-    to_dt = _parse(to_param) if to_param else None
+    to_dt = _parse(to_param, end_of_day=True) if to_param else None
     return from_dt, to_dt
 
 
@@ -124,13 +146,16 @@ class InteractionViewSet(viewsets.ModelViewSet):
         if structure_id:
             queryset = queryset.filter(interaction_structures__structure_id=structure_id)
 
-        # Filter by date range
+        # Filter by date range. ``end_date`` nue = fin de journée, même règle que
+        # ``_parse_period`` : comparée telle quelle, une date se lit à minuit et
+        # le dernier jour de la période disparaît de la liste alors qu'il compte
+        # dans le total juste à côté.
         start_date = self.request.query_params.get('start_date')
         end_date = self.request.query_params.get('end_date')
         if start_date:
             queryset = queryset.filter(occurred_at__gte=start_date)
         if end_date:
-            queryset = queryset.filter(occurred_at__lte=end_date)
+            queryset = queryset.filter(occurred_at__lte=_end_of_day(end_date))
         
         # Filter by tags
         tags = self.request.query_params.get('tags')
@@ -150,6 +175,24 @@ class InteractionViewSet(viewsets.ModelViewSet):
         supplier = self.request.query_params.get('supplier')
         if supplier is not None:
             queryset = queryset.filter(supplier=supplier)
+
+        # Filter by budget — « de quoi ce compteur est-il fait ? ».
+        #
+        # ``budget=none`` est une valeur à part entière, pas l'absence de filtre :
+        # « hors budget » est un seau qu'on veut pouvoir ouvrir comme les autres.
+        # Sans elle, la seule façon de lister ses dépenses serait de tout charger
+        # et de filtrer côté client.
+        budget = self.request.query_params.get('budget')
+        if budget:
+            if budget == UNBUDGETED:
+                queryset = queryset.filter(budget__isnull=True)
+            else:
+                try:
+                    queryset = queryset.filter(budget_id=uuid.UUID(budget))
+                except ValueError:
+                    # Un id malformé ne doit pas renvoyer *tout* le journal : la
+                    # liste vide est le seul résultat honnête.
+                    return queryset.none()
 
         return queryset
     
@@ -344,12 +387,22 @@ class InteractionViewSet(viewsets.ModelViewSet):
         supplier = request.query_params.get('supplier')
         kind = request.query_params.get('kind')
 
+        budget = request.query_params.get('budget') or None
+        if budget and budget != UNBUDGETED:
+            try:
+                uuid.UUID(budget)
+            except ValueError:
+                # Un id malformé atteint le driver comme un crash, pas comme un
+                # filtre : un mauvais paramètre est un 400, jamais un 500.
+                raise ValidationError({'budget': 'Expected a budget id or "none".'})
+
         return Response(compute_expense_summary(
             household_id=household.id,
             from_dt=from_dt,
             to_dt=to_dt,
             supplier=supplier if supplier else None,
             kind=kind if kind else None,
+            budget=budget,
         ))
 
 

--- a/docs/MODULES/budget.md
+++ b/docs/MODULES/budget.md
@@ -164,6 +164,34 @@ plafonnée ».
   dépassé ». ⚠️ Les snapshots **déjà figés** portent une string : `render.py`
   doit accepter les deux formes pour toujours.
 
+## Ouvrir un budget sur ses dépenses
+
+`/app/money/budgets/:id` (`features/money/BudgetDetailPage`). Le panneau affiche
+« 340 € / 400 € » ; la question suivante est toujours *lesquelles*. Jusqu'ici il
+fallait partir dans l'onglet Dépenses et refaire le filtre à la main, sans
+garantie de retomber sur le même chiffre.
+
+- La période par défaut est **le mois en cours**, celle du panneau : le total de
+  la page est celui sur lequel on vient de cliquer. Changer de période est
+  ensuite explicite.
+- **Le plafond ne s'affiche que sur le mois en cours.** Le comparer à un total
+  annuel donnerait « 4 200 € / 400 € » — un dépassement qui n'existe pas.
+- **« Hors budget » s'ouvre comme une enveloppe** (`/app/money/budgets/none`) :
+  c'est le seau où l'on cherche le plus souvent ce qu'il y a dedans. D'où le
+  paramètre `budget=none` sur la liste **et** sur le résumé : dans une query
+  string, l'absence de filtre et « aucun budget » sont deux demandes
+  différentes.
+- Le lien porte le **corps** de la carte, pas la carte entière : le dropdown
+  d'actions est un enfant, et l'imbriquer dans un `<a>` en ferait un
+  déclencheur de navigation.
+
+⚠️ **Une date de fin nue veut dire « fin de cette journée ».** Le filtre est un
+`__lte` : lue à minuit, `to=2026-07-31` excluait toutes les dépenses du 31 — le
+dernier jour de chaque période disparaissait des totaux **et** de la liste, en
+silence. Corrigé dans `_parse_period` et dans le filtre `end_date`, avec un test
+de régression (`TestTheLastDayOfThePeriodCounts`). Un instant explicite
+(`...T12:00:00Z`) reste respecté tel quel.
+
 ## Analyse fine — la lecture longue (`analysis.py`)
 
 `GET /api/budget/budgets/analysis/?months=12&budget=<id>` →

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -34,6 +34,7 @@ ui/src/features/money/
   ExpensesPanel.tsx    # ex-expenses/ExpensesPage
   BudgetsPanel.tsx     # ex-budget/BudgetPage
   AnalysisPage.tsx     # sous-page : analyse fine des dépenses par budget
+  BudgetDetailPage.tsx # sous-page : de quoi un budget est fait
   BudgetShareChart.tsx # anneau de répartition + légende chiffrée
 ```
 
@@ -121,7 +122,8 @@ valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage
 l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
-`/app/money/analysis`, `/app/budget/recurring`, `/app/budget/reports`.
+`/app/money/analysis`, `/app/money/budgets/:id`, `/app/budget/recurring`,
+`/app/budget/reports`.
 
 `/app/money/analysis` est la **lecture longue** des dépenses (tendance mensuelle
 par budget, répartition, fournisseurs, plus grosses dépenses) — le panneau

--- a/ui/src/features/budget/BudgetCard.tsx
+++ b/ui/src/features/budget/BudgetCard.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Pencil, Trash2 } from 'lucide-react';
 import { Card } from '@/design-system/card';
@@ -23,9 +24,13 @@ interface BudgetCardProps {
   row: BudgetOverviewRow;
   onEdit: () => void;
   onDelete: () => void;
+  /** Ouvre le détail — « de quoi ce compteur est-il fait ». */
+  to: string;
+  /** Pile de retour, pour que le détail sache d'où on vient. */
+  backState?: unknown;
 }
 
-export default function BudgetCard({ row, onEdit, onDelete }: BudgetCardProps) {
+export default function BudgetCard({ row, onEdit, onDelete, to, backState }: BudgetCardProps) {
   const { t } = useTranslation();
   // Pas de plafond → pas de barre, pas de pourcentage, pas de dépassement :
   // il n'y a rien à mesurer. On dit juste ce que la catégorie a coûté.
@@ -41,9 +46,14 @@ export default function BudgetCard({ row, onEdit, onDelete }: BudgetCardProps) {
   return (
     <Card className="p-3">
       <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0 flex-1">
+        {/* Le lien porte le corps de la carte, pas la carte entière : le
+            dropdown d'actions est un enfant, et l'imbriquer dans un <a> en
+            ferait un déclencheur de navigation au premier clic. */}
+        <Link to={to} state={backState} className="group min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
-            <span className="truncate font-medium text-foreground">{row.name}</span>
+            <span className="truncate font-medium text-foreground group-hover:underline">
+              {row.name}
+            </span>
             <span className={`shrink-0 text-sm tabular-nums ${TEXT_CLASS[row.state]}`}>
               {uncapped
                 ? formatAmount(row.spent)
@@ -76,7 +86,7 @@ export default function BudgetCard({ row, onEdit, onDelete }: BudgetCardProps) {
               {t('budget.committed', { amount: formatAmount(row.committed) })}
             </p>
           ) : null}
-        </div>
+        </Link>
 
         <CardActions actions={actions} />
       </div>

--- a/ui/src/features/money/BudgetDetailPage.tsx
+++ b/ui/src/features/money/BudgetDetailPage.tsx
@@ -1,0 +1,166 @@
+import * as React from 'react';
+import { useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { Receipt } from 'lucide-react';
+import PageHeader from '@/components/PageHeader';
+import BackLink from '@/components/BackLink';
+import EmptyState from '@/components/EmptyState';
+import { Card } from '@/design-system/card';
+import { FilterPill } from '@/design-system/filter-pill';
+import { formatAmount } from '@/lib/format';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useSessionState } from '@/lib/useSessionState';
+import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
+import { interactionKeys } from '@/features/interactions/hooks';
+import { useExpenseSummary } from '@/features/expenses/hooks';
+import { useBudgetOverview } from '@/features/budget/hooks';
+import { resolvePeriod, type PeriodPreset, type PeriodRange } from '@/features/expenses/period';
+import ExpenseList from '@/features/expenses/ExpenseList';
+
+/** Le seau « hors budget » s'ouvre comme une enveloppe — même page, même geste. */
+export const UNBUDGETED = 'none';
+
+/** Les mêmes périodes que l'onglet Dépenses, sans le « custom » : on ouvre un
+ *  compteur affiché, pas une recherche libre. */
+const PRESETS: PeriodPreset[] = ['currentMonth', 'previousMonth', 'last30Days', 'currentYear'];
+
+/**
+ * De quoi ce budget est-il fait (`/app/money/budgets/:id`).
+ *
+ * Le panneau Budgets affiche « 340 € / 400 € » et s'arrête là. La question
+ * suivante est toujours la même — *lesquelles* ? — et jusqu'ici il fallait
+ * partir dans l'onglet Dépenses et refaire le filtre à la main, sans garantie de
+ * retomber sur le même chiffre.
+ *
+ * Cette page part du compteur : la période par défaut est **le mois en cours**,
+ * celle du panneau, pour que le total affiché ici soit exactement celui sur
+ * lequel on a cliqué. Changer de période est ensuite un choix explicite.
+ */
+export default function BudgetDetailPage() {
+  const { t } = useTranslation();
+  const { id = '' } = useParams<{ id: string }>();
+  const isUnbudgeted = id === UNBUDGETED;
+
+  const [period, setPeriod] = useSessionState<PeriodRange>('budget.detail.period', {
+    preset: 'currentMonth',
+  });
+  const range = React.useMemo(() => resolvePeriod(period), [period]);
+
+  // Le nom et le plafond viennent de l'aperçu, déjà en cache quand on arrive du
+  // panneau : ouvrir un budget ne doit pas coûter un aller-retour de plus.
+  const overviewQuery = useBudgetOverview();
+  const row = React.useMemo(() => {
+    const rows = overviewQuery.data;
+    if (!rows) return null;
+    return [...rows.budgets, ...(rows.global ? [rows.global] : [])].find((b) => b.id === id) ?? null;
+  }, [overviewQuery.data, id]);
+
+  const summaryQuery = useExpenseSummary(
+    React.useMemo(
+      () => ({ from: range.from, to: range.to, budget: id }),
+      [range.from, range.to, id],
+    ),
+  );
+
+  const listFilters = React.useMemo(
+    () => ({
+      type: 'expense' as const,
+      budget: id,
+      ...(range.from ? { start_date: range.from } : {}),
+      ...(range.to ? { end_date: range.to } : {}),
+      limit: 100,
+    }),
+    [id, range.from, range.to],
+  );
+
+  const listQuery = useQuery({
+    queryKey: interactionKeys.list(listFilters),
+    queryFn: () => fetchInteractions(listFilters),
+  });
+
+  const items: InteractionListItem[] = listQuery.data?.items ?? [];
+  const summary = summaryQuery.data;
+  const isLoading = summaryQuery.isLoading || listQuery.isLoading;
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  const title = isUnbudgeted ? t('budget.unbudgeted.label') : (row?.name ?? t('budget.title'));
+  // Un plafond n'a de sens que sur le mois en cours : le comparer à un total
+  // annuel afficherait « 4 200 € / 400 € », un dépassement qui n'existe pas.
+  const showCeiling = period.preset === 'currentMonth' && row?.amount != null;
+
+  return (
+    <>
+      <BackLink fallback="/app/money?tab=budgets" fallbackLabel={t('budget.title')} />
+      <PageHeader
+        title={title}
+        description={
+          isUnbudgeted ? t('budget.unbudgeted.hint') : t('budgetDetail.description')
+        }
+      />
+
+      <div className="flex flex-wrap gap-1.5 pb-4">
+        {PRESETS.map((preset) => (
+          <FilterPill
+            key={preset}
+            active={period.preset === preset}
+            onClick={() => setPeriod({ preset })}
+          >
+            {t(`expenses.filters.period.${preset}`)}
+          </FilterPill>
+        ))}
+      </div>
+
+      {showSkeleton ? (
+        <div className="space-y-2">
+          <div className="h-20 animate-pulse rounded-lg bg-muted" />
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      ) : null}
+
+      {!isLoading && summary ? (
+        <div className="space-y-4">
+          <Card className="p-4">
+            <p className="text-xs text-muted-foreground">{t('budgetDetail.spent')}</p>
+            <p className="mt-0.5 text-2xl font-semibold tabular-nums text-foreground">
+              {formatAmount(summary.total)}
+              {showCeiling ? (
+                <span className="text-base font-normal text-muted-foreground">
+                  {' / '}
+                  {formatAmount(row?.amount)}
+                </span>
+              ) : null}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('budgetDetail.count', { count: summary.count })}
+            </p>
+          </Card>
+
+          {items.length === 0 ? (
+            <EmptyState
+              icon={Receipt}
+              title={t('budgetDetail.empty')}
+              description={t('budgetDetail.emptyDescription')}
+            />
+          ) : (
+            <>
+              <ExpenseList items={items} />
+              {/* La liste est plafonnée : le dire plutôt que laisser croire que
+                  le total ne correspond pas aux lignes affichées. */}
+              {(listQuery.data?.count ?? 0) > items.length ? (
+                <p className="text-center text-xs text-muted-foreground">
+                  {t('budgetDetail.truncated', {
+                    shown: items.length,
+                    total: listQuery.data?.count ?? 0,
+                  })}
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/ui/src/features/money/BudgetsPanel.tsx
+++ b/ui/src/features/money/BudgetsPanel.tsx
@@ -116,6 +116,8 @@ export default function BudgetsPanel() {
                 <h2 className="text-sm font-semibold text-foreground">{t('budget.global.heading')}</h2>
                 <BudgetCard
                   row={globalRow}
+                  to={`/app/money/budgets/${globalRow.id}`}
+                  backState={pushBack(location)}
                   onEdit={() => openEdit(rowToBudget(globalRow, true))}
                   onDelete={() => handleDelete(globalRow.id)}
                 />
@@ -151,6 +153,8 @@ export default function BudgetsPanel() {
                     <BudgetCard
                       key={row.id}
                       row={row}
+                      to={`/app/money/budgets/${row.id}`}
+                      backState={pushBack(location)}
                       onEdit={() => openEdit(rowToBudget(row, false))}
                       onDelete={() => handleDelete(row.id)}
                     />
@@ -159,16 +163,26 @@ export default function BudgetsPanel() {
               )}
             </div>
 
-            {/* Hors budget — always visible, no ceiling. */}
-            <Card className="flex items-center justify-between gap-3 p-3">
-              <div className="min-w-0">
-                <p className="font-medium text-foreground">{t('budget.unbudgeted.label')}</p>
-                <p className="text-xs text-muted-foreground">{t('budget.unbudgeted.hint')}</p>
-              </div>
-              <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
-                {formatAmount(overview.unbudgeted)}
-              </span>
-            </Card>
+            {/* Hors budget — toujours visible, sans plafond, et **ouvrable**
+                comme une enveloppe : c'est le seau où l'on cherche le plus
+                souvent « mais qu'est-ce qu'il y a là-dedans ? ». */}
+            <Link
+              to="/app/money/budgets/none"
+              state={pushBack(location)}
+              className="group block"
+            >
+              <Card className="flex items-center justify-between gap-3 p-3 transition-colors hover:bg-accent/60">
+                <div className="min-w-0">
+                  <p className="font-medium text-foreground group-hover:underline">
+                    {t('budget.unbudgeted.label')}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{t('budget.unbudgeted.hint')}</p>
+                </div>
+                <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
+                  {formatAmount(overview.unbudgeted)}
+                </span>
+              </Card>
+            </Link>
           </div>
         )
       ) : null}

--- a/ui/src/lib/api/expenses.ts
+++ b/ui/src/lib/api/expenses.ts
@@ -32,6 +32,8 @@ export interface ExpenseSummaryFilters {
   to?: string;
   supplier?: string;
   kind?: string;
+  /** Id d'un budget, ou `'none'` pour le seau « hors budget ». */
+  budget?: string;
 }
 
 export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): Promise<ExpenseSummary> {
@@ -40,6 +42,7 @@ export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): 
   if (filters.to) params.to = filters.to;
   if (filters.supplier) params.supplier = filters.supplier;
   if (filters.kind) params.kind = filters.kind;
+  if (filters.budget) params.budget = filters.budget;
   const { data } = await api.get<ExpenseSummary>('/interactions/interactions/expenses/summary/', { params });
   return data;
 }

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -80,6 +80,8 @@ interface FetchInteractionsOptions {
   end_date?: string;
   kind?: string;
   supplier?: string;
+  /** Id d'un budget, ou `'none'` pour le seau « hors budget ». */
+  budget?: string;
   limit?: number;
   offset?: number;
 }
@@ -143,6 +145,7 @@ export async function fetchInteractions(
     end_date,
     kind,
     supplier,
+    budget,
     limit = 8,
     offset = 0,
   } = options;
@@ -158,6 +161,8 @@ export async function fetchInteractions(
   if (end_date) params.end_date = end_date;
   if (kind) params.kind = kind;
   if (supplier !== undefined) params.supplier = supplier;
+  // `'none'` est une valeur (« hors budget »), pas l'absence de filtre.
+  if (budget) params.budget = budget;
   if (limit > 0) params.limit = limit;
   if (offset > 0) params.offset = offset;
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1585,7 +1585,7 @@
           },
           "track": {
             "title": "Den Monat verfolgen",
-            "body": "Jedes begrenzte Budget zeigt Ausgaben vs. Obergrenze mit einem Fortschrittsbalken — orange nahe der Grenze, rot bei Überschreitung. Eine Kategorie ohne Obergrenze zeigt nur ihre Summe. Die Zähler starten jeden Monat neu."
+            "body": "Jedes begrenzte Budget zeigt Ausgaben vs. Obergrenze mit einem Fortschrittsbalken — orange nahe der Grenze, rot bei Überschreitung. Eine Kategorie ohne Obergrenze zeigt nur ihre Summe. Die Zähler starten jeden Monat neu. Tippe auf ein Budget, um die Ausgaben zu sehen, aus denen sein Zähler besteht — „Ohne Budget“ öffnet sich genauso."
           },
           "analysis": {
             "title": "Sehen, wohin es wirklich geht",
@@ -3154,6 +3154,15 @@
     "uncapped": {
       "hint": "Verfolgte Kategorie, ohne Obergrenze"
     }
+  },
+  "budgetDetail": {
+    "description": "Die Ausgaben, aus denen dieser Zähler besteht.",
+    "spent": "Ausgegeben im Zeitraum",
+    "count_one": "{{count}} Ausgabe",
+    "count_other": "{{count}} Ausgaben",
+    "empty": "Keine Ausgabe in diesem Zeitraum",
+    "emptyDescription": "Ändere den Zeitraum oder ordne Ausgaben diesem Budget zu.",
+    "truncated": "{{shown}} von {{total}} Ausgaben angezeigt."
   },
   "analysis": {
     "title": "Ausgabenanalyse",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1585,7 +1585,7 @@
           },
           "track": {
             "title": "Track the month",
-            "body": "Each capped budget shows spent vs ceiling with a progress bar — amber near the limit, red once over. A category with no ceiling shows its total only. Counters reset every month."
+            "body": "Each capped budget shows spent vs ceiling with a progress bar — amber near the limit, red once over. A category with no ceiling shows its total only. Counters reset every month. Tap a budget to see the expenses its counter is made of — “Unbudgeted” opens the same way."
           },
           "analysis": {
             "title": "See where it actually goes",
@@ -3154,6 +3154,15 @@
     "uncapped": {
       "hint": "Tracked category, no ceiling"
     }
+  },
+  "budgetDetail": {
+    "description": "The expenses this counter is made of.",
+    "spent": "Spent over the period",
+    "count_one": "{{count}} expense",
+    "count_other": "{{count}} expenses",
+    "empty": "No expense in this period",
+    "emptyDescription": "Change the period, or sort some expenses into this budget.",
+    "truncated": "Showing {{shown}} of {{total}} expenses."
   },
   "analysis": {
     "title": "Spending analysis",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1585,7 +1585,7 @@
           },
           "track": {
             "title": "Seguir el mes",
-            "body": "Cada presupuesto con tope muestra lo gastado frente al tope con una barra de progreso — naranja cerca del límite, rojo al superarlo. Una categoría sin tope muestra solo su total. Los contadores se reinician cada mes."
+            "body": "Cada presupuesto con tope muestra lo gastado frente al tope con una barra de progreso — naranja cerca del límite, rojo al superarlo. Una categoría sin tope muestra solo su total. Los contadores se reinician cada mes. Toca un presupuesto para ver los gastos que componen su contador: «Sin presupuesto» se abre igual."
           },
           "analysis": {
             "title": "Ver adónde va de verdad",
@@ -3154,6 +3154,15 @@
     "uncapped": {
       "hint": "Categoría seguida, sin tope"
     }
+  },
+  "budgetDetail": {
+    "description": "Los gastos que componen este contador.",
+    "spent": "Gastado en el periodo",
+    "count_one": "{{count}} gasto",
+    "count_other": "{{count}} gastos",
+    "empty": "Ningún gasto en este periodo",
+    "emptyDescription": "Cambia de periodo o clasifica gastos en este presupuesto.",
+    "truncated": "Mostrando {{shown}} de {{total}} gastos."
   },
   "analysis": {
     "title": "Análisis de gastos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1585,7 +1585,7 @@
           },
           "track": {
             "title": "Suivre le mois",
-            "body": "Chaque budget plafonné affiche le dépensé vs le plafond avec une barre de progression — orange près de la limite, rouge en cas de dépassement. Une catégorie sans plafond affiche seulement son total. Les compteurs repartent à zéro chaque mois."
+            "body": "Chaque budget plafonné affiche le dépensé vs le plafond avec une barre de progression — orange près de la limite, rouge en cas de dépassement. Une catégorie sans plafond affiche seulement son total. Les compteurs repartent à zéro chaque mois. Touche un budget pour voir les dépenses qui composent son compteur — « Hors budget » s'ouvre pareil."
           },
           "analysis": {
             "title": "Comprendre où ça part",
@@ -3154,6 +3154,15 @@
     "uncapped": {
       "hint": "Catégorie suivie, sans plafond"
     }
+  },
+  "budgetDetail": {
+    "description": "Les dépenses qui composent ce compteur.",
+    "spent": "Dépensé sur la période",
+    "count_one": "{{count}} dépense",
+    "count_other": "{{count}} dépenses",
+    "empty": "Aucune dépense sur cette période",
+    "emptyDescription": "Change de période, ou range des dépenses dans ce budget.",
+    "truncated": "{{shown}} dépenses affichées sur {{total}}."
   },
   "analysis": {
     "title": "Analyse des dépenses",

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -50,6 +50,7 @@ const MoneyPage = lazyWithReload(() => import('./features/money/MoneyPage'));
 const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPage'));
 const ReportsPage = lazyWithReload(() => import('./features/budget/ReportsPage'));
 const MoneyAnalysisPage = lazyWithReload(() => import('./features/money/AnalysisPage'));
+const BudgetDetailPage = lazyWithReload(() => import('./features/money/BudgetDetailPage'));
 const BankingTransactionsPage = lazyWithReload(
   () => import('./features/banking/TransactionsPage'),
 );
@@ -87,6 +88,7 @@ export const router = createBrowserRouter([
       { path: 'money', element: <MoneyPage /> },
       { path: 'money/transactions', element: <BankingTransactionsPage /> },
       { path: 'money/analysis', element: <MoneyAnalysisPage /> },
+      { path: 'money/budgets/:id', element: <BudgetDetailPage /> },
       { path: 'budget/recurring', element: <RecurringPage /> },
       { path: 'budget/reports', element: <ReportsPage /> },
       // Anciennes URLs (parcours 26, lot 2) : les favoris, les liens de l'agent et


### PR DESCRIPTION
## Ce que ça fait

Toucher un budget dans le panneau ouvre `/app/money/budgets/:id` : le total de la période, le nombre de dépenses, et **la liste**. Jusqu'ici, la seule façon de voir *lesquelles* était de partir dans l'onglet Dépenses et de refaire le filtre à la main — sans garantie de retomber sur le même chiffre.

**« Hors budget » s'ouvre pareil** (`/app/money/budgets/none`) : c'est justement le seau où l'on cherche le plus souvent ce qu'il y a dedans.

## Les décisions

- **La période par défaut est le mois en cours**, celle du panneau : le total de la page est exactement celui sur lequel on vient de cliquer. Changer de période est ensuite un choix explicite.
- **Le plafond ne s'affiche que sur le mois en cours.** Le comparer à un total annuel donnerait « 4 200 € / 400 € » — un dépassement qui n'existe pas.
- **`budget=none` est une valeur, pas l'absence de filtre.** Dans une query string, « pas de filtre » et « aucun budget » sont deux demandes différentes ; sans cette valeur, lister le hors-budget imposerait de charger tout le journal et de le refiltrer côté client.
- **Le lien porte le corps de la carte**, pas la carte entière : le dropdown d'actions est un enfant, et l'imbriquer dans un `<a>` en ferait un déclencheur de navigation au premier clic.
- Un id malformé liste **zéro** dépense plutôt que tout le journal, et répond **400** sur le résumé plutôt que de crasher le driver. Le filtre s'applique après le scope foyer : il ne peut jamais l'élargir.

## Un bug silencieux trouvé en câblant

Une date de fin **nue** était lue à minuit sur un filtre `__lte`. Donc `to=2026-07-31` excluait **toutes** les dépenses du 31 : le dernier jour de chaque période disparaissait des totaux *et* de la liste, sans rien dire.

C'est ce qui m'a mis la puce à l'oreille : le détail d'un budget ne pouvait pas tomber d'accord avec le compteur affiché juste à côté, puisque les deux ne calculaient pas la même chose. Corrigé dans `_parse_period` **et** dans le filtre `end_date`, avec `TestTheLastDayOfThePeriodCounts`. Un instant explicite (`...T12:00:00Z`) reste respecté tel quel — qui écrit une heure sait ce qu'il demande.

**L'onglet Dépenses en bénéficie aussi** : ses totaux mensuels étaient amputés du dernier jour.

## Vérification

- `pytest --create-db` : **3369 passed, 2 skipped** (10 nouveaux)
- `npm run build` + `npm run lint` propres
- i18n ×4 (`budgetDetail`), tutoriel « Budgets » complété ×4
- `docs/MODULES/budget.md` + `docs/MODULES/money.md`