### PR TITLE
feat(money): les trois arbitrages laissés ouverts par l'audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -316,10 +316,16 @@ onglets : Contrôle / À ranger / Comptes / Dépenses / Budgets. Doc :
   ces clés n'existent plus dans `MODULES` ni dans `households.modules`. `money` est
   **core** (non désactivable) — conséquence assumée : les comptes bancaires ne sont
   plus un opt-in.
-- Toute nouvelle URL de la famille argent vit sous `/app/money`. Les trois
-  anciennes redirigent via `LegacyMoneyRedirect` en **préservant la query string**
-  (l'agent produit `/app/budget?b={id}`) — ne pas remplacer par un `<Navigate to>`
-  en dur.
+- Toute nouvelle URL de la famille argent vit sous `/app/money` — y compris
+  `/app/money/recurring` et `/app/money/reports`, entrées dans la famille en juillet
+  2026. Les anciennes redirigent en **préservant la query string** :
+  `LegacyMoneyRedirect` pour les trois onglets (l'agent produit `/app/budget?b={id}`),
+  `PreserveQueryRedirect` pour les sous-pages (`?r={id}`) — ne pas remplacer par un
+  `<Navigate to>` en dur, qui perd le paramètre et transforme un lien précis en lien
+  faux. **Un `url_template` d'agent de cette famille doit pointer directement sous
+  `/app/money`**, jamais via une redirection : une redirection rattrape un ancien
+  lien, elle ne justifie pas d'en produire de nouveaux. Tenu par
+  `agent/tests/test_registry.py::test_the_money_family_links_stay_inside_the_money_module`.
 - Les panneaux (`AccountsPanel`, `ExpensesPanel`, `BudgetsPanel`) n'ont **pas** de
   `PageHeader` : la coque porte le titre. Un panneau qui en ajoute un produit deux
   `h1`.
@@ -348,6 +354,16 @@ disent *sur quoi* et *où*, pas *de quelle nature*), et le détecteur
   « pas de plafond ».
 - Un `stats` de bilan **déjà figé** porte `"amount": "400.00"` ; `report/render.py`
   doit accepter la string *et* le `null` pour toujours.
+- **Le dépensé se dit en deux chiffres, jamais en un filtre.** Chaque ligne de
+  l'aperçu porte `spent_attested` / `spent_pending` **en plus** de `spent` — la part
+  qu'une ligne de relevé justifie, et le reste. Ne jamais filtrer
+  `bank_transaction__isnull=False` pour ne compter que le prouvé : une dépense saisie
+  hier est réelle avant l'import du relevé, donc le compteur reculerait au fil du mois
+  pour remonter d'un coup — **un plafond qui recule est pire qu'un plafond
+  incertain**. `spent` reste le compteur du plafond ; `spent_pending` est calculé **par
+  différence** (deux sommes indépendantes divergent d'un centime d'arrondi, et un total
+  qui ne se recompose pas ne se lit pas) ; et les deux chiffres sortent d'**un seul**
+  `GROUP BY` avec `Sum(filter=…)`, l'aperçu étant rechargé à chaque visite de l'onglet.
 
 #### Ventilation — budget et projet sont deux axes indépendants
 
@@ -362,6 +378,17 @@ comptent dans le chantier **et** dans l'enveloppe « Bricolage ».
   ré-édition — **chaque ré-édition laisse une dépense fantôme** toujours comptée
   dans le coût du projet. Test de régression :
   `banking/tests/test_allocation_axes.py::TestOwnershipRuleRegression`.
+- **⚠️ Et la portée de l'éditeur s'arrête là.** Il supprime ses lignes `kind='bank'`
+  et **ne touche à rien d'autre** — ni suppression, ni *détachement*. Enregistrer une
+  ventilation dé-rapprochait autrefois tout ce qu'elle ne possède pas : un achat de
+  projet rapproché à la main sur la même ligne redevenait « non rapproché » en
+  silence, et comme le dialogue rechargeait *toutes* les ventilations dans son
+  brouillon, il recréait une dépense `bank` pour le même argent — 180 € de dépenses
+  sur 150 €, chantier facturé deux fois. Corollaire : le montant déjà rattaché est un
+  **plancher** compté contre l'`outflow` (renvoyer la ligne rattachée = 400), et
+  détacher est un **geste explicite** (`unlink_interaction`, bloc « Dépenses déjà
+  rattachées » du dialogue), jamais l'effet de bord d'un enregistrement. Régression :
+  `banking/tests/test_allocation_axes.py::TestSavingASplitNeverUndoesAReconciliation`.
 - `kind` reste `bank` même avec une source : il dit *d'où vient* la dépense, pas
   *sur quoi elle porte*.
 - Toute résolution de source passe par

--- a/apps/agent/tests/test_registry.py
+++ b/apps/agent/tests/test_registry.py
@@ -111,3 +111,25 @@ class TestBootRegistry:
             assert "{id}" in spec.url_template, (
                 f"{spec.entity_type} url_template missing {{id}}"
             )
+
+    def test_the_money_family_links_stay_inside_the_money_module(self):
+        """Comptes, dépenses, budgets et récurrences sont **un** module (`money`).
+
+        Trois de ses entités pointaient sur `/app/banking`, `/app/expenses` et
+        `/app/budget` après la fusion du parcours 26 ; deux autres sur
+        `/app/budget/recurring`, resté hors de la famille jusqu'à l'audit de
+        juillet 2026. Une redirection rattrape l'ancien lien, mais un lien de
+        l'agent est produit *aujourd'hui* : le faire passer par une redirection,
+        c'est accepter qu'il pointe vers une URL qu'on a décidé d'abandonner.
+        """
+        money = {"budget", "recurring_expense"}
+        seen = set()
+        for spec in REGISTRY:
+            if spec.entity_type in money:
+                seen.add(spec.entity_type)
+                assert spec.url_template.startswith("/app/money"), (
+                    f"{spec.entity_type} points outside the money module: "
+                    f"{spec.url_template}"
+                )
+        # Sans ça, renommer une entité rendrait ce test muet au lieu de rouge.
+        assert seen == money, f"entités de la famille argent introuvables : {money - seen}"

--- a/apps/banking/services.py
+++ b/apps/banking/services.py
@@ -522,11 +522,11 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
     and gets it, which is the only way an "80/40 becomes 100/20" edit stays
     atomic.
 
-    The destructive half is deliberately narrow. Only the expenses this editor
-    created (``kind='bank'``) are deleted; anything else — a stock purchase that
-    was reconciled onto this line — is **detached**, not destroyed. Deleting it
-    would take its documents, tags, zones and possibly a
-    ``Task.source_interaction`` with it, to undo a split.
+    The destructive half is deliberately narrow, and so is its **reach**. Only
+    the expenses this editor created (``kind='bank'``) are touched at all; a
+    stock purchase or a project purchase that was reconciled onto this line is
+    **left exactly where it is**, and its amount is counted against the outflow
+    so the new split cannot overshoot it.
 
     ⚠️ The rule reads ``kind`` **alone**. It used to also require no source
     object, which was redundant (a stock purchase has ``kind='stock_purchase'``,
@@ -536,6 +536,16 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
     deleted on re-edit: **every re-split would leave a phantom expense behind**,
     still counted in the project's cost. Exactly the orphan this parcours exists
     to remove.
+
+    ⚠️ **Saving a split no longer detaches what it does not own.** It used to,
+    and that was the mirror image of the bug above: reconciling a 90 € project
+    purchase onto a 150 € line, then re-splitting the remaining 60 €, silently
+    un-reconciled the 90 € — it reappeared as an écart « dépense non rapprochée »
+    that the user had already resolved, and the editor happily re-created a
+    ``kind='bank'`` expense for the same 90 €, counting the money twice. Nothing
+    in the UI said so. Detaching is now a **gesture of its own**
+    (``unlink_interaction``, ``DELETE …/unlink/{id}/``), never a side effect of
+    saving something else.
 
     The row is locked for the duration so two concurrent edits cannot each see a
     stale total and jointly overshoot.
@@ -547,29 +557,24 @@ def set_allocations(*, household, user, transaction, lines: list[dict]) -> list:
         locked = BankTransaction.objects.select_for_update().get(pk=transaction.pk)
         assert_allocation_fits(transaction=locked, extra_amount=Decimal("0.00"))
 
+        existing = list(locked.interactions.all())
+        kept = [i for i in existing if i.kind not in OWNED_BY_ALLOCATION_EDITOR]
+        kept_total = sum((i.amount or Decimal("0.00") for i in kept), Decimal("0.00"))
+
         total = sum((Decimal(str(line.get("amount") or 0)) for line in lines), Decimal("0.00"))
-        if total > locked.outflow:
+        if total + kept_total > locked.outflow:
             raise ValidationError(
-                {"amount": f"Allocations would total {total} on an operation of {locked.outflow}."}
+                {
+                    "amount": (
+                        f"Allocations would total {total + kept_total} on an operation of "
+                        f"{locked.outflow}."
+                    )
+                }
             )
 
-        existing = list(locked.interactions.all())
         for interaction in existing:
-            owned = interaction.kind in OWNED_BY_ALLOCATION_EDITOR
-            if owned:
+            if interaction.kind in OWNED_BY_ALLOCATION_EDITOR:
                 interaction.delete()
-            else:
-                interaction.bank_transaction = None
-                interaction.reconciled_by = ""
-                interaction.updated_by = user
-                interaction.save(
-                    update_fields=[
-                        "bank_transaction",
-                        "reconciled_by",
-                        "updated_by",
-                        "updated_at",
-                    ]
-                )
 
         created = []
         for index, line in enumerate(lines):

--- a/apps/banking/tests/test_allocation_axes.py
+++ b/apps/banking/tests/test_allocation_axes.py
@@ -18,12 +18,14 @@ from datetime import date
 from decimal import Decimal
 
 import pytest
+from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from banking.dedup import compute_dedup_hash
 from banking.models import BankTransaction, TransactionDirection
-from banking.services import delete_transaction, set_allocations
+from banking.services import delete_transaction, set_allocations, unlink_interaction
+from banking.validators import allocated_total, remaining_to_allocate
 from budget.models import Budget
 from interactions.kinds import KIND_BANK, KIND_STOCK_PURCHASE
 from interactions.models import Interaction
@@ -315,10 +317,13 @@ class TestOwnershipRuleRegression:
         assert project_actual_cost(bathroom) == Decimal("120.00")
         assert project_actual_cost(kitchen) == Decimal("30.00")
 
-    def test_a_pre_existing_purchase_is_still_only_detached(self, ctx):
+    def test_a_pre_existing_purchase_is_neither_deleted_nor_detached(self, ctx):
         """The asymmetry that justified the rule in the first place is preserved:
         an expense that predates the statement is a fact of its own. Deleting it
-        would take its documents, tags and possibly a task with it."""
+        would take its documents, tags and possibly a task with it — and merely
+        *detaching* it, which is what this used to assert, silently undid a
+        reconciliation the user had made on purpose. The editor's reach stops at
+        what it created."""
         household, user, account, bathroom, _, _ = ctx
         txn = make_txn(account)
         purchase = Interaction.objects.create(
@@ -348,8 +353,7 @@ class TestOwnershipRuleRegression:
 
         purchase.refresh_from_db()
         assert purchase.pk is not None
-        assert purchase.bank_transaction_id is None
-        assert purchase.reconciled_by == ""
+        assert purchase.bank_transaction_id == txn.id
 
     def test_deleting_the_line_takes_its_project_allocations_with_it(self, ctx):
         household, user, account, bathroom, _, _ = ctx
@@ -372,3 +376,132 @@ class TestOwnershipRuleRegression:
 
         assert not Interaction.objects.filter(household=household, type="expense").exists()
         assert project_actual_cost(bathroom) == Decimal("0.00")
+
+
+@pytest.mark.django_db
+class TestSavingASplitNeverUndoesAReconciliation:
+    """The mirror of the ownership bug above, found by the audit of July 2026.
+
+    Same 150 € at the DIY store, but this time 90 € of it was already journalled
+    as a project purchase and reconciled onto the line **by hand**. Editing the
+    remaining 60 € used to *detach* that 90 €: a reconciliation the user had made
+    on purpose disappeared, the line fell back to « partiellement ventilée », and
+    the écart « dépense non rapprochée » reappeared on an expense that had been
+    resolved. Nothing in the UI said so — the money was, at best, counted once in
+    two different places, and at worst twice.
+
+    The rule is now symmetric with the one above: the editor deletes what it
+    created, and **touches nothing else at all**.
+    """
+
+    def _reconciled_project_purchase(self, household, user, txn, project, amount="90.00"):
+        return Interaction.objects.create(
+            household=household,
+            created_by=user,
+            subject="Carrelage payé à la caisse",
+            type="expense",
+            occurred_at=timezone.now(),
+            amount=Decimal(amount),
+            kind="project_purchase",
+            source_content_type=ContentType.objects.get_for_model(Project),
+            source_object_id=project.id,
+            bank_transaction=txn,
+            reconciled_by="manual",
+        )
+
+    def test_editing_the_rest_leaves_the_reconciled_purchase_attached(self, ctx):
+        household, user, account, bathroom, kitchen, _ = ctx
+        txn = make_txn(account)
+        purchase = self._reconciled_project_purchase(household, user, txn, bathroom)
+
+        set_allocations(
+            household=household,
+            user=user,
+            transaction=txn,
+            lines=[
+                {
+                    "amount": "60.00",
+                    "subject": "Peinture",
+                    "source_type": "projects.project",
+                    "source_id": str(kitchen.id),
+                },
+            ],
+        )
+
+        purchase.refresh_from_db()
+        assert purchase.bank_transaction_id == txn.id
+        assert purchase.reconciled_by == "manual"
+        # The line is whole: 90 € attached + 60 € allocated = 150 €.
+        assert allocated_total(txn) == Decimal("150.00")
+        assert remaining_to_allocate(txn) == Decimal("0.00")
+
+    def test_the_money_is_never_counted_twice_however_often_it_is_edited(self, ctx):
+        household, user, account, bathroom, kitchen, _ = ctx
+        txn = make_txn(account)
+        self._reconciled_project_purchase(household, user, txn, bathroom)
+
+        for amount in ("60.00", "50.00", "30.00"):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": amount,
+                        "subject": "Peinture",
+                        "source_type": "projects.project",
+                        "source_id": str(kitchen.id),
+                    },
+                ],
+            )
+
+        # Two expenses, ever: the pre-existing purchase and the current split.
+        assert Interaction.objects.filter(household=household, type="expense").count() == 2
+        # The bathroom's cost is the purchase, once — not once per re-edit.
+        assert project_actual_cost(bathroom) == Decimal("90.00")
+        assert project_actual_cost(kitchen) == Decimal("30.00")
+
+    def test_resending_the_linked_line_is_refused_instead_of_doubling_the_money(self, ctx):
+        """The payload the old dialog used to send, now a 400.
+
+        It loaded *every* allocation into its draft, linked ones included, so
+        saving sent the 90 € back as a line of its own. The service detached the
+        purchase and re-created it as ``kind='bank'`` — 180 € of expenses on a
+        150 € line, and the bathroom charged twice for the same tiles.
+        """
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account)
+        self._reconciled_project_purchase(household, user, txn, bathroom)
+
+        with pytest.raises(ValidationError):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[
+                    {
+                        "amount": "90.00",
+                        "subject": "Carrelage",
+                        "source_type": "projects.project",
+                        "source_id": str(bathroom.id),
+                    },
+                    {"amount": "60.00", "subject": "Peinture"},
+                ],
+            )
+
+        assert project_actual_cost(bathroom) == Decimal("90.00")
+
+    def test_detaching_is_available_as_its_own_gesture(self, ctx):
+        """What replaces the side effect: an explicit, single-purpose service."""
+        household, user, account, bathroom, _, _ = ctx
+        txn = make_txn(account)
+        purchase = self._reconciled_project_purchase(household, user, txn, bathroom)
+
+        unlink_interaction(user=user, interaction=purchase)
+
+        purchase.refresh_from_db()
+        assert purchase.bank_transaction_id is None
+        assert purchase.reconciled_by == ""
+        # Detached, not destroyed — the project still paid for its tiles.
+        assert project_actual_cost(bathroom) == Decimal("90.00")
+        assert remaining_to_allocate(txn) == Decimal("150.00")

--- a/apps/banking/tests/test_services_allocations.py
+++ b/apps/banking/tests/test_services_allocations.py
@@ -26,7 +26,7 @@ from banking.services import (
     set_allocations,
     unlink_interaction,
 )
-from banking.validators import remaining_to_allocate
+from banking.validators import allocated_total, remaining_to_allocate
 from budget.models import Budget
 from interactions.kinds import KIND_BANK, KIND_STOCK_PURCHASE
 from interactions.models import Interaction
@@ -219,9 +219,16 @@ class TestTheEditorOnlyDeletesWhatItCreated:
         link_interaction(user=user, transaction=txn, interaction=purchase)
         return purchase
 
-    def test_a_reconciled_purchase_is_detached_not_destroyed(self, context):
+    def test_a_reconciled_purchase_survives_an_edit_untouched(self, context):
+        """Saving a split leaves what it does not own **exactly** where it is.
+
+        It used to detach it, which quietly undid a reconciliation the user had
+        made on purpose — and, on a line with room left, let the editor recreate
+        a ``kind='bank'`` expense for the same money. Detaching is now its own
+        gesture (``unlink_interaction``), never a side effect of saving.
+        """
         household, user, account, groceries, _ = context
-        txn = make_txn(account)
+        txn = make_txn(account, amount="-240.00")
         purchase = self._reconciled_stock_purchase(household, user, txn)
 
         set_allocations(
@@ -232,9 +239,29 @@ class TestTheEditorOnlyDeletesWhatItCreated:
         )
 
         purchase.refresh_from_db()
-        assert Interaction.objects.filter(pk=purchase.pk).exists()
-        assert purchase.bank_transaction_id is None
-        assert purchase.reconciled_by == ""
+        assert purchase.bank_transaction_id == txn.id
+        assert purchase.reconciled_by == "manual"
+        # 120 € generated + 120 € pre-existing = the whole line, counted once.
+        assert allocated_total(txn) == Decimal("240.00")
+
+    def test_a_split_cannot_take_what_a_linked_expense_already_holds(self, context):
+        """The other half of not detaching: the linked amount is a floor.
+
+        Without counting it, a 120 € purchase on a 240 € line plus a 240 € split
+        would total 360 € of expenses on 240 € of money — the invariant the whole
+        ``validators`` module exists to keep.
+        """
+        household, user, account, groceries, _ = context
+        txn = make_txn(account, amount="-240.00")
+        self._reconciled_stock_purchase(household, user, txn)
+
+        with pytest.raises(ValidationError):
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=txn,
+                lines=[{"subject": "A", "amount": "240.00", "budget_id": groceries.id}],
+            )
 
     def test_deleting_the_line_keeps_the_purchase_and_drops_the_bank_rows(self, context):
         household, user, account, groceries, _ = context
@@ -246,9 +273,6 @@ class TestTheEditorOnlyDeletesWhatItCreated:
             transaction=txn,
             lines=[{"subject": "A", "amount": "100.00", "budget_id": groceries.id}],
         )
-        # `set_allocations` detached the purchase; re-link it to test both paths.
-        purchase.refresh_from_db()
-        link_interaction(user=user, transaction=txn, interaction=purchase)
 
         delete_transaction(user=user, transaction=txn)
 

--- a/apps/budget/aggregations.py
+++ b/apps/budget/aggregations.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 from typing import Any
 
 from django.conf import settings
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from django.db.models.functions import Coalesce
 
 from core.timezones import current_month_range as _current_month_range
@@ -46,15 +46,36 @@ def current_month_range(household) -> tuple[datetime, datetime, str]:
     return _current_month_range(household)
 
 
-def _spent_by_budget(household_id, start, end) -> dict:
-    """SUM of expense amounts for the month, grouped by ``budget_id`` (None = hors budget)."""
+def _spent_by_budget(household_id, start, end) -> tuple[dict, dict]:
+    """``(total, attesté)`` par ``budget_id`` (``None`` = hors budget).
+
+    Deux chiffres, **une** requête : le total du mois, et la part que le relevé
+    a vue (``bank_transaction`` non nul). Le premier ne change pas — c'est lui
+    que le plafond mesure, et il est lu par sept agrégations qu'on ne réécrit
+    pas. Le second dit seulement *ce qu'on peut prouver*.
+
+    Pourquoi pas un filtre dur sur les rapprochées : une dépense saisie
+    aujourd'hui, avant l'import du relevé de fin de mois, est parfaitement réelle.
+    L'exclure ferait baisser le compteur au fil du mois puis remonter à l'import —
+    un plafond qui recule est pire qu'un plafond incertain. On affiche donc le
+    même total, et **à côté** ce qui reste à attester.
+    """
     rows = (
         expenses(household_id=household_id)
         .filter(occurred_at__gte=start, occurred_at__lt=end)
         .values("budget_id")
-        .annotate(total=Coalesce(Sum("amount"), _zero()))
+        .annotate(
+            total=Coalesce(Sum("amount"), _zero()),
+            attested=Coalesce(
+                Sum("amount", filter=Q(bank_transaction__isnull=False)), _zero()
+            ),
+        )
     )
-    return {row["budget_id"]: row["total"] or _zero() for row in rows}
+    spent, attested = {}, {}
+    for row in rows:
+        spent[row["budget_id"]] = row["total"] or _zero()
+        attested[row["budget_id"]] = row["attested"] or _zero()
+    return spent, attested
 
 
 def _committed_by_budget(household_id, start, end) -> dict:
@@ -96,8 +117,14 @@ def _state(spent: Decimal, ceiling: Decimal | None) -> tuple[float, str]:
     return ratio, "ok"
 
 
-def _budget_row(budget: Budget, spent: Decimal, committed: Decimal | None = None) -> dict[str, Any]:
+def _budget_row(
+    budget: Budget,
+    spent: Decimal,
+    committed: Decimal | None = None,
+    attested: Decimal | None = None,
+) -> dict[str, Any]:
     ratio, state = _state(spent, budget.monthly_amount)
+    seen = attested if attested is not None else _zero()
     return {
         "id": str(budget.id),
         "name": budget.name,
@@ -105,6 +132,11 @@ def _budget_row(budget: Budget, spent: Decimal, committed: Decimal | None = None
         # zero read the same — and the second one is permanently over budget.
         "amount": None if budget.monthly_amount is None else _str(budget.monthly_amount),
         "spent": _str(spent),
+        # Deux chiffres **additionnels** : ``spent`` reste le compteur du plafond.
+        # ``spent_attested`` est ce qu'une ligne de relevé justifie, ``spent_pending``
+        # le reste. La somme des deux vaut ``spent``, toujours.
+        "spent_attested": _str(seen),
+        "spent_pending": _str(spent - seen),
         "committed": _str(committed if committed is not None else _zero()),
         "ratio": round(ratio, 4),
         "state": state,
@@ -119,15 +151,22 @@ def compute_budget_overview(*, household) -> dict[str, Any]:
         {
           "month": "2026-07",
           "global": {id, name, amount, spent, ratio, state} | null,
-          "budgets": [{id, name, amount, spent, ratio, state}, ...],
+          "budgets": [{id, name, amount, spent, spent_attested, spent_pending,
+                       committed, ratio, state}, ...],
           "unbudgeted": "700.00",
           "total_spent": "1850.00",
+          "total_attested": "1600.00",
+          "total_pending": "250.00",
           "named_total_amount": "1400.00",
           "named_exceeds_global": false
         }
+
+    ``spent_attested + spent_pending == spent``, par construction : le second est
+    calculé par différence. Deux sommes indépendantes finiraient par se contredire
+    d'un centime d'arrondi, et un total qui ne se recompose pas ne se lit pas.
     """
     start, end, month = current_month_range(household)
-    spent_map = _spent_by_budget(household.id, start, end)
+    spent_map, attested_map = _spent_by_budget(household.id, start, end)
     committed_map = _committed_by_budget(household.id, start, end)
 
     budgets = list(Budget.objects.filter(household_id=household.id))
@@ -135,11 +174,17 @@ def compute_budget_overview(*, household) -> dict[str, Any]:
     global_budget = next((b for b in budgets if b.is_global), None)
 
     total_spent = sum(spent_map.values(), _zero())
+    total_attested = sum(attested_map.values(), _zero())
     total_committed = sum(committed_map.values(), _zero())
     unbudgeted = spent_map.get(None, _zero())
 
     named_rows = [
-        _budget_row(b, spent_map.get(b.id, _zero()), committed_map.get(b.id, _zero()))
+        _budget_row(
+            b,
+            spent_map.get(b.id, _zero()),
+            committed_map.get(b.id, _zero()),
+            attested_map.get(b.id, _zero()),
+        )
         for b in named
     ]
     # Only the capped ones: an uncapped category promises nothing, so it cannot
@@ -151,7 +196,7 @@ def compute_budget_overview(*, household) -> dict[str, Any]:
     global_row = None
     named_exceeds_global = False
     if global_budget is not None:
-        global_row = _budget_row(global_budget, total_spent, total_committed)
+        global_row = _budget_row(global_budget, total_spent, total_committed, total_attested)
         named_exceeds_global = (
             global_budget.monthly_amount is not None
             and named_total_amount > global_budget.monthly_amount
@@ -163,6 +208,8 @@ def compute_budget_overview(*, household) -> dict[str, Any]:
         "budgets": named_rows,
         "unbudgeted": _str(unbudgeted),
         "total_spent": _str(total_spent),
+        "total_attested": _str(total_attested),
+        "total_pending": _str(total_spent - total_attested),
         "total_committed": _str(total_committed),
         "named_total_amount": _str(named_total_amount),
         "named_exceeds_global": named_exceeds_global,

--- a/apps/budget/apps.py
+++ b/apps/budget/apps.py
@@ -29,7 +29,7 @@ class BudgetConfig(AppConfig):
             model=RecurringExpense,
             search_fields=("label", "supplier"),
             label_attr="label",
-            url_template="/app/budget/recurring?r={id}",
+            url_template="/app/money/recurring?r={id}",
         ))
 
         # Write: the agent can create a budget on explicit request (undoable).
@@ -50,7 +50,7 @@ class BudgetConfig(AppConfig):
             resolve=_resolve_recurring_for_agent,
             delete=_delete_recurring_from_agent,
             label_attr="label",
-            url_template="/app/budget/recurring?r={id}",
+            url_template="/app/money/recurring?r={id}",
         ))
 
         # Proactive reminder: nudge when a recurrence is due (points to the app to

--- a/apps/budget/tests/test_api_budget.py
+++ b/apps/budget/tests/test_api_budget.py
@@ -738,3 +738,146 @@ class TestBudgetOverview:
     def test_anonymous_gets_401(self):
         response = _anon_client().get(reverse("budget-overview"))
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ===========================================================================
+# 7. TestWhatTheStatementAttests — deux chiffres par enveloppe
+# ===========================================================================
+
+
+@pytest.mark.django_db
+class TestWhatTheStatementAttests:
+    """« 340 € / 400 € » ne dit pas ce qui, dans les 340 €, est prouvé.
+
+    Une dépense saisie à la main et jamais rapprochée gonfle une enveloppe sans
+    qu'aucune ligne de relevé ne l'atteste. La réponse retenue est **deux chiffres,
+    pas un filtre** : le plafond continue de mesurer le total (une dépense d'hier
+    est réelle même si le relevé de fin de mois n'est pas importé), et l'enveloppe
+    dit à côté ce qui reste à attester. Filtrer aurait fait *reculer* le compteur
+    au fil du mois pour remonter d'un coup à l'import — un plafond qui recule est
+    pire qu'un plafond incertain.
+    """
+
+    def _expense(self, hh, user, amount, budget=None, transaction=None):
+        expense = create_manual_expense_interaction(
+            household=hh,
+            user=user,
+            subject=f"Dépense {amount}",
+            amount=Decimal(str(amount)),
+            occurred_at=timezone.now(),
+            budget_id=budget.id if budget else None,
+        )
+        if transaction is not None:
+            expense.bank_transaction = transaction
+            expense.save(update_fields=["bank_transaction"])
+        return expense
+
+    def _transaction(self, hh):
+        from banking.dedup import compute_dedup_hash
+        from banking.models import BankAccount, BankTransaction, TransactionDirection
+
+        account = BankAccount.objects.create(
+            household=hh, name="Courant", kind=BankAccount.Kind.BANK
+        )
+        booked_on = timezone.now().date()
+        return BankTransaction.objects.create(
+            household=hh,
+            account=account,
+            booked_on=booked_on,
+            label_raw="CB LECLERC",
+            label_norm="CB LECLERC",
+            amount=Decimal("-500.00"),
+            direction=TransactionDirection.OUT,
+            dedup_hash=compute_dedup_hash(
+                account_id=account.id,
+                booked_on=booked_on,
+                label_norm="CB LECLERC",
+                amount=Decimal("-500.00"),
+                currency="EUR",
+                discriminant="attested-test",
+            ),
+        )
+
+    def test_an_unreconciled_expense_still_counts_but_is_flagged_pending(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        groceries = _create_budget(hh, owner, name="Courses", monthly_amount=Decimal("400"))
+        self._expense(hh, owner, "120.00", budget=groceries)
+
+        row = _client_for(owner).get(reverse("budget-overview")).data["budgets"][0]
+
+        assert row["spent"] == "120.00"
+        assert row["spent_attested"] == "0.00"
+        assert row["spent_pending"] == "120.00"
+
+    def test_reconciling_moves_the_money_without_changing_the_total(self):
+        """The ceiling reads the same number before and after the statement lands."""
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        groceries = _create_budget(hh, owner, name="Courses", monthly_amount=Decimal("400"))
+        expense = self._expense(hh, owner, "120.00", budget=groceries)
+
+        before = _client_for(owner).get(reverse("budget-overview")).data["budgets"][0]
+
+        expense.bank_transaction = self._transaction(hh)
+        expense.save(update_fields=["bank_transaction"])
+
+        after = _client_for(owner).get(reverse("budget-overview")).data["budgets"][0]
+
+        assert before["spent"] == after["spent"] == "120.00"
+        assert before["ratio"] == after["ratio"]
+        assert after["spent_attested"] == "120.00"
+        assert after["spent_pending"] == "0.00"
+
+    def test_the_two_parts_always_recompose_the_total(self):
+        """Computed by difference on purpose: two independent sums would drift."""
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        groceries = _create_budget(hh, owner, name="Courses", monthly_amount=Decimal("400"))
+        txn = self._transaction(hh)
+        self._expense(hh, owner, "80.50", budget=groceries, transaction=txn)
+        self._expense(hh, owner, "39.50", budget=groceries)
+
+        data = _client_for(owner).get(reverse("budget-overview")).data
+        row = data["budgets"][0]
+
+        assert Decimal(row["spent_attested"]) + Decimal(row["spent_pending"]) == Decimal(
+            row["spent"]
+        )
+        assert Decimal(data["total_attested"]) + Decimal(data["total_pending"]) == Decimal(
+            data["total_spent"]
+        )
+        assert row["spent_attested"] == "80.50"
+
+    def test_the_global_envelope_carries_the_split_too(self):
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        _create_budget(hh, owner, name="Global", monthly_amount=Decimal("1000"), is_global=True)
+        txn = self._transaction(hh)
+        self._expense(hh, owner, "200.00", transaction=txn)
+        self._expense(hh, owner, "50.00")
+
+        data = _client_for(owner).get(reverse("budget-overview")).data
+
+        assert data["global"]["spent"] == "250.00"
+        assert data["global"]["spent_attested"] == "200.00"
+        assert data["global"]["spent_pending"] == "50.00"
+
+    def test_the_split_costs_no_extra_query(self, django_assert_max_num_queries):
+        """One conditional aggregate, not a second pass.
+
+        The overview is fetched on every visit to the Budgets tab; paying a round
+        trip per figure is how a panel becomes slow one honest addition at a time.
+        """
+        hh = HouseholdFactory()
+        owner = _make_owner(hh)
+        groceries = _create_budget(hh, owner, name="Courses", monthly_amount=Decimal("400"))
+        txn = self._transaction(hh)
+        for amount in ("10.00", "20.00", "30.00"):
+            self._expense(hh, owner, amount, budget=groceries, transaction=txn)
+        client = _client_for(owner)
+
+        # Quatre : session, foyer, l'agrégat des dépenses (les deux chiffres en
+        # un seul GROUP BY) et celui des récurrences.
+        with django_assert_max_num_queries(5):
+            client.get(reverse("budget-overview"))

--- a/apps/budget/views.py
+++ b/apps/budget/views.py
@@ -93,6 +93,8 @@ class BudgetViewSet(viewsets.ModelViewSet):
                     "budgets": [],
                     "unbudgeted": "0.00",
                     "total_spent": "0.00",
+                    "total_attested": "0.00",
+                    "total_pending": "0.00",
                     "total_committed": "0.00",
                     "named_total_amount": "0.00",
                     "named_exceeds_global": False,

--- a/docs/MODULES/budget.md
+++ b/docs/MODULES/budget.md
@@ -91,7 +91,7 @@ un modèle dédié. Le rattachement dépense→budget est une **vraie colonne** 
 - **Rappel** : `PingSpec('recurring_due')` — nudge Telegram **informatif** listant
   les échéances dues (pointe vers l'app ; la confirmation 1-clic reste in-app).
 - **Agent** : entité `recurring_expense` searchable + writable (create + undo).
-- **Frontend** : sous-page `/app/budget/recurring` (`RecurringPage` : projection,
+- **Frontend** : sous-page `/app/money/recurring` (`RecurringPage` : projection,
   section « à confirmer » avec confirm 1-clic, liste, dialogs, undo compound) ;
   carte d'accès depuis `BudgetPage` ; `committed` affiché sur les cards budget.
   i18n namespace `recurring.*` + `budget.committed`/`budget.recurringAccess.*` +
@@ -124,7 +124,7 @@ un modèle dédié. Le rattachement dépense→budget est une **vraie colonne** 
   `retrieve` par mois (`/2026-06/`). Texte rendu dans la langue de la requête.
 - **Ping** : `PingSpec('monthly_budget_report')` (le digest est quotidien ; ici
   mensuel, la cadence est portée par le `build_message` qui ne renvoie qu'au 1er).
-- **Frontend** : sous-page `/app/budget/reports` (`ReportsPage` : dernier bilan +
+- **Frontend** : sous-page `/app/money/reports` (`ReportsPage` : dernier bilan +
   historique) + carte d'accès depuis `BudgetPage`. i18n namespace `report.*` +
   `settings.pings.types.monthly_budget_report`.
 - **Réglage** : `BUDGET_REPORT_AI_POLISH_ENABLED` (défaut `False`).
@@ -163,6 +163,31 @@ plafonnée ».
 - Le bilan mensuel écrit « Cadeaux : 180 € » au lieu de « 180 € / 0 € —
   dépassé ». ⚠️ Les snapshots **déjà figés** portent une string : `render.py`
   doit accepter les deux formes pour toujours.
+
+## Ce que le relevé atteste, et ce qui attend de l'être
+
+Chaque ligne de l'aperçu porte `spent_attested` et `spent_pending` **en plus** de
+`spent` (idem `total_attested` / `total_pending` au niveau du foyer) : la part de
+la dépense qu'une ligne de relevé justifie, et le reste. Sans eux, « 340 € / 400 € »
+mélange sans le dire une dépense prouvée et une dépense seulement affirmée.
+
+- **`spent` ne change pas** : c'est lui que le plafond mesure, et sept agrégations
+  le lisent. La distinction est **additive**, comme le bloc `bank` du bilan.
+- **Pas de filtre `bank_transaction__isnull=False`.** Une dépense saisie hier est
+  réelle même si le relevé de fin de mois n'est pas importé ; ne compter que le
+  prouvé ferait *reculer* le compteur au fil du mois pour remonter d'un coup à
+  l'import. Un plafond qui recule est pire qu'un plafond incertain.
+- **`spent_pending` est calculé par différence.** Deux sommes indépendantes
+  divergeraient d'un centime d'arrondi, et un total qui ne se recompose pas ne se
+  lit pas. L'invariant `attested + pending == spent` est testé.
+- **Un seul `GROUP BY`** (`Sum(filter=Q(…))` conditionnel) : l'aperçu est rechargé
+  à chaque visite de l'onglet, et une requête par chiffre est la façon dont un
+  panneau devient lent une addition honnête à la fois.
+- La barre le montre en **deux nuances de la même couleur** — une autre teinte
+  laisserait croire à une autre nature de dépense — et sa longueur totale reste
+  celle de `spent`.
+
+Régression : `budget/tests/test_api_budget.py::TestWhatTheStatementAttests`.
 
 ## Ouvrir un budget sur ses dépenses
 

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -122,8 +122,16 @@ valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage
 l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
-`/app/money/analysis`, `/app/money/budgets/:id`, `/app/budget/recurring`,
-`/app/budget/reports`.
+`/app/money/analysis`, `/app/money/budgets/:id`, `/app/money/recurring`,
+`/app/money/reports`.
+
+Les deux dernières ont rejoint la famille en juillet 2026 ; `/app/budget/recurring`
+et `/app/budget/reports` redirigent via `PreserveQueryRedirect`, qui conserve la
+query string pour la même raison que `LegacyMoneyRedirect`. Un test tient la
+règle côté serveur : `agent/tests/test_registry.py::test_the_money_family_links_stay_inside_the_money_module`
+refuse tout `url_template` de la famille argent qui ne commence pas par
+`/app/money` — une redirection rattrape un ancien lien, elle ne justifie pas d'en
+produire de nouveaux.
 
 `/app/money/analysis` est la **lecture longue** des dépenses (tendance mensuelle
 par budget, répartition, fournisseurs, plus grosses dépenses) — le panneau
@@ -210,18 +218,55 @@ s'y rendre. `?allocation=todo` passe par `detectors.pending_outflows`, la même
 fonction que les compteurs du Contrôle : une file dont le nombre contredirait le
 badge ferait perdre leur crédit aux deux.
 
+### Détacher est un geste, plus un effet de bord
+
+L'endpoint `DELETE /transactions/{id}/unlink/{interaction_id}/` n'avait aucun
+appelant. En cherchant où le brancher, on a trouvé pourquoi il était inutile : le
+service le faisait déjà **tout seul**, au mauvais moment.
+
+`set_allocations` détachait tout ce qu'il ne possède pas. Concrètement : 150 € chez
+Leroy Merlin, dont 90 € déjà saisis comme achat de projet et rapprochés à la main ;
+éditer les 60 € restants dé-rapprochait les 90 €. L'écart « dépense non rapprochée »
+resurgissait sur une dépense que l'utilisateur avait résolue, et comme l'éditeur
+chargeait *toutes* les ventilations dans son brouillon, enregistrer recréait une
+dépense `kind='bank'` pour les mêmes 90 € — 180 € de dépenses sur 150 € d'argent,
+et le chantier facturé deux fois pour le même carrelage.
+
+Trois conséquences, symétriques de la règle de propriété du lot 3 :
+
+- **la portée de l'éditeur s'arrête à ce qu'il a créé.** Il supprime ses lignes
+  `kind='bank'`, et ne touche à rien d'autre — ni suppression, ni détachement ;
+- **le montant rattaché est un plancher.** `set_allocations` le compte contre
+  l'`outflow`, donc renvoyer la ligne rattachée dans le payload est un **400** au
+  lieu d'un doublement silencieux ;
+- **le geste existe** : le bloc « Dépenses déjà rattachées » de l'`AllocationDialog`
+  les affiche en lecture seule avec un bouton « Détacher », qui appelle l'endpoint.
+
+Régression : `banking/tests/test_allocation_axes.py::TestSavingASplitNeverUndoesAReconciliation`.
+
+### « 340 € / 400 € » : deux chiffres, jamais un filtre
+
+Une dépense jamais rapprochée gonfle une enveloppe sans qu'aucune ligne de relevé
+ne l'atteste. Chaque ligne de l'aperçu porte donc `spent_attested` et
+`spent_pending` **en plus** de `spent`, calculés en un seul `GROUP BY` (un
+`Sum(filter=…)` conditionnel — l'aperçu est rechargé à chaque visite de l'onglet).
+
+Ce qui n'a **pas** été fait, et pourquoi : filtrer `bank_transaction__isnull=False`
+pour ne compter que le prouvé. Une dépense saisie hier est réelle même si le relevé
+de fin de mois n'est pas importé ; le compteur reculerait au fil du mois pour
+remonter d'un coup à l'import. **Un plafond qui recule est pire qu'un plafond
+incertain.** Le plafond mesure donc toujours le total, et la barre dit la
+différence en deux nuances de la même couleur — une autre teinte laisserait croire
+à une autre nature de dépense.
+
+`spent_pending` est calculé **par différence**, jamais par une seconde somme : deux
+agrégats indépendants finissent par se contredire d'un centime d'arrondi, et un
+total qui ne se recompose pas ne se lit pas. Régression :
+`budget/tests/test_api_budget.py::TestWhatTheStatementAttests`.
+
 ### Reste ouvert
 
-Deux points de l'audit demandent un arbitrage produit, pas une correction :
-
-- **`DELETE /transactions/{id}/unlink/{interaction_id}/` n'a aucun appelant.**
-  Détacher une dépense mal rapprochée n'a pas de geste dans l'interface. Soit on
-  lui en donne un, soit on retire l'endpoint — mais un endpoint injoignable est
-  lui-même un orphelin.
-- **`/app/budget/recurring` et `/app/budget/reports`** vivent hors de la famille
-  `/app/money`, alors que `/app/budget` redirige vers elle. Les déplacer touche
-  les `url_template` de l'agent, les tutoriels et les redirections.
-
-Et un lot de dette hors périmètre : `features/settings` compte une trentaine de
-`t(…, { defaultValue })`, interdits par le CLAUDE.md — c'est pour cela que le
-garde-fou i18n couvre une liste de namespaces plutôt que tout le front.
+Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions
+de budget apprises** (`label_norm` + fournisseur + historique des budgets). C'est
+le vrai levier sur l'effort de rangement, mais l'apprendre demande un mois réel de
+données — le construire avant, c'est inventer les motifs qu'on croit avoir.

--- a/docs/parcours/PARCOURS_21_BUDGETS_ET_RECURRENCES.md
+++ b/docs/parcours/PARCOURS_21_BUDGETS_ET_RECURRENCES.md
@@ -72,7 +72,7 @@ Budget global : 1 850 / 2 000 €   92 %
 > Lot 2 livré : modèle `RecurringExpense` (app `budget`) + confirmation qui crée
 > une `Interaction` (`metadata.kind='recurring'`) et avance l'échéance + projection
 > de trésorerie + `committed` sur l'overview + ping `recurring_due` + sous-page
-> `/app/budget/recurring`. **Rappel V1 = nudge Telegram informatif** (pointe vers
+> `/app/money/recurring`. **Rappel V1 = nudge Telegram informatif** (pointe vers
 > l'app), la confirmation 1-clic reste in-app. Voir [docs/MODULES/budget.md](../MODULES/budget.md).
 
 ### Lot 3 — Bilan mensuel rédigé par l'IA · Should · #314
@@ -86,7 +86,7 @@ Budget global : 1 850 / 2 000 €   92 %
 > `apps/budget/report/` (stats → rendu déterministe localisé → polish IA optionnel,
 > miroir du digest) + endpoints `/api/budget/reports/` (historique + `latest`
 > lazy-génère) + ping mensuel `monthly_budget_report` + sous-page
-> `/app/budget/reports`. **Rédigé dans la langue de l'user** (rendu au read),
+> `/app/money/reports`. **Rédigé dans la langue de l'user** (rendu au read),
 > **fallback chiffres bruts** si pas de clé IA. **Parcours 21 COMPLET (Lots 1-3).**
 
 ## Limites V1 assumées

--- a/e2e/COVERAGE.md
+++ b/e2e/COVERAGE.md
@@ -432,7 +432,7 @@ Ancre : projet "Rénovation salle de bain" (seedé). Entité cible : second proj
 
 | Parcours | Statut |
 |---|---|
-| Link card "Dépenses récurrentes" depuis /app/budget → /app/budget/recurring + état vide | ✅ |
+| Link card "Dépenses récurrentes" depuis /app/budget → /app/money/recurring + état vide | ✅ |
 | Ouverture du SheetDialog (champs libellé, montant, cadence, échéance, fournisseur, notes) | ✅ |
 | Validation : libellé vide → erreur, dialog reste ouvert | ✅ |
 | Création "Netflix" 15 € échéance aujourd'hui → section "À confirmer (1)" + bouton "Confirmer" | ✅ |
@@ -536,13 +536,13 @@ Households stubés pour contrôler la présence ou l'absence de lat/lon.
 
 ## Bilan mensuel (`report.spec.ts`)
 
-Page `/app/budget/reports` — rapport mensuel généré en lazy par le backend (LLM).
+Page `/app/money/reports` — rapport mensuel généré en lazy par le backend (LLM).
 Les assertions sur le contenu du rapport sont tolérantes : la présence d'un rapport
 dépend des données seedées et du cycle calendaire (dernier mois clôturé).
 
 | Parcours | Statut |
 |---|---|
-| Link card "Bilan mensuel" depuis /app/budget → /app/budget/reports | ✅ |
+| Link card "Bilan mensuel" depuis /app/budget → /app/money/reports | ✅ |
 | BackLink "Budgets" + titre h1 "Bilan mensuel" + description visibles | ✅ |
 | Page sans rapport : EmptyState "Aucun bilan" | ✅ |
 | Page avec rapport : section "Mois dernier" + libellé de mois capitalisé | 🚧 (dépend du seed DB — tolérant) |

--- a/e2e/money.spec.ts
+++ b/e2e/money.spec.ts
@@ -80,6 +80,22 @@ test.describe('Module Argent — anciennes URLs', () => {
     await expect(page).toHaveURL(/\/app\/money\/transactions/);
     await expect(page.getByRole('heading', { level: 1, name: 'Journal bancaire' })).toBeVisible();
   });
+
+  test('/app/budget/recurring redirige en gardant son paramètre', async ({ page }) => {
+    // La dernière famille d'URLs à avoir rejoint /app/money. Le paramètre est
+    // celui de l'agent (`?r={id}`) : sans lui, un lien qui ouvrait *une*
+    // récurrence ouvrirait la liste — valide, et faux.
+    await page.goto('/app/budget/recurring?r=8f14e45f-ceea-467a-9c1e-000000000000');
+    await expect(page).toHaveURL(/\/app\/money\/recurring/);
+    await expect(page).toHaveURL(/r=8f14e45f-ceea-467a-9c1e-000000000000/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
+  });
+
+  test('/app/budget/reports redirige vers /app/money/reports', async ({ page }) => {
+    await page.goto('/app/budget/reports');
+    await expect(page).toHaveURL(/\/app\/money\/reports/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Bilan mensuel' })).toBeVisible();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -267,10 +283,10 @@ test.describe('Module Argent — non évaluable ≠ conforme', () => {
 
 test.describe('Module Argent — sous-pages', () => {
   test('les sous-pages restent accessibles en accès direct', async ({ page }) => {
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
 
-    await page.goto('/app/budget/reports');
+    await page.goto('/app/money/reports');
     await expect(page.getByRole('heading', { level: 1, name: 'Bilan mensuel' })).toBeVisible();
 
     await page.goto('/app/money/transactions');

--- a/e2e/recurring.spec.ts
+++ b/e2e/recurring.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Parcours 21 — Lot 2 : Dépenses récurrentes.
  *
  * Couvre :
- *  1. Navigation depuis l'onglet Budgets vers /app/budget/recurring via la link card
+ *  1. Navigation depuis l'onglet Budgets vers /app/money/recurring via la link card
  *  2. État vide ("Aucune dépense récurrente")
  *  3. Création d'une récurrence avec échéance aujourd'hui → apparaît sous "À confirmer"
  *     + cartes de projection trésorerie (30/90 jours)
@@ -87,16 +87,16 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
     await deleteAllRecurring(page);
   });
 
-  // ── 1. Navigation depuis l'onglet Budgets → /app/budget/recurring ────────
+  // ── 1. Navigation depuis l'onglet Budgets → /app/money/recurring ────────
 
-  test('la link card "Dépenses récurrentes" mène à /app/budget/recurring avec état vide', async ({ page }) => {
+  test('la link card "Dépenses récurrentes" mène à /app/money/recurring avec état vide', async ({ page }) => {
     // La link card n'apparaît qu'une fois l'overview chargé — attendre le titre
     await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // Cliquer sur la card "Dépenses récurrentes"
     await page.getByText('Dépenses récurrentes').click();
 
-    await expect(page).toHaveURL(/\/app\/budget\/recurring/);
+    await expect(page).toHaveURL(/\/app\/money\/recurring/);
 
     // Titre de la page
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
@@ -114,7 +114,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
   // ── 2. Ouverture du SheetDialog ───────────────────────────────────────────
 
   test('le bouton "Nouvelle récurrence" ouvre le SheetDialog avec tous les champs', async ({ page }) => {
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Nouvelle récurrence' }).click();
@@ -141,7 +141,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
   // ── 3. Création avec échéance aujourd'hui → section "À confirmer" ─────────
 
   test('crée "Netflix" 15 € échéance aujourd\'hui → apparaît sous "À confirmer" avec bouton "Confirmer"', async ({ page }) => {
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Nouvelle récurrence' }).click();
@@ -182,7 +182,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
   // ── 4. Validation : libellé requis ────────────────────────────────────────
 
   test('affiche une erreur si le libellé est vide', async ({ page }) => {
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Nouvelle récurrence' }).click();
@@ -207,7 +207,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
     await apiCreateRecurring(page, 'Spotify', 10, todayIso(), 'monthly');
 
     // Recharger pour afficher la récurrence
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
     await expect(page.getByText('Spotify')).toBeVisible();
 
@@ -246,7 +246,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
     // Créer directement via l'API
     await apiCreateRecurring(page, 'Disney+ E2E', 8, todayIso(), 'monthly');
 
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByRole('heading', { level: 1, name: 'Dépenses récurrentes' })).toBeVisible();
     await expect(page.getByText('Disney+ E2E')).toBeVisible();
 
@@ -269,7 +269,7 @@ test.describe('Dépenses récurrentes — parcours 21 lot 2', () => {
   test('suppression annulable : undo restaure la carte', async ({ page }) => {
     await apiCreateRecurring(page, 'Canal+ Undo', 25, todayIso(), 'monthly');
 
-    await page.goto('/app/budget/recurring');
+    await page.goto('/app/money/recurring');
     await expect(page.getByText('Canal+ Undo')).toBeVisible();
 
     const card = page.getByText('Canal+ Undo').locator('xpath=ancestor::*[4]');

--- a/e2e/report.spec.ts
+++ b/e2e/report.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from '@playwright/test';
  * Parcours 21 — Lot 3 : Bilan mensuel.
  *
  * Couvre :
- *  1. Navigation depuis l'onglet Budgets → /app/budget/reports via la link card "Bilan mensuel"
+ *  1. Navigation depuis l'onglet Budgets → /app/money/reports via la link card "Bilan mensuel"
  *  2. Structure de la page (BackLink vers Budgets, titre, description)
  *  3. État tolérant : soit un état vide ("Aucun bilan"), soit une card de rapport
  *     avec un libellé de mois capitalisé — le contenu dépend des données seedées
@@ -83,20 +83,20 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
 
   // ── 1. Navigation depuis /app/budget via la link card ──────────────────────
 
-  test('la link card "Bilan mensuel" depuis l\'onglet Budgets mène à /app/budget/reports', async ({ page }) => {
+  test('la link card "Bilan mensuel" depuis l\'onglet Budgets mène à /app/money/reports', async ({ page }) => {
     // Attendre que l'overview soit chargé (la link card n'apparaît qu'ensuite)
     await expect(page.getByRole('heading', { level: 1, name: 'Argent' })).toBeVisible();
 
     // La link card est identifiée par son titre "Bilan mensuel"
     await page.getByText('Bilan mensuel').click();
 
-    await expect(page).toHaveURL(/\/app\/budget\/reports/);
+    await expect(page).toHaveURL(/\/app\/money\/reports/);
   });
 
   // ── 2. Structure de la page ────────────────────────────────────────────────
 
-  test('la page /app/budget/reports affiche le BackLink, le titre et la description', async ({ page }) => {
-    await page.goto('/app/budget/reports');
+  test('la page /app/money/reports affiche le BackLink, le titre et la description', async ({ page }) => {
+    await page.goto('/app/money/reports');
 
     // BackLink vers Budgets
     await expect(page.getByRole('link', { name: 'Budgets' })).toBeVisible();
@@ -113,7 +113,7 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
   // ── 3. Contenu tolérant : état vide OU card de rapport ────────────────────
 
   test('la page affiche soit "Aucun bilan" soit une card de rapport avec un libellé de mois', async ({ page }) => {
-    await page.goto('/app/budget/reports');
+    await page.goto('/app/money/reports');
 
     // Attendre la fin du chargement : skeleton disparu → contenu visible
     // On attend que l'un des deux états soit présent (tolérant au contenu DB)
@@ -125,7 +125,7 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
   // ── 4. BackLink ramène au module Argent ───────────────────────────────────
 
   test('le BackLink "Budgets" navigue bien vers l\'onglet Budgets', async ({ page }) => {
-    await page.goto('/app/budget/reports');
+    await page.goto('/app/money/reports');
 
     await expect(page.getByRole('link', { name: 'Budgets' })).toBeVisible();
     await page.getByRole('link', { name: 'Budgets' }).click();
@@ -147,7 +147,7 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
     await apiCreatePreviousMonthExpense(page, `Dépense test bilan ${Date.now()}`, 42);
 
     // Naviguer sur la page des rapports
-    await page.goto('/app/budget/reports');
+    await page.goto('/app/money/reports');
 
     // Attendre la fin du chargement (skeleton résolu)
     await expect(
@@ -169,11 +169,11 @@ test.describe('Bilan mensuel — parcours 21 lot 3', () => {
 
   // ── 6. Accès direct par URL (deep-link) ───────────────────────────────────
 
-  test('accès direct à /app/budget/reports (sans passer par le module Argent) → page chargée correctement', async ({ page }) => {
+  test('accès direct à /app/money/reports (sans passer par le module Argent) → page chargée correctement', async ({ page }) => {
     // Accès direct sans state.back → BackLink affichera le fallback "Budgets"
-    await page.goto('/app/budget/reports');
+    await page.goto('/app/money/reports');
 
-    await expect(page).toHaveURL(/\/app\/budget\/reports/);
+    await expect(page).toHaveURL(/\/app\/money\/reports/);
     await expect(page.getByRole('heading', { level: 1, name: 'Bilan mensuel' })).toBeVisible();
     await expect(page.getByRole('link', { name: 'Budgets' })).toBeVisible();
   });

--- a/ui/src/components/PreserveQueryRedirect.tsx
+++ b/ui/src/components/PreserveQueryRedirect.tsx
@@ -1,0 +1,23 @@
+import { Navigate, useLocation } from 'react-router-dom';
+
+interface PreserveQueryRedirectProps {
+  /** Chemin de destination, sans query string. */
+  to: string;
+}
+
+/**
+ * Redirige vers `to` **en conservant la query string** de l'URL d'origine.
+ *
+ * `<Navigate to="/app/money/recurring" />` la perd, et ce n'est pas un détail :
+ * l'agent produit `/app/budget/recurring?r={id}`
+ * (`apps/budget/apps.py::SearchableSpec.url_template`). Sans le paramètre, un lien
+ * qui ouvrait *une* récurrence ouvre la liste — le lien reste valide et devient
+ * faux, ce qui est le pire des deux.
+ *
+ * Le pendant à un seul paramètre existe déjà pour les trois anciennes pages du
+ * module : `LegacyMoneyRedirect`, qui ajoute en plus l'onglet.
+ */
+export default function PreserveQueryRedirect({ to }: PreserveQueryRedirectProps) {
+  const location = useLocation();
+  return <Navigate to={`${to}${location.search}${location.hash}`} replace />;
+}

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Plus, Trash2 } from 'lucide-react';
+import { Link2Off, Plus, Trash2 } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
@@ -10,7 +10,7 @@ import { formatAmount } from '@/lib/format';
 import { ZoneMultiSelect } from '@/components/ZoneMultiSelect';
 import type { AllocationLine } from '@/lib/api/banking';
 import { useBudgets } from '@/features/budget/hooks';
-import { useAllocations, useSetAllocations } from './hooks';
+import { useAllocations, useSetAllocations, useUnlinkAllocation } from './hooks';
 import AllocationSourceSelect from './AllocationSourceSelect';
 import { NO_SOURCE, type AllocationSource } from './allocationSource';
 
@@ -35,6 +35,16 @@ interface DraftLine {
   source: AllocationSource;
   zoneIds: string[];
 }
+
+/**
+ * Le `kind` que cet éditeur possède — miroir de
+ * `interactions/kinds.py::OWNED_BY_ALLOCATION_EDITOR`.
+ *
+ * Tout le reste (un achat de projet, une occurrence de récurrence) a été
+ * rapproché ailleurs, délibérément : l'éditeur l'affiche, le compte contre le
+ * montant de l'opération, et n'y touche pas.
+ */
+const OWNED_KIND = 'bank';
 
 let lineCounter = 0;
 function blankLine(
@@ -65,6 +75,7 @@ export default function AllocationDialog({
   const allocationsQuery = useAllocations(open ? transactionId : undefined);
   const budgetsQuery = useBudgets();
   const mutation = useSetAllocations();
+  const unlinkMutation = useUnlinkAllocation();
 
   const [lines, setLines] = React.useState<DraftLine[]>([]);
   const [error, setError] = React.useState<string | null>(null);
@@ -73,13 +84,22 @@ export default function AllocationDialog({
   const label = transaction?.label_raw ?? '';
   const total = Math.abs(Number(transaction?.amount ?? 0));
 
+  // Les dépenses rapprochées ailleurs : affichées, comptées, jamais réécrites.
+  const linked = (allocationsQuery.data?.allocations ?? []).filter((a) => a.kind !== OWNED_KIND);
+  const linkedTotal = linked.reduce((sum, a) => sum + Number(a.amount ?? 0), 0);
+  /** Ce que cette ventilation peut se partager : l'opération moins les rattachements. */
+  const editable = total - linkedTotal;
+
   React.useEffect(() => {
     if (!open || !allocationsQuery.data) return;
     setError(null);
-    const existing = allocationsQuery.data.allocations;
+    const rows = allocationsQuery.data.allocations;
+    const owned = rows.filter((a) => a.kind === OWNED_KIND);
+    const free =
+      total - rows.filter((a) => a.kind !== OWNED_KIND).reduce((s, a) => s + Number(a.amount ?? 0), 0);
     setLines(
-      existing.length > 0
-        ? existing.map((a) =>
+      owned.length > 0
+        ? owned.map((a) =>
             blankLine(
               a.subject,
               a.amount ?? '',
@@ -90,9 +110,13 @@ export default function AllocationDialog({
               a.zone_ids ?? [],
             ),
           )
-        : // Première ventilation : on pré-remplit une ligne au montant total,
-          // le cas le plus fréquent (une opération = un poste).
-          [blankLine(label, total.toFixed(2), '')],
+        : free > 0
+          ? // Première ventilation : on pré-remplit une ligne au montant restant,
+            // le cas le plus fréquent (une opération = un poste).
+            [blankLine(label, free.toFixed(2), '')]
+          : // Tout est déjà rattaché : proposer une ligne à 0 € serait proposer
+            // une erreur de saisie.
+            [],
     );
   }, [open, allocationsQuery.data, label, total]);
 
@@ -100,7 +124,7 @@ export default function AllocationDialog({
     const value = Number(line.amount.replace(',', '.'));
     return sum + (Number.isFinite(value) ? value : 0);
   }, 0);
-  const remaining = total - allocated;
+  const remaining = editable - allocated;
 
   function update(key: string, patch: Partial<DraftLine>) {
     setLines((prev) => prev.map((l) => (l.key === key ? { ...l, ...patch } : l)));
@@ -137,8 +161,12 @@ export default function AllocationDialog({
       });
     }
 
-    if (allocated > total + 0.001) {
-      setError(t('banking.allocation.errors.overAllocated', { total: formatAmount(String(total)) }));
+    // Le plafond est ce qui reste **après** les dépenses déjà rattachées : le
+    // serveur les compte aussi, autant refuser ici avec le bon chiffre.
+    if (allocated > editable + 0.001) {
+      setError(
+        t('banking.allocation.errors.overAllocated', { total: formatAmount(editable.toFixed(2)) }),
+      );
       return;
     }
 
@@ -169,6 +197,52 @@ export default function AllocationDialog({
             </p>
           ) : null}
         </div>
+
+        {/* Ce que l'éditeur ne possède pas — un achat de projet rapproché à la
+            main, une occurrence de récurrence. Enregistrer la ventilation les
+            détachait autrefois **en silence**, ce qui défaisait un rapprochement
+            que l'utilisateur avait fait exprès et rendait la ligne à moitié
+            ventilée sans rien dire. Elles vivent donc ici : lisibles, comptées,
+            et détachables seulement si on le demande. */}
+        {linked.length > 0 ? (
+          <div className="space-y-2 rounded-lg border border-border p-3">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t('banking.allocation.linked.title')}
+            </p>
+            {linked.map((expense) => (
+              <div key={expense.id} className="flex items-center justify-between gap-2 text-sm">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-foreground">{expense.subject}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {[
+                      expense.budget?.name,
+                      expense.source_label,
+                      t(`expenses.kind.${expense.kind}`),
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </p>
+                </div>
+                <span className="shrink-0 tabular-nums text-foreground">
+                  {formatAmount(expense.amount ?? '0')}
+                </span>
+                <button
+                  type="button"
+                  onClick={() =>
+                    unlinkMutation.mutate({ transactionId, interactionId: expense.id })
+                  }
+                  disabled={unlinkMutation.isPending}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                  aria-label={t('banking.allocation.linked.detach')}
+                  title={t('banking.allocation.linked.detach')}
+                >
+                  <Link2Off className="h-4 w-4" aria-hidden />
+                </button>
+              </div>
+            ))}
+            <p className="text-xs text-muted-foreground">{t('banking.allocation.linked.hint')}</p>
+          </div>
+        ) : null}
 
         <div className="space-y-3">
           {lines.map((line, index) => (
@@ -268,6 +342,12 @@ export default function AllocationDialog({
               : 'border-border bg-muted/40 text-foreground'
           }`}
         >
+          {linkedTotal > 0 ? (
+            <div className="mb-1 flex justify-between text-muted-foreground">
+              <span>{t('banking.allocation.linked.total')}</span>
+              <span className="tabular-nums">{formatAmount(linkedTotal.toFixed(2))}</span>
+            </div>
+          ) : null}
           <div className="flex justify-between">
             <span>{t('banking.allocation.allocated')}</span>
             <span className="font-semibold tabular-nums">{formatAmount(allocated.toFixed(2))}</span>

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -20,6 +20,7 @@ import {
   restoreBankAccount,
   setAllocations,
   setBalanceAnchor,
+  unlinkAllocation,
   unlinkCashCounterpart,
   updateBankAccount,
   withdrawToCash,
@@ -274,6 +275,33 @@ export function useSetAllocations() {
       // vient de ranger — un compteur qui contredit l'écran est pire que pas de
       // compteur.
       toast({ description: t('banking.allocation.saved'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/**
+ * Détacher une dépense de sa ligne bancaire — sans la supprimer.
+ *
+ * Le geste manquait, et son absence n'était pas neutre : enregistrer une
+ * ventilation détachait *en silence* tout ce que l'éditeur ne possède pas (un
+ * achat de projet rapproché à la main). Le service ne le fait plus, donc il faut
+ * un endroit pour le vouloir explicitement — ici.
+ */
+export function useUnlinkAllocation() {
+  const invalidate = useInvalidateMoney();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({
+      transactionId,
+      interactionId,
+    }: {
+      transactionId: string;
+      interactionId: string;
+    }) => unlinkAllocation(transactionId, interactionId),
+    onSuccess: () => {
+      invalidate();
+      toast({ description: t('banking.allocation.linked.detached'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });

--- a/ui/src/features/budget/BudgetCard.tsx
+++ b/ui/src/features/budget/BudgetCard.tsx
@@ -38,6 +38,14 @@ export default function BudgetCard({ row, onEdit, onDelete, to, backState }: Bud
   const pct = Math.min(100, Math.round(row.ratio * 100));
   const overBy = Number(row.spent) - Number(row.amount ?? 0);
 
+  // Ce que le relevé atteste, et ce qui attend encore de l'être. Le plafond
+  // mesure toujours le total : une dépense saisie avant l'import est réelle, et
+  // un compteur qui reculerait en attendant le relevé serait pire qu'incertain.
+  // La barre le dit en deux nuances, sans changer sa longueur.
+  const spent = Number(row.spent);
+  const pending = Number(row.spent_pending);
+  const attestedPct = spent > 0 ? (Number(row.spent_attested) / spent) * pct : pct;
+
   const actions: CardAction[] = [
     { label: t('common.edit'), icon: Pencil, onClick: onEdit },
     { label: t('common.delete'), icon: Trash2, onClick: onDelete, variant: 'danger' },
@@ -62,14 +70,22 @@ export default function BudgetCard({ row, onEdit, onDelete, to, backState }: Bud
           </div>
 
           {uncapped ? null : (
-            <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="mt-2 flex h-2 w-full overflow-hidden rounded-full bg-muted"
+              role="progressbar"
+              aria-valuenow={pct}
+              aria-valuemin={0}
+              aria-valuemax={100}
+            >
               <div
-                className={`h-full rounded-full transition-all ${BAR_CLASS[row.state]}`}
-                style={{ width: `${pct}%` }}
-                role="progressbar"
-                aria-valuenow={pct}
-                aria-valuemin={0}
-                aria-valuemax={100}
+                className={`h-full transition-all ${BAR_CLASS[row.state]}`}
+                style={{ width: `${attestedPct}%` }}
+              />
+              {/* La part en attente : même couleur, moins affirmée. Une teinte
+                  différente laisserait croire à une autre catégorie de dépense. */}
+              <div
+                className={`h-full opacity-40 transition-all ${BAR_CLASS[row.state]}`}
+                style={{ width: `${pct - attestedPct}%` }}
               />
             </div>
           )}
@@ -81,6 +97,11 @@ export default function BudgetCard({ row, onEdit, onDelete, to, backState }: Bud
                 ? t('budget.overBy', { amount: formatAmount(String(overBy)) })
                 : t('budget.percentUsed', { pct })}
           </p>
+          {pending > 0 ? (
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {t('budget.pending', { amount: formatAmount(row.spent_pending) })}
+            </p>
+          ) : null}
           {Number(row.committed) > 0 ? (
             <p className="mt-0.5 text-xs text-muted-foreground">
               {t('budget.committed', { amount: formatAmount(row.committed) })}

--- a/ui/src/features/money/BudgetsPanel.tsx
+++ b/ui/src/features/money/BudgetsPanel.tsx
@@ -198,7 +198,7 @@ export default function BudgetsPanel() {
             hint={t('analysis.access.hint')}
           />
           <AccessCard
-            to="/app/budget/recurring"
+            to="/app/money/recurring"
             icon={CalendarClock}
             title={t('recurring.title')}
             hint={
@@ -210,7 +210,7 @@ export default function BudgetsPanel() {
             }
           />
           <AccessCard
-            to="/app/budget/reports"
+            to="/app/money/reports"
             icon={FileText}
             title={t('report.title')}
             hint={t('report.access.hint')}

--- a/ui/src/lib/api/budget.ts
+++ b/ui/src/lib/api/budget.ts
@@ -23,6 +23,13 @@ export interface BudgetOverviewRow {
   /** `null` quand la catégorie n'a pas de plafond — jamais "0.00". */
   amount: string | null;
   spent: string;
+  /**
+   * La part de `spent` qu'une ligne de relevé justifie, et le reste.
+   * `spent_attested + spent_pending === spent`, toujours : le second est calculé
+   * par différence côté serveur.
+   */
+  spent_attested: string;
+  spent_pending: string;
   committed: string;
   ratio: number;
   state: BudgetState;
@@ -34,6 +41,8 @@ export interface BudgetOverview {
   budgets: BudgetOverviewRow[];
   unbudgeted: string;
   total_spent: string;
+  total_attested: string;
+  total_pending: string;
   total_committed: string;
   named_total_amount: string;
   named_exceeds_global: boolean;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1624,7 +1624,7 @@
           },
           "track": {
             "title": "Den Monat verfolgen",
-            "body": "Jedes begrenzte Budget zeigt Ausgaben vs. Obergrenze mit einem Fortschrittsbalken — orange nahe der Grenze, rot bei Überschreitung. Eine Kategorie ohne Obergrenze zeigt nur ihre Summe. Die Zähler starten jeden Monat neu. Tippe auf ein Budget, um die Ausgaben zu sehen, aus denen sein Zähler besteht — „Ohne Budget“ öffnet sich genauso."
+            "body": "Jedes begrenzte Budget zeigt Ausgaben vs. Obergrenze mit einem Fortschrittsbalken — orange nahe der Grenze, rot bei Überschreitung. Eine Kategorie ohne Obergrenze zeigt nur ihre Summe. Die Zähler starten jeden Monat neu. Tippe auf ein Budget, um die Ausgaben zu sehen, aus denen sein Zähler besteht — „Ohne Budget“ öffnet sich genauso. Der Balken hat zwei Abstufungen: der kräftige Teil ist, was eine Kontozeile belegt, der blasse Teil das, was noch abzugleichen ist. Der Zähler selbst zählt alles — eine Ausgabe von gestern ist echt, auch bevor der Auszug importiert ist."
           },
           "analysis": {
             "title": "Sehen, wohin es wirklich geht",
@@ -3195,7 +3195,8 @@
     },
     "uncapped": {
       "hint": "Verfolgte Kategorie, ohne Obergrenze"
-    }
+    },
+    "pending": "Davon {{amount}} noch nicht abgeglichen"
   },
   "budgetDetail": {
     "description": "Die Ausgaben, aus denen dieser Zähler besteht.",
@@ -3439,6 +3440,13 @@
         "equipment": "Gerät",
         "stock": "Lagerartikel",
         "pick": "Auswählen…"
+      },
+      "linked": {
+        "title": "Bereits zugeordnete Ausgaben",
+        "hint": "Anderswo abgeglichen: Sie zählen auf diesen Vorgang, werden hier aber nicht bearbeitet.",
+        "detach": "Von diesem Vorgang lösen",
+        "detached": "Ausgabe vom Vorgang gelöst",
+        "total": "Bereits zugeordnet"
       }
     },
     "reconcile": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1624,7 +1624,7 @@
           },
           "track": {
             "title": "Track the month",
-            "body": "Each capped budget shows spent vs ceiling with a progress bar — amber near the limit, red once over. A category with no ceiling shows its total only. Counters reset every month. Tap a budget to see the expenses its counter is made of — “Unbudgeted” opens the same way."
+            "body": "Each capped budget shows spent vs ceiling with a progress bar — amber near the limit, red once over. A category with no ceiling shows its total only. Counters reset every month. Tap a budget to see the expenses its counter is made of — “Unbudgeted” opens the same way. The bar comes in two shades: the solid part is what a statement line attests to, the pale part what is still awaiting reconciliation. The counter itself counts everything — yesterday's expense is real even before the statement is imported."
           },
           "analysis": {
             "title": "See where it actually goes",
@@ -3195,7 +3195,8 @@
     },
     "uncapped": {
       "hint": "Tracked category, no ceiling"
-    }
+    },
+    "pending": "Including {{amount}} awaiting reconciliation"
   },
   "budgetDetail": {
     "description": "The expenses this counter is made of.",
@@ -3439,6 +3440,13 @@
         "equipment": "Equipment",
         "stock": "Stock item",
         "pick": "Pick one…"
+      },
+      "linked": {
+        "title": "Expenses already attached",
+        "hint": "Reconciled elsewhere: they count against this operation but are not edited here.",
+        "detach": "Detach from this operation",
+        "detached": "Expense detached from the operation",
+        "total": "Already attached"
       }
     },
     "reconcile": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1624,7 +1624,7 @@
           },
           "track": {
             "title": "Seguir el mes",
-            "body": "Cada presupuesto con tope muestra lo gastado frente al tope con una barra de progreso — naranja cerca del límite, rojo al superarlo. Una categoría sin tope muestra solo su total. Los contadores se reinician cada mes. Toca un presupuesto para ver los gastos que componen su contador: «Sin presupuesto» se abre igual."
+            "body": "Cada presupuesto con tope muestra lo gastado frente al tope con una barra de progreso — naranja cerca del límite, rojo al superarlo. Una categoría sin tope muestra solo su total. Los contadores se reinician cada mes. Toca un presupuesto para ver los gastos que componen su contador: «Sin presupuesto» se abre igual. La barra tiene dos matices: la parte sólida es lo que una línea del extracto acredita, la parte pálida lo que aún espera conciliación. El contador cuenta todo — un gasto de ayer es real incluso antes de importar el extracto."
           },
           "analysis": {
             "title": "Ver adónde va de verdad",
@@ -3195,7 +3195,8 @@
     },
     "uncapped": {
       "hint": "Categoría seguida, sin tope"
-    }
+    },
+    "pending": "De los cuales {{amount}} pendientes de conciliación"
   },
   "budgetDetail": {
     "description": "Los gastos que componen este contador.",
@@ -3439,6 +3440,13 @@
         "equipment": "Equipo",
         "stock": "Artículo de inventario",
         "pick": "Elegir…"
+      },
+      "linked": {
+        "title": "Gastos ya vinculados",
+        "hint": "Conciliados en otro lugar: cuentan en esta operación pero no se modifican aquí.",
+        "detach": "Desvincular de esta operación",
+        "detached": "Gasto desvinculado de la operación",
+        "total": "Ya vinculado"
       }
     },
     "reconcile": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1624,7 +1624,7 @@
           },
           "track": {
             "title": "Suivre le mois",
-            "body": "Chaque budget plafonné affiche le dépensé vs le plafond avec une barre de progression — orange près de la limite, rouge en cas de dépassement. Une catégorie sans plafond affiche seulement son total. Les compteurs repartent à zéro chaque mois. Touche un budget pour voir les dépenses qui composent son compteur — « Hors budget » s'ouvre pareil."
+            "body": "Chaque budget plafonné affiche le dépensé vs le plafond avec une barre de progression — orange près de la limite, rouge en cas de dépassement. Une catégorie sans plafond affiche seulement son total. Les compteurs repartent à zéro chaque mois. Touche un budget pour voir les dépenses qui composent son compteur — « Hors budget » s'ouvre pareil. La barre a deux nuances : la partie franche est ce qu'une ligne de relevé atteste, la partie pâle ce qui attend encore d'être rapproché. Le compteur, lui, compte tout — une dépense d'hier est réelle même si le relevé n'est pas encore importé."
           },
           "analysis": {
             "title": "Comprendre où ça part",
@@ -3195,7 +3195,8 @@
     },
     "uncapped": {
       "hint": "Catégorie suivie, sans plafond"
-    }
+    },
+    "pending": "Dont {{amount}} en attente de rapprochement"
   },
   "budgetDetail": {
     "description": "Les dépenses qui composent ce compteur.",
@@ -3439,6 +3440,13 @@
         "equipment": "Équipement",
         "stock": "Article de stock",
         "pick": "Choisir…"
+      },
+      "linked": {
+        "title": "Dépenses déjà rattachées",
+        "hint": "Rapprochées ailleurs : elles comptent sur cette opération mais ne sont pas modifiées ici.",
+        "detach": "Détacher de cette opération",
+        "detached": "Dépense détachée de l'opération",
+        "total": "Déjà rattaché"
       }
     },
     "reconcile": {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -2,6 +2,7 @@ import { createBrowserRouter, Navigate } from 'react-router-dom';
 import ProtectedLayout from './components/ProtectedLayout';
 import ModuleRoute from './components/ModuleRoute';
 import LegacyMoneyRedirect from './components/LegacyMoneyRedirect';
+import PreserveQueryRedirect from './components/PreserveQueryRedirect';
 import LoginPage from './features/auth/LoginPage';
 import ForgotPasswordPage from './features/auth/ForgotPasswordPage';
 import ResetPasswordPage from './features/auth/ResetPasswordPage';
@@ -89,8 +90,8 @@ export const router = createBrowserRouter([
       { path: 'money/transactions', element: <BankingTransactionsPage /> },
       { path: 'money/analysis', element: <MoneyAnalysisPage /> },
       { path: 'money/budgets/:id', element: <BudgetDetailPage /> },
-      { path: 'budget/recurring', element: <RecurringPage /> },
-      { path: 'budget/reports', element: <ReportsPage /> },
+      { path: 'money/recurring', element: <RecurringPage /> },
+      { path: 'money/reports', element: <ReportsPage /> },
       // Anciennes URLs (parcours 26, lot 2) : les favoris, les liens de l'agent et
       // les tutoriels pointent encore dessus. La query string est **préservée** —
       // `?b={id}` vient de `budget/apps.py::SearchableSpec.url_template`.
@@ -98,6 +99,10 @@ export const router = createBrowserRouter([
       { path: 'budget', element: <LegacyMoneyRedirect tab="budgets" /> },
       { path: 'banking', element: <LegacyMoneyRedirect tab="accounts" /> },
       { path: 'banking/transactions', element: <Navigate to="/app/money/transactions" replace /> },
+      // Les deux dernières pages restées hors de la famille : `?r={id}` de l'agent
+      // survit au déplacement.
+      { path: 'budget/recurring', element: <PreserveQueryRedirect to="/app/money/recurring" /> },
+      { path: 'budget/reports', element: <PreserveQueryRedirect to="/app/money/reports" /> },
       { path: 'projects', element: <ProjectsPage /> },
       { path: 'projects/:id', element: <ProjectDetailPage /> },
       { path: 'equipment', element: <EquipmentPage /> },


### PR DESCRIPTION
Les trois points que l'audit du module Argent avait remontés sans les traiter,
parce qu'ils demandaient une décision plutôt qu'une correction.

## 1. Détacher une dépense rapprochée

`DELETE /transactions/{id}/unlink/{interaction_id}/` n'avait aucun appelant. En
cherchant où le brancher, j'ai trouvé pourquoi il était inutile : **le service le
faisait déjà tout seul, au mauvais moment.**

`set_allocations` détachait tout ce qu'il ne possède pas. Concrètement : 150 € chez
Leroy Merlin dont 90 € déjà saisis comme achat de projet et rapprochés à la main ;
éditer les 60 € restants dé-rapprochait les 90 €. L'écart « dépense non
rapprochée » resurgissait sur une dépense que l'utilisateur avait résolue — et
comme le dialogue rechargeait *toutes* les ventilations dans son brouillon,
enregistrer recréait une dépense `kind='bank'` pour les mêmes 90 € : 180 € de
dépenses sur 150 € d'argent, et le chantier facturé deux fois pour le même
carrelage.

Trois conséquences, symétriques de la règle de propriété du lot 3 :

- la **portée de l'éditeur s'arrête à ce qu'il a créé** — ni suppression, ni
  détachement ;
- le montant rattaché est un **plancher** compté contre l'`outflow` : renvoyer la
  ligne rattachée dans le payload est un **400**, plus un doublement silencieux ;
- **le geste existe** — bloc « Dépenses déjà rattachées » dans
  l'`AllocationDialog`, en lecture seule, avec un bouton « Détacher ».

Deux tests figeaient l'ancien comportement ; ils figent le nouveau. Régression :
`TestSavingASplitNeverUndoesAReconciliation` (4 des 7 assertions échouent sur
l'ancien service — vérifié).

## 2. Les deux sous-pages rejoignent `/app/money`

`/app/money/recurring` et `/app/money/reports`. Les anciennes URLs redirigent via
`PreserveQueryRedirect`, qui **conserve la query string** — l'agent produit
`?r={id}`, et un lien qui perd son paramètre reste valide en devenant faux.

Les deux `url_template` de l'agent pointent directement sur les nouvelles URLs :
une redirection rattrape un ancien lien, elle ne justifie pas d'en produire de
nouveaux. Un test le tient pour toute la famille
(`test_the_money_family_links_stay_inside_the_money_module`), avec une assertion
qui l'empêche de devenir muet si une entité est renommée.

## 3. Budget « attesté / en attente »

Chaque enveloppe porte `spent_attested` et `spent_pending` **en plus** de `spent`,
et la barre le montre en deux nuances de la même couleur.

**Ce que je n'ai pas fait, et pourquoi** : filtrer `bank_transaction__isnull=False`
pour ne compter que le prouvé. Une dépense saisie hier est réelle même si le relevé
de fin de mois n'est pas importé ; le compteur reculerait au fil du mois pour
remonter d'un coup à l'import. **Un plafond qui recule est pire qu'un plafond
incertain.**

- `spent` ne change pas — c'est lui que le plafond mesure, et sept agrégations le
  lisent. La distinction est **additive**.
- `spent_pending` est calculé **par différence** : deux sommes indépendantes
  divergent d'un centime d'arrondi, et un total qui ne se recompose pas ne se lit
  pas. L'invariant est testé.
- **Un seul `GROUP BY`** (`Sum(filter=…)`) : l'aperçu est rechargé à chaque visite
  de l'onglet. Le test borne à 5 requêtes.

## Vérification

- `pytest` : **3406 passed, 2 skipped**
- `npm run build` (`tsc -b`) : propre · `npm run lint` : 0 erreur, 5 warnings préexistants
- `npm run test` : 22 tests, dont le garde-fou i18n sur les 4 nouvelles clés `banking.allocation.linked.*` et `budget.pending`
- i18n ×4, `CLAUDE.md`, `docs/MODULES/{money,budget}.md`, tutoriel « Suivre le mois » ×4
- E2E repointées + deux nouvelles assertions de redirection (E2E reste hors CI, issue #410)
- Pas de régénération de types : l'`overview` n'a pas de serializer, aucune route API ne bouge

## Reste ouvert

Les **suggestions de budget apprises** (`label_norm` + fournisseur + historique) —
le vrai levier sur l'effort de rangement, mais l'apprendre demande un mois réel de
données.