### PR TITLE
fix(money): un compteur ne peut pas avoir deux définitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Les tests unitaires du front n'étaient lancés par personne. C'est là que
+      # vit le garde-fou i18n : il compare le code aux quatre catalogues, et
+      # c'est le seul contrôle capable d'attraper une clé écrasée — la parité
+      # entre langues ne voit rien quand la clé manque partout.
+      - name: Unit tests
+        run: npm run test -- --run
+
       - name: Build
         run: npm run build
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,7 +255,23 @@ Doc : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` + section « Conformité 
   « conforme » sans avoir vérifié que le contrôle a pu s'exécuter.
 - **Le badge doit rester bon marché** : `DetectorSpec.count` est un `COUNT(*)`
   indexé, `findings` est paginé et ne tourne que pour le groupe ouvert. Ne jamais
-  matérialiser les écarts en Python pour les compter.
+  matérialiser les écarts en Python pour les compter. Et **ouvrir un groupe ne
+  recompte que lui** (`compliance.group_result`) : passer par `summary()` pour
+  sérialiser un seul en-tête relançait les quatorze détecteurs, dont la marche
+  arithmétique sur les soldes.
+- **Un détecteur non-SQL passe par `compliance.apply_window_to_pairs`.** La moitié
+  du catalogue raisonne sur ce qu'aucun `COUNT(*)` n'exprime (une chaîne de soldes,
+  une reconstruction, un solde espèces) et renvoie `[(objet, détail), …]` ; le
+  filtrage `pks / exclude_pks / limit / offset` est le même pour tous et n'a pas à
+  être réécrit — il l'a été six fois.
+- **Toute écriture sur l'argent invalide tout l'argent** (`useInvalidateMoney`,
+  `ui/src/features/money/invalidate.ts`). Les cinq racines de cache — `banking`,
+  `interactions`, `expenses`, `budget`, `compliance` — sont déclarées dans
+  `money/keys.ts` et jamais en littéral au point d'appel. Chaque hook listait sa
+  propre combinaison et elles avaient dérivé : importer un relevé n'invalidait que
+  `banking`, rattacher une dépense ne touchait pas la conformité. Invalider trop
+  large coûte quelques requêtes ; invalider trop étroit coûte la confiance dans
+  les chiffres, et ne se voit pas en revue.
 - Le libellé utilisateur d'un `kind` vit dans le namespace i18n **`money`** du
   front, pas en `gettext` backend : ajouter un détecteur ne doit pas imposer un
   passage dans quatre `.po`.
@@ -574,6 +590,52 @@ import { formatAmount } from '@/lib/format';
 formatAmount('12.50')                      // « 12,50 € » (fr)
 formatAmount(420, { fractionDigits: 0 })   // « 420 € »
 ```
+
+### Dates de calendrier — jamais `toISOString()`
+
+Même règle, pour la même raison. Une date `YYYY-MM-DD` passe par
+**`toLocalISODate` / `todayISO` de `@/lib/format`**, jamais par
+`new Date().toISOString().slice(0, 10)`.
+
+```ts
+// ❌ Interdit — convertit en UTC avant de formater
+const from = new Date(y, m, 1).toISOString().slice(0, 10);
+
+// ✅ Correct
+import { todayISO, toLocalISODate } from '@/lib/format';
+```
+
+**Pourquoi :** `toISOString()` passe en UTC. À Paris, minuit local recule d'un
+jour, et tout ce qui se produit entre minuit et 2 h est daté de la veille. Les
+quatre périodes de l'onglet Dépenses partaient décalées aux deux bouts (« ce mois-ci »
+= 30 juin → 30 juillet), et dix formulaires proposaient « hier » comme date du
+jour pendant deux heures chaque nuit. Régression :
+`ui/src/features/expenses/period.test.ts`.
+
+Côté serveur, le pendant est `core.timezones` (voir plus bas).
+
+### Le fuseau du foyer — `core.timezones`, et rien d'autre
+
+Toute borne de période, toute notion d'« aujourd'hui », passe par
+`apps/core/timezones.py` : `household_tz`, `household_today`, `start_of_day`,
+`end_of_day`, `month_range`, `current_month_range`.
+
+- **Jamais `date.today()`** (horloge du serveur, UTC en conteneur) ni
+  `timezone.localdate()` (le `TIME_ZONE` du projet, UTC aussi) quand la question
+  est « quel jour est-on **chez le foyer** ».
+- **Jamais un `try: ZoneInfo(...) except:` local** — le helper existait en six
+  exemplaires, et c'est cette dispersion qui a produit le bug ci-dessous.
+- **Une date nue en fin d'intervalle vaut fin de journée.** Un `__lte` la lit
+  sinon à minuit et exclut le dernier jour de la période.
+
+**Pourquoi c'est du métier et pas de la plomberie :** « ce mois-ci » avait deux
+définitions — fuseau du foyer pour le panneau Budgets, UTC pour le résumé des
+dépenses. La borne d'un mois décide de quel budget relève un euro, donc cliquer
+sur « 340 € / 400 € » pouvait ouvrir une page annonçant 352 €, chacune juste
+selon sa propre borne. C'est la règle « un écart ne se dit jamais deux fois avec
+deux voix » appliquée à un montant : **un compteur ne peut pas avoir deux
+définitions.** Régression :
+`apps/interactions/tests/test_period_bounds.py::TestTheTwoScreensAgree`.
 
 ---
 

--- a/apps/banking/aggregations.py
+++ b/apps/banking/aggregations.py
@@ -70,24 +70,29 @@ def _unallocated_outflow(qs) -> Decimal:
     Calculée par différence sur la **même** requête que les totaux, et non par une
     somme de dépenses : mélanger les deux sources est précisément ce que la règle
     transverse interdit.
+
+    Passe par ``queries.with_allocation`` — la **même** annotation que le marqueur
+    du journal et que les détecteurs. Elle était réécrite ici à la main, ce qui
+    faisait trois copies d'une définition dont le docstring dit qu'elle doit être
+    unique : la troisième aurait fini par diverger d'un filtre, et le taux de
+    couverture aurait contredit le contrôle sans que personne sache lequel croire.
+
+    Ce que ce chiffre mesure reste distinct de ce que le Contrôle *exige* : ici,
+    tout ce qui est sorti sur la période demandée et que rien n'explique ; là-bas,
+    seulement ce qui tombe dans la fenêtre de conformité. Une mesure et une
+    exigence, pas deux verdicts sur le même fait.
     """
-    from django.db.models import Q, Sum
-    from django.db.models.functions import Coalesce
+    from .queries import with_allocation
 
-    from .queries import ZERO, outflow_expr
-
-    rows = qs.filter(amount__lt=0).annotate(
-        allocated=Coalesce(
-            Sum("interactions__amount", filter=Q(interactions__type="expense")),
-            ZERO,
+    rows = with_allocation(qs.filter(amount__lt=0)).values("allocated", "outflow_value")
+    total = sum(
+        (
+            row["outflow_value"] - row["allocated"]
+            for row in rows
+            if row["outflow_value"] > row["allocated"]
         ),
-        outflow_value=outflow_expr(),
+        Decimal("0.00"),
     )
-    total = Decimal("0.00")
-    for row in rows.values("allocated", "outflow_value"):
-        gap = row["outflow_value"] - row["allocated"]
-        if gap > 0:
-            total += gap
     return total.quantize(Decimal("0.01"))
 
 

--- a/apps/banking/compliance.py
+++ b/apps/banking/compliance.py
@@ -160,6 +160,30 @@ def apply_window(qs: QuerySet, *, pks=None, exclude_pks=None, limit=None, offset
     return qs
 
 
+def apply_window_to_pairs(pairs, *, pks=None, exclude_pks=None, limit=None, offset=None):
+    """Same contract as :func:`apply_window`, for detectors that cannot be SQL.
+
+    Half the catalogue reasons about something no ``COUNT(*)`` can express — a
+    balance chain walked in arithmetic order, a reconstruction re-verified, a cash
+    balance computed. Those detectors return ``[(object, detail), …]`` and were
+    each re-implementing this filtering by hand: six identical copies, and the
+    next non-SQL detector would have made seven.
+
+    Kept byte-for-byte equivalent to the queryset version, exclusions **before**
+    the slice included — a page of 20 must hold 20 open écarts.
+    """
+    if pks is not None:
+        wanted = {str(p) for p in pks}
+        pairs = [pair for pair in pairs if str(pair[0].pk) in wanted]
+    if exclude_pks:
+        unwanted = {str(p) for p in exclude_pks}
+        pairs = [pair for pair in pairs if str(pair[0].pk) not in unwanted]
+    if offset or limit:
+        start = offset or 0
+        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    return pairs
+
+
 # --- Waiver resolution -------------------------------------------------------
 
 
@@ -220,20 +244,27 @@ def _split_waived(household, spec: DetectorSpec) -> tuple[dict[str, object], dic
     return fresh, stale
 
 
+def group_result(household, spec: DetectorSpec) -> GroupResult:
+    """Counts for **one** detector.
+
+    Extracted so opening a group costs one detector instead of all of them: the
+    detail endpoint used to call :func:`summary` just to serialize the header of
+    the group it was already computing, which re-ran fourteen counts — including
+    the balance-chain walk and the cash-balance computation — for a number it
+    needed once.
+    """
+    fresh, stale = _split_waived(household, spec)
+    return GroupResult(
+        spec=spec,
+        detected=spec.count(household),
+        waived=len(fresh),
+        stale=len(stale),
+    )
+
+
 def summary(household) -> list[GroupResult]:
     """Counts for every registered detector — what the shell badge reads."""
-    results = []
-    for spec in REGISTRY:
-        fresh, stale = _split_waived(household, spec)
-        results.append(
-            GroupResult(
-                spec=spec,
-                detected=spec.count(household),
-                waived=len(fresh),
-                stale=len(stale),
-            )
-        )
-    return results
+    return [group_result(household, spec) for spec in REGISTRY]
 
 
 def open_findings(household, spec: DetectorSpec, *, limit=None, offset=None) -> list[Finding]:

--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -27,10 +27,11 @@ Registered from ``banking.apps.BankingConfig.ready()``.
 """
 from __future__ import annotations
 
-from datetime import date
 from decimal import Decimal
 
 from django.db.models import F, Q
+
+from core.timezones import household_today
 
 from .balances import check_balance_chain
 from .compliance import (
@@ -40,6 +41,7 @@ from .compliance import (
     DetectorSpec,
     Finding,
     apply_window,
+    apply_window_to_pairs,
     fingerprint_of,
     get_detector,
     register,
@@ -68,6 +70,30 @@ ACCOUNT_ANCHOR_STALE = "account_anchor_stale"
 # --- Shared base: spendable outflows inside their account's window -----------
 
 
+def _window_scope(household) -> Q:
+    """``Q`` matching every line inside its own account's conformity window.
+
+    Matches nothing when no account has a window at all: nothing can be asserted,
+    and the prerequisite detector is the one doing the talking. That case is an
+    impossible ``Q``, not ``.none()`` — an ``EmptyQuerySet`` carries no annotations,
+    so callers filtering on ``allocated`` would hit a ``FieldError`` instead of
+    getting zero rows.
+    """
+    scope = Q(pk__in=[])
+    for account, window in accounts_with_window(household):
+        scope |= Q(account=account, booked_on__gte=window.start, booked_on__lte=window.end)
+    return scope
+
+
+def _scoped_lines(household):
+    """Every line inside its account's conformity window, unfiltered otherwise."""
+    return (
+        BankTransaction.objects.filter(household=household)
+        .filter(_window_scope(household))
+        .select_related("account")
+    )
+
+
 def _allocatable_outflows(household):
     """Outgoing operations the household is expected to account for.
 
@@ -78,26 +104,29 @@ def _allocatable_outflows(household):
       when the cash they fed is actually spent — allocating them would double it,
       which is the same rule ``validators.assert_allocation_fits`` enforces;
     - anything outside its account's conformity window.
-
-    Matches nothing when no account has a window at all: nothing can be asserted,
-    and the prerequisite detector is the one doing the talking. That case is an
-    impossible ``Q``, not ``.none()`` — an ``EmptyQuerySet`` carries no annotations,
-    so callers filtering on ``allocated`` would hit a ``FieldError`` instead of
-    getting zero rows.
     """
-    pairs = accounts_with_window(household)
-
-    scope = Q(pk__in=[])
-    for account, window in pairs:
-        scope |= Q(account=account, booked_on__gte=window.start, booked_on__lte=window.end)
-
     # ``with_allocation`` is shared with the journal badge on purpose: the count
     # on the Contrôle tab and the marker on the line must be the same judgement.
     return with_allocation(
-        BankTransaction.objects.filter(household=household)
-        .filter(scope)
-        .filter(amount__lt=0, is_internal=False, transfer_counterpart__isnull=True)
-    ).select_related("account")
+        _scoped_lines(household).filter(
+            amount__lt=0, is_internal=False, transfer_counterpart__isnull=True
+        )
+    )
+
+
+def pending_outflows(household):
+    """Les lignes que le contrôle réclame — non ventilées **et** partielles.
+
+    Union exacte des deux détecteurs de rangement, exprimée une fois : le journal
+    l'utilise pour son filtre « à traiter », le Contrôle pour ses compteurs. Un
+    filtre qui recalculerait son propre critère finirait par montrer une liste
+    dont le nombre de lignes ne tombe pas d'accord avec le badge juste au-dessus —
+    et c'est précisément ce que la règle « jamais deux voix » interdit.
+
+    ``allocated < outflow_value`` couvre les deux cas d'un coup : zéro alloué, et
+    partiellement alloué.
+    """
+    return _allocatable_outflows(household).filter(allocated__lt=F("outflow_value"))
 
 
 def _unallocated_qs(household):
@@ -284,15 +313,9 @@ def _count_without_window(household) -> int:
 
 def _find_without_window(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _accounts_without_window(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(
@@ -329,17 +352,6 @@ def _earliest_line_date(account) -> str | None:
 
 
 # --- Receipts and internal movements (lot 5) ---------------------------------
-
-
-def _scoped_lines(household):
-    """Every line inside its account's conformity window, unfiltered otherwise."""
-    pairs = accounts_with_window(household)
-    scope = Q(pk__in=[])
-    for account, window in pairs:
-        scope |= Q(account=account, booked_on__gte=window.start, booked_on__lte=window.end)
-    return (
-        BankTransaction.objects.filter(household=household).filter(scope).select_related("account")
-    )
 
 
 def _unclassified_inflow_qs(household):
@@ -447,15 +459,9 @@ def _count_period_gaps(household) -> int:
 
 def _find_period_gaps(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _period_gap_pairs(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(
@@ -577,15 +583,9 @@ def _count_stale_anchors(household) -> int:
 
 def _find_stale_anchors(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _stale_anchor_pairs(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(
@@ -619,11 +619,17 @@ def _overdue_recurring_qs(household):
     No conformity window here: a recurrence is a *schedule*, not a statement line.
     Its due date being in the past is a fact regardless of which periods have been
     imported.
+
+    « Aujourd'hui » se lit **chez le foyer**, jamais avec ``date.today()`` : ce
+    dernier lit l'horloge du serveur (UTC en conteneur), donc un foyer à Paris
+    voyait une échéance basculer « en retard » deux heures trop tôt — et le
+    Contrôle comptait autre chose que la liste « échéances dues », qui utilisait
+    déjà le bon fuseau.
     """
     from budget.models import RecurringExpense
 
     return RecurringExpense.objects.filter(
-        household=household, next_due_date__lt=date.today()
+        household=household, next_due_date__lt=household_today(household)
     )
 
 
@@ -632,7 +638,7 @@ def _count_overdue_recurring(household) -> int:
 
 
 def _find_overdue_recurring(household, **window) -> list[Finding]:
-    today = date.today()
+    today = household_today(household)
     return [
         Finding(
             kind=RECURRING_OVERDUE,
@@ -697,15 +703,9 @@ def _count_double_confirmed(household) -> int:
 
 def _find_double_confirmed(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _double_confirmed_pairs(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(
@@ -752,15 +752,9 @@ def _count_negative_cash(household) -> int:
 
 def _find_negative_cash(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _negative_cash_pairs(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(
@@ -796,15 +790,9 @@ def _count_chain_broken(household) -> int:
 
 def _find_chain_broken(household, *, pks=None, exclude_pks=None, limit=None, offset=None):
     pairs = _chain_broken_pairs(household)
-    if pks is not None:
-        wanted = {str(p) for p in pks}
-        pairs = [p for p in pairs if str(p[0].pk) in wanted]
-    if exclude_pks:
-        unwanted = {str(p) for p in exclude_pks}
-        pairs = [p for p in pairs if str(p[0].pk) not in unwanted]
-    if offset or limit:
-        start = offset or 0
-        pairs = pairs[start : start + limit] if limit else pairs[start:]
+    pairs = apply_window_to_pairs(
+        pairs, pks=pks, exclude_pks=exclude_pks, limit=limit, offset=offset
+    )
 
     return [
         Finding(

--- a/apps/banking/matching.py
+++ b/apps/banking/matching.py
@@ -22,6 +22,8 @@ from zoneinfo import ZoneInfo
 from django.conf import settings
 from django.db.transaction import atomic
 
+from core.timezones import household_tz as _household_tz
+
 from .importers.parsing import normalize_label
 from .models import BankTransaction
 from interactions.kinds import KIND_RECURRING
@@ -52,13 +54,6 @@ class MatchCandidate:
     @property
     def is_exact_amount(self) -> bool:
         return self.amount_delta == 0
-
-
-def _household_tz(household) -> ZoneInfo:
-    try:
-        return ZoneInfo(getattr(household, "timezone", "") or "UTC")
-    except Exception:
-        return ZoneInfo("UTC")
 
 
 def _occurred_date(interaction, tz: ZoneInfo) -> date:

--- a/apps/banking/services.py
+++ b/apps/banking/services.py
@@ -541,7 +541,6 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
     stale total and jointly overshoot.
     """
     from interactions.kinds import OWNED_BY_ALLOCATION_EDITOR
-    from interactions.models import Interaction
     from interactions.services import create_bank_expense_interaction
 
     with atomic():
@@ -602,8 +601,6 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
                 # message actionable on a five-line split.
                 raise ValidationError({"lines": f"line {index + 1}: {exc}"})
 
-        # Refresh so the caller sees the linked state rather than a stale copy.
-        Interaction.objects.filter(pk__in=[i.pk for i in created])
         return created
 
 

--- a/apps/banking/tests/test_compliance.py
+++ b/apps/banking/tests/test_compliance.py
@@ -806,3 +806,94 @@ class TestExpenseWithoutBudget:
 
         result = group(household, EXPENSE_WITHOUT_BUDGET)
         assert (result.open, result.waived) == (0, 1)
+
+
+# --- Le coût d'ouvrir un groupe (audit du parcours 26) ------------------------
+
+
+@pytest.mark.django_db
+class TestOpeningOneGroupCostsOneDetector:
+    """Ouvrir un groupe ne doit pas recompter les treize autres.
+
+    L'endpoint de détail sérialisait son en-tête en appelant ``summary()``, donc
+    en relançant **tous** les détecteurs — dont la marche arithmétique sur la
+    chaîne de soldes et le calcul du solde espèces — pour un chiffre dont il
+    n'avait besoin qu'une fois. Le badge, lui, a le droit : c'est son travail.
+    """
+
+    def test_group_result_is_cheaper_than_the_whole_summary(
+        self, ctx, django_assert_max_num_queries
+    ):
+        household, _, account, _ = ctx
+        for index in range(5):
+            make_txn(account, label=f"CB ACHAT {index}")
+
+        with django_assert_max_num_queries(500) as captured:
+            compliance.summary(household)
+        full = len(captured.captured_queries)
+
+        with django_assert_max_num_queries(500) as captured:
+            compliance.group_result(household, get_detector(TRANSACTION_UNALLOCATED))
+        one = len(captured.captured_queries)
+
+        # Une borne relative, pas un nombre magique : elle survit à l'ajout d'un
+        # détecteur, et c'est bien la propriété qu'on veut tenir.
+        assert one < full
+        assert one <= full // len(compliance.REGISTRY) + 3
+
+    def test_it_says_the_same_thing_as_the_summary(self, ctx):
+        """Moins cher, mais pas différent — sinon l'en-tête du détail
+        contredirait le badge, ce qui est précisément l'écart qu'on chasse."""
+        household, _, account, _ = ctx
+        make_txn(account)
+
+        for spec in compliance.REGISTRY:
+            from_summary = group(household, spec.kind)
+            direct = compliance.group_result(household, spec)
+            assert (direct.detected, direct.waived, direct.stale) == (
+                from_summary.detected,
+                from_summary.waived,
+                from_summary.stale,
+            ), spec.kind
+
+
+# --- « Aujourd'hui » se lit chez le foyer -------------------------------------
+
+
+@pytest.mark.django_db
+class TestOverdueIsJudgedInTheHouseholdTimezone:
+    """Une échéance bascule « en retard » à minuit **chez le foyer**.
+
+    Le détecteur lisait ``date.today()`` — l'horloge du serveur, UTC en
+    conteneur — alors que la liste « échéances dues » utilisait déjà le fuseau du
+    foyer. Deux heures par jour, le Contrôle et la liste ne comptaient pas la
+    même chose.
+    """
+
+    def test_todays_due_date_is_not_late_yet(self, ctx, monkeypatch):
+        from zoneinfo import ZoneInfo
+
+        from banking.detectors import RECURRING_OVERDUE
+        from budget.models import RecurringExpense
+        from core import timezones as core_tz
+
+        household, user, _, budget = ctx
+        household.timezone = "Pacific/Kiritimati"  # UTC+14 : demain avant tout le monde
+        household.save(update_fields=["timezone"])
+
+        # 23 h 00 UTC le 14 : il est déjà le 15 chez le foyer.
+        fixed = timezone.datetime(2026, 3, 14, 23, 0, tzinfo=ZoneInfo("UTC"))
+        monkeypatch.setattr(core_tz.timezone, "now", lambda: fixed)
+
+        RecurringExpense.objects.create(
+            household=household,
+            budget=budget,
+            label="Assurance",
+            amount=Decimal("30.00"),
+            cadence="monthly",
+            next_due_date=date(2026, 3, 15),
+            created_by=user,
+        )
+
+        # Échéance le 15, on est le 15 chez le foyer : due, pas en retard.
+        assert group(household, RECURRING_OVERDUE).detected == 0

--- a/apps/banking/tests/test_journal_marker.py
+++ b/apps/banking/tests/test_journal_marker.py
@@ -251,3 +251,71 @@ class TestItStaysCheapAndFresh:
 
         assert body["transaction"]["allocation_state"] == "allocated"
         assert body["transaction"]["remaining_amount"] == "0.00"
+
+
+@pytest.mark.django_db
+class TestTheToSortOutFilter:
+    """`?allocation=todo` — le compagnon du marqueur.
+
+    Le marqueur dit ligne par ligne ce qu'il reste à faire ; sans filtre, sur un
+    relevé de 160 lignes, il énonce un reproche qu'on ne peut pas suivre. Le
+    filtre passe par la **même** fonction que les compteurs du Contrôle
+    (``detectors.pending_outflows``) : une liste dont le nombre contredirait le
+    badge ferait perdre leur crédit aux deux.
+    """
+
+    def test_it_keeps_exactly_the_unallocated_and_the_partial(self, ctx):
+        household, user, account, budget, client = ctx
+        untouched = make_txn(account, amount="-120.00", label="CB LECLERC")
+        partial = make_txn(account, amount="-150.00", label="CB LEROY MERLIN")
+        allocate(household, user, partial, budget, "90.00")
+        done = make_txn(account, amount="-40.00", label="CB BOULANGERIE")
+        allocate(household, user, done, budget, "40.00")
+
+        body = client.get(f"{LIST_URL}?allocation=todo").json()
+
+        assert {r["id"] for r in body["results"]} == {str(untouched.pk), str(partial.pk)}
+
+    def test_a_receipt_is_never_to_sort_out(self, ctx):
+        """Une recette n'est pas une dépense à ranger — elle a son propre écart."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="2100.00", label="VIR SALAIRE")
+
+        body = client.get(f"{LIST_URL}?allocation=todo").json()
+
+        assert body["results"] == []
+
+    def test_an_internal_movement_is_never_to_sort_out(self, ctx):
+        """L'argent qui change de poche est compté plus tard, quand il est dépensé."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="-60.00", label="RETRAIT DAB", internal=True)
+
+        body = client.get(f"{LIST_URL}?allocation=todo").json()
+
+        assert body["results"] == []
+
+    def test_the_filter_count_equals_the_control_count(self, ctx):
+        """Le test qui porte la garantie : la file et le badge, nombre pour nombre."""
+        from banking.compliance import get_detector, group_result
+
+        household, user, account, budget, client = ctx
+        for index in range(4):
+            make_txn(account, amount="-30.00", label=f"CB ACHAT {index}")
+        partial = make_txn(account, amount="-80.00", label="CB BRICO")
+        allocate(household, user, partial, budget, "20.00")
+
+        listed = client.get(f"{LIST_URL}?allocation=todo").json()["count"]
+        counted = (
+            group_result(household, get_detector(TRANSACTION_UNALLOCATED)).detected
+            + group_result(household, get_detector(TRANSACTION_PARTIAL)).detected
+        )
+
+        assert listed == counted == 5
+
+    def test_without_the_filter_nothing_is_hidden(self, ctx):
+        """Le filtre est un choix, jamais un défaut : le journal reste entier."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="-120.00")
+        make_txn(account, amount="2100.00", label="VIR SALAIRE")
+
+        assert client.get(LIST_URL).json()["count"] == 2

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -11,6 +11,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
+from core.timezones import household_today
 
 from . import importers
 from .aggregations import EMPTY_FLOW, compute_account_flow
@@ -23,6 +24,7 @@ from .anchoring import (
 from .balances import compute_balance, serialize_balance
 from .compliance import (
     get_detector,
+    group_result,
     open_findings,
     serialize_finding,
     serialize_group,
@@ -385,6 +387,22 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
         if internal is not None and internal != "":
             qs = qs.filter(is_internal=internal.lower() in ("1", "true", "yes"))
 
+        # « À traiter » : les lignes que le contrôle réclame, et rien d'autre.
+        #
+        # Le marqueur par ligne existe depuis #413, mais il n'y avait aucun moyen
+        # de ne voir que celles-là — sur un relevé de 160 lignes, le badge disait
+        # quoi faire sans qu'on puisse s'y rendre. Le filtre passe par
+        # ``detectors.pending_outflows``, donc par le **même** jugement que le
+        # compteur : une liste dont le nombre contredirait le badge serait pire
+        # que pas de filtre du tout.
+        if params.get("allocation") == "todo":
+            household = self.request.household
+            if household is None:
+                return qs.none()
+            from .detectors import pending_outflows
+
+            qs = qs.filter(pk__in=pending_outflows(household).values("pk"))
+
         term = params.get("q")
         if term:
             qs = search(qs, term)
@@ -460,7 +478,12 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
         if account is None:
             raise ValidationError({"account": "Unknown account for this household."})
 
-        booked_on = _parse_date_param(request.data.get("booked_on"), "booked_on") or date.today()
+        # ``household_today`` et non ``date.today()`` : une dépense en espèces
+        # saisie le soir à Paris serait datée du lendemain par l'horloge UTC du
+        # serveur — donc rangée dans le mois suivant deux fois par an.
+        booked_on = _parse_date_param(
+            request.data.get("booked_on"), "booked_on"
+        ) or household_today(household)
 
         try:
             transaction_row, allocations = record_cash_expense(
@@ -740,13 +763,12 @@ class ComplianceViewSet(viewsets.ViewSet):
         )
         return Response(
             {
-                **serialize_group(
-                    next(
-                        group
-                        for group in compliance_summary(household)
-                        if group.spec.kind == spec.kind
-                    )
-                ),
+                # ``group_result`` et non ``summary`` : ouvrir un groupe ne doit
+                # pas recompter les treize autres, dont la marche arithmétique sur
+                # la chaîne de soldes et le calcul du solde espèces. Le badge lit
+                # le résumé complet, c'est son travail ; le détail n'a besoin que
+                # de son propre en-tête.
+                **serialize_group(group_result(household, spec)),
                 "results": [serialize_finding(f) for f in findings],
                 "limit": limit,
                 "offset": offset,

--- a/apps/briefings/schedule.py
+++ b/apps/briefings/schedule.py
@@ -10,23 +10,19 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, time, timedelta
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.utils import timezone
+
+from core.timezones import household_tz as _household_tz
 
 logger = logging.getLogger(__name__)
 
 MIN_SLOT_GAP = timedelta(hours=1)
 
 
-def household_tz(household) -> ZoneInfo:
-    """The household's timezone, falling back to UTC (same as pings)."""
-    name = getattr(household, "timezone", "") or "UTC"
-    try:
-        return ZoneInfo(name)
-    except (ZoneInfoNotFoundError, ValueError):
-        logger.warning("briefings: invalid household timezone %r, using UTC", name)
-        return ZoneInfo("UTC")
+#: Ré-export — la définition vit dans ``core.timezones``, importée ici sous son
+#: nom historique pour ne pas casser les appelants du module.
+household_tz = _household_tz
 
 
 def next_send_at(briefing, *, now: datetime | None = None) -> datetime | None:

--- a/apps/budget/aggregations.py
+++ b/apps/budget/aggregations.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 from datetime import datetime
 from decimal import Decimal
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from django.conf import settings
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
-from django.utils import timezone
 
+from core.timezones import current_month_range as _current_month_range
+from core.timezones import household_today
 from interactions.queries import expenses
 
 from .models import Budget, RecurringExpense
@@ -36,25 +36,14 @@ def _str(amount: Decimal | None) -> str:
 
 
 def current_month_range(household) -> tuple[datetime, datetime, str]:
-    """Return (start, end_exclusive, 'YYYY-MM') for the household's current month.
+    """``(début, fin_exclusive, 'YYYY-MM')`` du mois en cours chez le foyer.
 
-    The month boundary follows the household's IANA timezone so the counters
-    roll over at local midnight on the 1st, not UTC. ``occurred_at`` is stored
-    timezone-aware, so the aware local bounds filter correctly.
+    Alias de ``core.timezones.current_month_range``, conservé parce que c'est le
+    nom sous lequel le module est importé ailleurs. La définition, elle, est
+    unique : le résumé des dépenses la lit aussi, et c'est ce qui garantit que le
+    compteur d'une enveloppe et la page qui l'ouvre bornent le même mois.
     """
-    tz_name = getattr(household, "timezone", "") or "UTC"
-    try:
-        tz = ZoneInfo(tz_name)
-    except Exception:  # pragma: no cover - defensive against a bad tz string
-        tz = ZoneInfo("UTC")
-
-    now_local = timezone.now().astimezone(tz)
-    start = datetime(now_local.year, now_local.month, 1, tzinfo=tz)
-    if now_local.month == 12:
-        end = datetime(now_local.year + 1, 1, 1, tzinfo=tz)
-    else:
-        end = datetime(now_local.year, now_local.month + 1, 1, tzinfo=tz)
-    return start, end, f"{now_local.year:04d}-{now_local.month:02d}"
+    return _current_month_range(household)
 
 
 def _spent_by_budget(household_id, start, end) -> dict:
@@ -200,12 +189,7 @@ def compute_cashflow_projection(*, household, today=None, horizons=(30, 90)) -> 
     from .services import advance_due_date
 
     if today is None:
-        tz_name = getattr(household, "timezone", "") or "UTC"
-        try:
-            tz = ZoneInfo(tz_name)
-        except Exception:  # pragma: no cover
-            tz = ZoneInfo("UTC")
-        today = timezone.now().astimezone(tz).date()
+        today = household_today(household)
 
     recurrences = list(RecurringExpense.objects.filter(household_id=household.id))
     max_horizon = max(horizons) if horizons else 0

--- a/apps/budget/report/service.py
+++ b/apps/budget/report/service.py
@@ -14,10 +14,11 @@ history via the persisted snapshot.
 from __future__ import annotations
 
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from django.db import IntegrityError
-from django.utils import timezone, translation
+from django.utils import translation
+
+from core.timezones import household_today
 
 from ..models import BudgetReport
 from .polish import polish_report
@@ -27,12 +28,8 @@ from .stats import compute_month_stats, previous_month
 
 def last_closed_month(household) -> str:
     """Return the previous calendar month (``YYYY-MM``) in the household tz."""
-    try:
-        tz = ZoneInfo(getattr(household, "timezone", "") or "UTC")
-    except Exception:  # pragma: no cover
-        tz = ZoneInfo("UTC")
-    now = timezone.now().astimezone(tz)
-    return previous_month(f"{now.year:04d}-{now.month:02d}")
+    today = household_today(household)
+    return previous_month(f"{today.year:04d}-{today.month:02d}")
 
 
 def get_or_generate_report(household, month: str) -> BudgetReport:

--- a/apps/budget/report/stats.py
+++ b/apps/budget/report/stats.py
@@ -12,11 +12,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
+from core.timezones import household_tz, month_range
 from interactions.queries import expenses
 
 from ..aggregations import _state, _str, _zero
@@ -25,20 +25,14 @@ from ..models import Budget
 TOP_EXPENSES_LIMIT = 5
 
 
-def _tz(household) -> ZoneInfo:
-    try:
-        return ZoneInfo(getattr(household, "timezone", "") or "UTC")
-    except Exception:  # pragma: no cover - defensive
-        return ZoneInfo("UTC")
+#: Alias historique — la définition vit dans ``core.timezones``.
+_tz = household_tz
 
 
 def month_bounds(household, month: str) -> tuple[datetime, datetime]:
     """Return (start, end_exclusive) aware datetimes for a ``YYYY-MM`` month."""
     year, mon = (int(p) for p in month.split("-"))
-    tz = _tz(household)
-    start = datetime(year, mon, 1, tzinfo=tz)
-    end = datetime(year + 1, 1, 1, tzinfo=tz) if mon == 12 else datetime(year, mon + 1, 1, tzinfo=tz)
-    return start, end
+    return month_range(household, year=year, month=mon)
 
 
 def previous_month(month: str) -> str:

--- a/apps/budget/views.py
+++ b/apps/budget/views.py
@@ -1,14 +1,12 @@
 """Budget REST API views."""
-from zoneinfo import ZoneInfo
-
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.utils import timezone
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
+from core.timezones import household_today
 
 from .aggregations import compute_budget_overview, compute_cashflow_projection
 from .analysis import DEFAULT_MONTHS, compute_budget_analysis
@@ -29,16 +27,6 @@ from .services import (
     update_budget,
     update_recurring_expense,
 )
-
-
-def _household_today(household):
-    """Household-local calendar date (recurrences are date-based, tz-aware)."""
-    tz_name = getattr(household, "timezone", "") or "UTC"
-    try:
-        tz = ZoneInfo(tz_name)
-    except Exception:
-        tz = ZoneInfo("UTC")
-    return timezone.now().astimezone(tz).date()
 
 
 class BudgetViewSet(viewsets.ModelViewSet):
@@ -223,7 +211,7 @@ class RecurringExpenseViewSet(viewsets.ModelViewSet):
         household = request.household
         if household is None:
             return Response([])
-        today = _household_today(household)
+        today = household_today(household)
         qs = self.get_queryset().filter(next_due_date__lte=today)
         return Response(self.get_serializer(qs, many=True).data)
 

--- a/apps/core/timezones.py
+++ b/apps/core/timezones.py
@@ -1,0 +1,103 @@
+"""Le fuseau du foyer — une seule définition, pour tout le projet.
+
+Ce module existe à cause d'un bug qu'aucune de ses six copies ne pouvait
+attraper seule. « Ce mois-ci » était calculé dans le fuseau du foyer par
+``budget.aggregations`` et en UTC par ``interactions.views`` : le panneau Budgets
+et la page qui s'ouvre en cliquant dessus affichaient deux totaux différents pour
+la même enveloppe, et les deux étaient « justes » selon leur propre borne.
+
+La règle du projet dit qu'un écart ne se dit jamais deux fois avec deux voix.
+Elle vaut aussi pour un montant : **un compteur ne peut pas avoir deux
+définitions**. Une borne de période est ce qui décide de quel mois relève un
+euro, donc de quel budget — c'est du métier, pas de la plomberie.
+
+Trois fonctions suffisent, et tout ce qui borne une période dans le projet passe
+par elles :
+
+- :func:`household_tz` — le fuseau, jamais relu depuis ``household.timezone``
+  ailleurs ;
+- :func:`household_today` — la date **locale du foyer**, jamais ``date.today()``
+  (qui lit l'horloge du serveur : en conteneur elle est en UTC, donc fausse de
+  deux heures huit mois par an) ;
+- :func:`start_of_day` / :func:`end_of_day` / :func:`month_range` — les bornes,
+  toujours *aware*.
+
+Une date nue en fin d'intervalle vaut **fin de journée**. Un ``__lte`` la lisant
+à minuit exclut silencieusement la journée entière qu'on croyait inclure : c'est
+le second bug que ce module ferme, cette fois pour de bon, puisqu'il n'y a plus
+qu'un endroit où l'oublier.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+UTC = ZoneInfo("UTC")
+
+
+def household_tz(household) -> ZoneInfo:
+    """Le fuseau IANA du foyer, UTC par défaut.
+
+    Tolérant sur l'entrée (``None``, chaîne vide, fuseau inconnu) parce qu'un
+    fuseau invalide ne doit jamais faire tomber une agrégation — mais il est
+    logué, sinon un foyer entier lirait ses mois de travers sans trace.
+    """
+    name = getattr(household, "timezone", "") or "UTC"
+    try:
+        return ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        logger.warning("invalid household timezone %r, falling back to UTC", name)
+        return UTC
+
+
+def household_today(household) -> date:
+    """La date du calendrier **chez le foyer**.
+
+    À préférer systématiquement à ``date.today()`` et à
+    ``timezone.localdate()`` : le premier lit l'horloge du serveur, le second le
+    ``TIME_ZONE`` du projet (UTC ici). Pour un foyer à Paris, les deux se
+    trompent de jour entre minuit et 2 h du matin — soit exactement le moment où
+    une échéance « en retard » bascule.
+    """
+    return timezone.now().astimezone(household_tz(household)).date()
+
+
+def start_of_day(day: date, household) -> datetime:
+    """Minuit local, *aware*. Borne basse inclusive d'une période."""
+    return datetime.combine(day, time.min, tzinfo=household_tz(household))
+
+
+def end_of_day(day: date, household) -> datetime:
+    """Dernier instant de la journée locale, *aware*.
+
+    Borne haute d'un ``__lte``. Sans elle, ``to=2026-07-31`` exclut le 31.
+    """
+    return datetime.combine(day, time.max, tzinfo=household_tz(household))
+
+
+def month_range(household, *, year: int, month: int) -> tuple[datetime, datetime]:
+    """``(début, fin_exclusive)`` du mois, en instants *aware* locaux.
+
+    Fin **exclusive** : c'est la forme sûre pour un ``__lt``, qui ne peut pas
+    rater une microseconde de fin de mois comme le ferait un ``__lte`` sur une
+    borne arrondie.
+    """
+    tz = household_tz(household)
+    start = datetime(year, month, 1, tzinfo=tz)
+    if month == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=tz)
+    else:
+        end = datetime(year, month + 1, 1, tzinfo=tz)
+    return start, end
+
+
+def current_month_range(household) -> tuple[datetime, datetime, str]:
+    """``(début, fin_exclusive, 'YYYY-MM')`` du mois en cours chez le foyer."""
+    today = household_today(household)
+    start, end = month_range(household, year=today.year, month=today.month)
+    return start, end, f"{today.year:04d}-{today.month:02d}"

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -13,7 +13,6 @@ from datetime import datetime, time
 from decimal import Decimal
 from typing import Any
 from uuid import UUID
-from zoneinfo import ZoneInfo
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
@@ -23,6 +22,7 @@ from django.db.transaction import atomic as transaction_atomic
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from core.timezones import household_tz
 from zones.models import Zone
 
 from .models import Interaction, InteractionZone
@@ -726,9 +726,4 @@ def household_noon(household, day) -> datetime:
     dated the 1st or the 31st changes month — and therefore changes monthly
     budget. Noon is far enough from both edges for every real timezone offset.
     """
-    tz_name = getattr(household, "timezone", "") or "UTC"
-    try:
-        tz = ZoneInfo(tz_name)
-    except Exception:
-        tz = ZoneInfo("UTC")
-    return datetime.combine(day, time(12, 0), tzinfo=tz)
+    return datetime.combine(day, time(12, 0), tzinfo=household_tz(household))

--- a/apps/interactions/tests/test_period_bounds.py
+++ b/apps/interactions/tests/test_period_bounds.py
@@ -1,0 +1,214 @@
+"""Les bornes de période se lisent chez le foyer — et les deux écrans s'accordent.
+
+Régression du parcours 26. « Ce mois-ci » avait deux définitions dans le module
+Argent : le panneau Budgets bornait le mois sur le fuseau du foyer, le résumé des
+dépenses le bornait en UTC. Pour un foyer à Paris, les deux premières heures du
+1er et les deux dernières du 31 tombaient d'un côté ou de l'autre selon l'écran.
+
+Ce n'est pas une imprécision d'affichage : c'est le mois qui décide de quel budget
+relève un euro. Cliquer sur « 340 € / 400 € » pouvait donc ouvrir une page
+annonçant 352 €, chacune juste selon sa propre borne — exactement le « deux voix
+pour un même fait » que le parcours interdit.
+"""
+from datetime import datetime
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from budget.aggregations import compute_budget_overview
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from zones.models import Zone
+
+PARIS = ZoneInfo("Europe/Paris")
+
+
+@pytest.fixture
+def paris_household(db):
+    """Un foyer à Paris — le décalage n'existe pas sous UTC, donc le test non plus."""
+    household = Household.objects.create(name="Maison", timezone="Europe/Paris")
+    user = UserFactory()
+    HouseholdMember.objects.create(
+        user=user, household=household, role=HouseholdMember.Role.OWNER
+    )
+    Zone.objects.create(household=household, name="Maison", created_by=user)
+    return household, user
+
+
+def _client(user, household) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    client.cookies["household_id"] = str(household.id)
+    return client
+
+
+def _expense(household, user, *, amount, occurred_at, budget=None):
+    return Interaction.objects.create(
+        household=household,
+        created_by=user,
+        subject="Dépense",
+        type="expense",
+        kind="manual",
+        amount=Decimal(amount),
+        budget=budget,
+        occurred_at=occurred_at,
+    )
+
+
+@pytest.mark.django_db
+class TestABareDateIsReadInTheHouseholdTimezone:
+    def test_the_first_hours_of_the_month_belong_to_that_month(self, paris_household):
+        """00 h 30 le 1er juillet à Paris, c'est 22 h 30 le 30 juin en UTC.
+
+        Lue en UTC, la borne basse `from=2026-07-01` excluait cette dépense de
+        juillet — et le panneau Budgets, lui, la comptait.
+        """
+        household, user = paris_household
+        _expense(
+            household,
+            user,
+            amount="40.00",
+            occurred_at=datetime(2026, 7, 1, 0, 30, tzinfo=PARIS),
+        )
+
+        response = _client(user, household).get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-01", "to": "2026-07-31"},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["total"] == "40.00"
+
+    def test_the_last_hours_of_the_month_belong_to_that_month(self, paris_household):
+        """23 h 30 le 31 juillet : la borne haute est une fin de journée locale."""
+        household, user = paris_household
+        _expense(
+            household,
+            user,
+            amount="25.00",
+            occurred_at=datetime(2026, 7, 31, 23, 30, tzinfo=PARIS),
+        )
+
+        response = _client(user, household).get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-01", "to": "2026-07-31"},
+        )
+
+        assert response.data["total"] == "25.00"
+
+    def test_the_previous_month_does_not_leak_in(self, paris_household):
+        """Le miroir : 23 h 30 le 30 juin reste en juin."""
+        household, user = paris_household
+        _expense(
+            household,
+            user,
+            amount="99.00",
+            occurred_at=datetime(2026, 6, 30, 23, 30, tzinfo=PARIS),
+        )
+
+        response = _client(user, household).get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-01", "to": "2026-07-31"},
+        )
+
+        assert response.data["total"] == "0.00"
+
+    def test_the_list_agrees_with_the_summary(self, paris_household):
+        """La liste et le total sont affichés côte à côte : ils comptent pareil.
+
+        Les deux filtres étaient écrits séparément — l'un via `_parse_period`,
+        l'autre en comparant la chaîne brute — ce qui laissait une page afficher
+        un total qui ne correspondait pas aux lignes en dessous.
+        """
+        household, user = paris_household
+        for moment in (
+            datetime(2026, 7, 1, 0, 30, tzinfo=PARIS),
+            datetime(2026, 7, 15, 12, 0, tzinfo=PARIS),
+            datetime(2026, 7, 31, 23, 30, tzinfo=PARIS),
+        ):
+            _expense(household, user, amount="10.00", occurred_at=moment)
+
+        client = _client(user, household)
+        summary = client.get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-01", "to": "2026-07-31"},
+        )
+        listing = client.get(
+            reverse("interaction-list"),
+            {"type": "expense", "start_date": "2026-07-01", "end_date": "2026-07-31"},
+        )
+
+        assert summary.data["count"] == 3
+        assert summary.data["total"] == "30.00"
+        assert listing.data["count"] == 3
+
+    def test_an_explicit_instant_is_respected(self, paris_household):
+        """Écrire une heure, c'est savoir ce qu'on demande — on n'y touche pas."""
+        household, user = paris_household
+        _expense(
+            household,
+            user,
+            amount="12.00",
+            occurred_at=datetime(2026, 7, 10, 18, 0, tzinfo=PARIS),
+        )
+
+        response = _client(user, household).get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-10T00:00", "to": "2026-07-10T12:00"},
+        )
+
+        assert response.data["total"] == "0.00"
+
+
+@pytest.mark.django_db
+class TestTheTwoScreensAgree:
+    """Le compteur du panneau Budgets et le total de la page qui l'ouvre.
+
+    C'est *le* test de la régression : il compare les deux lectures nombre pour
+    nombre, sur un mois dont les deux extrémités tombent dans la zone de
+    décalage. Tant qu'ils passent par la même définition du mois, il tient.
+    """
+
+    def test_the_budget_counter_equals_the_expense_summary(
+        self, paris_household, monkeypatch
+    ):
+        from budget.models import Budget
+        from core import timezones as core_tz
+
+        household, user = paris_household
+        budget = Budget.objects.create(
+            household=household,
+            name="Courses",
+            monthly_amount=Decimal("400.00"),
+            created_by=user,
+        )
+
+        # Un instant fixe en plein juillet : sinon le test se met à dépendre du
+        # jour où il tourne, et ne dit plus rien les 1ers et 31 du mois.
+        fixed_now = datetime(2026, 7, 15, 10, 0, tzinfo=PARIS)
+        monkeypatch.setattr(
+            core_tz.timezone, "now", lambda: fixed_now.astimezone(ZoneInfo("UTC"))
+        )
+
+        for moment in (
+            datetime(2026, 7, 1, 0, 30, tzinfo=PARIS),   # début de fenêtre décalée
+            datetime(2026, 7, 20, 9, 0, tzinfo=PARIS),
+            datetime(2026, 7, 31, 23, 30, tzinfo=PARIS),  # fin de fenêtre décalée
+        ):
+            _expense(household, user, amount="30.00", occurred_at=moment, budget=budget)
+
+        overview = compute_budget_overview(household=household)
+        row = next(b for b in overview["budgets"] if b["id"] == str(budget.id))
+
+        response = _client(user, household).get(
+            reverse("interaction-expenses-summary"),
+            {"from": "2026-07-01", "to": "2026-07-31", "budget": str(budget.id)},
+        )
+
+        assert row["spent"] == "90.00"
+        assert response.data["total"] == row["spent"]

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -2,7 +2,7 @@
 Interaction views for REST API.
 """
 import uuid
-from datetime import datetime, time, timedelta, timezone as dt_timezone
+from datetime import datetime, timedelta
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
@@ -16,6 +16,12 @@ from django_filters.rest_framework import DjangoFilterBackend
 from django.db.models import Q, Count
 
 from core.permissions import IsHouseholdMember
+from core.timezones import (
+    current_month_range,
+    end_of_day,
+    household_tz,
+    start_of_day,
+)
 from documents.models import Document, DocumentLink
 from zones.models import Zone
 from .aggregations import UNBUDGETED, compute_expense_summary
@@ -37,54 +43,47 @@ from .services import (
 )
 
 
-def _end_of_day(value: str) -> str:
-    """``'2026-07-31'`` → ``'2026-07-31 23:59:59.999999'``, sinon la valeur telle quelle.
+def _parse_bound(value: str, household, *, closing: bool) -> datetime:
+    """Une borne de période, toujours *aware*, toujours dans le fuseau du foyer.
 
-    Un filtre ``__lte`` sur une colonne datetime lit une date nue à minuit, donc
-    exclut la journée entière qu'on croyait inclure. Un instant explicite est
-    respecté : l'appelant qui écrit une heure sait ce qu'il demande.
+    Deux erreurs qu'un seul endroit ferme désormais :
+
+    - **une date nue en fin d'intervalle vaut fin de journée.** Le filtre est un
+      ``__lte`` : lue à minuit, ``to=2026-07-31`` excluait toutes les dépenses du
+      31 ;
+    - **une date nue se lit chez le foyer, pas en UTC.** Elle était forcée à
+      ``tzinfo=utc`` alors que le panneau Budgets bornait son mois sur le fuseau
+      du foyer : les deux écrans annonçaient deux totaux pour la même enveloppe,
+      chacun juste selon sa propre borne. Le décalage n'est que de deux heures,
+      mais il tombe pile sur la frontière d'un mois — donc sur un budget.
+
+    Un instant explicite (``...T14:00``) est respecté ; naïf, il est simplement
+    ancré dans le fuseau du foyer plutôt que dans celui du serveur.
     """
     try:
-        parsed = datetime.strptime(value, '%Y-%m-%d')
+        day = datetime.strptime(value, '%Y-%m-%d').date()
     except (TypeError, ValueError):
-        return value
-    return datetime.combine(parsed.date(), time.max).isoformat(sep=' ')
+        moment = datetime.fromisoformat(value)
+        if timezone.is_naive(moment):
+            return moment.replace(tzinfo=household_tz(household))
+        return moment
+    return end_of_day(day, household) if closing else start_of_day(day, household)
 
 
-def _parse_period(from_param: str | None, to_param: str | None):
-    """Resolve from/to query params, defaulting to the current calendar month.
+def _parse_period(from_param: str | None, to_param: str | None, household):
+    """Resolve from/to query params, defaulting to the household's current month.
 
-    Accepts ISO date (YYYY-MM-DD) or full datetime. Always returns aware
-    datetimes (UTC for date-only inputs).
-
-    **Une date de fin nue veut dire « fin de cette journée ».** Le filtre est un
-    ``__lte`` : en la lisant à minuit, ``to=2026-07-31`` excluait toutes les
-    dépenses du 31 — le dernier jour de chaque période disparaissait des totaux,
-    en silence. C'est d'autant plus visible depuis qu'on peut ouvrir un budget
-    sur ses dépenses : le détail et le compteur du panneau ne tombaient pas
-    d'accord. Un instant explicite (``...T14:00``) est respecté tel quel.
+    Le défaut passe par ``core.timezones`` — la **même** fonction que le panneau
+    Budgets. C'est ce qui garantit qu'ouvrir une enveloppe affiche le total sur
+    lequel on vient de cliquer.
     """
-    def _parse(value: str, *, end_of_day: bool = False) -> datetime:
-        # Try date-only first, then full datetime.
-        try:
-            d = datetime.strptime(value, '%Y-%m-%d')
-            moment = time.max if end_of_day else time.min
-            return datetime.combine(d.date(), moment, tzinfo=dt_timezone.utc)
-        except ValueError:
-            pass
-        return datetime.fromisoformat(value)
-
     if not from_param and not to_param:
-        now = timezone.now()
-        from_dt = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        if from_dt.month == 12:
-            next_month = from_dt.replace(year=from_dt.year + 1, month=1)
-        else:
-            next_month = from_dt.replace(month=from_dt.month + 1)
-        return from_dt, next_month - timedelta(microseconds=1)
+        start, end, _month = current_month_range(household)
+        # Fin inclusive : le contrat de l'agrégat est un ``__lte``.
+        return start, end - timedelta(microseconds=1)
 
-    from_dt = _parse(from_param) if from_param else None
-    to_dt = _parse(to_param, end_of_day=True) if to_param else None
+    from_dt = _parse_bound(from_param, household, closing=False) if from_param else None
+    to_dt = _parse_bound(to_param, household, closing=True) if to_param else None
     return from_dt, to_dt
 
 
@@ -146,16 +145,22 @@ class InteractionViewSet(viewsets.ModelViewSet):
         if structure_id:
             queryset = queryset.filter(interaction_structures__structure_id=structure_id)
 
-        # Filter by date range. ``end_date`` nue = fin de journée, même règle que
-        # ``_parse_period`` : comparée telle quelle, une date se lit à minuit et
-        # le dernier jour de la période disparaît de la liste alors qu'il compte
-        # dans le total juste à côté.
+        # Filter by date range — **les mêmes bornes que le résumé**, via
+        # ``_parse_bound``. La liste et le total affichés côte à côte sur la page
+        # d'un budget doivent compter les mêmes dépenses ; comparer une chaîne
+        # brute les faisait lire minuit UTC là où l'agrégat lisait le fuseau du
+        # foyer.
+        household_for_dates = self.request.household
         start_date = self.request.query_params.get('start_date')
         end_date = self.request.query_params.get('end_date')
         if start_date:
-            queryset = queryset.filter(occurred_at__gte=start_date)
+            queryset = queryset.filter(
+                occurred_at__gte=_parse_bound(start_date, household_for_dates, closing=False)
+            )
         if end_date:
-            queryset = queryset.filter(occurred_at__lte=_end_of_day(end_date))
+            queryset = queryset.filter(
+                occurred_at__lte=_parse_bound(end_date, household_for_dates, closing=True)
+            )
         
         # Filter by tags
         tags = self.request.query_params.get('tags')
@@ -383,6 +388,7 @@ class InteractionViewSet(viewsets.ModelViewSet):
         from_dt, to_dt = _parse_period(
             request.query_params.get('from'),
             request.query_params.get('to'),
+            household,
         )
         supplier = request.query_params.get('supplier')
         kind = request.query_params.get('kind')

--- a/apps/pings/services.py
+++ b/apps/pings/services.py
@@ -16,10 +16,10 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from django.utils import timezone, translation
 
+from core.timezones import household_tz
 from telegram.models import TelegramAccount
 
 from . import registry
@@ -183,13 +183,8 @@ def _deliver(user, household, text: str) -> bool:
     return delivered
 
 
-def _household_tz(household) -> ZoneInfo:
-    name = getattr(household, "timezone", "") or "UTC"
-    try:
-        return ZoneInfo(name)
-    except (ZoneInfoNotFoundError, ValueError):
-        logger.warning("pings: invalid household timezone %r, using UTC", name)
-        return ZoneInfo("UTC")
+#: Alias — la définition (et son log) vivent dans ``core.timezones``.
+_household_tz = household_tz
 
 
 def _recipient_language(pref: PingPreference) -> str:

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -153,3 +153,75 @@ vérifiée directement sur l'API.
 
 Les specs `budget`, `report`, `recurring`, `expense-adhoc`, `expenses-summary` ont
 été retargetées sur les nouvelles URLs.
+
+## L'audit de cohérence (juillet 2026)
+
+Un passage complet sur les trois apps (`banking`, `budget`, `interactions`) et les
+quatre features front. L'architecture tenait ; les défauts étaient tous **aux
+jointures** — là où deux modules répondent à la même question sans passer par la
+même fonction. Les conclusions valent au-delà de l'argent.
+
+### Un compteur ne peut pas avoir deux définitions
+
+« Ce mois-ci » était borné dans le fuseau du foyer par `budget.aggregations` et en
+UTC par `interactions.views`. Deux heures d'écart — mais placées exactement sur la
+frontière d'un mois, donc sur un budget. Cliquer sur « 340 € / 400 € » pouvait
+ouvrir une page annonçant 352 €.
+
+`apps/core/timezones.py` est désormais le seul endroit qui sait ce qu'est un mois,
+une journée, ou « aujourd'hui » chez un foyer. Six copies locales du helper de
+fuseau (dont deux correctes, quatre approximatives) sont devenues des alias.
+Côté front, `toLocalISODate` / `todayISO` remplacent les
+`toISOString().slice(0, 10)` — qui décalaient les quatre périodes d'un jour aux
+deux bouts et proposaient « hier » comme date du jour entre minuit et 2 h.
+
+Régressions : `interactions/tests/test_period_bounds.py`,
+`ui/src/features/expenses/period.test.ts`.
+
+### Un cache périmé est un compteur qui ment
+
+Huit mutations touchent à l'argent, chacune déclarait sa propre liste
+d'invalidations, et cinq en oubliaient au moins une. La pire : **importer un
+relevé** n'invalidait que `banking`, alors que c'est le moment où les compteurs de
+conformité passent de zéro à cent.
+
+`useInvalidateMoney` remplace les huit listes. Invalider trop large coûte quelques
+requêtes ; invalider trop étroit coûte la confiance dans les chiffres — et le bug
+est invisible en revue, parce que chaque liste prise isolément a l'air réfléchie.
+
+### La parité entre catalogues ne voit pas une clé écrasée
+
+Le dialogue « dépense en espèces » (lot 4) a réutilisé le namespace
+`banking.cash.*` et effacé les douze clés du dialogue « retirer vers les espèces ».
+En production, le journal affichait `banking.cash.action` sur chaque ligne
+sortante, et le dialogue de retrait portait le titre du dialogue de dépense.
+
+Le contrôle de parité entre les quatre langues était vert : la clé manquait
+**partout**. Comparer les langues entre elles ne suffit pas — il faut comparer le
+**code** au catalogue. C'est ce que fait `ui/src/locales/keys.test.ts`, désormais
+lancé par la CI (les tests unitaires du front n'étaient exécutés par personne).
+
+Le retrait vit maintenant sous `banking.withdraw.*`.
+
+### Le journal a un filtre « À traiter »
+
+Le marqueur par ligne (#413) disait ce qu'il restait à ranger sans qu'on puisse
+s'y rendre. `?allocation=todo` passe par `detectors.pending_outflows`, la même
+fonction que les compteurs du Contrôle : une file dont le nombre contredirait le
+badge ferait perdre leur crédit aux deux.
+
+### Reste ouvert
+
+Deux points de l'audit demandent un arbitrage produit, pas une correction :
+
+- **`DELETE /transactions/{id}/unlink/{interaction_id}/` n'a aucun appelant.**
+  Détacher une dépense mal rapprochée n'a pas de geste dans l'interface. Soit on
+  lui en donne un, soit on retire l'endpoint — mais un endpoint injoignable est
+  lui-même un orphelin.
+- **`/app/budget/recurring` et `/app/budget/reports`** vivent hors de la famille
+  `/app/money`, alors que `/app/budget` redirige vers elle. Les déplacer touche
+  les `url_template` de l'agent, les tutoriels et les redirections.
+
+Et un lot de dette hors périmètre : `features/settings` compte une trentaine de
+`t(…, { defaultValue })`, interdits par le CLAUDE.md — c'est pour cela que le
+garde-fou i18n couvre une liste de namespaces plutôt que tout le front.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
     "gen:api": "openapi --input http://127.0.0.1:8001/api/schema/ --output ui/src/gen/api --client fetch --useUnionTypes",
     "gen:api:clean": "rm -rf ui/src/gen/api",
     "gen:api:refresh": "npm run gen:api:clean && npm run gen:api",
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "test:coverage": "vitest run --coverage",
+    "test": "TZ=Europe/Paris vitest --config ui/vite.config.ts",
+    "test:ui": "TZ=Europe/Paris vitest --ui --config ui/vite.config.ts",
+    "test:coverage": "TZ=Europe/Paris vitest run --coverage --config ui/vite.config.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed"

--- a/ui/src/components/TabShell.tsx
+++ b/ui/src/components/TabShell.tsx
@@ -33,6 +33,19 @@ interface TabShellProps<T extends string> {
    * user can still open one to add its first item. Selecting one activates it.
    */
   moreTabs?: TabConfig<T>[];
+  /**
+   * Mode contrôlé : l'onglet actif vit chez le parent.
+   *
+   * Nécessaire dès qu'un **enfant** doit changer d'onglet (le panneau « À ranger »
+   * renvoie vers « Contrôle » quand un prérequis le vide). Sans ça, le parent
+   * n'avait d'autre prise que d'écrire dans `sessionStorage` et de recharger la
+   * page — un `window.location.assign` au milieu d'une SPA, qui jetait tout le
+   * cache React Query pour un changement d'onglet.
+   *
+   * Omis, le composant reste autonome et persiste dans la session comme avant.
+   */
+  value?: T;
+  onValueChange?: (tab: T) => void;
 }
 
 export function TabShell<T extends string>({
@@ -43,9 +56,21 @@ export function TabShell<T extends string>({
   actions,
   onTabChange,
   moreTabs = [],
+  value,
+  onValueChange,
 }: TabShellProps<T>) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useSessionState<T>(sessionKey, defaultTab);
+  const [storedTab, setStoredTab] = useSessionState<T>(sessionKey, defaultTab);
+
+  const isControlled = value !== undefined;
+  const activeTab = isControlled ? value : storedTab;
+  const setActiveTab = React.useCallback(
+    (tab: T) => {
+      if (isControlled) onValueChange?.(tab);
+      else setStoredTab(tab);
+    },
+    [isControlled, onValueChange, setStoredTab],
+  );
 
   // Guard: if the stored tab no longer exists (e.g. after a config change), reset
   // to default. `moreTabs` are known too — an active tab picked from the « + »

--- a/ui/src/features/banking/AccountDialog.tsx
+++ b/ui/src/features/banking/AccountDialog.tsx
@@ -7,6 +7,7 @@ import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import type { BankAccount, BankAccountKind } from '@/lib/api/banking';
 import { useCreateBankAccount, useUpdateBankAccount } from './hooks';
+import { todayISO } from '@/lib/format';
 
 interface AccountDialogProps {
   open: boolean;
@@ -49,7 +50,7 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
       // Aujourd'hui par défaut : le cas le plus fréquent est « je commence à suivre
       // ce compte maintenant », et proposer une valeur juste vaut mieux qu'exiger
       // une saisie de plus.
-      setOpeningBalanceDate(new Date().toISOString().slice(0, 10));
+      setOpeningBalanceDate(todayISO());
     }
   }, [open, existing]);
 

--- a/ui/src/features/banking/BalanceAnchorDialog.tsx
+++ b/ui/src/features/banking/BalanceAnchorDialog.tsx
@@ -6,7 +6,7 @@ import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
-import { formatAmount } from '@/lib/format';
+import { formatAmount, todayISO } from '@/lib/format';
 import type { BankAccount } from '@/lib/api/banking';
 import { useBalanceAnchor, useSetBalanceAnchor } from './hooks';
 
@@ -54,7 +54,7 @@ export default function BalanceAnchorDialog({
   React.useEffect(() => {
     if (!open) return;
     setBalance('');
-    setAsOf(new Date().toISOString().slice(0, 10));
+    setAsOf(todayISO());
     setConfirmed(false);
     setError(null);
   }, [open]);

--- a/ui/src/features/banking/TransactionFilters.tsx
+++ b/ui/src/features/banking/TransactionFilters.tsx
@@ -79,6 +79,15 @@ export default function TransactionFilters({
         >
           {t('banking.journal.internal')}
         </FilterPill>
+        {/* Le compagnon du marqueur de ligne : il dit depuis #413 ce qu'il reste
+            à ranger, sans qu'on puisse s'y rendre. Sur 160 lignes, c'est la
+            différence entre un reproche et une file de travail. */}
+        <FilterPill
+          active={filters.allocation === 'todo'}
+          onClick={() => set('allocation', filters.allocation === 'todo' ? '' : 'todo')}
+        >
+          {t('banking.journal.toSortOut')}
+        </FilterPill>
       </div>
     </div>
   );

--- a/ui/src/features/banking/TransactionRow.tsx
+++ b/ui/src/features/banking/TransactionRow.tsx
@@ -55,10 +55,10 @@ export default function TransactionRow({
       : []),
     // Verser aux espèces n'a de sens que sur une sortie encore libre.
     ...(isOut && !hasCounterpart && canFeedCash
-      ? [{ label: t('banking.cash.action'), icon: Banknote, onClick: onFeedCash }]
+      ? [{ label: t('banking.withdraw.action'), icon: Banknote, onClick: onFeedCash }]
       : []),
     ...(hasCounterpart
-      ? [{ label: t('banking.cash.unlink'), icon: Link2Off, onClick: onUnlinkCash }]
+      ? [{ label: t('banking.withdraw.unlink'), icon: Link2Off, onClick: onUnlinkCash }]
       : []),
     // Classer n'a de sens que sur une recette : une sortie n'a pas de nature.
     ...(!isOut && !transaction.is_internal
@@ -114,7 +114,7 @@ export default function TransactionRow({
               ) : (
                 <Repeat className="h-3 w-3" aria-hidden />
               )}
-              {hasCounterpart ? t('banking.cash.linkedBadge') : t('banking.journal.internal')}
+              {hasCounterpart ? t('banking.withdraw.linkedBadge') : t('banking.journal.internal')}
             </span>
           ) : null}
 

--- a/ui/src/features/banking/WithdrawToCashDialog.tsx
+++ b/ui/src/features/banking/WithdrawToCashDialog.tsx
@@ -49,12 +49,12 @@ export default function WithdrawToCashDialog({
     setError(null);
 
     if (!cashAccount) {
-      setError(t('banking.cash.errors.accountRequired'));
+      setError(t('banking.withdraw.errors.accountRequired'));
       return;
     }
     const parsed = Number(amount.trim().replace(',', '.'));
     if (!Number.isFinite(parsed) || parsed <= 0 || parsed > Number(fullAmount)) {
-      setError(t('banking.cash.errors.amountInvalid', { max: formatAmount(fullAmount) }));
+      setError(t('banking.withdraw.errors.amountInvalid', { max: formatAmount(fullAmount) }));
       return;
     }
 
@@ -70,9 +70,9 @@ export default function WithdrawToCashDialog({
   }
 
   return (
-    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.cash.title')}>
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.withdraw.title')}>
       <form onSubmit={handleSubmit} className="mt-4 space-y-4">
-        <p className="text-sm text-muted-foreground">{t('banking.cash.intro')}</p>
+        <p className="text-sm text-muted-foreground">{t('banking.withdraw.intro')}</p>
 
         <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
           <p className="font-medium text-foreground">{transaction.label_raw}</p>
@@ -84,11 +84,11 @@ export default function WithdrawToCashDialog({
 
         {cashAccounts.length === 0 ? (
           <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm text-muted-foreground">
-            {t('banking.cash.noCashAccount')}
+            {t('banking.withdraw.noCashAccount')}
           </div>
         ) : (
           <>
-            <FormField label={t('banking.cash.fields.account')} htmlFor="cash-account">
+            <FormField label={t('banking.withdraw.fields.account')} htmlFor="cash-account">
               <Select
                 id="cash-account"
                 value={cashAccount}
@@ -97,7 +97,7 @@ export default function WithdrawToCashDialog({
               />
             </FormField>
 
-            <FormField label={t('banking.cash.fields.amount')} htmlFor="cash-amount">
+            <FormField label={t('banking.withdraw.fields.amount')} htmlFor="cash-amount">
               <Input
                 id="cash-amount"
                 type="number"
@@ -107,7 +107,7 @@ export default function WithdrawToCashDialog({
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
               />
-              <p className="text-xs text-muted-foreground">{t('banking.cash.fields.amountHint')}</p>
+              <p className="text-xs text-muted-foreground">{t('banking.withdraw.fields.amountHint')}</p>
             </FormField>
           </>
         )}
@@ -123,7 +123,7 @@ export default function WithdrawToCashDialog({
             {t('common.cancel')}
           </Button>
           <Button type="submit" disabled={mutation.isPending || cashAccounts.length === 0}>
-            {t('banking.cash.action')}
+            {t('banking.withdraw.action')}
           </Button>
         </div>
       </form>

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   archiveBankAccount,
@@ -31,10 +31,11 @@ import {
   type TransactionFilters,
 } from '@/lib/api/banking';
 import { toast } from '@/lib/toast';
-import { complianceKeys } from '@/features/money/keys';
+import { BANKING_ROOT } from '@/features/money/keys';
+import { useInvalidateMoney } from '@/features/money/invalidate';
 
 export const bankingKeys = {
-  all: ['banking'] as const,
+  all: BANKING_ROOT,
   accounts: (includeArchived: boolean) =>
     [...bankingKeys.all, 'accounts', includeArchived] as const,
   imports: (accountId?: string) => [...bankingKeys.all, 'imports', accountId ?? 'all'] as const,
@@ -57,15 +58,8 @@ export function useBankAccounts(includeArchived = false) {
   });
 }
 
-function useInvalidateBanking() {
-  const qc = useQueryClient();
-  return () => {
-    void qc.invalidateQueries({ queryKey: bankingKeys.all });
-  };
-}
-
 export function useCreateBankAccount() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: BankAccountPayload) => createBankAccount(payload),
@@ -78,7 +72,7 @@ export function useCreateBankAccount() {
 }
 
 export function useUpdateBankAccount() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<BankAccountPayload> }) =>
@@ -93,7 +87,7 @@ export function useUpdateBankAccount() {
 
 /** Bare archive mutation — la page l'enveloppe dans useDeleteWithUndo. */
 export function useArchiveBankAccount() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (id: string) => archiveBankAccount(id),
     onSuccess: invalidate,
@@ -101,7 +95,7 @@ export function useArchiveBankAccount() {
 }
 
 export function useRestoreBankAccount() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (id: string) => restoreBankAccount(id),
@@ -126,8 +120,7 @@ export function useBalanceAnchor(accountId: string | undefined) {
 }
 
 export function useSetBalanceAnchor() {
-  const invalidate = useInvalidateBanking();
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({
@@ -141,7 +134,6 @@ export function useSetBalanceAnchor() {
       invalidate();
       // Le solde d'ouverture ouvre la fenêtre de conformité : les compteurs de
       // contrôle changent dans la foulée, souvent de zéro à plusieurs centaines.
-      void qc.invalidateQueries({ queryKey: complianceKeys.all });
       toast({ description: t('banking.anchor.applied'), variant: 'success' });
     },
   });
@@ -168,7 +160,7 @@ export function usePreviewStatementFile() {
  * il lit `status` et `created_count` sur la trace retournée.
  */
 export function useImportStatementFile() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (params: {
       accountId: string;
@@ -197,7 +189,7 @@ export function useAccountFlow(filters: TransactionFilters) {
 }
 
 export function useQualifyTransaction() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({
@@ -226,7 +218,7 @@ export function useAccountBalance(accountId: string | undefined, asOf?: string) 
 }
 
 export function useWithdrawToCash() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({
@@ -238,20 +230,20 @@ export function useWithdrawToCash() {
     }) => withdrawToCash(transactionId, payload),
     onSuccess: () => {
       invalidate();
-      toast({ description: t('banking.cash.linked'), variant: 'success' });
+      toast({ description: t('banking.withdraw.linked'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }
 
 export function useUnlinkCashCounterpart() {
-  const invalidate = useInvalidateBanking();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (transactionId: string) => unlinkCashCounterpart(transactionId),
     onSuccess: () => {
       invalidate();
-      toast({ description: t('banking.cash.unlinked'), variant: 'success' });
+      toast({ description: t('banking.withdraw.unlinked'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
@@ -268,8 +260,7 @@ export function useAllocations(transactionId: string | undefined) {
 }
 
 export function useSetAllocations() {
-  const invalidate = useInvalidateBanking();
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ transactionId, lines }: { transactionId: string; lines: AllocationLine[] }) =>
@@ -278,14 +269,10 @@ export function useSetAllocations() {
       invalidate();
       // La ventilation crée/supprime des Interaction : les listes de dépenses et
       // les compteurs de budget doivent se rafraîchir aussi.
-      void qc.invalidateQueries({ queryKey: ['interactions'] });
-      void qc.invalidateQueries({ queryKey: ['expenses'] });
-      void qc.invalidateQueries({ queryKey: ['budget'] });
       // Ventiler résout (ou déplace) un écart : sans cette invalidation, le badge
       // « Contrôle » et la file « À ranger » afficheraient encore la ligne qu'on
       // vient de ranger — un compteur qui contredit l'écran est pire que pas de
       // compteur.
-      void qc.invalidateQueries({ queryKey: complianceKeys.all });
       toast({ description: t('banking.allocation.saved'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
@@ -295,17 +282,13 @@ export function useSetAllocations() {
 // --- Rapprochement automatique (lot 6) --------------------------------------
 
 export function useReconcile() {
-  const invalidate = useInvalidateBanking();
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (params: { date_from?: string; date_to?: string } = {}) =>
       reconcileTransactions(params),
     onSuccess: (outcome) => {
       invalidate();
-      void qc.invalidateQueries({ queryKey: ['interactions'] });
-      void qc.invalidateQueries({ queryKey: ['budget'] });
-      void qc.invalidateQueries({ queryKey: complianceKeys.all });
 
       // Deux compteurs, un seul toast : la passe rapproche des dépenses **et**
       // confirme des échéances. Les annoncer séparément ferait deux toasts pour
@@ -338,15 +321,13 @@ export function useSuggestions(transactionId: string | undefined) {
 }
 
 export function useLinkInteraction() {
-  const invalidate = useInvalidateBanking();
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ transactionId, interactionId }: { transactionId: string; interactionId: string }) =>
       linkInteraction(transactionId, interactionId),
     onSuccess: () => {
       invalidate();
-      void qc.invalidateQueries({ queryKey: ['interactions'] });
       toast({ description: t('banking.reconcile.linked'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
@@ -354,8 +335,7 @@ export function useLinkInteraction() {
 }
 
 export function useRecordCashExpense() {
-  const invalidate = useInvalidateBanking();
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: CashExpensePayload) => recordCashExpense(payload),
@@ -364,10 +344,6 @@ export function useRecordCashExpense() {
       // L'opération crée aussi une Interaction : dépenses, budgets et conformité
       // doivent se rafraîchir, sinon la dépense qu'on vient de saisir n'apparaît
       // nulle part avant un reload.
-      void qc.invalidateQueries({ queryKey: ['interactions'] });
-      void qc.invalidateQueries({ queryKey: ['expenses'] });
-      void qc.invalidateQueries({ queryKey: ['budget'] });
-      void qc.invalidateQueries({ queryKey: complianceKeys.all });
       toast({ description: t('banking.cash.recorded'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),

--- a/ui/src/features/budget/BudgetCard.tsx
+++ b/ui/src/features/budget/BudgetCard.tsx
@@ -9,14 +9,14 @@ import type { BudgetOverviewRow, BudgetState } from '@/lib/api/budget';
 const BAR_CLASS: Record<BudgetState, string> = {
   uncapped: 'bg-muted-foreground/30',
   ok: 'bg-primary',
-  warning: 'bg-amber-500',
+  warning: 'bg-warning',
   over: 'bg-destructive',
 };
 
 const TEXT_CLASS: Record<BudgetState, string> = {
   uncapped: 'text-muted-foreground',
   ok: 'text-muted-foreground',
-  warning: 'text-amber-600',
+  warning: 'text-warning',
   over: 'text-destructive',
 };
 

--- a/ui/src/features/budget/RecurringCard.tsx
+++ b/ui/src/features/budget/RecurringCard.tsx
@@ -35,7 +35,7 @@ export default function RecurringCard({ recurring, isDue, onEdit, onDelete, onCo
           <p className="mt-0.5 text-xs text-muted-foreground">
             {t(`recurring.cadence.${recurring.cadence}`)}
             {' · '}
-            <span className={isDue ? 'font-medium text-amber-600' : undefined}>
+            <span className={isDue ? 'font-medium text-warning' : undefined}>
               {isDue
                 ? t('recurring.dueOn', { date: formatDate(recurring.next_due_date) })
                 : t('recurring.nextOn', { date: formatDate(recurring.next_due_date) })}

--- a/ui/src/features/budget/RecurringExpenseDialog.tsx
+++ b/ui/src/features/budget/RecurringExpenseDialog.tsx
@@ -8,11 +8,12 @@ import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import type { Cadence, RecurringExpense } from '@/lib/api/budget';
 import { useBudgets, useCreateRecurringExpense, useUpdateRecurringExpense } from './hooks';
+import { todayISO } from '@/lib/format';
 
 const CADENCES: Cadence[] = ['monthly', 'quarterly', 'yearly'];
 
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 interface Props {

--- a/ui/src/features/budget/hooks.ts
+++ b/ui/src/features/budget/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   confirmRecurringOccurrence,
@@ -20,9 +20,11 @@ import {
   type RecurringExpensePayload,
 } from '@/lib/api/budget';
 import { toast } from '@/lib/toast';
+import { BUDGET_ROOT } from '@/features/money/keys';
+import { useInvalidateMoney } from '@/features/money/invalidate';
 
 export const budgetKeys = {
-  all: ['budget'] as const,
+  all: BUDGET_ROOT,
   list: () => [...budgetKeys.all, 'list'] as const,
   overview: () => [...budgetKeys.all, 'overview'] as const,
   recurring: () => [...budgetKeys.all, 'recurring'] as const,
@@ -42,15 +44,8 @@ export function useBudgetOverview() {
   return useQuery({ queryKey: budgetKeys.overview(), queryFn: fetchBudgetOverview });
 }
 
-function useInvalidateBudget() {
-  const qc = useQueryClient();
-  return () => {
-    void qc.invalidateQueries({ queryKey: budgetKeys.all });
-  };
-}
-
 export function useCreateBudget() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: BudgetPayload) => createBudget(payload),
@@ -63,7 +58,7 @@ export function useCreateBudget() {
 }
 
 export function useUpdateBudget() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<BudgetPayload> }) =>
@@ -78,7 +73,7 @@ export function useUpdateBudget() {
 
 /** Bare delete mutation — the page wraps it in useDeleteWithUndo for the toast. */
 export function useDeleteBudget() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (id: string) => deleteBudget(id),
     onSuccess: invalidate,
@@ -100,7 +95,7 @@ export function useCashflowProjection() {
 }
 
 export function useCreateRecurringExpense() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: RecurringExpensePayload) => createRecurringExpense(payload),
@@ -113,7 +108,7 @@ export function useCreateRecurringExpense() {
 }
 
 export function useUpdateRecurringExpense() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<RecurringExpensePayload> }) =>
@@ -128,7 +123,7 @@ export function useUpdateRecurringExpense() {
 
 /** Bare delete mutation — the page wraps it in useDeleteWithUndo. */
 export function useDeleteRecurringExpense() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (id: string) => deleteRecurringExpense(id),
     onSuccess: invalidate,
@@ -136,7 +131,7 @@ export function useDeleteRecurringExpense() {
 }
 
 export function useConfirmRecurringOccurrence() {
-  const invalidate = useInvalidateBudget();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: ({ id, amount }: { id: string; amount?: number | null }) =>
       confirmRecurringOccurrence(id, amount),

--- a/ui/src/features/chickens/ChickenEventDialog.tsx
+++ b/ui/src/features/chickens/ChickenEventDialog.tsx
@@ -13,9 +13,10 @@ import {
   type ChickenEventType,
 } from '@/lib/api/chickens';
 import { useCreateChickenEvent, useUpdateChickenEvent } from './hooks';
+import { todayISO } from '@/lib/format';
 
 function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 interface ChickenEventDialogProps {

--- a/ui/src/features/chickens/EggLogBanner.tsx
+++ b/ui/src/features/chickens/EggLogBanner.tsx
@@ -5,9 +5,10 @@ import { Card } from '@/design-system/card';
 import { Button } from '@/design-system/button';
 import { Input } from '@/design-system/input';
 import { useEggStats, useLogEggs } from './hooks';
+import { todayISO } from '@/lib/format';
 
 function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 /**

--- a/ui/src/features/electricity/TariffsDialog.tsx
+++ b/ui/src/features/electricity/TariffsDialog.tsx
@@ -10,6 +10,7 @@ import { FormField } from '@/design-system/form-field';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import type { ElectricityMeter, MeterTariff } from '@/lib/api/electricity';
+import { todayISO } from '@/lib/format';
 import {
   consumptionKeys,
   useCreateMeterTariff,
@@ -72,7 +73,7 @@ export default function TariffsDialog({ open, onOpenChange, meter }: TariffsDial
       setPriceHc(target.price_hc ?? '');
       setSubscription(target.subscription_eur_month ?? '');
     } else {
-      setValidFrom(new Date().toISOString().slice(0, 10));
+      setValidFrom(todayISO());
       setPriceBase('');
       setPriceHp('');
       setPriceHc('');

--- a/ui/src/features/expenses/ExpenseFilters.tsx
+++ b/ui/src/features/expenses/ExpenseFilters.tsx
@@ -3,11 +3,12 @@ import { FilterPill } from '@/design-system/filter-pill';
 import { Input } from '@/design-system/input';
 import { FormField } from '@/design-system/form-field';
 import type { PeriodPreset, PeriodRange } from './period';
+import { todayISO } from '@/lib/format';
 
 const PRESETS: PeriodPreset[] = ['currentMonth', 'previousMonth', 'last30Days', 'currentYear', 'custom'];
 
 function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 interface ExpenseFiltersProps {

--- a/ui/src/features/expenses/hooks.ts
+++ b/ui/src/features/expenses/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   createManualExpense,
@@ -7,9 +7,11 @@ import {
   type ManualExpensePayload,
 } from '@/lib/api/expenses';
 import { toast } from '@/lib/toast';
+import { EXPENSES_ROOT } from '@/features/money/keys';
+import { useInvalidateMoney } from '@/features/money/invalidate';
 
 export const expenseKeys = {
-  all: ['expenses'] as const,
+  all: EXPENSES_ROOT,
   summary: (filters?: ExpenseSummaryFilters) =>
     [...expenseKeys.all, 'summary', filters] as const,
 };
@@ -22,13 +24,12 @@ export function useExpenseSummary(filters: ExpenseSummaryFilters = {}) {
 }
 
 export function useCreateManualExpense() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: ManualExpensePayload) => createManualExpense(payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: expenseKeys.all });
-      qc.invalidateQueries({ queryKey: ['interactions'] });
+      invalidate();
       toast({ description: t('expenses.adhoc.created'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),

--- a/ui/src/features/expenses/period.test.ts
+++ b/ui/src/features/expenses/period.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { resolvePeriod } from './period';
+
+/**
+ * Les bornes de période, vues depuis un fuseau à l'est de UTC.
+ *
+ * Le fuseau est imposé par le script `npm run test` (`TZ=Europe/Paris`), et ce
+ * n'est pas un détail de confort : sous UTC le bug était **invisible**, ce qui
+ * est exactement pourquoi il a vécu jusqu'en production. `toISOString()`
+ * convertit avant de formater, donc minuit local reculait d'un jour — « ce
+ * mois-ci » allait du 30 juin au 30 juillet.
+ */
+describe('resolvePeriod, vu depuis Paris', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    // 15 juillet 2026, milieu de mois : aucune borne n'est proche d'un bord,
+    // donc un échec ne peut venir que du décalage de fuseau.
+    vi.setSystemTime(new Date('2026-07-15T10:00:00+02:00'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it("le fuseau du test est bien à l'est de UTC, sinon il ne prouve rien", () => {
+    expect(new Date().getTimezoneOffset()).toBeLessThan(0);
+  });
+
+  it('le mois en cours va du 1er au dernier jour, pas de la veille à l’avant-dernier', () => {
+    expect(resolvePeriod({ preset: 'currentMonth' })).toEqual({
+      from: '2026-07-01',
+      to: '2026-07-31',
+    });
+  });
+
+  it('le mois précédent est un mois entier', () => {
+    expect(resolvePeriod({ preset: 'previousMonth' })).toEqual({
+      from: '2026-06-01',
+      to: '2026-06-30',
+    });
+  });
+
+  it("l'année en cours commence le 1er janvier, pas le 31 décembre d'avant", () => {
+    expect(resolvePeriod({ preset: 'currentYear' })).toEqual({
+      from: '2026-01-01',
+      to: '2026-12-31',
+    });
+  });
+
+  it('les 30 derniers jours se terminent aujourd’hui', () => {
+    expect(resolvePeriod({ preset: 'last30Days' })).toEqual({
+      from: '2026-06-15',
+      to: '2026-07-15',
+    });
+  });
+
+  it('une période personnalisée est rendue telle quelle', () => {
+    expect(resolvePeriod({ preset: 'custom', from: '2026-02-03', to: '2026-02-09' })).toEqual({
+      from: '2026-02-03',
+      to: '2026-02-09',
+    });
+  });
+});

--- a/ui/src/features/expenses/period.ts
+++ b/ui/src/features/expenses/period.ts
@@ -1,3 +1,5 @@
+import { toLocalISODate } from '@/lib/format';
+
 export type PeriodPreset = 'currentMonth' | 'previousMonth' | 'last30Days' | 'currentYear' | 'custom';
 
 export interface PeriodRange {
@@ -6,28 +8,41 @@ export interface PeriodRange {
   to?: string;   // ISO date YYYY-MM-DD (inclusive)
 }
 
+/**
+ * Les bornes d'une période, en dates de calendrier.
+ *
+ * Elles passent par `toLocalISODate` et **jamais** par `toISOString()`, qui
+ * convertit en UTC avant de formater : à Paris, minuit local du 1er juillet
+ * devient `2026-06-30T22:00Z`, donc « 2026-06-30 » une fois tronqué. Toutes les
+ * périodes partaient décalées d'un jour aux deux bouts — « ce mois-ci » allait
+ * du 30 juin au 30 juillet, « cette année » commençait le 31 décembre précédent.
+ * Le 31 disparaissait des totaux pendant que le 30 du mois d'avant s'y invitait.
+ *
+ * Le serveur ancre ensuite ces dates dans le fuseau du foyer
+ * (`core.timezones`), ce qui referme la boucle : même mois des deux côtés.
+ */
 export function resolvePeriod(range: PeriodRange): { from?: string; to?: string } {
   const now = new Date();
   if (range.preset === 'currentMonth') {
     const from = new Date(now.getFullYear(), now.getMonth(), 1);
     const to = new Date(now.getFullYear(), now.getMonth() + 1, 0);
-    return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+    return { from: toLocalISODate(from), to: toLocalISODate(to) };
   }
   if (range.preset === 'previousMonth') {
     const from = new Date(now.getFullYear(), now.getMonth() - 1, 1);
     const to = new Date(now.getFullYear(), now.getMonth(), 0);
-    return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+    return { from: toLocalISODate(from), to: toLocalISODate(to) };
   }
   if (range.preset === 'last30Days') {
     const to = now;
     const from = new Date(now);
     from.setDate(from.getDate() - 30);
-    return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+    return { from: toLocalISODate(from), to: toLocalISODate(to) };
   }
   if (range.preset === 'currentYear') {
     const from = new Date(now.getFullYear(), 0, 1);
     const to = new Date(now.getFullYear(), 11, 31);
-    return { from: from.toISOString().slice(0, 10), to: to.toISOString().slice(0, 10) };
+    return { from: toLocalISODate(from), to: toLocalISODate(to) };
   }
   return { from: range.from, to: range.to };
 }

--- a/ui/src/features/interactions/PurchaseForm.tsx
+++ b/ui/src/features/interactions/PurchaseForm.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
+import { todayISO } from '@/lib/format';
 
 export interface PurchaseFormPayload {
   delta?: number;
@@ -45,7 +46,7 @@ interface FormState {
 }
 
 function todayIsoDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 function emptyState(currentQuantity?: number): FormState {

--- a/ui/src/features/interactions/hooks.ts
+++ b/ui/src/features/interactions/hooks.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
 import {
   fetchInteractions,
   createInteraction,
@@ -7,6 +7,8 @@ import {
   updateInteraction,
   type CreateInteractionInput,
 } from '@/lib/api/interactions';
+import { INTERACTIONS_ROOT } from '@/features/money/keys';
+import { useInvalidateMoney } from '@/features/money/invalidate';
 
 interface InteractionFilters {
   search?: string;
@@ -24,7 +26,7 @@ interface InteractionFilters {
 }
 
 export const interactionKeys = {
-  all: ['interactions'] as const,
+  all: INTERACTIONS_ROOT,
   list: (filters?: InteractionFilters) =>
     [...interactionKeys.all, 'list', filters] as const,
   detail: (id: string) => [...interactionKeys.all, 'detail', id] as const,
@@ -38,18 +40,18 @@ export function useInteractions(filters: InteractionFilters = {}) {
 }
 
 export function useCreateInteraction() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (payload: CreateInteractionInput) => createInteraction(payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: interactionKeys.all }),
+    onSuccess: invalidate,
   });
 }
 
 export function useDeleteInteraction() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: (id: string) => deleteInteraction(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: interactionKeys.all }),
+    onSuccess: invalidate,
   });
 }
 
@@ -62,10 +64,10 @@ export function useInteraction(id: string) {
 }
 
 export function useUpdateInteraction() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidateMoney();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<CreateInteractionInput> }) =>
       updateInteraction(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: interactionKeys.all }),
+    onSuccess: invalidate,
   });
 }

--- a/ui/src/features/money/AccessCard.tsx
+++ b/ui/src/features/money/AccessCard.tsx
@@ -1,0 +1,41 @@
+import { Link, useLocation } from 'react-router-dom';
+import { ChevronRight, type LucideIcon } from 'lucide-react';
+import { Card } from '@/design-system/card';
+import { pushBack } from '@/lib/backNavigation';
+
+interface AccessCardProps {
+  to: string;
+  icon: LucideIcon;
+  title: string;
+  hint: string;
+}
+
+/**
+ * Une porte vers une sous-page du module Argent — analyse, récurrences, bilans.
+ *
+ * Le panneau Budgets en portait trois, écrites trois fois à l'identique en
+ * `<div className="rounded-lg border border-border bg-card …">`, alors que la
+ * règle du projet dit de toujours passer par `Card`. Le balisage manuel n'était
+ * pas qu'une entorse de style : il refait à la main ce que `Card` garantit
+ * (rayon, bordure, fond en tokens), donc il dérive au premier ajustement du
+ * design-system, et seulement sur ces trois cartes-là.
+ *
+ * Le `pushBack` est intégré : une sous-page ouverte d'ici doit revenir ici, et
+ * l'oublier sur une seule des trois portes est exactement le genre d'écart qu'un
+ * composant partagé rend impossible.
+ */
+export default function AccessCard({ to, icon: Icon, title, hint }: AccessCardProps) {
+  const location = useLocation();
+  return (
+    <Link to={to} state={pushBack(location)} className="group block">
+      <Card className="flex items-center gap-3 p-3 transition-colors hover:bg-accent/60">
+        <Icon className="h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium text-foreground group-hover:underline">{title}</p>
+          <p className="text-xs text-muted-foreground">{hint}</p>
+        </div>
+        <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+      </Card>
+    </Link>
+  );
+}

--- a/ui/src/features/money/BudgetsPanel.tsx
+++ b/ui/src/features/money/BudgetsPanel.tsx
@@ -5,7 +5,6 @@ import {
   AlertTriangle,
   BarChart3,
   CalendarClock,
-  ChevronRight,
   FileText,
 } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
@@ -21,6 +20,7 @@ import type { Budget, BudgetOverviewRow } from '@/lib/api/budget';
 import { useBudgetOverview, useDeleteBudget } from '@/features/budget/hooks';
 import BudgetCard from '@/features/budget/BudgetCard';
 import BudgetDialog from '@/features/budget/BudgetDialog';
+import AccessCard from './AccessCard';
 
 /** Rebuild an editable Budget from an overview row (avoids a second fetch). */
 function rowToBudget(row: BudgetOverviewRow, isGlobal: boolean): Budget {
@@ -122,7 +122,7 @@ export default function BudgetsPanel() {
                   onDelete={() => handleDelete(globalRow.id)}
                 />
                 {overview.named_exceeds_global ? (
-                  <div className="flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-700">
+                  <div className="flex items-start gap-2 rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground dark:text-warning">
                     <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
                     <span>
                       {t('budget.namedExceedsGlobal', {
@@ -190,54 +190,32 @@ export default function BudgetsPanel() {
       {/* L'analyse en premier des trois accès : c'est la seule qui répond à
           « est-ce que ça dérive », question qu'aucune carte au-dessus ne pose. */}
       {!overviewQuery.isLoading && overview ? (
-        <Link
-          to="/app/money/analysis"
-          state={pushBack(location)}
-          className="mt-5 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
-        >
-          <BarChart3 className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="font-medium text-foreground">{t('analysis.title')}</p>
-            <p className="text-xs text-muted-foreground">{t('analysis.access.hint')}</p>
-          </div>
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </Link>
-      ) : null}
-
-      {!overviewQuery.isLoading && overview ? (
-        <Link
-          to="/app/budget/recurring"
-          state={pushBack(location)}
-          className="mt-2 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
-        >
-          <CalendarClock className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="font-medium text-foreground">{t('recurring.title')}</p>
-            <p className="text-xs text-muted-foreground">
-              {overview.total_committed && Number(overview.total_committed) > 0
+        <div className="mt-5 space-y-2">
+          <AccessCard
+            to="/app/money/analysis"
+            icon={BarChart3}
+            title={t('analysis.title')}
+            hint={t('analysis.access.hint')}
+          />
+          <AccessCard
+            to="/app/budget/recurring"
+            icon={CalendarClock}
+            title={t('recurring.title')}
+            hint={
+              Number(overview.total_committed) > 0
                 ? t('budget.recurringAccess.committed', {
                     amount: formatAmount(overview.total_committed),
                   })
-                : t('budget.recurringAccess.hint')}
-            </p>
-          </div>
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </Link>
-      ) : null}
-
-      {!overviewQuery.isLoading && overview ? (
-        <Link
-          to="/app/budget/reports"
-          state={pushBack(location)}
-          className="mt-2 flex items-center gap-3 rounded-lg border border-border bg-card p-3 transition-colors hover:bg-accent/60"
-        >
-          <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
-          <div className="min-w-0 flex-1">
-            <p className="font-medium text-foreground">{t('report.title')}</p>
-            <p className="text-xs text-muted-foreground">{t('report.access.hint')}</p>
-          </div>
-          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
-        </Link>
+                : t('budget.recurringAccess.hint')
+            }
+          />
+          <AccessCard
+            to="/app/budget/reports"
+            icon={FileText}
+            title={t('report.title')}
+            hint={t('report.access.hint')}
+          />
+        </div>
       ) : null}
 
       <BudgetDialog

--- a/ui/src/features/money/CashExpenseDialog.tsx
+++ b/ui/src/features/money/CashExpenseDialog.tsx
@@ -8,6 +8,7 @@ import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
 import { useBudgets } from '@/features/budget/hooks';
+import { todayISO } from '@/lib/format';
 import {
   useBankAccounts,
   useCreateBankAccount,
@@ -112,7 +113,7 @@ export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDia
         // honnête : c'est aussi le prérequis de conformité (sans date d'ouverture,
         // aucun contrôle ne porte sur ce compte).
         opening_balance: '0',
-        opening_balance_date: new Date().toISOString().slice(0, 10),
+        opening_balance_date: todayISO(),
       });
       setAccountId(created.id);
     } catch {

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -485,7 +485,7 @@ function FindingRow({
           </p>
         ) : null}
         {finding.is_stale ? (
-          <p className="text-xs text-amber-600">
+          <p className="text-xs text-warning">
             {t('money.compliance.stale', { reason: finding.waiver_reason })}
           </p>
         ) : null}

--- a/ui/src/features/money/MoneyPage.tsx
+++ b/ui/src/features/money/MoneyPage.tsx
@@ -3,6 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/PageHeader';
 import { TabShell, type TabConfig } from '@/components/TabShell';
+import { useSessionState } from '@/lib/useSessionState';
 import { useComplianceSummary } from './hooks';
 import { PENDING_KINDS } from './keys';
 import CompliancePanel from './CompliancePanel';
@@ -34,33 +35,25 @@ export default function MoneyPage() {
   const [searchParams] = useSearchParams();
   const summaryQuery = useComplianceSummary();
 
-  /** Bascule d'onglet impérative — `TabShell` lit sa valeur dans la session. */
-  const goToTab = React.useCallback((tab: MoneyTab) => {
-    try {
-      sessionStorage.setItem(MONEY_TAB_SESSION_KEY, JSON.stringify(tab));
-    } catch {
-      // sessionStorage indisponible : la navigation manuelle reste possible.
-    }
-    // `TabShell` ne réagit pas au storage ; un reload de la route applique la valeur.
-    window.location.assign(`/app/money?tab=${tab}`);
-  }, []);
-
-  // Deep link `?tab=budgets` — les anciennes URLs (/app/budget…) et les liens de
-  // l'agent y atterrissent. Écrit dans la session **avant** que TabShell lise sa
-  // valeur initiale : l'initialiseur d'état du parent s'exécute avant le montage
-  // de l'enfant, ce qui rend le tour de passe-passe fiable plutôt que fragile.
+  // L'onglet actif vit ici, et `TabShell` en est le miroir contrôlé.
+  //
+  // Il vivait dans `TabShell`, ce qui laissait le parent sans prise : pour
+  // renvoyer l'utilisateur de « À ranger » vers « Contrôle », la seule voie était
+  // d'écrire dans `sessionStorage` puis de faire un `window.location.assign` —
+  // un rechargement complet du navigateur au milieu d'une SPA, qui vidait tout le
+  // cache React Query et refetchait chaque compteur pour un changement d'onglet.
+  // Le deep link `?tab=budgets` (anciennes URLs, liens de l'agent) devient au
+  // passage une simple valeur initiale, au lieu d'un tour de passe-passe sur
+  // l'ordre de montage des composants.
   const requestedTab = searchParams.get('tab');
-  React.useState(() => {
-    if (isMoneyTab(requestedTab)) {
-      try {
-        sessionStorage.setItem(MONEY_TAB_SESSION_KEY, JSON.stringify(requestedTab));
-      } catch {
-        // sessionStorage indisponible (navigation privée) — l'onglet par défaut
-        // s'affiche, ce qui est dégradé mais pas cassé.
-      }
-    }
-    return null;
-  });
+  const [tab, setTab] = useSessionState<MoneyTab>(
+    MONEY_TAB_SESSION_KEY,
+    isMoneyTab(requestedTab) ? requestedTab : 'control',
+  );
+
+  React.useEffect(() => {
+    if (isMoneyTab(requestedTab)) setTab(requestedTab);
+  }, [requestedTab, setTab]);
 
   const summary = summaryQuery.data;
 
@@ -86,17 +79,19 @@ export default function MoneyPage() {
       <TabShell
         tabs={tabs}
         sessionKey={MONEY_TAB_SESSION_KEY}
-        defaultTab={isMoneyTab(requestedTab) ? requestedTab : 'control'}
+        defaultTab="control"
+        value={tab}
+        onValueChange={setTab}
       >
-        {(tab) => {
-          if (tab === 'control') return <CompliancePanel />;
-          if (tab === 'pending') {
+        {(activeTab) => {
+          if (activeTab === 'control') return <CompliancePanel />;
+          if (activeTab === 'pending') {
             // La file renvoie vers Contrôle quand un prérequis la rend vide : sinon
             // l'utilisateur voit une file vide sans savoir où agir.
-            return <PendingQueue onGoToControl={() => goToTab('control')} />;
+            return <PendingQueue onGoToControl={() => setTab('control')} />;
           }
-          if (tab === 'accounts') return <AccountsPanel />;
-          if (tab === 'expenses') return <ExpensesPanel />;
+          if (activeTab === 'accounts') return <AccountsPanel />;
+          if (activeTab === 'expenses') return <ExpensesPanel />;
           return <BudgetsPanel />;
         }}
       </TabShell>

--- a/ui/src/features/money/PendingCard.tsx
+++ b/ui/src/features/money/PendingCard.tsx
@@ -88,7 +88,7 @@ export default function PendingCard({
           </div>
 
           {row.isPartial ? (
-            <p className="mt-1 text-xs text-amber-600">
+            <p className="mt-1 text-xs text-warning">
               {t('money.pending.partial', {
                 allocated: formatAmount(row.allocated),
                 remaining: formatAmount(row.remaining),
@@ -97,7 +97,7 @@ export default function PendingCard({
           ) : null}
 
           {row.isStale ? (
-            <p className="mt-1 text-xs italic text-amber-600">
+            <p className="mt-1 text-xs italic text-warning">
               {t('money.compliance.stale', { reason: row.waiverReason })}
             </p>
           ) : null}

--- a/ui/src/features/money/hooks.ts
+++ b/ui/src/features/money/hooks.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import {
   createWaiver,
@@ -6,9 +6,9 @@ import {
   fetchComplianceGroup,
   fetchComplianceSummary,
 } from '@/lib/api/banking';
-import { bankingKeys } from '@/features/banking/hooks';
 import { toast } from '@/lib/toast';
 import { complianceKeys } from './keys';
+import { useInvalidateMoney } from './invalidate';
 
 export { complianceKeys };
 
@@ -39,25 +39,12 @@ export function useComplianceGroup(
 }
 
 /**
- * Invalide la conformité **et** le journal bancaire : ventiler une ligne change
- * un écart *et* la ligne elle-même, et laisser l'un des deux caches en arrière
- * afficherait un compteur qui contredit la liste juste en dessous.
- */
-function useInvalidateCompliance() {
-  const qc = useQueryClient();
-  return () => {
-    void qc.invalidateQueries({ queryKey: complianceKeys.all });
-    void qc.invalidateQueries({ queryKey: bankingKeys.all });
-  };
-}
-
-/**
  * Arbitrer un écart. Jamais un « ignorer » : le motif part au serveur, qui le
  * refuse s'il est vide. Un second appel sur le même écart met à jour le motif et
  * le fingerprint — c'est le chemin du « ré-arbitrer » sur un arbitrage périmé.
  */
 export function useWaiveFinding() {
-  const invalidate = useInvalidateCompliance();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: { finding_kind: string; object_id: string; reason: string }) =>
@@ -72,7 +59,7 @@ export function useWaiveFinding() {
 
 /** Révoquer : l'écart resurgit à l'identique. C'est ce qui rend l'arbitrage sûr. */
 export function useRevokeWaiver() {
-  const invalidate = useInvalidateCompliance();
+  const invalidate = useInvalidateMoney();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (id: string) => deleteWaiver(id),

--- a/ui/src/features/money/invalidate.ts
+++ b/ui/src/features/money/invalidate.ts
@@ -1,0 +1,48 @@
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  BANKING_ROOT,
+  BUDGET_ROOT,
+  COMPLIANCE_ROOT,
+  EXPENSES_ROOT,
+  INTERACTIONS_ROOT,
+} from './keys';
+
+/**
+ * Ce qu'une écriture sur l'argent rend périmé — **déclaré une fois**.
+ *
+ * L'argent est une seule donnée lue par cinq caches : le journal bancaire, le
+ * journal des interactions, le résumé des dépenses, les compteurs de budget et
+ * la conformité. Une ligne ventilée les touche tous les cinq ; un relevé importé
+ * aussi ; classer une recette change un écart.
+ *
+ * Chaque hook listait pourtant sa propre combinaison, et elles avaient dérivé —
+ * cinq mutations sur huit oubliaient au moins une famille :
+ *
+ * - **importer un relevé** n'invalidait que `banking`, alors que c'est le moment
+ *   où les compteurs passent de zéro à cent ;
+ * - **rapprocher** oubliait les dépenses, que la passe crée pourtant en
+ *   confirmant des récurrences ;
+ * - **rattacher une dépense**, **classer une recette**, **refléter un retrait**
+ *   n'invalidaient pas la conformité : l'écart disparaissait de l'écran et
+ *   restait dans le badge.
+ *
+ * Un compteur qui contredit la liste juste en dessous fait perdre leur crédit
+ * aux deux. La règle est donc devenue une seule fonction : **toute mutation qui
+ * touche à l'argent invalide tout l'argent.** Invalider trop large coûte
+ * quelques requêtes sur des vues déjà montées ; invalider trop étroit coûte la
+ * confiance dans les chiffres, et le bug est invisible en revue.
+ */
+export function useInvalidateMoney() {
+  const queryClient = useQueryClient();
+  return () => {
+    for (const root of [
+      BANKING_ROOT,
+      INTERACTIONS_ROOT,
+      EXPENSES_ROOT,
+      BUDGET_ROOT,
+      COMPLIANCE_ROOT,
+    ]) {
+      void queryClient.invalidateQueries({ queryKey: root });
+    }
+  };
+}

--- a/ui/src/features/money/keys.ts
+++ b/ui/src/features/money/keys.ts
@@ -8,8 +8,24 @@
  * fichiers (où elle finirait par diverger d'un caractère).
  */
 
+/**
+ * Les cinq racines de cache que l'argent partage.
+ *
+ * Elles vivent ici et pas dans le `hooks.ts` de chaque feature parce qu'une
+ * mutation bancaire doit pouvoir invalider les budgets, et réciproquement. Tant
+ * qu'elles étaient écrites en littéraux au point d'appel (`['budget']`,
+ * `['expenses']`…), chaque hook déclarait sa propre liste — et elles ont dérivé :
+ * cinq mutations sur huit oubliaient au moins une famille. Voir
+ * `useInvalidateMoney`.
+ */
+export const BANKING_ROOT = ['banking'] as const;
+export const INTERACTIONS_ROOT = ['interactions'] as const;
+export const EXPENSES_ROOT = ['expenses'] as const;
+export const BUDGET_ROOT = ['budget'] as const;
+export const COMPLIANCE_ROOT = ['compliance'] as const;
+
 export const complianceKeys = {
-  all: ['compliance'] as const,
+  all: COMPLIANCE_ROOT,
   summary: () => [...complianceKeys.all, 'summary'] as const,
   group: (kind: string, waived: boolean, offset: number) =>
     [...complianceKeys.all, 'group', kind, waived, offset] as const,

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -305,7 +305,7 @@ export default function ProjectDetailPage() {
           <div className="flex flex-wrap items-center gap-x-5 gap-y-2 rounded-lg border bg-muted/30 px-4 py-3 text-sm">
             {planned > 0 ? (
               <span>
-                {t('projects.summary.budget', { defaultValue: 'Budget' })}{' '}
+                {t('projects.summary.budget')}{' '}
                 <span className={`font-medium ${overBudget ? 'text-destructive' : ''}`}>
                   {formatAmount(actual, { fractionDigits: 0 })}
                 </span>

--- a/ui/src/features/renovation/RenovationDialog.tsx
+++ b/ui/src/features/renovation/RenovationDialog.tsx
@@ -17,6 +17,7 @@ import {
   type RenovationType,
 } from '@/lib/api/renovation';
 import { useCreateRenovation, useUpdateRenovation } from './hooks';
+import { todayISO } from '@/lib/format';
 
 interface RenovationDialogProps {
   open: boolean;
@@ -28,7 +29,7 @@ interface RenovationDialogProps {
 }
 
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  return todayISO();
 }
 
 export default function RenovationDialog({

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -269,6 +269,8 @@ export interface TransactionFilters {
   date_to?: string;
   direction?: TransactionDirection | '';
   is_internal?: 'true' | 'false' | '';
+  /** `'todo'` = seulement les sorties que le contrôle réclame (non ventilées ou partielles). */
+  allocation?: 'todo' | '';
   q?: string;
 }
 

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -42,6 +42,27 @@ export function formatAmount(
   }).format(parsed);
 }
 
+/**
+ * `Date` → `YYYY-MM-DD` **dans le fuseau du navigateur**.
+ *
+ * `toISOString().slice(0, 10)` convertit d'abord en UTC : à Paris, tout ce qui
+ * se passe entre minuit et 2 h du matin est daté de la veille, et une borne de
+ * période construite à minuit local recule d'un jour entier. C'est le formatteur
+ * unique des dates de calendrier, comme `formatAmount` l'est des montants — ne
+ * jamais réintroduire un `toISOString().slice(0, 10)` local.
+ */
+export function toLocalISODate(value: Date): string {
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, '0');
+  const day = String(value.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** La date d'aujourd'hui telle que l'utilisateur la lit — valeur par défaut des formulaires. */
+export function todayISO(): string {
+  return toLocalISODate(new Date());
+}
+
 /** true si la date est dans le passé (garantie / échéance dépassée, péremption…). */
 export function isPast(value?: string | null): boolean {
   if (!value) return false;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2572,6 +2572,9 @@
       "actions": {
         "add": "Ausgabe"
       }
+    },
+    "summary": {
+      "budget": "Budget"
     }
   },
   "notifications": {
@@ -3317,7 +3320,8 @@
       "empty": {
         "title": "Keine Buchungen",
         "description": "Importiere einen Kontoauszug auf der Konten-Seite oder erweitere deine Filter."
-      }
+      },
+      "toSortOut": "Zu erledigen"
     },
     "balance": {
       "uncertain": "zu prüfen",
@@ -3348,6 +3352,25 @@
       "noAccountHint": "Legen Sie im Reiter Konten ein Konto „Bargeld“ an: eine Barausgabe wird dann eine Kontobuchung wie jede andere.",
       "createAccount": "Barkonto anlegen",
       "defaultAccountName": "Bargeld"
+    },
+    "withdraw": {
+      "title": "Auf Bargeld übertragen",
+      "intro": "Diese Abhebung ist keine Ausgabe: Das Geld wechselt nur die Tasche. Wird sie auf ein Bargeldkonto gespiegelt, zählt sie genau einmal — wenn das Bargeld tatsächlich ausgegeben wird.",
+      "action": "Bargeldkonto speisen",
+      "fields": {
+        "account": "Bargeldkonto",
+        "amount": "Gespiegelter Betrag",
+        "amountHint": "Standardmäßig die gesamte Abhebung. Verringern Sie ihn, wenn ein Teil nicht in die gemeinsame Kasse gewandert ist."
+      },
+      "errors": {
+        "accountRequired": "Wählen Sie das zu belastende Bargeldkonto.",
+        "amountInvalid": "Geben Sie einen positiven Betrag an, höchstens {{max}}."
+      },
+      "noCashAccount": "Noch kein Bargeldkonto vorhanden. Legen Sie eines im Tab „Konten“ an, um Bargeld zu verfolgen.",
+      "linked": "Abhebung auf Bargeld gespiegelt.",
+      "unlinked": "Bargeld-Gegenbuchung entfernt.",
+      "linkedBadge": "Bargeld",
+      "unlink": "Gegenbuchung entfernen"
     },
     "allocation": {
       "title": "Diese Buchung aufteilen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2572,6 +2572,9 @@
       "actions": {
         "add": "Expense"
       }
+    },
+    "summary": {
+      "budget": "Budget"
     }
   },
   "notifications": {
@@ -3317,7 +3320,8 @@
       "empty": {
         "title": "No operations",
         "description": "Import a statement from the Accounts page, or widen your filters."
-      }
+      },
+      "toSortOut": "To sort out"
     },
     "balance": {
       "uncertain": "to check",
@@ -3348,6 +3352,25 @@
       "noAccountHint": "Declare a “Cash” account in the Accounts tab: a cash spend then becomes an account operation, like every other.",
       "createAccount": "Create my cash account",
       "defaultAccountName": "Cash"
+    },
+    "withdraw": {
+      "title": "Move to cash",
+      "intro": "This withdrawal is not spending: the money changes pocket. Mirroring it onto a cash account means it gets counted once — when that cash is actually spent.",
+      "action": "Feed the cash account",
+      "fields": {
+        "account": "Cash account",
+        "amount": "Amount mirrored",
+        "amountHint": "The whole withdrawal by default. Lower it if part of it never reached the shared pot."
+      },
+      "errors": {
+        "accountRequired": "Pick the cash account to credit.",
+        "amountInvalid": "Enter a positive amount, at most {{max}}."
+      },
+      "noCashAccount": "No cash account yet. Create one from the Accounts tab to start tracking physical money.",
+      "linked": "Withdrawal mirrored onto cash.",
+      "unlinked": "Cash counterpart removed.",
+      "linkedBadge": "Cash",
+      "unlink": "Remove the counterpart"
     },
     "allocation": {
       "title": "Split this operation",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2572,6 +2572,9 @@
       "actions": {
         "add": "Gasto"
       }
+    },
+    "summary": {
+      "budget": "Presupuesto"
     }
   },
   "notifications": {
@@ -3317,7 +3320,8 @@
       "empty": {
         "title": "Ninguna operación",
         "description": "Importa un extracto desde la página Cuentas, o amplía los filtros."
-      }
+      },
+      "toSortOut": "Por ordenar"
     },
     "balance": {
       "uncertain": "por comprobar",
@@ -3348,6 +3352,25 @@
       "noAccountHint": "Declare una cuenta «Efectivo» en la pestaña Cuentas: un gasto en metálico pasa entonces a ser una operación de cuenta, como las demás.",
       "createAccount": "Crear mi cuenta de efectivo",
       "defaultAccountName": "Efectivo"
+    },
+    "withdraw": {
+      "title": "Pasar a efectivo",
+      "intro": "Esta retirada no es un gasto: el dinero cambia de bolsillo. Al reflejarla en una cuenta de efectivo se cuenta una sola vez — cuando ese efectivo se gaste de verdad.",
+      "action": "Alimentar el efectivo",
+      "fields": {
+        "account": "Cuenta de efectivo",
+        "amount": "Importe reflejado",
+        "amountHint": "Por defecto, la retirada completa. Redúzcalo si una parte no llegó al fondo común."
+      },
+      "errors": {
+        "accountRequired": "Elija la cuenta de efectivo que se abonará.",
+        "amountInvalid": "Indique un importe positivo, como máximo {{max}}."
+      },
+      "noCashAccount": "Aún no hay cuenta de efectivo. Cree una en la pestaña Cuentas para poder seguir el dinero físico.",
+      "linked": "Retirada reflejada en el efectivo.",
+      "unlinked": "Contrapartida en efectivo eliminada.",
+      "linkedBadge": "Efectivo",
+      "unlink": "Eliminar la contrapartida"
     },
     "allocation": {
       "title": "Desglosar esta operación",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2572,6 +2572,9 @@
       "actions": {
         "add": "Dépense"
       }
+    },
+    "summary": {
+      "budget": "Budget"
     }
   },
   "notifications": {
@@ -3317,7 +3320,8 @@
       "empty": {
         "title": "Aucune opération",
         "description": "Importe un relevé depuis la page Comptes, ou élargis tes filtres."
-      }
+      },
+      "toSortOut": "À traiter"
     },
     "balance": {
       "uncertain": "à vérifier",
@@ -3348,6 +3352,25 @@
       "noAccountHint": "Déclarez un compte « Espèces » dans l'onglet Comptes : une dépense en liquide devient alors une opération de compte, comme les autres.",
       "createAccount": "Créer mon compte espèces",
       "defaultAccountName": "Espèces"
+    },
+    "withdraw": {
+      "title": "Retirer vers les espèces",
+      "intro": "Ce retrait n'est pas une dépense : l'argent change de poche. En le reflétant sur un compte espèces, il sera compté une seule fois — quand ces espèces seront réellement dépensées.",
+      "action": "Alimenter les espèces",
+      "fields": {
+        "account": "Compte espèces",
+        "amount": "Montant reflété",
+        "amountHint": "Par défaut, la totalité du retrait. Réduisez-le si une partie n'a pas rejoint la caisse commune."
+      },
+      "errors": {
+        "accountRequired": "Choisissez le compte espèces à créditer.",
+        "amountInvalid": "Indiquez un montant positif, au plus {{max}}."
+      },
+      "noCashAccount": "Aucun compte espèces déclaré. Créez-en un dans l'onglet Comptes pour pouvoir suivre le liquide.",
+      "linked": "Retrait reflété sur les espèces.",
+      "unlinked": "Contrepartie espèces supprimée.",
+      "linkedBadge": "Espèces",
+      "unlink": "Supprimer la contrepartie"
     },
     "allocation": {
       "title": "Ventiler cette opération",

--- a/ui/src/locales/keys.test.ts
+++ b/ui/src/locales/keys.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Le garde-fou i18n : toute clé appelée existe, dans les quatre langues.
+ *
+ * Ce test existe à cause d'une régression qui a vécu en production. Le dialogue
+ * « dépense en espèces » a réutilisé le namespace `banking.cash.*` et **écrasé**
+ * les clés du dialogue « retirer vers les espèces » : douze clés disparues d'un
+ * coup, dont le libellé d'un bouton présent sur chaque ligne sortante du
+ * journal, qui affichait donc littéralement `banking.cash.action`.
+ *
+ * Rien ne l'a signalé, et les deux garde-fous existants ont chacun regardé à
+ * côté :
+ *
+ * - la règle « jamais de `defaultValue` » (CLAUDE.md) fait afficher la clé brute
+ *   au lieu d'un texte anglais — encore faut-il que quelqu'un ouvre l'écran ;
+ * - la parité entre catalogues était **verte**, parce que la clé manquait
+ *   partout. Comparer les langues entre elles ne voit pas ce trou-là.
+ *
+ * D'où les deux assertions : le **code** contre le français, puis les trois
+ * autres langues contre le français.
+ */
+
+const LANGUAGES = ['en', 'de', 'es'] as const;
+
+/** Les clés `t('…')` littérales. Une clé construite n'est pas vérifiable ici. */
+const CALL = /\bt\(\s*['"]([a-zA-Z0-9_.-]+)['"]/g;
+
+const catalogues = import.meta.glob<Record<string, unknown>>('./*/translation.json', {
+  eager: true,
+  import: 'default',
+});
+
+/**
+ * Namespaces couverts. Volontairement une liste, pas « tout le front » :
+ * `features/settings` traîne une trentaine de `t(…, { defaultValue })` hérités
+ * qui violent déjà la règle du projet, et faire échouer ce test dessus le ferait
+ * désactiver au lieu d'être lu. Élargir au fur et à mesure qu'ils sont résorbés.
+ */
+const sources = import.meta.glob<string>(
+  '../features/{money,banking,budget,expenses,interactions}/**/*.{ts,tsx}',
+  { eager: true, query: '?raw', import: 'default' },
+);
+
+function flatten(node: unknown, prefix = '', out = new Set<string>()): Set<string> {
+  if (node && typeof node === 'object' && !Array.isArray(node)) {
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+      flatten(value, prefix ? `${prefix}.${key}` : key, out);
+    }
+  } else {
+    out.add(prefix);
+  }
+  return out;
+}
+
+function catalogue(language: string): Set<string> {
+  const found = catalogues[`./${language}/translation.json`];
+  if (!found) throw new Error(`catalogue introuvable : ${language}`);
+  return flatten(found);
+}
+
+/** i18next résout `foo` via `foo_one` / `foo_other` : une clé pluralisée compte. */
+function isKnown(key: string, keys: Set<string>): boolean {
+  if (keys.has(key)) return true;
+  for (const candidate of keys) {
+    if (candidate.startsWith(`${key}_`)) return true;
+  }
+  return false;
+}
+
+describe('catalogues de traduction', () => {
+  const french = catalogue('fr');
+
+  it('toute clé appelée par le module Argent existe en français', () => {
+    const missing: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      if (file.endsWith('.test.ts') || file.endsWith('.test.tsx')) continue;
+      for (const match of source.matchAll(CALL)) {
+        if (!isKnown(match[1], french)) missing.push(`${match[1]} → ${file}`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('les fichiers du module Argent sont bien lus (le test ne teste pas le vide)', () => {
+    expect(Object.keys(sources).length).toBeGreaterThan(30);
+  });
+
+  it.each(LANGUAGES)('le catalogue %s a exactement les mêmes clés que le français', (language) => {
+    const other = catalogue(language);
+    expect([...french].filter((key) => !other.has(key)).sort()).toEqual([]);
+    expect([...other].filter((key) => !french.has(key)).sort()).toEqual([]);
+  });
+});

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -53,6 +53,8 @@ html { visibility: visible; }
   --color-accent-foreground:      hsl(var(--accent-foreground));
   --color-destructive:            hsl(var(--destructive));
   --color-destructive-foreground: hsl(var(--destructive-foreground));
+  --color-warning:                hsl(var(--warning));
+  --color-warning-foreground:     hsl(var(--warning-foreground));
   --color-border:                 hsl(var(--border));
   --color-input:                  hsl(var(--input));
   --color-ring:                   hsl(var(--ring));

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -56,6 +56,12 @@
   --accent-foreground: 222 47% 11%;
   --destructive: 0 84% 60%;
   --destructive-foreground: 0 0% 100%;
+  /* « attention », le cran avant le dépassement : un budget à 80 %, une échéance
+     due, une ligne partiellement rangée. Il manquait à la palette, alors chaque
+     écran l'écrivait en `amber-500` en dur — donc en clair fixe, y compris en
+     thème sombre. Un token, pas sept littéraux. */
+  --warning: 38 92% 50%;
+  --warning-foreground: 26 83% 24%;
   --border: 214 32% 91%;
   --input: 214 32% 91%;
   --ring: var(--primary);
@@ -97,6 +103,10 @@
   --accent-foreground: 210 40% 98%;
   --destructive: 0 63% 31%;
   --destructive-foreground: 210 40% 98%;
+  /* Plus clair qu'en thème clair : sur fond sombre, l'ambre saturé du jour
+     devient illisible en texte. */
+  --warning: 43 96% 62%;
+  --warning-foreground: 26 83% 14%;
   --border: 217 33% 26%;
   --input: 217 33% 26%;
   --ring: var(--primary);


### PR DESCRIPTION
Audit complet du module Argent (`banking`, `budget`, `interactions` + les quatre features front), puis correction de tout ce qu'il a trouvé.

L'architecture tenait — fenêtre de conformité, convention de signe, `with_allocation` partagé, registre de détecteurs. Les défauts étaient tous **aux jointures** : là où deux modules répondent à la même question sans passer par la même fonction.

## Ce que l'utilisateur voyait

| | |
|---|---|
| **Deux totaux pour une enveloppe** | « Ce mois-ci » était borné dans le fuseau du foyer par le panneau Budgets, en UTC par le résumé des dépenses. Cliquer sur « 340 € / 400 € » pouvait ouvrir une page annonçant 352 €. |
| **Toutes les périodes décalées d'un jour** | `toISOString()` convertit en UTC avant de formater : à Paris, « ce mois-ci » allait du **30 juin au 30 juillet**, « cette année » commençait le 31 décembre précédent. |
| **« Hier » comme date du jour** | Même cause, dans dix formulaires, entre minuit et 2 h chaque nuit. |
| **Des clés brutes dans le journal** | Le dialogue « dépense en espèces » (#404) avait écrasé les 12 clés du dialogue « retirer vers les espèces ». Le menu de chaque ligne sortante affichait `banking.cash.action`, et le dialogue de retrait portait le titre du dialogue de dépense. |
| **Des compteurs périmés** | 5 mutations sur 8 laissaient un cache en arrière. Importer un relevé — le moment où les écarts passent de zéro à cent — n'invalidait que `banking`. |

## Les définitions uniques posées

- **`apps/core/timezones.py`** — le seul endroit qui sait ce qu'est un mois, une journée, ou « aujourd'hui » chez un foyer. Six copies locales du helper de fuseau (dont quatre approximatives) deviennent des alias ; `date.today()` disparaît du module.
- **`toLocalISODate` / `todayISO`** dans `@/lib/format` — le pendant front, avec la même règle que `formatAmount`.
- **`useInvalidateMoney`** — les cinq racines de cache déclarées une fois, au lieu de huit listes ad-hoc qui avaient dérivé.
- **`compliance.apply_window_to_pairs`** — le filtrage des détecteurs non-SQL, copié six fois mot pour mot.
- **`detectors.pending_outflows`** — le nouveau filtre « À traiter » du journal lit la **même** fonction que les compteurs du Contrôle.

## Aussi

- `compliance.group_result` : ouvrir un groupe ne relance plus les 14 détecteurs pour sérialiser un en-tête.
- `_unallocated_outflow` passe par `with_allocation` — c'était la troisième copie d'une annotation dont le docstring dit qu'elle doit être unique.
- Token `--warning` : la palette n'avait pas la couleur, donc sept écrans l'écrivaient en `amber-500` en dur, y compris en thème sombre.
- `AccessCard` remplace trois cartes en balisage manuel ; `TabShell` devient contrôlable, ce qui retire un `window.location.assign` — un rechargement complet du navigateur au milieu d'une SPA — pour un changement d'onglet.
- Une instruction morte dans `set_allocations`.

## Garde-fous

Les tests unitaires du front **n'étaient lancés par personne**. Ils entrent en CI, avec `TZ=Europe/Paris` : sous UTC le décalage est invisible, ce qui est exactement pourquoi il a vécu jusqu'en production.

- `ui/src/locales/keys.test.ts` compare le **code** aux quatre catalogues. Le contrôle de parité entre langues était vert — la clé manquait *partout*.
- `ui/src/features/expenses/period.test.ts` — les quatre périodes.
- `interactions/tests/test_period_bounds.py::TestTheTwoScreensAgree` — le compteur du panneau et le total de la page qui l'ouvre, nombre pour nombre.
- `banking/tests/test_journal_marker.py::TestTheToSortOutFilter` — la file et le badge comptent pareil.

**3383 backend** (+14), **21 front** (+17), lint et build propres. Vérifié que chaque nouveau test **échoue** sur l'ancien code.

## Laissé de côté — deux arbitrages produit, pas des corrections

- `DELETE /transactions/{id}/unlink/{interaction_id}/` **n'a aucun appelant** : détacher une dépense mal rapprochée n'a pas de geste. Lui en donner un, ou retirer l'endpoint — un endpoint injoignable est lui-même un orphelin.
- `/app/budget/recurring` et `/app/budget/reports` vivent hors de `/app/money`, alors que `/app/budget` y redirige. Les déplacer touche les `url_template` de l'agent, les tutoriels et les redirections.

Hors périmètre : `features/settings` compte une trentaine de `t(…, { defaultValue })`, interdits par le CLAUDE.md — c'est pourquoi le garde-fou i18n couvre une liste de namespaces plutôt que tout le front.

Docs : `CLAUDE.md` (deux règles nouvelles) + `docs/MODULES/money.md`.