### PR TITLE
feat(money): une dépense dit si le relevé la justifie, et laquelle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,18 @@ Doc : `docs/parcours/PARCOURS_26_CONFORMITE_ARGENT.md` + section « Conformité 
   verdict dépend de la fenêtre de conformité, et une ligne verte dans un écran
   face à un écart dans l'autre fait perdre leur crédit aux deux. Régression :
   `banking/tests/test_journal_marker.py::TestTheMarkerAgreesWithTheControl`.
+- **Et la même règle vaut depuis l'autre rive.** « Cette dépense est-elle
+  justifiée par un relevé ? » se lit dans `reconciliation_state`
+  (`banking.queries`, servi par `InteractionSerializer`, rendu par
+  `money/ReconciliationBadge.tsx`), **jamais** dérivé de `bank_transaction == null`
+  côté client : sans la fenêtre, le badge accusait en rouge des dépenses
+  antérieures au premier relevé, insolubles par construction et que le Contrôle ne
+  réclamait pas. Corollaires : `cash` se déduit du **type du compte** de la ligne,
+  jamais de `reconciled_by` (que le créateur met toujours à `manual`, ce qui
+  rendait la branche morte) ; et le badge **mène à l'opération**
+  (`/app/money/transactions/:id`) — « rapprochée » sans pouvoir aller voir à quoi
+  est invérifiable. Régression :
+  `banking/tests/test_expense_marker.py::TestTheMarkerAgreesWithTheControl`.
 
 #### Le module « Argent » — une seule clé, cinq onglets
 

--- a/apps/banking/queries.py
+++ b/apps/banking/queries.py
@@ -15,6 +15,7 @@ from decimal import Decimal
 
 from django.db.models import Case, DecimalField, F, Q, QuerySet, Sum, Value, When
 from django.db.models.functions import Coalesce
+from django.utils import timezone
 
 from .models import BankTransaction
 
@@ -124,6 +125,54 @@ def allocation_state(txn, *, allocated: Decimal, window) -> str:
     if window is None or not window.contains(txn.booked_on):
         return OUT_OF_SCOPE
     return PARTIAL if allocated > 0 else UNALLOCATED
+
+
+# --- The same question, asked from the expense's side ------------------------
+
+#: Not an expense — a note, a renovation entry. No reconciliation to speak of.
+NOT_RECONCILABLE = ""
+#: A statement line justifies this expense.
+ATTESTED = "attested"
+#: A cash-account line justifies it. Attached like the above, but nobody
+#: "reconciled" anything: the operation was typed in with its expense (lot 4).
+CASH = "cash"
+#: No line, and the bank *should* have seen it — the écart ``expense_unreconciled``.
+UNRECONCILED = "pending"
+#: No line, outside the household's conformity horizon. An expense from before
+#: any account was tracked has no line to attach to and never will; one from
+#: after the last import is simply waiting for the next statement. Neither is an
+#: orphan, and saying so in red is what makes a control panel stop being read.
+UNRECONCILED_OUT_OF_SCOPE = "out_of_scope"
+
+
+def reconciliation_state(expense, *, window) -> str:
+    """Whether a statement line justifies this expense, from the reader's side.
+
+    Exact mirror of :func:`allocation_state`, and it exists for the same reason:
+    the answer depends on the conformity window, so a client that derives it from
+    ``bank_transaction == null`` will contradict the Contrôle tab — green in one
+    screen, écart in the other, and both lose their credit. The window is the
+    household's (:func:`coverage.household_covered_period`), the same one
+    ``detectors._unreconciled_qs`` filters on.
+
+    Same deliberate asymmetry as the bank side: an expense that *is* attached
+    reads « rapprochée » even outside the window. Being done is a fact; being
+    required is a scope.
+    """
+    if expense.type != "expense":
+        return NOT_RECONCILABLE
+
+    account = getattr(getattr(expense, "bank_transaction", None), "account", None)
+    if account is not None:
+        return CASH if account.kind == account.Kind.CASH else ATTESTED
+
+    # ``localdate`` and not ``.date()``: the detector filters on ``occurred_at__date``,
+    # which SQL evaluates in the *active* timezone. Two readings of the same
+    # instant that differ by a day is precisely the disagreement this function
+    # exists to prevent.
+    if window is None or not window.contains(timezone.localdate(expense.occurred_at)):
+        return UNRECONCILED_OUT_OF_SCOPE
+    return UNRECONCILED
 
 
 def sum_outflow(qs: QuerySet) -> Decimal:

--- a/apps/banking/tests/test_expense_marker.py
+++ b/apps/banking/tests/test_expense_marker.py
@@ -1,0 +1,322 @@
+# banking/tests/test_expense_marker.py
+"""Le marqueur « rapprochée / en attente » d'une dépense — l'autre bout du pont.
+
+Symétrique de ``test_journal_marker.py``. Le journal bancaire dit d'une **ligne**
+si elle est ventilée ; ici une **dépense** dit si une ligne de relevé la justifie.
+C'est la même question posée depuis l'autre rive, donc la même exigence : le
+verdict doit être celui que compte l'onglet Contrôle (``expense_unreconciled``),
+sinon le journal des dépenses accuse en rouge ce que le Contrôle ne réclame pas.
+
+Le piège est concret : une dépense antérieure au premier relevé n'a aucune ligne
+à laquelle se rattacher et n'en aura jamais. Le détecteur le sait — il borne par
+la fenêtre de conformité du foyer. Un client qui lirait `bank_transaction === null`
+ne le saurait pas.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date, datetime, time, timezone as dt_timezone
+from decimal import Decimal
+
+import pytest
+from rest_framework.test import APIClient
+
+from banking.dedup import compute_dedup_hash
+from banking.detectors import EXPENSE_UNRECONCILED
+from banking.models import (
+    BankAccount,
+    BankTransaction,
+    ImportStatus,
+    StatementImport,
+    TransactionDirection,
+)
+from budget.models import Budget
+from households.models import HouseholdMember
+from interactions.models import Interaction
+from interactions.services import create_bank_expense_interaction
+
+from .factories import BankAccountFactory, HouseholdFactory, HouseholdMemberFactory, UserFactory
+
+EXPENSES_URL = "/api/interactions/interactions/?type=expense"
+_counter = itertools.count()
+
+
+def make_txn(account, *, amount, booked_on=date(2026, 3, 10), label="CB LECLERC"):
+    value = Decimal(amount)
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    """Un foyer dont la fenêtre de conformité couvre janvier→mars 2026."""
+    household = HouseholdFactory()
+    user = UserFactory()
+    HouseholdMemberFactory(household=household, user=user, role=HouseholdMember.Role.MEMBER)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    account = BankAccountFactory(
+        household=household,
+        name="Courant",
+        opening_balance=Decimal("1000.00"),
+        opening_balance_date=date(2026, 1, 1),
+    )
+    StatementImport.objects.create(
+        household=household,
+        account=account,
+        provider="generic_csv",
+        status=ImportStatus.COMPLETED,
+        period_start=date(2026, 1, 1),
+        period_end=date(2026, 3, 31),
+    )
+    budget = Budget.objects.create(household=household, name="Courses", monthly_amount=400)
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return household, user, account, budget, client
+
+
+def loose_expense(household, user, *, day=date(2026, 2, 12), amount="42.00", subject="Boulangerie"):
+    """Une dépense saisie dans l'app, qu'aucune ligne de relevé ne justifie."""
+    return Interaction.objects.create(
+        household=household,
+        created_by=user,
+        subject=subject,
+        type="expense",
+        occurred_at=datetime.combine(day, time(12, 0), tzinfo=dt_timezone.utc),
+        amount=Decimal(amount),
+        kind="manual",
+    )
+
+
+def row_for(client, expense):
+    body = client.get(EXPENSES_URL).json()
+    items = body["results"] if isinstance(body, dict) else body
+    return next(r for r in items if r["id"] == str(expense.pk))
+
+
+@pytest.mark.django_db
+class TestTheTwoStatesThatMatter:
+    def test_an_expense_no_statement_justifies_says_so(self, ctx):
+        household, user, _, _, client = ctx
+        expense = loose_expense(household, user)
+
+        row = row_for(client, expense)
+
+        assert row["reconciliation_state"] == "pending"
+        assert row["bank_line"] is None
+
+    def test_an_expense_born_of_a_statement_line_names_it(self, ctx):
+        """« Rapprochée » sans dire *à quoi* reste une affirmation invérifiable."""
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-42.00", label="CB BOULANGERIE MARTIN")
+        expense = create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Boulangerie",
+            amount=Decimal("42.00"),
+            budget_id=budget.id,
+        )
+
+        row = row_for(client, expense)
+
+        assert row["reconciliation_state"] == "attested"
+        assert row["bank_line"] == {
+            "id": str(txn.id),
+            "label": "CB BOULANGERIE MARTIN",
+            "booked_on": "2026-03-10",
+            "account_name": "Courant",
+        }
+
+    def test_a_cash_expense_is_attached_but_nobody_reconciled_anything(self, ctx):
+        """Née avec sa ligne (lot 4) : rattachée, oui — « rapprochée », non.
+
+        Le mot compte : dire « rapprochée » d'une dépense en liquide suggérerait
+        qu'une banque l'a vue passer.
+        """
+        household, user, _, budget, client = ctx
+        cash = BankAccountFactory(
+            household=household,
+            name="Liquide",
+            kind=BankAccount.Kind.CASH,
+            opening_balance=Decimal("200.00"),
+            opening_balance_date=date(2026, 1, 1),
+        )
+        txn = make_txn(cash, amount="-20.00", label="Marché")
+        expense = create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Marché",
+            amount=Decimal("20.00"),
+            budget_id=budget.id,
+        )
+
+        assert row_for(client, expense)["reconciliation_state"] == "cash"
+
+    def test_a_note_carries_no_marker_at_all(self, ctx):
+        """Un reproche de rapprochement sur une note serait un faux reproche."""
+        household, user, _, _, client = ctx
+        note = Interaction.objects.create(
+            household=household,
+            created_by=user,
+            subject="Le plombier repasse jeudi",
+            type="note",
+            occurred_at=datetime(2026, 2, 12, 12, 0, tzinfo=dt_timezone.utc),
+        )
+
+        body = client.get("/api/interactions/interactions/?type=note").json()
+        items = body["results"] if isinstance(body, dict) else body
+        row = next(r for r in items if r["id"] == str(note.pk))
+
+        assert row["reconciliation_state"] == ""
+
+
+@pytest.mark.django_db
+class TestOutsideTheWindow:
+    """Là où House ne peut rien exiger, elle ne reproche rien — comme le Contrôle."""
+
+    def test_an_expense_older_than_the_first_statement_is_out_of_scope(self, ctx):
+        household, user, _, _, client = ctx
+        expense = loose_expense(household, user, day=date(2025, 9, 3))
+
+        assert row_for(client, expense)["reconciliation_state"] == "out_of_scope"
+
+    def test_an_expense_after_the_last_import_is_waiting_not_orphaned(self, ctx):
+        """Une dépense d'hier est réelle avant l'import du relevé suivant."""
+        household, user, _, _, client = ctx
+        expense = loose_expense(household, user, day=date(2026, 5, 20))
+
+        assert row_for(client, expense)["reconciliation_state"] == "out_of_scope"
+
+    def test_a_household_without_any_window_never_reads_pending(self, ctx):
+        household, user, account, _, client = ctx
+        account.opening_balance_date = None
+        account.save(update_fields=["opening_balance_date"])
+        expense = loose_expense(household, user)
+
+        assert row_for(client, expense)["reconciliation_state"] == "out_of_scope"
+
+    def test_but_being_attached_is_a_fact_not_a_scope(self, ctx):
+        """Hors fenêtre House n'exige rien — mais une dépense rattachée l'est."""
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-30.00", booked_on=date(2025, 9, 3))
+        expense = create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Vieil achat",
+            amount=Decimal("30.00"),
+            budget_id=budget.id,
+        )
+
+        assert row_for(client, expense)["reconciliation_state"] == "attested"
+
+
+@pytest.mark.django_db
+class TestTheMarkerAgreesWithTheControl:
+    """Preuve par les nombres : le journal des dépenses et le Contrôle comptent pareil.
+
+    C'est la régression qui compte. La première version de ce badge vivait dans
+    le client et lisait `bank_transaction === null` : elle affichait « en attente
+    de rapprochement » en rouge sur trois dépenses de 2025 que le Contrôle, lui,
+    ne réclamait pas — deux écrans en désaccord sur le même fait.
+    """
+
+    def test_same_verdict_expense_by_expense(self, ctx):
+        from banking.compliance import summary
+
+        household, user, account, budget, client = ctx
+        loose_expense(household, user, subject="Boulangerie")  # en attente
+        loose_expense(household, user, subject="Pharmacie")  # en attente
+        loose_expense(household, user, day=date(2025, 9, 3), subject="Vieux")  # hors fenêtre
+        loose_expense(household, user, day=date(2026, 6, 1), subject="Récent")  # hors fenêtre
+        txn = make_txn(account, amount="-60.00")
+        create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Courses",
+            amount=Decimal("60.00"),
+            budget_id=budget.id,
+        )
+
+        body = client.get(f"{EXPENSES_URL}&limit=50").json()
+        items = body["results"] if isinstance(body, dict) else body
+        states = [r["reconciliation_state"] for r in items]
+        groups = {g.spec.kind: g.open for g in summary(household)}
+
+        assert states.count("pending") == groups[EXPENSE_UNRECONCILED] == 2
+        assert states.count("out_of_scope") == 2
+        assert states.count("attested") == 1
+
+
+@pytest.mark.django_db
+class TestItStaysCheap:
+    """Le marqueur coûte un nombre **fixe** de requêtes, pas une par dépense.
+
+    On ne borne pas le total de la page : la liste des interactions a un N+1
+    antérieur (documents, contacts, structures, équipements — sept requêtes par
+    ligne), et une borne globale mesurerait surtout celui-là. Ce qui est vérifié
+    ici est ce que ce marqueur ajoute, et la propriété qui compte est qu'il
+    n'augmente pas avec le nombre de lignes : sans le ``select_related`` et sans
+    le cache de fenêtre, chaque dépense coûtait sa ligne, son compte, et une
+    reconstruction complète de la fenêtre de conformité du foyer.
+    """
+
+    BANKING_TABLES = ("bank_transactions", "bank_accounts", "bank_statement_imports")
+
+    def _banking_queries(self, captured) -> int:
+        return sum(
+            1 for q in captured if any(table in q["sql"] for table in self.BANKING_TABLES)
+        )
+
+    def test_the_marker_costs_the_same_for_five_expenses_as_for_forty(self, ctx):
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        household, user, account, budget, client = ctx
+
+        def fill(count):
+            for i in range(count):
+                if i % 2:
+                    loose_expense(household, user, subject=f"Ad hoc {i}")
+                else:
+                    txn = make_txn(account, amount=f"-{i + 1}.00")
+                    create_bank_expense_interaction(
+                        household=household,
+                        user=user,
+                        transaction=txn,
+                        subject=f"Courses {i}",
+                        amount=Decimal(i + 1),
+                        budget_id=budget.id,
+                    )
+
+        fill(5)
+        with CaptureQueriesContext(connection) as few:
+            client.get(f"{EXPENSES_URL}&limit=100")
+        fill(35)
+        with CaptureQueriesContext(connection) as many:
+            client.get(f"{EXPENSES_URL}&limit=100")
+
+        assert self._banking_queries(few.captured_queries) == self._banking_queries(
+            many.captured_queries
+        )
+        # Trois : la fenêtre du compte (deux agrégats) et la liste des comptes.
+        # Les lignes elles-mêmes arrivent jointes à la requête des interactions.
+        assert self._banking_queries(many.captured_queries) <= 4

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -601,7 +601,11 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
     def _allocation_payload(self, instance) -> dict:
         from interactions.serializers import InteractionSerializer
 
-        allocations = list(instance.interactions.all().select_related("budget"))
+        allocations = list(
+            instance.interactions.all().select_related(
+                "budget", "household", "bank_transaction__account"
+            )
+        )
         return {
             "transaction": self.get_serializer(instance).data,
             "allocations": InteractionSerializer(allocations, many=True).data,

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -151,6 +151,9 @@ class InteractionSerializer(serializers.ModelSerializer):
     # Optional monthly budget attached to an expense (parcours 21).
     budget = serializers.SerializerMethodField()
     budget_id = serializers.UUIDField(write_only=True, required=False, allow_null=True)
+    # Is this expense justified by a statement line, and which one (parcours 27).
+    reconciliation_state = serializers.SerializerMethodField()
+    bank_line = serializers.SerializerMethodField()
 
     class Meta:
         model = Interaction
@@ -164,6 +167,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'equipments', 'equipment_ids',
             'budget', 'budget_id',
             'bank_transaction', 'reconciled_by',
+            'reconciliation_state', 'bank_line',
             'created_at', 'updated_at', 'created_by', 'created_by_name'
         ]
         read_only_fields = [
@@ -233,6 +237,52 @@ class InteractionSerializer(serializers.ModelSerializer):
         if not obj.budget_id:
             return None
         return {'id': str(obj.budget_id), 'name': obj.budget.name}
+
+    def get_reconciliation_state(self, obj) -> str:
+        """« Rapprochée ou non » — decided here, never in the client.
+
+        The verdict depends on the household's conformity window, exactly like
+        the ``expense_unreconciled`` détecteur it must agree with. A client that
+        reads ``bank_transaction === null`` would flag, in red, an expense from
+        before the first statement — something nobody can ever resolve — while
+        the Contrôle tab counts it as nothing. Both screens would then be
+        arguing, and the user would stop believing either.
+        """
+        from banking.queries import reconciliation_state
+
+        return reconciliation_state(obj, window=self._conformity_window(obj))
+
+    def get_bank_line(self, obj) -> dict | None:
+        """Enough of the statement line to name it and link to it, or ``None``.
+
+        The FK id already ships as ``bank_transaction``; what the reader needs on
+        top is *which operation* — a date and the bank's own wording. Without
+        them the link is a uuid, and « la dépense est rapprochée » remains a
+        claim the user cannot check.
+        """
+        line = obj.bank_transaction
+        if line is None:
+            return None
+        return {
+            'id': str(line.id),
+            'label': line.label_raw,
+            'booked_on': line.booked_on.isoformat(),
+            'account_name': line.account.name,
+        }
+
+    def _conformity_window(self, obj):
+        """The household's window, computed once per response.
+
+        ``household_covered_period`` walks every account and costs two aggregates
+        each; a page of interactions holds up to a hundred rows, all of the same
+        household.
+        """
+        from banking.coverage import household_covered_period
+
+        cache = self.context.setdefault('_conformity_windows', {})
+        if obj.household_id not in cache:
+            cache[obj.household_id] = household_covered_period(obj.household)
+        return cache[obj.household_id]
 
     def _apply_budget(self, interaction, budget_id):
         """Resolve + attach a budget to an expense, mapping errors to 400s.

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -106,8 +106,11 @@ class InteractionViewSet(viewsets.ModelViewSet):
     
     def get_queryset(self):
         """Filter interactions to households where current user is a member."""
+        # ``bank_transaction__account``: the serializer answers « rapprochée ? »
+        # and names the operation for the link. Without the join that is two
+        # queries per row.
         queryset = Interaction.objects.for_user_households(self.request.user).select_related(
-            'created_by', 'budget'
+            'created_by', 'budget', 'household', 'bank_transaction__account'
         ).prefetch_related('zones', 'documents', 'source', 'tags__tag')
 
         selected_household = self.request.household

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -263,6 +263,12 @@ Une recette, un mouvement interne et une contrepartie espèces n'ont **pas** de
 marqueur (état `""`) : il n'y a rien à ventiler, et un badge y serait un faux
 reproche.
 
+**Le marqueur symétrique existe côté dépense** — `queries.reconciliation_state`,
+même fenêtre, mêmes règles, même exception (« être fait est un fait »). Il répond
+à la question depuis l'autre rive : *cette dépense, une ligne de relevé la
+justifie-t-elle ?* Voir `docs/MODULES/money.md`, section « Une dépense dit si le
+relevé la justifie ».
+
 ⚠️ `refresh_from_db()` ne rafraîchit **pas** une annotation. Après un
 `PUT allocations/`, la réponse se relit par `get_object()` sur le queryset
 annoté, sinon elle renvoie l'état d'avant l'écriture.
@@ -296,10 +302,18 @@ ignoré : une liste filtrée à tort est pire qu'une erreur.
 
 ### Frontend
 
-Sous-page `/app/banking/transactions` (`TransactionsPage`) : `FlowSummaryCards` en
+Sous-page `/app/money/transactions` (`TransactionsPage`) : `FlowSummaryCards` en
 tête, `TransactionFilters` (recherche, compte, période, pills direction/interne),
 `TransactionList` + `TransactionRow` avec les deux actions de qualification et la
 pastille d'état (`AllocationBadge`). Les filtres sont persistés en session.
+
+Le libellé d'une ligne mène à **`/app/money/transactions/:id`**
+(`TransactionDetailPage`) : l'opération en entier — montant, dates, compte, solde
+imprimé, référence — et surtout **ce qu'elle justifie**, c'est-à-dire les dépenses
+qui la ventilent avec le reste à ventiler. C'est la destination des badges de
+rapprochement du module Argent ; elle tient en une requête
+(`GET …/transactions/{id}/allocations/`, qui renvoie déjà la ligne, ses
+ventilations et les deux totaux).
 
 ## Soldes, continuité & espèces (lot 4)
 

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -122,8 +122,8 @@ valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage
 l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
-`/app/money/analysis`, `/app/money/budgets/:id`, `/app/money/recurring`,
-`/app/money/reports`.
+`/app/money/transactions/:id`, `/app/money/analysis`, `/app/money/budgets/:id`,
+`/app/money/recurring`, `/app/money/reports`.
 
 Les deux dernières ont rejoint la famille en juillet 2026 ; `/app/budget/recurring`
 et `/app/budget/reports` redirigent via `PreserveQueryRedirect`, qui conserve la
@@ -263,6 +263,46 @@ différence en deux nuances de la même couleur — une autre teinte laisserait 
 agrégats indépendants finissent par se contredire d'un centime d'arrondi, et un
 total qui ne se recompose pas ne se lit pas. Régression :
 `budget/tests/test_api_budget.py::TestWhatTheStatementAttests`.
+
+### Une dépense dit si le relevé la justifie — et laquelle
+
+Le marqueur du journal bancaire répondait « où en est cette **ligne** ». Il
+manquait la même question depuis l'autre rive : « cette **dépense**, la banque
+l'a-t-elle vue passer ? ». C'est `reconciliation_state`, servi par
+`InteractionSerializer`, rendu par `ui/src/features/money/ReconciliationBadge.tsx`,
+et posé partout où une dépense s'affiche — onglet Dépenses, journal des
+interactions, détail d'une interaction, onglet Dépenses d'un projet.
+
+Cinq états, miroir exact de `AllocationProgress` : `''` (pas une dépense),
+`attested`, `cash`, `pending`, `out_of_scope`.
+
+- **Le verdict est calculé côté serveur** (`banking.queries.reconciliation_state`),
+  jamais dérivé de `bank_transaction === null` côté client. C'est la même règle que
+  le marqueur bancaire, et pour la même raison : il dépend de la fenêtre de
+  conformité. La première version du badge (lot 7 du parcours 26) lisait la FK et
+  affichait « en attente de rapprochement » **en rouge** sur des dépenses
+  antérieures au premier relevé — que le Contrôle, lui, ne réclamait pas. Deux
+  écrans en désaccord sur le même fait. Régression :
+  `banking/tests/test_expense_marker.py::TestTheMarkerAgreesWithTheControl`.
+- **`cash` ne se déduit pas de `reconciled_by`.** L'ancienne règle
+  (`reconciled_by === ''` → espèces) était morte : `create_bank_expense_interaction`
+  écrit `manual` sur *tous* les rattachements, y compris ceux nés d'une dépense en
+  liquide, et détacher remet la FK à `null` avant qu'on arrive au test. Le
+  discriminant est le **type du compte** de la ligne — un fait, pas une trace.
+- **Le badge mène à l'opération.** « Rapprochée » sans pouvoir aller voir *à quoi*
+  reste une affirmation invérifiable. La destination est une vraie page,
+  `/app/money/transactions/:id`, et non le journal filtré : sur un relevé de
+  160 lignes, « elle est quelque part dans cette liste » ne vérifie rien. Ce que
+  cette page montre et que le journal ne peut pas : les **autres** ventilations de
+  la même opération — arriver là depuis une dépense de 90 €, c'est découvrir que la
+  ligne en faisait 150.
+
+Coût : trois requêtes fixes par réponse (la fenêtre du foyer), la ligne et son
+compte arrivant par `select_related`. Borné par
+`test_expense_marker.py::TestItStaysCheap`, qui compare cinq dépenses à quarante
+plutôt que de plafonner le total de la page — la liste des interactions a un N+1
+antérieur (documents, contacts, structures, équipements : sept requêtes par ligne)
+qu'une borne globale mesurerait à la place.
 
 ### Reste ouvert
 

--- a/ui/src/features/banking/TransactionDetailPage.tsx
+++ b/ui/src/features/banking/TransactionDetailPage.tsx
@@ -1,0 +1,242 @@
+import * as React from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { PieChart, Repeat, Banknote } from 'lucide-react';
+import PageHeader from '@/components/PageHeader';
+import BackLink from '@/components/BackLink';
+import InfoField from '@/components/InfoField';
+import LoadError from '@/components/LoadError';
+import ListSkeleton from '@/components/ListSkeleton';
+import { Badge } from '@/design-system/badge';
+import { Button } from '@/design-system/button';
+import { Card, CardTitle } from '@/design-system/card';
+import { pushBack } from '@/lib/backNavigation';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { formatAmount, formatDate } from '@/lib/format';
+import type { AllocatedExpense } from '@/lib/api/banking';
+import { useAllocations, useBankAccounts } from './hooks';
+import AllocationDialog from './AllocationDialog';
+
+/**
+ * Une ligne de relevé, en entier.
+ *
+ * Elle existe parce qu'une dépense doit pouvoir dire *à quoi* elle est
+ * rapprochée. Un lien vers le journal filtré n'aurait pas suffi : sur un relevé
+ * de 160 lignes, la ligne visée est page trois, et « la voici quelque part dans
+ * cette liste » ne vérifie rien.
+ *
+ * Ce que cette page montre et que le journal ne peut pas : les **autres**
+ * ventilations de la même opération. Arriver ici depuis une dépense de 90 €,
+ * c'est découvrir que la ligne en faisait 150 et que les 60 restants sont
+ * ailleurs — ou nulle part.
+ */
+export default function TransactionDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const [allocateOpen, setAllocateOpen] = React.useState(false);
+
+  const { data, isLoading, error } = useAllocations(id);
+  const accountsQuery = useBankAccounts(true);
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  if (!id) return null;
+  if (showSkeleton) return <ListSkeleton className="space-y-2 p-4" />;
+  if (isLoading) return null;
+
+  if (error || !data) {
+    return (
+      <LoadError
+        message={t('banking.transaction.notFound')}
+        link={{ to: '/app/money/transactions', label: t('banking.journal.title') }}
+      />
+    );
+  }
+
+  const { transaction, allocations } = data;
+  const isOut = transaction.direction === 'out';
+  const hasCounterpart = Boolean(transaction.transfer_counterpart);
+  const account = (accountsQuery.data ?? []).find((a) => a.id === transaction.account);
+  const remaining = Number(data.remaining);
+
+  return (
+    <>
+      <PageHeader
+        backLink={
+          <BackLink fallback="/app/money/transactions" fallbackLabel={t('banking.journal.title')} />
+        }
+        title={transaction.label_raw}
+        titleSuffix={
+          <Badge variant={isOut ? 'destructive' : 'secondary'}>
+            {t(`banking.transaction.direction.${transaction.direction}`)}
+          </Badge>
+        }
+        description={`${formatDate(transaction.booked_on)}${
+          account ? ` · ${account.name}` : ''
+        }`}
+      >
+        {isOut && !hasCounterpart ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 px-3 text-sm"
+            onClick={() => setAllocateOpen(true)}
+          >
+            <PieChart className="mr-1.5 h-3.5 w-3.5" />
+            {t('banking.allocation.action')}
+          </Button>
+        ) : null}
+      </PageHeader>
+
+      <div className="space-y-6">
+        <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <InfoField label={t('banking.transaction.amount')}>
+            <span
+              className={`text-base font-semibold tabular-nums ${
+                transaction.is_internal
+                  ? 'text-muted-foreground'
+                  : isOut
+                    ? 'text-destructive'
+                    : 'text-primary'
+              }`}
+            >
+              {formatAmount(transaction.amount)}
+            </span>
+          </InfoField>
+
+          <InfoField label={t('banking.transaction.bookedOn')}>
+            {formatDate(transaction.booked_on)}
+          </InfoField>
+
+          {transaction.value_on ? (
+            <InfoField label={t('banking.transaction.valueOn')}>
+              {formatDate(transaction.value_on)}
+            </InfoField>
+          ) : null}
+
+          {account ? (
+            <InfoField label={t('banking.transaction.account')}>{account.name}</InfoField>
+          ) : null}
+
+          {/* Le solde n'est jamais dénormalisé ; celui-ci est le solde **imprimé
+              par la banque** sur cette ligne — l'ancre de toute la chaîne. */}
+          {transaction.balance_after ? (
+            <InfoField label={t('banking.transaction.balanceAfter')}>
+              {formatAmount(transaction.balance_after)}
+            </InfoField>
+          ) : null}
+
+          {transaction.external_id ? (
+            <InfoField label={t('banking.transaction.reference')}>
+              <span className="break-all font-mono text-xs">{transaction.external_id}</span>
+            </InfoField>
+          ) : null}
+        </dl>
+
+        <div className="flex flex-wrap gap-1.5">
+          {transaction.is_internal ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              {hasCounterpart ? (
+                <Banknote className="h-3 w-3" aria-hidden />
+              ) : (
+                <Repeat className="h-3 w-3" aria-hidden />
+              )}
+              {hasCounterpart ? t('banking.withdraw.linkedBadge') : t('banking.journal.internal')}
+            </span>
+          ) : null}
+          {!isOut && !transaction.is_internal ? (
+            <span
+              className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs ${
+                transaction.inflow_nature
+                  ? 'bg-primary/10 text-primary'
+                  : 'bg-muted text-muted-foreground'
+              }`}
+            >
+              {transaction.inflow_nature
+                ? t(`banking.inflow.natures.${transaction.inflow_nature}`)
+                : t('banking.inflow.unclassified')}
+            </span>
+          ) : null}
+        </div>
+
+        {transaction.notes ? (
+          <Card className="p-3">
+            <p className="text-sm italic text-muted-foreground">{transaction.notes}</p>
+          </Card>
+        ) : null}
+
+        {isOut && !hasCounterpart ? (
+          <section className="space-y-2">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+              <h2 className="text-base font-semibold text-foreground">
+                {t('banking.transaction.allocationsTitle')}
+              </h2>
+              <p className="text-xs text-muted-foreground">
+                {t('banking.transaction.allocatedOf', {
+                  allocated: formatAmount(data.allocated),
+                  total: formatAmount(Math.abs(Number(transaction.amount))),
+                })}
+              </p>
+            </div>
+
+            {allocations.length === 0 ? (
+              <p className="text-sm italic text-muted-foreground">
+                {t('banking.transaction.noAllocation')}
+              </p>
+            ) : (
+              <ul className="space-y-2">
+                {allocations.map((expense) => (
+                  <AllocationLine key={expense.id} expense={expense} />
+                ))}
+              </ul>
+            )}
+
+            {remaining > 0 ? (
+              <p className="text-xs text-destructive">
+                {t('banking.transaction.remaining', { amount: formatAmount(data.remaining) })}
+              </p>
+            ) : null}
+          </section>
+        ) : null}
+      </div>
+
+      {allocateOpen ? (
+        <AllocationDialog
+          open
+          onOpenChange={(next) => !next && setAllocateOpen(false)}
+          transactionId={transaction.id}
+        />
+      ) : null}
+    </>
+  );
+}
+
+/** Une dépense que cette opération justifie — avec par où elle compte. */
+function AllocationLine({ expense }: { expense: AllocatedExpense }) {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const meta = [expense.budget?.name, expense.source_label].filter(Boolean).join(' · ');
+
+  return (
+    <li>
+      <Card className="p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/app/interactions/${expense.id}`}
+              state={pushBack(location)}
+              className="group text-foreground hover:text-primary"
+            >
+              <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">
+                {expense.subject}
+              </CardTitle>
+            </Link>
+            {meta ? <p className="mt-1 text-xs text-muted-foreground">{meta}</p> : null}
+          </div>
+          <p className="shrink-0 text-sm font-semibold tabular-nums">
+            {expense.amount ? formatAmount(expense.amount) : t('expenses.list.noAmount')}
+          </p>
+        </div>
+      </Card>
+    </li>
+  );
+}

--- a/ui/src/features/banking/TransactionRow.tsx
+++ b/ui/src/features/banking/TransactionRow.tsx
@@ -1,3 +1,4 @@
+import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
   Banknote,
@@ -13,6 +14,7 @@ import {
 import { Card } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import { formatAmount } from '@/lib/format';
+import { pushBack } from '@/lib/backNavigation';
 import type { BankTransaction } from '@/lib/api/banking';
 
 interface TransactionRowProps {
@@ -41,6 +43,7 @@ export default function TransactionRow({
   onClassify,
 }: TransactionRowProps) {
   const { t } = useTranslation();
+  const location = useLocation();
   const isOut = transaction.direction === 'out';
   const hasCounterpart = Boolean(transaction.transfer_counterpart);
 
@@ -80,9 +83,13 @@ export default function TransactionRow({
         <div className="min-w-0 flex-1">
           <div className="flex items-baseline justify-between gap-2">
             {/* Libellé brut de la banque — jamais réécrit. */}
-            <span className="truncate text-sm font-medium text-foreground">
+            <Link
+              to={`/app/money/transactions/${transaction.id}`}
+              state={pushBack(location)}
+              className="truncate text-sm font-medium text-foreground hover:text-primary hover:underline"
+            >
               {transaction.label_raw}
-            </span>
+            </Link>
             <span
               className={`shrink-0 text-sm font-semibold tabular-nums ${
                 transaction.is_internal

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -3,26 +3,11 @@ import { useTranslation } from 'react-i18next';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import { formatAmount, formatDate } from '@/lib/format';
+import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import type { InteractionListItem } from '@/lib/api/interactions';
 
 interface ExpenseListProps {
   items: InteractionListItem[];
-}
-
-/**
- * D'où vient cette dépense — la question que le parcours 26 rend visible.
- *
- * Trois provenances, et la troisième est la seule qui appelle une action : une
- * dépense saisie dans l'app que la banque n'a jamais confirmée est un écart, pas un
- * état normal. Le dire ici, dans la liste où on la lit, plutôt que seulement dans
- * l'onglet Contrôle.
- */
-function provenanceOf(item: InteractionListItem): 'statement' | 'cash' | 'pending' {
-  if (!item.bank_transaction) return 'pending';
-  // Une dépense en espèces est née avec sa ligne (lot 4) : même provenance
-  // technique qu'un relevé, mais un sens différent pour l'utilisateur — personne
-  // n'a « rapproché » quoi que ce soit, l'opération a été saisie à la main.
-  return item.reconciled_by === '' ? 'cash' : 'statement';
 }
 
 export default function ExpenseList({ items }: ExpenseListProps) {
@@ -48,14 +33,10 @@ export default function ExpenseList({ items }: ExpenseListProps) {
                         {t(`expenses.kind.${item.kind}`)}
                       </Badge>
                     ) : null}
-                    <Badge
-                      variant={
-                        provenanceOf(item) === 'pending' ? 'destructive' : 'secondary'
-                      }
-                      className="text-xs"
-                    >
-                      {t(`expenses.provenance.${provenanceOf(item)}`)}
-                    </Badge>
+                    <ReconciliationBadge
+                      state={item.reconciliation_state}
+                      line={item.bank_line}
+                    />
                   </div>
                   <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
                     <span>{formatDate(item.occurred_at)}</span>

--- a/ui/src/features/interactions/InteractionCard.tsx
+++ b/ui/src/features/interactions/InteractionCard.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardTitle } from '@/design-system/card';
 import { pushBack } from '@/lib/backNavigation';
+import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import type { InteractionListItem } from '@/lib/api/interactions';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 
@@ -46,6 +47,8 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
               </CardTitle>
             </Link>
             <Badge variant="outline">{t(typeLabelKey)}</Badge>
+            {/* Sur une dépense seulement — le composant ne rend rien sinon. */}
+            <ReconciliationBadge state={item.reconciliation_state} line={item.bank_line} />
           </div>
 
           {item.content ? (

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -14,6 +14,7 @@ import ListSkeleton from '@/components/ListSkeleton';
 import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { formatAmount, formatDateTime } from '@/lib/format';
+import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import { useInteraction, useDeleteInteraction } from './hooks';
 
 // ── Main page ──────────────────────────────────────────────
@@ -128,6 +129,25 @@ export default function InteractionDetailPage() {
 
           {isExpense && supplier ? (
             <InfoField label={t('interactions.contact_label')}>{supplier}</InfoField>
+          ) : null}
+
+          {/* Rapprochée ou non — et si oui, l'opération qui le prouve. C'est ici
+              que la question se pose vraiment : sur la page d'une dépense, « la
+              banque l'a-t-elle vue passer ? » n'a pas d'autre endroit où être lue. */}
+          {isExpense ? (
+            <InfoField label={t('money.reconciliation.label')}>
+              <div className="space-y-1.5">
+                <ReconciliationBadge
+                  state={interaction.reconciliation_state}
+                  line={interaction.bank_line}
+                />
+                {interaction.bank_line ? (
+                  <p className="text-xs text-muted-foreground">
+                    {interaction.bank_line.account_name} · {interaction.bank_line.label}
+                  </p>
+                ) : null}
+              </div>
+            </InfoField>
           ) : null}
         </dl>
 

--- a/ui/src/features/money/ReconciliationBadge.tsx
+++ b/ui/src/features/money/ReconciliationBadge.tsx
@@ -1,0 +1,86 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Banknote, CircleDashed, Coins, HelpCircle } from 'lucide-react';
+import { formatDate } from '@/lib/format';
+import type { BankLineRef, ReconciliationState } from '@/lib/api/interactions';
+
+interface ReconciliationBadgeProps {
+  state: ReconciliationState | undefined;
+  /** La ligne qui justifie la dépense — rend le badge cliquable quand elle existe. */
+  line?: BankLineRef | null;
+  /** `false` sur une carte déjà cliquable : un lien dans un lien ne s'ouvre pas. */
+  linked?: boolean;
+  className?: string;
+}
+
+const STYLES: Record<Exclude<ReconciliationState, ''>, string> = {
+  attested: 'bg-primary/10 text-primary',
+  cash: 'bg-primary/10 text-primary',
+  // Hors fenêtre, House n'exige rien : en gris, jamais en rouge — un reproche
+  // qu'on ne peut pas résoudre est ce qui fait abandonner le contrôle.
+  out_of_scope: 'bg-muted text-muted-foreground',
+  pending: 'bg-destructive/10 text-destructive',
+};
+
+const ICONS: Record<Exclude<ReconciliationState, ''>, typeof Banknote> = {
+  attested: Banknote,
+  cash: Coins,
+  out_of_scope: CircleDashed,
+  pending: HelpCircle,
+};
+
+/**
+ * Est-ce qu'une ligne de relevé justifie cette dépense — et laquelle.
+ *
+ * ⚠️ L'état vient du serveur (`reconciliation_state`), il n'est **pas** dérivé
+ * de `bank_transaction`. Le verdict dépend de la fenêtre de conformité du foyer
+ * et doit rester celui que compte l'onglet Contrôle ; une dépense verte ici et
+ * un écart là-bas, et les deux écrans perdent leur crédit. Miroir exact de
+ * `AllocationBadge` côté journal bancaire.
+ *
+ * Quand la ligne existe, le badge y mène : « rapprochée » sans pouvoir aller
+ * voir *à quoi* reste une affirmation que l'utilisateur ne peut pas vérifier.
+ */
+export default function ReconciliationBadge({
+  state,
+  line,
+  linked = true,
+  className = '',
+}: ReconciliationBadgeProps) {
+  const { t } = useTranslation();
+
+  if (!state) return null;
+
+  const Icon = ICONS[state];
+  const label =
+    line && (state === 'attested' || state === 'cash')
+      ? t(`money.reconciliation.${state}`, { date: formatDate(line.booked_on) })
+      : t(`money.reconciliation.${state}`);
+
+  const body = (
+    <>
+      <Icon className="h-3 w-3 shrink-0" aria-hidden />
+      {label}
+    </>
+  );
+  const shell = `inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs ${STYLES[state]} ${className}`;
+
+  if (!line || !linked) {
+    return (
+      <span className={shell} title={line ? `${line.account_name} · ${line.label}` : undefined}>
+        {body}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      to={`/app/money/transactions/${line.id}`}
+      onClick={(e) => e.stopPropagation()}
+      className={`${shell} hover:underline`}
+      title={`${line.account_name} · ${line.label}`}
+    >
+      {body}
+    </Link>
+  );
+}

--- a/ui/src/features/projects/ProjectDetailPage.tsx
+++ b/ui/src/features/projects/ProjectDetailPage.tsx
@@ -27,6 +27,7 @@ import {
   projectKeys,
 } from './hooks';
 import ProjectDialog from './ProjectDialog';
+import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import EntityDocumentsTab from '@/features/documents/EntityDocumentsTab';
 import EntityPhotosTab from '@/features/photos/EntityPhotosTab';
 import ProjectPurchaseDialog from './ProjectPurchaseDialog';
@@ -128,7 +129,14 @@ function TabInteractions({
               >
                 <div className="flex items-start justify-between gap-2">
                   <span className="font-medium">{item.subject || '—'}</span>
-                  <div className="flex shrink-0 gap-1">
+                  <div className="flex shrink-0 items-center gap-1">
+                    {/* Une dépense de chantier saisie à la main est aussi une
+                        dépense que la banque n'a peut-être jamais vue passer. */}
+                    <ReconciliationBadge
+                      state={item.reconciliation_state}
+                      line={item.bank_line}
+                      linked={false}
+                    />
                     {item.type ? (
                       <Badge variant="outline" className="h-5 text-[10px]">
                         {t(`interactions.type.${item.type}`)}

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -83,7 +83,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   // fenêtre qui exclut volontairement des données, un zéro qui peut vouloir dire
   // « non évaluable ») qu'aucun parcours procédural ne fait comprendre.
   { key: 'money', moduleKey: 'money', Icon: ShieldCheck, to: '/app/money?tab=control', stepIds: ['source', 'allocation', 'axes', 'window', 'arbitrate', 'notEvaluable', 'cash'] },
-  { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'review'] },
+  { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'trace', 'review'] },
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'analysis', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },

--- a/ui/src/gen/api/models/Interaction.ts
+++ b/ui/src/gen/api/models/Interaction.ts
@@ -71,6 +71,26 @@ export type Interaction = {
      * * `manual` - Manual
      */
     readonly reconciled_by: ReconciledByEnum;
+    /**
+     * « Rapprochée ou non » — decided here, never in the client.
+     *
+     * The verdict depends on the household's conformity window, exactly like
+     * the ``expense_unreconciled`` détecteur it must agree with. A client that
+     * reads ``bank_transaction === null`` would flag, in red, an expense from
+     * before the first statement — something nobody can ever resolve — while
+     * the Contrôle tab counts it as nothing. Both screens would then be
+     * arguing, and the user would stop believing either.
+     */
+    readonly reconciliation_state: string;
+    /**
+     * Enough of the statement line to name it and link to it, or ``None``.
+     *
+     * The FK id already ships as ``bank_transaction``; what the reader needs on
+     * top is *which operation* — a date and the bank's own wording. Without
+     * them the link is a uuid, and « la dépense est rapprochée » remains a
+     * claim the user cannot check.
+     */
+    readonly bank_line: Record<string, any> | null;
     readonly created_at: string;
     readonly updated_at: string;
     readonly created_by: number | null;

--- a/ui/src/gen/api/models/InteractionDetail.ts
+++ b/ui/src/gen/api/models/InteractionDetail.ts
@@ -71,6 +71,26 @@ export type InteractionDetail = {
      * * `manual` - Manual
      */
     readonly reconciled_by: ReconciledByEnum;
+    /**
+     * « Rapprochée ou non » — decided here, never in the client.
+     *
+     * The verdict depends on the household's conformity window, exactly like
+     * the ``expense_unreconciled`` détecteur it must agree with. A client that
+     * reads ``bank_transaction === null`` would flag, in red, an expense from
+     * before the first statement — something nobody can ever resolve — while
+     * the Contrôle tab counts it as nothing. Both screens would then be
+     * arguing, and the user would stop believing either.
+     */
+    readonly reconciliation_state: string;
+    /**
+     * Enough of the statement line to name it and link to it, or ``None``.
+     *
+     * The FK id already ships as ``bank_transaction``; what the reader needs on
+     * top is *which operation* — a date and the bank's own wording. Without
+     * them the link is a uuid, and « la dépense est rapprochée » remains a
+     * claim the user cannot check.
+     */
+    readonly bank_line: Record<string, any> | null;
     readonly created_at: string;
     readonly updated_at: string;
     readonly created_by: number | null;

--- a/ui/src/gen/api/models/PatchedInteraction.ts
+++ b/ui/src/gen/api/models/PatchedInteraction.ts
@@ -71,6 +71,26 @@ export type PatchedInteraction = {
      * * `manual` - Manual
      */
     readonly reconciled_by?: ReconciledByEnum;
+    /**
+     * « Rapprochée ou non » — decided here, never in the client.
+     *
+     * The verdict depends on the household's conformity window, exactly like
+     * the ``expense_unreconciled`` détecteur it must agree with. A client that
+     * reads ``bank_transaction === null`` would flag, in red, an expense from
+     * before the first statement — something nobody can ever resolve — while
+     * the Contrôle tab counts it as nothing. Both screens would then be
+     * arguing, and the user would stop believing either.
+     */
+    readonly reconciliation_state?: string;
+    /**
+     * Enough of the statement line to name it and link to it, or ``None``.
+     *
+     * The FK id already ships as ``bank_transaction``; what the reader needs on
+     * top is *which operation* — a date and the bank's own wording. Without
+     * them the link is a uuid, and « la dépense est rapprochée » remains a
+     * claim the user cannot check.
+     */
+    readonly bank_line?: Record<string, any> | null;
     readonly created_at?: string;
     readonly updated_at?: string;
     readonly created_by?: number | null;

--- a/ui/src/gen/api/models/PatchedZone.ts
+++ b/ui/src/gen/api/models/PatchedZone.ts
@@ -4,6 +4,13 @@
 /* eslint-disable */
 /**
  * Serializer for zones.
+ *
+ * Les compteurs de contenu (`equipment_count`, `open_task_count`,
+ * `active_project_count`, `children_count`) sont lus depuis l'annotation posée
+ * par ``zones.queries.with_content_counts`` — c'est le chemin normal. Le repli
+ * par requête n'existe que pour les instances non annotées (création, détail
+ * récupéré via `get_object`) ; il ne doit jamais devenir le chemin d'une liste,
+ * sinon on retombe sur un N+1 par zone.
  */
 export type PatchedZone = {
     readonly id?: string;
@@ -12,17 +19,18 @@ export type PatchedZone = {
     parent?: string | null;
     readonly parent_name?: string;
     note?: string;
-    /**
-     * Surface area (e.g., square meters)
-     */
     surface?: string | null;
     /**
      * Hex color code for zone display
      */
     color?: string;
+    readonly position?: number;
     readonly full_path?: string;
     readonly depth?: string;
     readonly children_count?: string;
+    readonly equipment_count?: string;
+    readonly open_task_count?: string;
+    readonly active_project_count?: string;
     readonly created_at?: string;
     readonly updated_at?: string;
     readonly created_by?: number | null;

--- a/ui/src/gen/api/models/Zone.ts
+++ b/ui/src/gen/api/models/Zone.ts
@@ -4,6 +4,13 @@
 /* eslint-disable */
 /**
  * Serializer for zones.
+ *
+ * Les compteurs de contenu (`equipment_count`, `open_task_count`,
+ * `active_project_count`, `children_count`) sont lus depuis l'annotation posée
+ * par ``zones.queries.with_content_counts`` — c'est le chemin normal. Le repli
+ * par requête n'existe que pour les instances non annotées (création, détail
+ * récupéré via `get_object`) ; il ne doit jamais devenir le chemin d'une liste,
+ * sinon on retombe sur un N+1 par zone.
  */
 export type Zone = {
     readonly id: string;
@@ -12,17 +19,18 @@ export type Zone = {
     parent?: string | null;
     readonly parent_name: string;
     note?: string;
-    /**
-     * Surface area (e.g., square meters)
-     */
     surface?: string | null;
     /**
      * Hex color code for zone display
      */
     color?: string;
+    readonly position: number;
     readonly full_path: string;
     readonly depth: string;
     readonly children_count: string;
+    readonly equipment_count: string;
+    readonly open_task_count: string;
+    readonly active_project_count: string;
     readonly created_at: string;
     readonly updated_at: string;
     readonly created_by: number | null;

--- a/ui/src/gen/api/models/ZoneTree.ts
+++ b/ui/src/gen/api/models/ZoneTree.ts
@@ -12,17 +12,18 @@ export type ZoneTree = {
     parent?: string | null;
     readonly parent_name: string;
     note?: string;
-    /**
-     * Surface area (e.g., square meters)
-     */
     surface?: string | null;
     /**
      * Hex color code for zone display
      */
     color?: string;
+    readonly position: number;
     readonly full_path: string;
     readonly depth: string;
     readonly children_count: string;
+    readonly equipment_count: string;
+    readonly open_task_count: string;
+    readonly active_project_count: string;
     readonly created_at: string;
     readonly updated_at: string;
     readonly created_by: number | null;

--- a/ui/src/gen/api/services/ZonesService.ts
+++ b/ui/src/gen/api/services/ZonesService.ts
@@ -94,6 +94,10 @@ export class ZonesService {
     }
     /**
      * Reject stale writes when last_known_updated_at is provided.
+     *
+     * ``partial=True`` doit être réinjecté : router vers ``update()`` sans lui
+     * faisait valider tout PATCH comme un PUT complet, donc un PATCH d'un seul
+     * champ (``{"surface": "24.75"}``) repartait en 400 pour ``name`` manquant.
      * @param id A UUID string identifying this zone.
      * @param requestBody
      * @returns Zone
@@ -223,6 +227,30 @@ export class ZonesService {
         });
     }
     /**
+     * Décale la zone d'un rang parmi ses frères (`{"direction": "up"|"down"}`).
+     *
+     * Sert le menu contextuel de la liste. Être déjà en butée n'est pas une
+     * erreur — la réponse porte `moved: false` et le client n'a rien à deviner.
+     * @param id A UUID string identifying this zone.
+     * @param requestBody
+     * @returns Zone
+     * @throws ApiError
+     */
+    public static zonesMoveCreate(
+        id: string,
+        requestBody: Zone,
+    ): CancelablePromise<Zone> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/zones/{id}/move/',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * Get photos linked to this zone.
      * @param id A UUID string identifying this zone.
      * @returns Zone
@@ -262,6 +290,25 @@ export class ZonesService {
             path: {
                 'id': id,
             },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Applique un ordre explicite à une fratrie (glisser-déposer).
+     *
+     * Corps : `{"parent": "<uuid>|null", "zone_ids": [...]}` — la liste doit
+     * couvrir toute la fratrie, le service refuse un sous-ensemble.
+     * @param requestBody
+     * @returns Zone
+     * @throws ApiError
+     */
+    public static zonesReorderCreate(
+        requestBody: Zone,
+    ): CancelablePromise<Zone> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/zones/reorder/',
             body: requestBody,
             mediaType: 'application/json',
         });

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -15,6 +15,32 @@ export interface InteractionEquipmentSummary {
   name: string;
 }
 
+/**
+ * Est-ce qu'une ligne de relevé justifie cette dépense — **verdict du serveur**.
+ *
+ * Ne jamais le redériver de `bank_transaction === null` : le verdict dépend de
+ * la fenêtre de conformité du foyer, exactement comme le détecteur
+ * `expense_unreconciled` qu'il doit refléter. Une dépense antérieure au premier
+ * relevé n'a aucune ligne à laquelle se rattacher et n'en aura jamais — la
+ * badger en rouge fabriquerait une tâche insoluble que le Contrôle, lui, ne
+ * réclame pas. Miroir exact de `AllocationProgress` côté banque.
+ *
+ * - `''` — pas une dépense, aucun marqueur.
+ * - `attested` — une ligne de relevé la justifie.
+ * - `cash` — une ligne d'un compte espèces : rattachée, mais personne n'a rapproché.
+ * - `pending` — rien ne la justifie, et la banque aurait dû la voir. C'est l'écart.
+ * - `out_of_scope` — rien ne la justifie, hors de la fenêtre. Pas un écart.
+ */
+export type ReconciliationState = '' | 'attested' | 'cash' | 'pending' | 'out_of_scope';
+
+/** De quoi nommer l'opération qui justifie une dépense, et lier vers elle. */
+export interface BankLineRef {
+  id: string;
+  label: string;
+  booked_on: string;
+  account_name: string;
+}
+
 export interface InteractionListItem {
   id: string;
   subject: string;
@@ -38,6 +64,10 @@ export interface InteractionListItem {
   bank_transaction?: string | null;
   /** `auto` | `manual` | `''` — comment le rapprochement s'est fait. */
   reconciled_by?: string;
+  /** Voir {@link ReconciliationState} — calculé par le serveur, jamais ici. */
+  reconciliation_state?: ReconciliationState;
+  /** De quoi nommer l'opération et y aller. `null` quand rien ne la justifie. */
+  bank_line?: BankLineRef | null;
   contacts?: InteractionContactSummary[];
   structures?: InteractionStructureSummary[];
   equipments?: InteractionEquipmentSummary[];

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -1,4 +1,5 @@
 import { api } from '@/lib/axios';
+import type { BankLineRef, ReconciliationState } from '@/lib/api/interactions';
 
 export type ProjectStatus = 'draft' | 'active' | 'on_hold' | 'completed' | 'cancelled';
 export type ProjectType =
@@ -201,6 +202,9 @@ export interface ProjectInteractionItem {
   content: string;
   type: string;
   occurred_at: string;
+  /** Sur une dépense : est-ce qu'une ligne de relevé la justifie (verdict serveur). */
+  reconciliation_state?: ReconciliationState;
+  bank_line?: BankLineRef | null;
 }
 
 export async function fetchProjectInteractions(

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1509,6 +1509,10 @@
           "control": {
             "title": "Prüfen, ob Ihre Zahlen stimmen",
             "body": "Der Reiter „Kontrolle“ zeigt alles, was genauen Zahlen im Weg steht: nicht zugeordnete Buchungen, Ausgaben, die die Bank nie gesehen hat, Salden, die nicht zusammenpassen. Jede Abweichung wird gelöst — oder mit einer Begründung abgelegt, die sichtbar und widerrufbar bleibt."
+          },
+          "trace": {
+            "title": "Zur Buchung zurückgehen",
+            "body": "Jede Ausgabe zeigt, ob eine Kontoauszugszeile sie belegt. „Kontoauszug vom 12. Juli“ ist ein Link: Sie landen auf der Buchung, mit Betrag, Konto und den weiteren Ausgaben, die sie abdeckt. „Abgleich ausstehend“ bedeutet das Gegenteil — eine Ausgabe, die die Bank nie gesehen hat, also eine Abweichung, die das Kontrollregister zählt. Außerhalb des geprüften Zeitraums erscheint nichts: dort kann die App nichts verlangen."
           }
         }
       },
@@ -3037,11 +3041,6 @@
       },
       "budget": "Budget",
       "budgetNone": "Kein Budget"
-    },
-    "provenance": {
-      "statement": "Auszug",
-      "cash": "Bargeld",
-      "pending": "Abgleich ausstehend"
     }
   },
   "aiUsage": {
@@ -3523,6 +3522,23 @@
         "periodGap": "Ein Zeitraum des Intervalls wurde nie importiert: Die abzuziehenden Bewegungen sind unvollständig.",
         "noLines": "Dieses Konto enthält keine Buchung zum Abziehen."
       }
+    },
+    "transaction": {
+      "notFound": "Buchung nicht gefunden.",
+      "direction": {
+        "out": "Ausgang",
+        "in": "Eingang"
+      },
+      "amount": "Betrag",
+      "bookedOn": "Buchungsdatum",
+      "valueOn": "Wertstellung",
+      "account": "Konto",
+      "balanceAfter": "Saldo nach Buchung",
+      "reference": "Bankreferenz",
+      "allocationsTitle": "Wofür diese Buchung steht",
+      "allocatedOf": "{{allocated}} von {{total}} zugeordnet",
+      "noAllocation": "Dieser Buchung ist noch nichts zugeordnet.",
+      "remaining": "Noch {{amount}} zuzuordnen"
     }
   },
   "pwa": {
@@ -3750,6 +3766,13 @@
       "blocked": "Noch nichts bewertbar",
       "blockedHint": "Eine Voraussetzung blockiert die Kontrolle: {{prerequisite}}. Ihre Buchungen existieren, aber keine Regel kann sie erfassen.",
       "blockedAction": "Kontrolle öffnen"
+    },
+    "reconciliation": {
+      "label": "Abgleich",
+      "attested": "Kontoauszug vom {{date}}",
+      "cash": "Bargeld vom {{date}}",
+      "pending": "Abgleich ausstehend",
+      "out_of_scope": "Außerhalb des geprüften Zeitraums"
     }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1509,6 +1509,10 @@
           "control": {
             "title": "Check that your figures are right",
             "body": "The “Control” tab lists everything standing between you and accurate figures: unaccounted operations, expenses the bank never saw, balances that do not chain. Each one is resolved — or arbitrated with a motive that stays visible and revocable."
+          },
+          "trace": {
+            "title": "Trace it back to the operation",
+            "body": "Every expense shows whether a statement line accounts for it. “Statement of 12 July” is a link: it takes you to the operation, with its amount, its account, and the other expenses it covers. “Awaiting reconciliation” means the opposite — an expense the bank never saw, which is a discrepancy the Control tab counts. Nothing shows outside the checked period: there, the app cannot require anything."
           }
         }
       },
@@ -3037,11 +3041,6 @@
       },
       "budget": "Budget",
       "budgetNone": "No budget"
-    },
-    "provenance": {
-      "statement": "Statement",
-      "cash": "Cash",
-      "pending": "Awaiting reconciliation"
     }
   },
   "aiUsage": {
@@ -3523,6 +3522,23 @@
         "periodGap": "A period of the interval was never imported: the movements to subtract are incomplete.",
         "noLines": "This account holds no operation to subtract."
       }
+    },
+    "transaction": {
+      "notFound": "Operation not found.",
+      "direction": {
+        "out": "Outgoing",
+        "in": "Incoming"
+      },
+      "amount": "Amount",
+      "bookedOn": "Booking date",
+      "valueOn": "Value date",
+      "account": "Account",
+      "balanceAfter": "Balance after operation",
+      "reference": "Bank reference",
+      "allocationsTitle": "What this operation accounts for",
+      "allocatedOf": "{{allocated}} allocated out of {{total}}",
+      "noAllocation": "Nothing is attached to this operation yet.",
+      "remaining": "{{amount}} left to allocate"
     }
   },
   "pwa": {
@@ -3750,6 +3766,13 @@
       "blocked": "Nothing evaluable yet",
       "blockedHint": "A prerequisite blocks the control: {{prerequisite}}. Your operations exist, but no rule can cover them yet.",
       "blockedAction": "Open the control"
+    },
+    "reconciliation": {
+      "label": "Reconciliation",
+      "attested": "Statement of {{date}}",
+      "cash": "Cash on {{date}}",
+      "pending": "Awaiting reconciliation",
+      "out_of_scope": "Outside the checked period"
     }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1509,6 +1509,10 @@
           "control": {
             "title": "Compruebe que su visión es correcta",
             "body": "La pestaña «Control» enumera todo lo que impide que sus cifras sean exactas: operaciones sin asignar, gastos que el banco nunca vio, saldos que no encadenan. Cada discrepancia se resuelve — o se justifica con un motivo que sigue visible y se puede revocar."
+          },
+          "trace": {
+            "title": "Remontar hasta la operación",
+            "body": "Cada gasto indica si una línea del extracto lo justifica. «Extracto del 12 de julio» es un enlace: llegas a la operación, con su importe, su cuenta y los demás gastos que cubre. «Pendiente de conciliación» significa lo contrario — un gasto que el banco nunca vio, es decir una discrepancia que la pestaña Control cuenta. Fuera del periodo controlado no aparece nada: ahí la app no puede exigir nada."
           }
         }
       },
@@ -3037,11 +3041,6 @@
       },
       "budget": "Presupuesto",
       "budgetNone": "Sin presupuesto"
-    },
-    "provenance": {
-      "statement": "Extracto",
-      "cash": "Efectivo",
-      "pending": "Pendiente de conciliar"
     }
   },
   "aiUsage": {
@@ -3523,6 +3522,23 @@
         "periodGap": "Un periodo del intervalo nunca se importó: los movimientos a restar están incompletos.",
         "noLines": "Esta cuenta no tiene ninguna operación que restar."
       }
+    },
+    "transaction": {
+      "notFound": "Operación no encontrada.",
+      "direction": {
+        "out": "Salida",
+        "in": "Entrada"
+      },
+      "amount": "Importe",
+      "bookedOn": "Fecha de operación",
+      "valueOn": "Fecha valor",
+      "account": "Cuenta",
+      "balanceAfter": "Saldo tras la operación",
+      "reference": "Referencia bancaria",
+      "allocationsTitle": "Lo que justifica esta operación",
+      "allocatedOf": "{{allocated}} asignados de {{total}}",
+      "noAllocation": "Todavía no hay nada vinculado a esta operación.",
+      "remaining": "Quedan {{amount}} por asignar"
     }
   },
   "pwa": {
@@ -3750,6 +3766,13 @@
       "blocked": "Nada evaluable por ahora",
       "blockedHint": "Un requisito bloquea el control: {{prerequisite}}. Sus operaciones existen, pero ninguna regla puede cubrirlas todavía.",
       "blockedAction": "Ver el control"
+    },
+    "reconciliation": {
+      "label": "Conciliación",
+      "attested": "Extracto del {{date}}",
+      "cash": "Efectivo del {{date}}",
+      "pending": "Pendiente de conciliación",
+      "out_of_scope": "Fuera del periodo controlado"
     }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1509,6 +1509,10 @@
           "control": {
             "title": "Vérifiez que votre vision est juste",
             "body": "L'onglet « Contrôle » énumère tout ce qui empêche vos chiffres d'être exacts : opérations non affectées, dépenses jamais vues par la banque, soldes qui ne s'enchaînent pas. Chaque écart se résout — ou s'arbitre avec un motif, qui reste consultable et révocable."
+          },
+          "trace": {
+            "title": "Remonter à l'opération",
+            "body": "Chaque dépense affiche si une ligne de relevé la justifie. « Relevé du 12 juillet » est cliquable : vous arrivez sur l'opération, avec son montant, son compte, et les autres dépenses qu'elle couvre. « En attente de rapprochement » signale au contraire une dépense que la banque n'a jamais vue — c'est un écart, et le Contrôle la compte. Rien n'apparaît hors de la période contrôlée : là, l'app ne peut rien exiger."
           }
         }
       },
@@ -3037,11 +3041,6 @@
       },
       "budget": "Budget",
       "budgetNone": "Aucun budget"
-    },
-    "provenance": {
-      "statement": "Relevé",
-      "cash": "Espèces",
-      "pending": "En attente de rapprochement"
     }
   },
   "aiUsage": {
@@ -3523,6 +3522,23 @@
         "periodGap": "Une période de l'intervalle n'a jamais été importée : les mouvements à retrancher sont incomplets.",
         "noLines": "Ce compte ne porte aucune opération à retrancher."
       }
+    },
+    "transaction": {
+      "notFound": "Opération introuvable.",
+      "direction": {
+        "out": "Sortie",
+        "in": "Entrée"
+      },
+      "amount": "Montant",
+      "bookedOn": "Date d'opération",
+      "valueOn": "Date de valeur",
+      "account": "Compte",
+      "balanceAfter": "Solde après opération",
+      "reference": "Référence bancaire",
+      "allocationsTitle": "Ce que cette opération justifie",
+      "allocatedOf": "{{allocated}} ventilés sur {{total}}",
+      "noAllocation": "Rien n'est encore rattaché à cette opération.",
+      "remaining": "Reste {{amount}} à ventiler"
     }
   },
   "pwa": {
@@ -3750,6 +3766,13 @@
       "blocked": "Rien d'évaluable pour l'instant",
       "blockedHint": "Un prérequis bloque le contrôle : {{prerequisite}}. Tes opérations existent, mais aucune règle ne peut encore porter sur elles.",
       "blockedAction": "Voir le contrôle"
+    },
+    "reconciliation": {
+      "label": "Rapprochement",
+      "attested": "Relevé du {{date}}",
+      "cash": "Espèces du {{date}}",
+      "pending": "En attente de rapprochement",
+      "out_of_scope": "Hors période contrôlée"
     }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -55,6 +55,9 @@ const BudgetDetailPage = lazyWithReload(() => import('./features/money/BudgetDet
 const BankingTransactionsPage = lazyWithReload(
   () => import('./features/banking/TransactionsPage'),
 );
+const BankingTransactionDetailPage = lazyWithReload(
+  () => import('./features/banking/TransactionDetailPage'),
+);
 const ChangelogPage = lazyWithReload(() => import('./features/changelog/ChangelogPage'));
 const TutorialsPage = lazyWithReload(() => import('./features/tutorials/TutorialsPage'));
 const TutorialGuidePage = lazyWithReload(() => import('./features/tutorials/TutorialGuidePage'));
@@ -88,6 +91,7 @@ export const router = createBrowserRouter([
       { path: 'interactions/:id/edit', element: <InteractionEditPage /> },
       { path: 'money', element: <MoneyPage /> },
       { path: 'money/transactions', element: <BankingTransactionsPage /> },
+      { path: 'money/transactions/:id', element: <BankingTransactionDetailPage /> },
       { path: 'money/analysis', element: <MoneyAnalysisPage /> },
       { path: 'money/budgets/:id', element: <BudgetDetailPage /> },
       { path: 'money/recurring', element: <RecurringPage /> },


### PR DESCRIPTION
## Ce que ça change

Partout où une dépense s'affiche, elle porte désormais son état de rapprochement
— et quand une ligne de relevé la justifie, le badge y mène.

| Écran | Avant | Après |
|---|---|---|
| Onglet Dépenses | badge « Relevé / En attente » dérivé de la FK | badge serveur, cliquable |
| Journal des interactions | rien | badge sur les dépenses |
| Détail d'une interaction | rien | champ « Rapprochement » + compte et libellé de la ligne |
| Onglet Dépenses d'un projet | rien | badge |
| Journal bancaire | — | le libellé mène au détail de la ligne |

Nouvelle page : **`/app/money/transactions/:id`**.

## Pourquoi le verdict est calculé côté serveur

Le badge posé au lot 7 du parcours 26 lisait `bank_transaction === null`. Il
affichait donc « en attente de rapprochement », **en rouge**, sur des dépenses
antérieures au premier relevé — insolubles par construction, et que l'onglet
Contrôle ne réclamait pas. Deux écrans en désaccord sur le même fait, ce qui est
exactement la règle que `allocation_state` avait posée côté banque.

`banking.queries.reconciliation_state` est son miroir exact : même fenêtre de
conformité, même exception (« être fait est un fait ; être exigé est un
périmètre »). Régression : `test_expense_marker.py::TestTheMarkerAgreesWithTheControl`,
qui compare les deux lectures nombre par nombre.

## Deux défauts trouvés en chemin

- **Le badge « Espèces » ne s'est jamais affiché.** Il se déduisait de
  `reconciled_by === ''`, or `create_bank_expense_interaction` écrit `manual` sur
  *tous* les rattachements — y compris ceux nés d'une dépense en liquide — et
  détacher remet la FK à `null` avant qu'on arrive au test. La branche était
  morte. Le discriminant est maintenant le **type du compte** de la ligne.
- **`docs/MODULES/banking.md` documentait encore `/app/banking/transactions`**,
  déplacé au lot 2 du parcours 26. Corrigé.

## Pourquoi une page plutôt qu'un lien vers le journal

Un lien vers une liste paginée filtrée n'est pas une destination : sur un relevé
de 160 lignes, la ligne visée est page trois. Et la page montre ce que le journal
ne peut pas — les **autres** ventilations de la même opération. Arriver là depuis
une dépense de 90 €, c'est découvrir que la ligne en faisait 150.

Une seule requête : `GET …/transactions/{id}/allocations/` renvoyait déjà tout.

## Coût

Trois requêtes fixes par réponse (la fenêtre du foyer) ; la ligne et son compte
arrivent par `select_related`. Le test de coût compare cinq dépenses à quarante
plutôt que de plafonner le total de la page — voir « Hors périmètre » plus bas.

## Hors périmètre, signalé

La liste des interactions a un **N+1 antérieur** : `get_contacts`,
`get_structures`, `get_equipments` et les documents refont une requête par ligne
(sept par ligne, ~150 pour 20 dépenses). Non touché ici — c'est un refactor du
sérialiseur partagé, pas une conséquence de ce changement.

## Vérification

- `pytest` : **3445 passed, 2 skipped**
- `tsc -b` : 0 erreur — `npm run lint` : 0 erreur (5 warnings antérieurs)
- vitest : 22 passed (dont le garde-fou i18n, 4 catalogues)
- types API régénérés ; tutoriel « Dépenses » : nouvelle étape « Remonter à l'opération » ×4