### PR TITLE
fix(i18n): retirer les defaultValue, qui cachaient trois défauts en production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,12 +94,35 @@ Ne jamais utiliser de `defaultValue` dans les appels `t()` :
 ```ts
 // ❌ Interdit
 t('tasks.title', 'Tasks')
+t('tasks.title', { defaultValue: 'Tasks' })
 
 // ✅ Correct
 t('tasks.title')
 ```
 
 **Pourquoi :** les `defaultValue` masquent les traductions manquantes. Sans eux, une clé absente du fichier JSON affiche la clé brute, ce qui permet de repérer immédiatement ce qui n'est pas traduit.
+
+**La règle est tenue par un test**, `ui/src/locales/keys.test.ts`, lancé en CI. Il
+fait trois choses, et les trois sont nécessaires :
+
+1. **toute clé `t('…')` littérale existe en français** — c'est le seul contrôle
+   qui compare le *code* au catalogue ;
+2. **aucun fichier ne contient `defaultValue:`** — sans quoi le premier contrôle
+   se laisse contourner ;
+3. **les quatre catalogues ont exactement les mêmes clés.**
+
+Le n° 3 existait déjà de fait, et il n'a rien vu quand le lot 4 a écrasé les douze
+clés de `banking.cash.*` : la clé manquait **partout**, donc la parité était
+verte. Comparer les langues entre elles ne suffit jamais.
+
+Les 111 `defaultValue` historiques masquaient trois vrais défauts en production —
+un titre de dialogue réduit à « Créer », deux échecs distincts fondus en « Échec
+de la requête », une `<legend>` affichant `tagSelector.legend`.
+
+**Limite connue :** une clé construite (`t(\`documents.type.${v}\`)`, `t(labelKey)`)
+n'est pas vérifiable statiquement. Pour une énumération, la contrepartie est que le
+catalogue doit couvrir **toutes** ses valeurs — c'est ce qui rend le `defaultValue`
+inutile là aussi, et non un mal nécessaire.
 
 ## Auto-création d'`Interaction` — pattern write-time + service helper
 

--- a/ui/src/features/documents/DocumentEditDialog.tsx
+++ b/ui/src/features/documents/DocumentEditDialog.tsx
@@ -58,7 +58,7 @@ export default function DocumentEditDialog({
 
   const typeOptions = DOCUMENT_TYPES.map((v) => ({
     value: v,
-    label: t(`documents.type.${v}`, { defaultValue: v }),
+    label: t(`documents.type.${v}`),
   }));
 
   return (

--- a/ui/src/features/documents/DocumentsPage.tsx
+++ b/ui/src/features/documents/DocumentsPage.tsx
@@ -70,7 +70,7 @@ export default function DocumentsPage() {
     { value: '', label: t('documents.filter.allTypes') },
     ...DOCUMENT_TYPES.map((v) => ({
       value: v,
-      label: t(`documents.type.${v}`, { defaultValue: v }),
+      label: t(`documents.type.${v}`),
     })),
   ];
 

--- a/ui/src/features/equipment/EquipmentDetailPage.tsx
+++ b/ui/src/features/equipment/EquipmentDetailPage.tsx
@@ -267,9 +267,7 @@ export default function EquipmentDetailPage() {
                             <div className="flex shrink-0 gap-1">
                               {item.interaction_type ? (
                                 <Badge variant="outline" className="h-5 text-[10px]">
-                                  {t(`equipment.interaction_type.${item.interaction_type}`, {
-                                    defaultValue: item.interaction_type,
-                                  })}
+                                  {t(`equipment.interaction_type.${item.interaction_type}`)}
                                 </Badge>
                               ) : null}
                             </div>

--- a/ui/src/features/expenses/ExpenseFilters.tsx
+++ b/ui/src/features/expenses/ExpenseFilters.tsx
@@ -91,7 +91,7 @@ export default function ExpenseFilters({
           </FilterPill>
           {kindOptions.map((value) => (
             <FilterPill key={value} active={kind === value} onClick={() => onKindChange(value)}>
-              {t(`expenses.kind.${value}`, { defaultValue: value })}
+              {t(`expenses.kind.${value}`)}
             </FilterPill>
           ))}
         </div>

--- a/ui/src/features/interactions/ExpenseFields.tsx
+++ b/ui/src/features/interactions/ExpenseFields.tsx
@@ -51,7 +51,7 @@ export default function ExpenseFields({
         </h3>
         {kind ? (
           <Badge variant="outline" className="text-xs">
-            {t(`expenses.kind.${kind}`, { defaultValue: kind })}
+            {t(`expenses.kind.${kind}`)}
           </Badge>
         ) : null}
       </div>

--- a/ui/src/features/interactions/InteractionCard.tsx
+++ b/ui/src/features/interactions/InteractionCard.tsx
@@ -45,7 +45,7 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
                 {item.subject}
               </CardTitle>
             </Link>
-            <Badge variant="outline">{t(typeLabelKey, { defaultValue: item.type })}</Badge>
+            <Badge variant="outline">{t(typeLabelKey)}</Badge>
           </div>
 
           {item.content ? (

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -251,7 +251,7 @@ export default function InteractionEditPage() {
             >
               {TYPE_OPTIONS.map((v) => (
                 <option key={v} value={v}>
-                  {t(`equipment.interaction_type.${v}`, { defaultValue: v })}
+                  {t(`equipment.interaction_type.${v}`)}
                 </option>
               ))}
             </select>

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -223,7 +223,7 @@ export default function InteractionNewPage() {
             >
               {typeOptions.map((v) => (
                 <option key={v} value={v}>
-                  {t(`equipment.interaction_type.${v}`, { defaultValue: v })}
+                  {t(`equipment.interaction_type.${v}`)}
                 </option>
               ))}
             </select>

--- a/ui/src/features/interactions/InteractionsPage.tsx
+++ b/ui/src/features/interactions/InteractionsPage.tsx
@@ -152,7 +152,7 @@ export default function InteractionsPage() {
                 { value: '', label: t('interactions.all_types') },
                 ...TYPE_OPTIONS.map((v) => ({
                   value: v,
-                  label: t(`equipment.interaction_type.${v}`, { defaultValue: v }),
+                  label: t(`equipment.interaction_type.${v}`),
                 })),
               ],
             },

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -131,12 +131,7 @@ function TabInteractions({
                   <div className="flex shrink-0 gap-1">
                     {item.type ? (
                       <Badge variant="outline" className="h-5 text-[10px]">
-                        {t(`interactions.type.${item.type}`, { defaultValue: item.type })}
-                      </Badge>
-                    ) : null}
-                    {item.status ? (
-                      <Badge variant="secondary" className="h-5 text-[10px]">
-                        {t(`interactions.status.${item.status}`, { defaultValue: item.status })}
+                        {t(`interactions.type.${item.type}`)}
                       </Badge>
                     ) : null}
                   </div>

--- a/ui/src/features/settings/components/AvatarSection.tsx
+++ b/ui/src/features/settings/components/AvatarSection.tsx
@@ -36,7 +36,7 @@ export function AvatarSection({ user, onUserUpdate }: AvatarSectionProps) {
       document.body.dispatchEvent(new CustomEvent('profile-updated'));
       toast({ description: t('settings.avatarUpdated'), variant: 'success' });
     } catch (err) {
-      toast({ description: err instanceof Error ? err.message : t('settings.requestFailed', { defaultValue: 'Upload failed.' }), variant: 'destructive' });
+      toast({ description: err instanceof Error ? err.message : t('settings.avatarUploadFailed'), variant: 'destructive' });
     } finally {
       setSaving(false);
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -51,7 +51,7 @@ export function AvatarSection({ user, onUserUpdate }: AvatarSectionProps) {
       document.body.dispatchEvent(new CustomEvent('profile-updated'));
       toast({ description: t('settings.avatarRemoved'), variant: 'success' });
     } catch (err) {
-      toast({ description: err instanceof Error ? err.message : t('settings.requestFailed', { defaultValue: 'Delete failed.' }), variant: 'destructive' });
+      toast({ description: err instanceof Error ? err.message : t('settings.avatarDeleteFailed'), variant: 'destructive' });
     } finally {
       setSaving(false);
     }
@@ -84,7 +84,7 @@ export function AvatarSection({ user, onUserUpdate }: AvatarSectionProps) {
                 onClick={() => fileInputRef.current?.click()}
                 disabled={saving}
               >
-                {saving ? t('settings.updating') : t('settings.avatarUpload', { defaultValue: 'Upload' })}
+                {saving ? t('settings.updating') : t('settings.avatarUpload')}
               </Button>
               {currentAvatarUrl && (
                 <Button

--- a/ui/src/features/settings/components/HouseholdManagement/components/HouseholdCard.tsx
+++ b/ui/src/features/settings/components/HouseholdManagement/components/HouseholdCard.tsx
@@ -112,11 +112,11 @@ export function HouseholdCard({
         <div className="flex items-center gap-2 flex-wrap">
           <span className="font-medium">{household.name}</span>
           <span className="text-xs text-muted-foreground">
-            {household.members_count} {t('settings.members', { defaultValue: 'members' })}
+            {household.members_count} {t('settings.members')}
           </span>
           {activeId === household.id && (
             <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
-              {t('settings.activeHousehold', { defaultValue: 'Active' })}
+              {t('settings.activeHousehold')}
             </span>
           )}
         </div>
@@ -128,7 +128,7 @@ export function HouseholdCard({
               size="icon"
               variant="ghost"
               className="h-8 w-8 rounded-lg border border-transparent text-muted-foreground hover:border-border hover:bg-accent/70 hover:text-foreground"
-              aria-label={t('common.actions', { defaultValue: 'Actions' })}
+              aria-label={t('common.actions')}
             >
               <MoreHorizontal className="h-4 w-4" />
             </Button>
@@ -136,7 +136,7 @@ export function HouseholdCard({
           <DropdownMenuContent align="end">
             {canSwitch && (
               <DropdownMenuItem onSelect={() => void onSwitch(household.id)} disabled={switching}>
-                {t('settings.setActiveHousehold', { defaultValue: 'Set as active' })}
+                {t('settings.setActiveHousehold')}
               </DropdownMenuItem>
             )}
 
@@ -144,21 +144,21 @@ export function HouseholdCard({
               <>
                 {canSwitch && <DropdownMenuSeparator />}
                 <DropdownMenuItem onSelect={() => onStartEdit(household)}>
-                  {t('common.edit', { defaultValue: 'Edit' })}
+                  {t('common.edit')}
                 </DropdownMenuItem>
                 <DropdownMenuItem onSelect={() => onStartInvite(household.id)}>
-                  {t('settings.invite', { defaultValue: 'Invite' })}
+                  {t('settings.invite')}
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onSelect={() => onStartArchive(household.id)} className="text-destructive focus:text-destructive">
-                  {t('common.archive', { defaultValue: 'Archive' })}
+                  {t('common.archive')}
                 </DropdownMenuItem>
               </>
             ) : (
               <>
                 {canSwitch && <DropdownMenuSeparator />}
                 <DropdownMenuItem onSelect={() => void onLeave(household.id)} disabled={loading}>
-                  {t('settings.leave', { defaultValue: 'Leave' })}
+                  {t('settings.leave')}
                 </DropdownMenuItem>
               </>
             )}
@@ -174,8 +174,8 @@ export function HouseholdCard({
               {' — '}
               <span className="capitalize">
                 {member.role === 'owner'
-                  ? t('settings.owner', { defaultValue: 'Owner' })
-                  : t('settings.member', { defaultValue: 'Member' })}
+                  ? t('settings.owner')
+                  : t('settings.member')}
               </span>
             </li>
           ))}
@@ -187,7 +187,7 @@ export function HouseholdCard({
       {isOwner && (
         <HouseholdEditSheet
           household={household}
-          title={t('settings.editHousehold', { defaultValue: 'Edit household' })}
+          title={t('settings.editHousehold')}
           isOpen={activePanel?.id === household.id && activePanel.mode === 'edit'}
           isSaving={editSaving}
           values={editForm}
@@ -197,21 +197,21 @@ export function HouseholdCard({
           onSubmit={onEditSave}
           trigger={<Button type="button" className="hidden" aria-hidden tabIndex={-1} />}
           labels={{
-            edit: t('common.edit', { defaultValue: 'Edit' }),
-            submit: t('common.save', { defaultValue: 'Save' }),
-            submitting: t('settings.saving', { defaultValue: 'Saving…' }),
-            name: t('settings.householdName', { defaultValue: 'Household name' }),
-            sectionLocation: t('settings.sectionLocation', { defaultValue: 'Location' }),
-            address: t('settings.address', { defaultValue: 'Address' }),
-            city: t('settings.city', { defaultValue: 'City' }),
-            postalCode: t('settings.postalCode', { defaultValue: 'Postal code' }),
-            country: t('settings.country', { defaultValue: 'Country' }),
-            countryPlaceholder: t('settings.countryPlaceholder', { defaultValue: '— Select country —' }),
-            timezone: t('settings.timezone', { defaultValue: 'Timezone' }),
-            timezonePlaceholder: t('settings.timezonePlaceholder', { defaultValue: '— Select timezone —' }),
-            sectionContext: t('settings.sectionContext', { defaultValue: 'Context & AI' }),
-            contextNotes: t('settings.contextNotes', { defaultValue: 'Household notes' }),
-            aiPromptContext: t('settings.aiPromptContext', { defaultValue: 'AI prompt context' }),
+            edit: t('common.edit'),
+            submit: t('common.save'),
+            submitting: t('settings.saving'),
+            name: t('settings.householdName'),
+            sectionLocation: t('settings.sectionLocation'),
+            address: t('settings.address'),
+            city: t('settings.city'),
+            postalCode: t('settings.postalCode'),
+            country: t('settings.country'),
+            countryPlaceholder: t('settings.countryPlaceholder'),
+            timezone: t('settings.timezone'),
+            timezonePlaceholder: t('settings.timezonePlaceholder'),
+            sectionContext: t('settings.sectionContext'),
+            contextNotes: t('settings.contextNotes'),
+            aiPromptContext: t('settings.aiPromptContext'),
           }}
         />
       )}
@@ -221,13 +221,13 @@ export function HouseholdCard({
         onOpenChange={(open) => {
           if (!open) onClosePanel();
         }}
-        title={t('settings.invite', { defaultValue: 'Invite' })}
-        description={t('settings.inviteDescription', { defaultValue: 'Enter the email address of the person you want to invite to this household.' })}
+        title={t('settings.invite')}
+        description={t('settings.inviteDescription')}
       >
         <form onSubmit={(event) => void onInvite(event, household.id)} className="space-y-3 pt-1">
           <Input
             type="email"
-            placeholder={t('settings.inviteEmailPlaceholder', { defaultValue: 'member@example.com' })}
+            placeholder={t('settings.inviteEmailPlaceholder')}
             value={inviteEmail}
             onChange={(event) => onSetInviteEmail(event.target.value)}
             className="w-full"
@@ -235,10 +235,10 @@ export function HouseholdCard({
           />
           <div className="flex justify-end gap-2">
             <Button size="sm" variant="ghost" onClick={onClosePanel} type="button">
-              {t('common.cancel', { defaultValue: 'Cancel' })}
+              {t('common.cancel')}
             </Button>
             <Button type="submit" size="sm" disabled={inviting}>
-              {inviting ? t('settings.sending', { defaultValue: 'Sending…' }) : t('settings.send', { defaultValue: 'Send' })}
+              {inviting ? t('settings.sending') : t('settings.send')}
             </Button>
           </div>
         </form>
@@ -249,12 +249,12 @@ export function HouseholdCard({
         onOpenChange={(open) => {
           if (!open) onClosePanel();
         }}
-        title={t('common.archive', { defaultValue: 'Archive' })}
-        description={t('common.confirmArchive', { defaultValue: 'Archive this household? It will no longer be accessible.' })}
+        title={t('common.archive')}
+        description={t('common.confirmArchive')}
       >
         <div className="flex justify-end gap-2 pt-2">
           <Button type="button" variant="ghost" onClick={onClosePanel}>
-            {t('common.cancel', { defaultValue: 'Cancel' })}
+            {t('common.cancel')}
           </Button>
           <Button
             type="button"
@@ -263,8 +263,8 @@ export function HouseholdCard({
             disabled={loading}
           >
             {loading
-              ? t('settings.saving', { defaultValue: 'Saving…' })
-              : t('common.archive', { defaultValue: 'Archive' })}
+              ? t('settings.saving')
+              : t('common.archive')}
           </Button>
         </div>
       </HouseholdActionDialog>

--- a/ui/src/features/settings/components/HouseholdManagement/index.tsx
+++ b/ui/src/features/settings/components/HouseholdManagement/index.tsx
@@ -63,14 +63,14 @@ export function HouseholdManagement({
           size="icon"
           variant="ghost"
           className="h-8 w-8 rounded-lg border border-transparent text-muted-foreground hover:border-border hover:bg-accent/70 hover:text-foreground"
-          aria-label={t('common.actions', { defaultValue: 'Actions' })}
+          aria-label={t('common.actions')}
         >
           <MoreHorizontal className="h-4 w-4" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <HouseholdCreateSheet
-          title={t('settings.createHousehold', { defaultValue: 'Create household' })}
+          title={t('settings.createHouseholdTitle')}
           isSaving={creating}
           values={createForm}
           onOpen={startCreate}
@@ -78,26 +78,26 @@ export function HouseholdManagement({
           onSubmit={handleCreate}
           trigger={
             <DropdownMenuItem>
-              {t('settings.createHousehold', { defaultValue: 'Create' })}
+              {t('settings.createHousehold')}
             </DropdownMenuItem>
           }
           labels={{
-            create: t('settings.createHousehold', { defaultValue: 'Create' }),
-            creating: t('settings.creating', { defaultValue: 'Creating…' }),
-            submit: t('settings.createHousehold', { defaultValue: 'Create' }),
-            submitting: t('settings.creating', { defaultValue: 'Creating\u2026' }),
-            name: t('settings.householdName', { defaultValue: 'Household name' }),
-            sectionLocation: t('settings.sectionLocation', { defaultValue: 'Location' }),
-            address: t('settings.address', { defaultValue: 'Address' }),
-            city: t('settings.city', { defaultValue: 'City' }),
-            postalCode: t('settings.postalCode', { defaultValue: 'Postal code' }),
-            country: t('settings.country', { defaultValue: 'Country' }),
-            countryPlaceholder: t('settings.countryPlaceholder', { defaultValue: '— Select country —' }),
-            timezone: t('settings.timezone', { defaultValue: 'Timezone' }),
-            timezonePlaceholder: t('settings.timezonePlaceholder', { defaultValue: '— Select timezone —' }),
-            sectionContext: t('settings.sectionContext', { defaultValue: 'Context & AI' }),
-            contextNotes: t('settings.contextNotes', { defaultValue: 'Household notes' }),
-            aiPromptContext: t('settings.aiPromptContext', { defaultValue: 'AI prompt context' }),
+            create: t('settings.createHousehold'),
+            creating: t('settings.creating'),
+            submit: t('settings.createHousehold'),
+            submitting: t('settings.creating'),
+            name: t('settings.householdName'),
+            sectionLocation: t('settings.sectionLocation'),
+            address: t('settings.address'),
+            city: t('settings.city'),
+            postalCode: t('settings.postalCode'),
+            country: t('settings.country'),
+            countryPlaceholder: t('settings.countryPlaceholder'),
+            timezone: t('settings.timezone'),
+            timezonePlaceholder: t('settings.timezonePlaceholder'),
+            sectionContext: t('settings.sectionContext'),
+            contextNotes: t('settings.contextNotes'),
+            aiPromptContext: t('settings.aiPromptContext'),
           }}
         />
       </DropdownMenuContent>
@@ -106,12 +106,12 @@ export function HouseholdManagement({
 
   return (
     <SettingsSection
-      title={t('settings.householdsTitle', { defaultValue: 'Households' })}
+      title={t('settings.householdsTitle')}
       actions={actionsMenu}
     >
         {households.length === 0 ? (
           <p className="text-sm text-muted-foreground">
-            {t('settings.noHouseholds', { defaultValue: 'No households yet.' })}
+            {t('settings.noHouseholds')}
           </p>
         ) : (
           <ul className="space-y-3">

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -200,7 +200,6 @@ export interface ProjectInteractionItem {
   subject: string;
   content: string;
   type: string;
-  status: string | null;
   occurred_at: string;
 }
 

--- a/ui/src/lib/components/DocumentSelector.tsx
+++ b/ui/src/lib/components/DocumentSelector.tsx
@@ -46,7 +46,7 @@ export function DocumentSelector({
   maxSuggestions = 8,
 }: DocumentSelectorProps) {
   const { t } = useTranslation();
-  const resolvedLegend = legend ?? t('documentSelector.legend', { defaultValue: 'Linked documents' });
+  const resolvedLegend = legend ?? t('documentSelector.legend');
   const [query, setQuery] = React.useState('');
   const [selectedType, setSelectedType] = React.useState<string>('');
   const [documents, setDocuments] = React.useState<DocumentItem[]>([]);
@@ -61,7 +61,7 @@ export function DocumentSelector({
   const [uploadNotes, setUploadNotes] = React.useState('');
 
   const typeOptions = React.useMemo(
-    () => DOCUMENT_TYPES.map((value) => ({ value, label: t(`documents.type.${value}`, { defaultValue: value }) })),
+    () => DOCUMENT_TYPES.map((value) => ({ value, label: t(`documents.type.${value}`) })),
     [t]
   );
 
@@ -79,7 +79,7 @@ export function DocumentSelector({
         }
       } catch {
         if (isMounted) {
-          setError(t('documentSelector.error', { defaultValue: 'Unable to load documents.' }));
+          setError(t('documentSelector.error'));
         }
       } finally {
         if (isMounted) {
@@ -137,7 +137,7 @@ export function DocumentSelector({
     event.preventDefault();
 
     if (!selectedFile) {
-      setUploadError(t('documentSelector.upload_file_required', { defaultValue: 'Select a file first.' }));
+      setUploadError(t('documentSelector.upload_file_required'));
       return;
     }
 
@@ -165,7 +165,7 @@ export function DocumentSelector({
       setUploadNotes('');
       setUploadOpen(false);
     } catch {
-      setUploadError(t('documentSelector.upload_failed', { defaultValue: 'Unable to upload the document.' }));
+      setUploadError(t('documentSelector.upload_failed'));
     } finally {
       setUploading(false);
     }
@@ -186,10 +186,7 @@ export function DocumentSelector({
         <legend className="text-sm font-medium">{resolvedLegend}</legend>
         {selectedDocumentIds.length > 0 ? (
           <span className="text-xs text-muted-foreground">
-            {t('documentSelector.selected_count', {
-              count: selectedDocumentIds.length,
-              defaultValue: '{{count}} selected',
-            })}
+            {t('documentSelector.selected_count', { count: selectedDocumentIds.length })}
           </span>
         ) : null}
       </div>
@@ -203,10 +200,7 @@ export function DocumentSelector({
                 type="button"
                 onClick={() => removeDocument(document.id)}
                 className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-medium text-emerald-950 transition-colors hover:bg-emerald-100"
-                aria-label={t('documentSelector.remove_document', {
-                  name: document.name,
-                  defaultValue: `Remove ${document.name}`,
-                })}
+                aria-label={t('documentSelector.remove_document', { name: document.name })}
               >
                 <FileText className="h-3.5 w-3.5" />
                 <span>{document.name}</span>
@@ -216,15 +210,13 @@ export function DocumentSelector({
           </div>
         ) : (
           <p className="text-xs text-muted-foreground">
-            {t('documentSelector.none_selected', {
-              defaultValue: 'No documents linked yet.',
-            })}
+            {t('documentSelector.none_selected')}
           </p>
         )}
 
         <div className="space-y-2">
           <label htmlFor="document-selector-input" className="text-xs font-medium text-muted-foreground">
-            {t('documentSelector.search_label', { defaultValue: 'Find an existing document' })}
+            {t('documentSelector.search_label')}
           </label>
           <div className="grid gap-2 md:grid-cols-[minmax(0,1.8fr)_minmax(12rem,1fr)]">
             <div className="relative">
@@ -233,7 +225,7 @@ export function DocumentSelector({
                 id="document-selector-input"
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
-                placeholder={t('documentSelector.placeholder', { defaultValue: 'Search by document name' })}
+                placeholder={t('documentSelector.placeholder')}
                 className="pl-9"
               />
             </div>
@@ -241,13 +233,11 @@ export function DocumentSelector({
               value={selectedType}
               onChange={(event) => setSelectedType(event.target.value)}
               options={typeOptions}
-              placeholder={t('documentSelector.type_filter_placeholder', { defaultValue: 'All document types' })}
+              placeholder={t('documentSelector.type_filter_placeholder')}
             />
           </div>
           <p className="text-xs text-muted-foreground">
-            {t('documentSelector.helper', {
-              defaultValue: 'Select one or more existing documents to link to this activity.',
-            })}
+            {t('documentSelector.helper')}
           </p>
         </div>
 
@@ -255,14 +245,14 @@ export function DocumentSelector({
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
               <p className="text-xs font-medium text-foreground">
-                {t('documentSelector.upload_title', { defaultValue: 'Add a document now' })}
+                {t('documentSelector.upload_title')}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                {t('documentSelector.upload_helper', { defaultValue: 'Upload a document here and link it immediately to this activity.' })}
+                {t('documentSelector.upload_helper')}
               </p>
             </div>
             <Button type="button" variant="outline" size="sm" onClick={() => setUploadOpen((current) => !current)}>
-              {uploadOpen ? t('documentSelector.upload_cancel', { defaultValue: 'Close upload' }) : t('documentSelector.upload_open', { defaultValue: 'Upload a document' })}
+              {uploadOpen ? t('documentSelector.upload_cancel') : t('documentSelector.upload_open')}
             </Button>
           </div>
 
@@ -272,7 +262,7 @@ export function DocumentSelector({
 
               <div className="space-y-1.5">
                 <label htmlFor="interaction-document-upload-file" className="text-xs font-medium text-muted-foreground">
-                  {t('documents.new.selectFile', { defaultValue: 'Select a file' })}
+                  {t('documents.new.selectFile')}
                 </label>
                 <Input id="interaction-document-upload-file" type="file" onChange={handleFileChange} required />
                 {selectedFile ? (
@@ -286,7 +276,7 @@ export function DocumentSelector({
               <div className="grid gap-3 md:grid-cols-2">
                 <div className="space-y-1.5">
                   <label htmlFor="interaction-document-upload-name" className="text-xs font-medium text-muted-foreground">
-                    {t('documents.fieldName', { defaultValue: 'Name' })}
+                    {t('documents.fieldName')}
                   </label>
                   <Input
                     id="interaction-document-upload-name"
@@ -296,28 +286,28 @@ export function DocumentSelector({
                 </div>
                 <div className="space-y-1.5">
                   <label htmlFor="interaction-document-upload-type" className="text-xs font-medium text-muted-foreground">
-                    {t('documents.fieldType', { defaultValue: 'Type' })}
+                    {t('documents.fieldType')}
                   </label>
                   <Select
                     id="interaction-document-upload-type"
                     value={uploadType}
                     onChange={(event) => setUploadType(event.target.value as DocumentType | '')}
                     options={typeOptions}
-                    placeholder={t('documents.fieldType', { defaultValue: 'Type' })}
+                    placeholder={t('documents.fieldType')}
                   />
                 </div>
               </div>
 
               <div className="space-y-1.5">
                 <label htmlFor="interaction-document-upload-notes" className="text-xs font-medium text-muted-foreground">
-                  {t('documents.fieldNotes', { defaultValue: 'Notes' })}
+                  {t('documents.fieldNotes')}
                 </label>
                 <Textarea
                   id="interaction-document-upload-notes"
                   rows={3}
                   value={uploadNotes}
                   onChange={(event) => setUploadNotes(event.target.value)}
-                  placeholder={t('documents.fieldNotesPlaceholder', { defaultValue: 'Optional notes…' })}
+                  placeholder={t('documents.fieldNotesPlaceholder')}
                 />
               </div>
 
@@ -325,12 +315,12 @@ export function DocumentSelector({
                 <Button type="submit" size="sm" disabled={uploading}>
                   <Upload className="mr-1 h-4 w-4" />
                   {uploading
-                    ? t('documentSelector.upload_submitting', { defaultValue: 'Uploading…' })
-                    : t('documentSelector.upload_submit', { defaultValue: 'Upload and link' })}
+                    ? t('documentSelector.upload_submitting')
+                    : t('documentSelector.upload_submit')}
                 </Button>
                 <Button type="button" variant="ghost" size="sm" onClick={() => setUploadOpen(false)}>
                   <X className="mr-1 h-4 w-4" />
-                  {t('common.cancel', { defaultValue: 'Cancel' })}
+                  {t('common.cancel')}
                 </Button>
               </div>
             </form>
@@ -339,7 +329,7 @@ export function DocumentSelector({
 
         {loading ? (
           <p className="text-xs text-muted-foreground">
-            {t('documentSelector.loading', { defaultValue: 'Loading documents…' })}
+            {t('documentSelector.loading')}
           </p>
         ) : null}
 
@@ -351,8 +341,8 @@ export function DocumentSelector({
               <div className="space-y-2">
                 <p className="text-xs font-medium text-muted-foreground">
                   {normalizedQuery
-                    ? t('documentSelector.results_label', { defaultValue: 'Matching documents' })
-                    : t('documentSelector.recent_label', { defaultValue: 'Recent documents' })}
+                    ? t('documentSelector.results_label')
+                    : t('documentSelector.recent_label')}
                 </p>
                 <div className="space-y-2">
                   {suggestions.map((document) => (
@@ -367,25 +357,24 @@ export function DocumentSelector({
                           <p className="truncate text-sm font-medium text-foreground">{document.name}</p>
                           {document.qualification.qualification_state === 'without_activity' ? (
                             <span className="rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-900">
-                              {t('documentSelector.priority_badge', { defaultValue: 'To link first' })}
+                              {t('documentSelector.priority_badge')}
                             </span>
                           ) : null}
                         </div>
                         <p className="mt-1 text-xs text-muted-foreground">
-                          {t(`documents.type.${document.type}`, { defaultValue: document.type })}
+                          {t(`documents.type.${document.type}`)}
                         </p>
                       </div>
                       <div className="shrink-0 text-right">
                         <span className="text-xs font-medium text-primary">
-                          {t('documentSelector.add_action', { defaultValue: 'Link' })}
+                          {t('documentSelector.add_action')}
                         </span>
                         <p className="mt-1 text-[10px] text-muted-foreground">
                           {document.qualification.linked_interactions_count > 0
                             ? t('documentSelector.activity_count', {
                                 count: document.qualification.linked_interactions_count,
-                                defaultValue: '{{count}} activity',
                               })
-                            : t('documentSelector.no_activity_yet', { defaultValue: 'No activity yet' })}
+                            : t('documentSelector.no_activity_yet')}
                         </p>
                       </div>
                     </button>
@@ -394,9 +383,7 @@ export function DocumentSelector({
               </div>
             ) : (
               <p className="text-xs text-muted-foreground">
-                {t('documentSelector.empty', {
-                  defaultValue: 'No document matches this search.',
-                })}
+                {t('documentSelector.empty')}
               </p>
             )}
           </div>

--- a/ui/src/lib/components/TagSelector.tsx
+++ b/ui/src/lib/components/TagSelector.tsx
@@ -54,10 +54,10 @@ export function TagSelector({
   maxSuggestions = 8,
 }: TagSelectorProps) {
   const { t } = useTranslation();
-  const resolvedLegend = legend ?? t('tagSelector.legend', { defaultValue: 'Tags' });
-  const resolvedPlaceholder = placeholder ?? t('tagSelector.placeholder', { defaultValue: 'Add a tag' });
+  const resolvedLegend = legend ?? t('tagSelector.legend');
+  const resolvedPlaceholder = placeholder ?? t('tagSelector.placeholder');
   const resolvedHelperText =
-    helperText ?? t('tagSelector.helper', { defaultValue: 'Press Enter or comma to add a tag.' });
+    helperText ?? t('tagSelector.helper');
 
   const [query, setQuery] = React.useState('');
   const [availableTags, setAvailableTags] = React.useState<TagOption[]>([]);
@@ -106,7 +106,7 @@ export function TagSelector({
         }
       } catch {
         if (isMounted) {
-          setError(t('tagSelector.error', { defaultValue: 'Unable to load tags.' }));
+          setError(t('tagSelector.error'));
         }
       } finally {
         if (isMounted) {
@@ -164,10 +164,7 @@ export function TagSelector({
         <legend className="text-sm font-medium">{resolvedLegend}</legend>
         {selectedTagNames.length > 0 ? (
           <span className="text-xs text-muted-foreground">
-            {t('tagSelector.selected_count', {
-              count: selectedTagNames.length,
-              defaultValue: '{{count}} selected',
-            })}
+            {t('tagSelector.selected_count', { count: selectedTagNames.length })}
           </span>
         ) : null}
       </div>
@@ -181,10 +178,7 @@ export function TagSelector({
                 type="button"
                 onClick={() => removeTag(tagName)}
                 className="inline-flex items-center gap-1.5 rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 text-[11px] font-medium text-sky-950 transition-colors hover:bg-sky-100"
-                aria-label={t('tagSelector.remove_tag', {
-                  name: tagName,
-                  defaultValue: `Remove ${tagName}`,
-                })}
+                aria-label={t('tagSelector.remove_tag', { name: tagName })}
               >
                 <TagIcon className="h-3.5 w-3.5" />
                 <span>{tagName}</span>
@@ -196,7 +190,7 @@ export function TagSelector({
 
         <div className="space-y-2">
           <label htmlFor="tag-selector-input" className="text-xs font-medium text-muted-foreground">
-            {t('tagSelector.search_label', { defaultValue: 'Find or create a tag' })}
+            {t('tagSelector.search_label')}
           </label>
           <div className="relative">
             <TagIcon className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
@@ -212,7 +206,7 @@ export function TagSelector({
           <p className="text-xs text-muted-foreground">{resolvedHelperText}</p>
         </div>
 
-        {loading ? <p className="text-xs text-muted-foreground">{t('tagSelector.loading', { defaultValue: 'Loading tags…' })}</p> : null}
+        {loading ? <p className="text-xs text-muted-foreground">{t('tagSelector.loading')}</p> : null}
         {error ? <p className="text-xs text-destructive">{error}</p> : null}
 
         {!loading && !error ? (
@@ -225,10 +219,7 @@ export function TagSelector({
               >
                 <Plus className="h-4 w-4 shrink-0" />
                 <span>
-                  {t('tagSelector.create_tag', {
-                    name: normalizeTagName(query),
-                    defaultValue: `Add tag "${normalizeTagName(query)}"`,
-                  })}
+                  {t('tagSelector.create_tag', { name: normalizeTagName(query) })}
                 </span>
               </button>
             ) : null}
@@ -236,7 +227,7 @@ export function TagSelector({
             {suggestions.length > 0 ? (
               <div className="space-y-2">
                 <p className="text-xs font-medium text-muted-foreground">
-                  {t('tagSelector.suggestions_label', { defaultValue: 'Suggested tags' })}
+                  {t('tagSelector.suggestions_label')}
                 </p>
                 <div className="flex flex-wrap gap-2">
                   {suggestions.map((tag) => (
@@ -259,7 +250,7 @@ export function TagSelector({
 
             {!canCreateTag && suggestions.length === 0 ? (
               <p className="text-xs text-muted-foreground">
-                {t('tagSelector.empty', { defaultValue: 'No tag matches this search.' })}
+                {t('tagSelector.empty')}
               </p>
             ) : null}
           </div>

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -651,7 +651,8 @@
     "suggestions_label": "Vorgeschlagene Tags",
     "create_tag": "Tag \"{{name}}\" hinzufügen",
     "empty": "Kein Tag entspricht dieser Suche.",
-    "remove_tag": "{{name}} entfernen"
+    "remove_tag": "{{name}} entfernen",
+    "legend": "Tags"
   },
   "documentSelector": {
     "selected_count": "{{count}} ausgewählt",
@@ -1099,7 +1100,10 @@
       "testNoDevice": "Kein abonniertes Gerät",
       "permissionDenied": "Benachrichtigungen sind blockiert. Aktiviere sie in den Browsereinstellungen.",
       "iosHint": "Füge die App auf dem iPhone zuerst zum Startbildschirm hinzu (Teilen → Zum Home-Bildschirm), um Benachrichtigungen zu aktivieren."
-    }
+    },
+    "createHouseholdTitle": "Haushalt erstellen",
+    "avatarUploadFailed": "Upload fehlgeschlagen.",
+    "avatarDeleteFailed": "Löschen fehlgeschlagen."
   },
   "tutorials": {
     "title": "Tutorial",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -651,7 +651,8 @@
     "suggestions_label": "Suggested tags",
     "create_tag": "Add tag \"{{name}}\"",
     "empty": "No tag matches this search.",
-    "remove_tag": "Remove {{name}}"
+    "remove_tag": "Remove {{name}}",
+    "legend": "Tags"
   },
   "documentSelector": {
     "selected_count": "{{count}} selected",
@@ -1099,7 +1100,10 @@
       "testNoDevice": "No subscribed device",
       "permissionDenied": "Notifications are blocked. Re-enable them in your browser settings.",
       "iosHint": "On iPhone, first add the app to your home screen (Share → Add to Home Screen) to enable notifications."
-    }
+    },
+    "createHouseholdTitle": "Create household",
+    "avatarUploadFailed": "Upload failed.",
+    "avatarDeleteFailed": "Delete failed."
   },
   "tutorials": {
     "title": "Tutorial",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -651,7 +651,8 @@
     "suggestions_label": "Tags sugeridos",
     "create_tag": "Añadir el tag \"{{name}}\"",
     "empty": "Ningún tag coincide con esta búsqueda.",
-    "remove_tag": "Quitar {{name}}"
+    "remove_tag": "Quitar {{name}}",
+    "legend": "Etiquetas"
   },
   "documentSelector": {
     "selected_count": "{{count}} seleccionado(s)",
@@ -1099,7 +1100,10 @@
       "testNoDevice": "Ningún dispositivo suscrito",
       "permissionDenied": "Las notificaciones están bloqueadas. Reactívalas en los ajustes del navegador.",
       "iosHint": "En iPhone, primero añade la app a la pantalla de inicio (Compartir → Añadir a pantalla de inicio) para activar las notificaciones."
-    }
+    },
+    "createHouseholdTitle": "Crear un hogar",
+    "avatarUploadFailed": "Error al subir la foto.",
+    "avatarDeleteFailed": "Error al eliminar la foto."
   },
   "tutorials": {
     "title": "Tutorial",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -651,7 +651,8 @@
     "suggestions_label": "Tags suggérés",
     "create_tag": "Ajouter le tag \"{{name}}\"",
     "empty": "Aucun tag ne correspond à cette recherche.",
-    "remove_tag": "Retirer {{name}}"
+    "remove_tag": "Retirer {{name}}",
+    "legend": "Tags"
   },
   "documentSelector": {
     "selected_count": "{{count}} sélectionné(s)",
@@ -1099,7 +1100,10 @@
       "testNoDevice": "Aucun appareil abonné",
       "permissionDenied": "Les notifications sont bloquées. Réactivez-les dans les réglages de votre navigateur.",
       "iosHint": "Sur iPhone, installez d'abord l'app sur l'écran d'accueil (Partager → Sur l'écran d'accueil) pour activer les notifications."
-    }
+    },
+    "createHouseholdTitle": "Créer un foyer",
+    "avatarUploadFailed": "Échec de l'envoi de la photo.",
+    "avatarDeleteFailed": "Échec de la suppression de la photo."
   },
   "tutorials": {
     "title": "Tutoriel",

--- a/ui/src/locales/keys.test.ts
+++ b/ui/src/locales/keys.test.ts
@@ -26,21 +26,38 @@ const LANGUAGES = ['en', 'de', 'es'] as const;
 /** Les clés `t('…')` littérales. Une clé construite n'est pas vérifiable ici. */
 const CALL = /\bt\(\s*['"]([a-zA-Z0-9_.-]+)['"]/g;
 
+/**
+ * `defaultValue` dans un `t()` — interdit par le CLAUDE.md.
+ *
+ * C'est la contrepartie du test ci-dessus, et elle est indispensable : un
+ * `defaultValue` rend une clé manquante **indétectable**, puisque l'écran affiche
+ * un texte anglais plausible au lieu de la clé brute. Les 111 occurrences
+ * historiques masquaient trois vrais défauts — un titre de dialogue réduit à
+ * « Créer », deux échecs distincts fondus en « Échec de la requête », et une
+ * `<legend>` qui affichait `tagSelector.legend`.
+ *
+ * ⚠️ Le motif ne cherche pas `t(`, seulement la propriété : un `defaultValue`
+ * réparti sur plusieurs lignes échapperait à une détection par appel.
+ */
+const DEFAULT_VALUE = /\bdefaultValue\s*:/;
+
 const catalogues = import.meta.glob<Record<string, unknown>>('./*/translation.json', {
   eager: true,
   import: 'default',
 });
 
+/** Tout le front — pas une liste de namespaces choisis. */
+const sources = import.meta.glob<string>('../{features,components,lib}/**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
 /**
- * Namespaces couverts. Volontairement une liste, pas « tout le front » :
- * `features/settings` traîne une trentaine de `t(…, { defaultValue })` hérités
- * qui violent déjà la règle du projet, et faire échouer ce test dessus le ferait
- * désactiver au lieu d'être lu. Élargir au fur et à mesure qu'ils sont résorbés.
+ * `useSessionState(key, defaultValue)` porte ce nom pour son propre paramètre :
+ * ce n'est pas un `t()`, et le nom est le bon là où il est.
  */
-const sources = import.meta.glob<string>(
-  '../features/{money,banking,budget,expenses,interactions}/**/*.{ts,tsx}',
-  { eager: true, query: '?raw', import: 'default' },
-);
+const DEFAULT_VALUE_ALLOWED = ['../lib/useSessionState.ts'];
 
 function flatten(node: unknown, prefix = '', out = new Set<string>()): Set<string> {
   if (node && typeof node === 'object' && !Array.isArray(node)) {
@@ -71,7 +88,7 @@ function isKnown(key: string, keys: Set<string>): boolean {
 describe('catalogues de traduction', () => {
   const french = catalogue('fr');
 
-  it('toute clé appelée par le module Argent existe en français', () => {
+  it('toute clé appelée par le front existe en français', () => {
     const missing: string[] = [];
     for (const [file, source] of Object.entries(sources)) {
       if (file.endsWith('.test.ts') || file.endsWith('.test.tsx')) continue;
@@ -82,8 +99,18 @@ describe('catalogues de traduction', () => {
     expect(missing).toEqual([]);
   });
 
-  it('les fichiers du module Argent sont bien lus (le test ne teste pas le vide)', () => {
-    expect(Object.keys(sources).length).toBeGreaterThan(30);
+  it("aucun t() ne porte de defaultValue — il masquerait la clé qu'il remplace", () => {
+    const offenders: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      if (file.endsWith('.test.ts') || file.endsWith('.test.tsx')) continue;
+      if (DEFAULT_VALUE_ALLOWED.includes(file)) continue;
+      if (DEFAULT_VALUE.test(source)) offenders.push(file);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('le front est bien lu en entier (le test ne teste pas le vide)', () => {
+    expect(Object.keys(sources).length).toBeGreaterThan(300);
   });
 
   it.each(LANGUAGES)('le catalogue %s a exactement les mêmes clés que le français', (language) => {


### PR DESCRIPTION
Suite de #418. Le garde-fou i18n y couvrait une **liste de namespaces** parce que `features/settings` traînait une trentaine de `t(…, { defaultValue })` — l'élargir l'aurait fait échouer aussitôt, donc désactiver. Dette réglée : il couvre maintenant tout le front.

## Ce que les `defaultValue` cachaient

111 occurrences, dont **110 sur des clés déjà présentes** au catalogue : du poids mort, puisque i18next préfère toujours la valeur traduite. Mais trois masquaient un défaut réel, visible en production.

| Clé | Ce que l'utilisateur voyait | Correction |
|---|---|---|
| `settings.createHousehold` | Le dialogue de création de foyer était titré **« Créer »** — la clé vaut « Créer », le `defaultValue` disait « Create household » | nouvelle clé `settings.createHouseholdTitle` |
| `settings.requestFailed` | Échec d'envoi et échec de suppression de photo affichaient tous deux **« Échec de la requête »** | `settings.avatarUploadFailed` / `settings.avatarDeleteFailed` |
| `tagSelector.legend` | **Absente des quatre langues** : la `<legend>` du champ Tags affichait la clé brute dès qu'aucune prop `legend` n'était passée | ajoutée ×4 |

Et un reste mort : le badge `interactions.status` de la page projet lisait un champ **retiré du modèle** avec le type `todo` (migration `interactions.0018`), sur un namespace i18n qui n'a jamais existé. Le badge et le champ du type TS partent avec.

## Le garde-fou

`ui/src/locales/keys.test.ts` couvre désormais `features`, `components` et `lib`, et fait trois choses dont aucune n'est redondante :

1. **toute clé `t('…')` littérale existe en français** — le seul contrôle qui compare le *code* au catalogue ;
2. **aucun fichier ne contient `defaultValue:`** — sans quoi le premier se laisse contourner ;
3. **les quatre catalogues ont exactement les mêmes clés.**

Le n° 3 existait déjà de fait, et il n'a rien vu quand le lot 4 a écrasé les douze clés de `banking.cash.*` : la clé manquait *partout*, donc la parité était verte. Comparer les langues entre elles ne suffit jamais.

Vérifié que les deux nouveaux contrôles **échouent** sur une clé inventée et sur un `defaultValue` réintroduit, tous deux hors du module Argent (`features/tasks`).

## Limite, assumée et documentée

Une clé construite — `t(\`documents.type.${v}\`)`, `t(labelKey)` — n'est pas vérifiable statiquement. La contrepartie est que le catalogue doit couvrir **toutes** les valeurs de l'énumération : vérifié pour les cinq concernées (`expenses.kind`, `equipment.interaction_type`, `documents.type`, `interactions.type`, et `interactions.status` qui n'existait plus). C'est ce qui rend leur `defaultValue` inutile plutôt que nécessaire.

3395 tests backend, 22 front (+1), build et lint propres. `CLAUDE.md` : la règle dit maintenant quel test la tient, et pourquoi les trois assertions sont nécessaires.