### PR TITLE
feat(interactions): les dépenses quittent la page Activité

### DIFF
--- a/apps/interactions/tests/test_api_interactions.py
+++ b/apps/interactions/tests/test_api_interactions.py
@@ -699,3 +699,77 @@ class TestInteractionSourceLink:
         interaction.refresh_from_db()
         assert interaction.subject == "Tâche mise à jour"
         assert interaction.source == project
+
+
+@pytest.mark.django_db
+class TestExcludingTypesFromTheList:
+    """`?exclude_type=` — le pendant de `?type=`, et il doit vivre sur le serveur.
+
+    La page Activité ne montre plus les dépenses. Les écarter côté client aurait
+    été plus court et faux : la liste est paginée par huit, donc une page de huit
+    dépenses se serait affichée **vide** sous un compteur annonçant huit
+    résultats. Ces tests tiennent la pagination autant que le filtre.
+    """
+
+    def _entry(self, household, owner, zone, *, subject, kind):
+        interaction = Interaction.objects.create(
+            household=household,
+            created_by=owner,
+            subject=subject,
+            type=kind,
+            occurred_at=timezone.now(),
+        )
+        interaction.zones.add(zone)
+        return interaction
+
+    def test_an_excluded_type_leaves_the_list(self, owner_client, household, owner, primary_zone):
+        self._entry(household, owner, primary_zone, subject="Chaudière révisée", kind="maintenance")
+        self._entry(household, owner, primary_zone, subject="Courses", kind="expense")
+
+        response = owner_client.get(reverse("interaction-list"), {"exclude_type": "expense"})
+
+        assert response.status_code == status.HTTP_200_OK
+        subjects = [row["subject"] for row in response.data["results"]]
+        assert subjects == ["Chaudière révisée"]
+
+    def test_the_count_matches_what_is_shown(self, owner_client, household, owner, primary_zone):
+        """Un compteur qui annonce ce qu'on ne voit pas est le bug qu'on évite."""
+        for i in range(9):
+            self._entry(household, owner, primary_zone, subject=f"Dépense {i}", kind="expense")
+        self._entry(household, owner, primary_zone, subject="La seule note", kind="note")
+
+        response = owner_client.get(reverse("interaction-list"), {"exclude_type": "expense"})
+
+        assert response.data["count"] == 1
+        assert len(response.data["results"]) == 1
+
+    def test_several_types_can_be_excluded_at_once(self, owner_client, household, owner, primary_zone):
+        self._entry(household, owner, primary_zone, subject="Note", kind="note")
+        self._entry(household, owner, primary_zone, subject="Courses", kind="expense")
+        self._entry(household, owner, primary_zone, subject="Fuite", kind="repair")
+
+        response = owner_client.get(
+            reverse("interaction-list"), {"exclude_type": "expense,repair"}
+        )
+
+        assert [row["subject"] for row in response.data["results"]] == ["Note"]
+
+    def test_without_the_param_nothing_is_hidden(self, owner_client, household, owner, primary_zone):
+        """Le filtre est un choix d'écran, jamais une règle du modèle.
+
+        L'onglet Dépenses et l'onglet d'un projet lisent le même endpoint et
+        doivent continuer à voir les dépenses.
+        """
+        self._entry(household, owner, primary_zone, subject="Note", kind="note")
+        self._entry(household, owner, primary_zone, subject="Courses", kind="expense")
+
+        response = owner_client.get(reverse("interaction-list"))
+
+        assert response.data["count"] == 2
+
+    def test_an_empty_value_is_not_a_filter(self, owner_client, household, owner, primary_zone):
+        self._entry(household, owner, primary_zone, subject="Courses", kind="expense")
+
+        response = owner_client.get(reverse("interaction-list"), {"exclude_type": " , "})
+
+        assert response.data["count"] == 1

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -116,7 +116,21 @@ class InteractionViewSet(viewsets.ModelViewSet):
         selected_household = self.request.household
         if selected_household:
             queryset = queryset.filter(household=selected_household)
-        
+
+        # Exclure des types — le pendant de ``?type=``, et il doit être **serveur**.
+        #
+        # La page Activité ne montre plus les dépenses : elles ont leur module, avec
+        # leurs filtres, leur badge de rapprochement et leur budget, et à cent
+        # soixante lignes par mois elles noyaient les notes et les maintenances.
+        # Filtrer côté client aurait été plus court et faux : la page est paginée par
+        # huit, donc une page de huit dépenses se serait affichée vide sous un
+        # compteur qui en annonce huit.
+        exclude_type = self.request.query_params.get('exclude_type')
+        if exclude_type:
+            excluded = [value.strip() for value in exclude_type.split(',') if value.strip()]
+            if excluded:
+                queryset = queryset.exclude(type__in=excluded)
+
         # Filter by zone
         zone_id = self.request.query_params.get('zone')
         if zone_id:

--- a/docs/MODULES/interactions.md
+++ b/docs/MODULES/interactions.md
@@ -23,4 +23,27 @@
 - Lien `événement source → tâche` stocké dans `metadata.source_interaction_id` (pas de FK), choix V1 documenté dans `PARCOURS_03_BACKLOG_TECHNIQUE.md` lignes 132-140.
 - Ordre de tri par défaut : `-occurred_at` (`apps/interactions/models.py:102`).
 - **Création par l'agent IA (lot 8, 2026-07)** : l'agent peut créer une **note** (`Interaction` type=note) via son tool `create_entity` (`entity_type='note'`). Logique dans `apps/interactions/services.py::create_note_interaction`, enregistrée comme `WritableSpec` dans `interactions/apps.py`. En conversation ancrée projet, la note atterrit dans la timeline du projet. Rejoint les services d'écriture existants (`create_expense_interaction`, `create_manual_expense_interaction`). Voir `docs/MODULES/agent.md`.
+- **Les dépenses ont quitté la page Activité (2026-07)** : `/app/interactions` et le
+  fil « Activité récente » du dashboard passent `?exclude_type=expense`. Une dépense
+  reste une `Interaction` — sa fiche, son édition et son détail sont inchangés — mais
+  elle ne se lit plus dans le journal : elle a son module, avec sa période, son
+  budget et son badge de rapprochement, et à cent soixante lignes par mois elle
+  noyait les notes et les maintenances. Trois points à préserver :
+  - **`exclude_type` est un filtre serveur**, jamais un `.filter()` sur le résultat.
+    La liste est paginée par huit : écarter des lignes après coup afficherait une
+    page vide sous un compteur qui en annonce huit. Tests :
+    `test_api_interactions.py::TestExcludingTypesFromTheList`.
+  - **C'est un choix d'écran, pas une règle du modèle.** Sans le paramètre, rien
+    n'est masqué — l'onglet Dépenses et l'onglet d'un projet lisent le même endpoint
+    avec `?type=expense`.
+  - **Le fil du dashboard applique la même exclusion** : son lien « Toute l'activité »
+    mène à la page Activité, et y cliquer une dépense pour atterrir sur une liste qui
+    ne la contient pas serait un cul-de-sac.
+- **`InteractionNewPage` ne crée plus de dépense (2026-07)**, et ce n'était pas
+  qu'une question de cohérence d'écran : ce formulaire écrivait `amount` et
+  `supplier` dans `metadata`, où plus rien ne les lit depuis leur promotion en
+  colonnes (`interactions.0024`). Une dépense saisie par ce chemin valait **0 €**
+  dans tous les budgets et tous les totaux. `InteractionEditPage` écrit bien les
+  colonnes ; c'était la seule voie fautive. La saisie ad hoc passe désormais par le
+  module Argent (`CashExpenseDialog`).
 - **Carnet de rénovation par zone (parcours 13, 2026-07)** : une entrée de carnet est une `Interaction` discriminée par `metadata.kind == "renovation"` — **aucun nouveau modèle**. Elle porte un `type` curaté (installation/replacement/upgrade/repair/maintenance) et des champs structurés en `metadata` (`element`, `product`, `brand`, `reference`), et s'appuie sur le M2M zones (une entrée peut couvrir N pièces — cas « toutes les menuiseries de la maison »). Services : `create_renovation_interaction` / `update_renovation_interaction` / `delete_renovation_interaction` (`services.py`), avec le builder `_build_renovation_metadata`. Endpoints : `POST /api/interactions/interactions/renovation/` + `PATCH .../{id}/renovation/`. UI : onglet « Rénovation » du détail zone (`ui/src/features/renovation/`). Agent : `WritableSpec(entity_type='renovation')` (create + undo) — l'**édition agent est volontairement hors périmètre** car le snapshot d'undo d'`update_entity` lit des attributs modèle, pas les clés `metadata` ; l'édition passe par l'UI/REST. Cadrage : `docs/parcours/PARCOURS_13_CARNET_DE_RENOVATION_PAR_ZONE.md`.

--- a/ui/src/features/dashboard/hooks.ts
+++ b/ui/src/features/dashboard/hooks.ts
@@ -64,7 +64,12 @@ export function useRecentActivity() {
   return useQuery({
     queryKey: dashboardKeys.activity(),
     queryFn: async () => {
-      const { data } = await api.get('/interactions/interactions/', { params: { limit: 6 } });
+      // Même exclusion que la page Activité, à laquelle « Toute l'activité »
+      // renvoie : sans elle, on cliquerait ici une dépense pour atterrir sur une
+      // liste où elle ne figure pas.
+      const { data } = await api.get('/interactions/interactions/', {
+        params: { limit: 6, exclude_type: 'expense' },
+      });
       return normalizeList<DashboardInteraction>(data);
     },
   });

--- a/ui/src/features/interactions/InteractionCard.tsx
+++ b/ui/src/features/interactions/InteractionCard.tsx
@@ -6,7 +6,6 @@ import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardTitle } from '@/design-system/card';
 import { pushBack } from '@/lib/backNavigation';
-import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import type { InteractionListItem } from '@/lib/api/interactions';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 
@@ -47,8 +46,6 @@ export default function InteractionCard({ item, onDelete }: InteractionCardProps
               </CardTitle>
             </Link>
             <Badge variant="outline">{t(typeLabelKey)}</Badge>
-            {/* Sur une dépense seulement — le composant ne rend rien sinon. */}
-            <ReconciliationBadge state={item.reconciliation_state} line={item.bank_line} />
           </div>
 
           {item.content ? (

--- a/ui/src/features/interactions/InteractionNewPage.tsx
+++ b/ui/src/features/interactions/InteractionNewPage.tsx
@@ -10,13 +10,21 @@ import { fetchContacts, type Contact } from '@/lib/api/contacts';
 import { fetchStructures, type Structure } from '@/lib/api/structures';
 import { fetchEquipmentList, type EquipmentListItem } from '@/lib/api/equipment';
 import { useCreateInteraction } from './hooks';
-import ExpenseFields from './ExpenseFields';
 import ZonePicker from '@/features/zones/ZonePicker';
 import { useZones } from '@/features/zones/hooks';
 
+/**
+ * `expense` n'est plus créable ici — une dépense se saisit dans le module Argent.
+ *
+ * Deux raisons, et la seconde est la plus sérieuse. La page Activité ne montre
+ * plus les dépenses : ce formulaire y renvoyait après création, donc il aurait
+ * fabriqué une entrée invisible. Et surtout il écrivait le montant et le
+ * fournisseur dans `metadata`, là où plus rien ne les lit depuis leur promotion
+ * en colonnes (`interactions.0024`) — une dépense saisie ici valait **0 €** dans
+ * tous les budgets et tous les totaux, sans que rien ne le dise.
+ */
 const TYPE_OPTIONS = [
   'note',
-  'expense',
   'maintenance',
   'repair',
   'installation',
@@ -47,21 +55,14 @@ export default function InteractionNewPage() {
   const createMutation = useCreateInteraction();
 
   // Read initial values from query params. 'todo' is no longer an interaction
-  // type (todos live in the Task model) — old links fall back to 'note'.
+  // type (todos live in the Task model), 'expense' no longer one either (money
+  // module) — old links fall back to 'note' via the same guard.
   const requestedType = searchParams.get('type') ?? 'note';
-  const rawParamType = TYPE_OPTIONS.includes(requestedType) ? requestedType : 'note';
+  const paramType = TYPE_OPTIONS.includes(requestedType) ? requestedType : 'note';
   const paramZoneId = searchParams.get('zone_id') ?? '';
   const paramProjectId = searchParams.get('project_id') ?? '';
   const paramEquipmentId = searchParams.get('equipment_id') ?? '';
   const paramSourceInteractionId = searchParams.get('source_interaction_id') ?? '';
-
-  // Une dépense liée à un projet passe exclusivement par le dialog d'achat
-  // (ProjectPurchaseDialog, #235) — le form complet ne propose pas ce type
-  // quand un projet est imposé via l'URL.
-  const paramType = paramProjectId && rawParamType === 'expense' ? 'note' : rawParamType;
-  const typeOptions = paramProjectId
-    ? TYPE_OPTIONS.filter((v) => v !== 'expense')
-    : TYPE_OPTIONS;
 
   const [subject, setSubject] = React.useState('');
   const [type, setType] = React.useState(paramType);
@@ -78,11 +79,8 @@ export default function InteractionNewPage() {
   const [structures, setStructures] = React.useState<Structure[]>([]);
   const [equipmentId, setEquipmentId] = React.useState(paramEquipmentId);
   const [equipmentList, setEquipmentList] = React.useState<EquipmentListItem[]>([]);
-  const [amount, setAmount] = React.useState('');
-  const [supplier, setSupplier] = React.useState('');
   const [formError, setFormError] = React.useState<string | null>(null);
 
-  const isExpense = type === 'expense';
   const zoneIsLocked = !!paramZoneId;
 
   React.useEffect(() => {
@@ -129,21 +127,9 @@ export default function InteractionNewPage() {
       .map((s) => s.trim())
       .filter(Boolean);
 
-    // Build metadata: source_interaction (when relevant) + expense fields (when type=expense).
     let metadata: Record<string, unknown> | undefined;
     if (paramSourceInteractionId) {
       metadata = { source_interaction: paramSourceInteractionId };
-    }
-    if (isExpense) {
-      const trimmedAmount = amount.trim();
-      metadata = {
-        ...(metadata ?? {}),
-        kind: 'manual',
-        source_name: null,
-        amount: trimmedAmount ? trimmedAmount : null,
-        unit_price: null,
-        supplier: supplier.trim(),
-      };
     }
 
     try {
@@ -221,7 +207,7 @@ export default function InteractionNewPage() {
               value={type}
               onChange={(e) => setType(e.target.value)}
             >
-              {typeOptions.map((v) => (
+              {TYPE_OPTIONS.map((v) => (
                 <option key={v} value={v}>
                   {t(`equipment.interaction_type.${v}`)}
                 </option>
@@ -229,15 +215,6 @@ export default function InteractionNewPage() {
             </select>
           </div>
         </div>
-
-        {isExpense ? (
-          <ExpenseFields
-            amount={amount}
-            onAmountChange={setAmount}
-            supplier={supplier}
-            onSupplierChange={setSupplier}
-          />
-        ) : null}
 
         {/* Date / time */}
         <div className="space-y-2">

--- a/ui/src/features/interactions/InteractionsPage.tsx
+++ b/ui/src/features/interactions/InteractionsPage.tsx
@@ -13,9 +13,23 @@ import { useInteractions, useDeleteInteraction, interactionKeys } from './hooks'
 import InteractionCard from './InteractionCard';
 import ZonePicker from '@/features/zones/ZonePicker';
 
+/**
+ * Les dépenses ne sont plus de l'« activité ».
+ *
+ * Elles ont leur module — onglet Dépenses, avec leurs filtres de période, leur
+ * budget et leur badge de rapprochement. Ici, à cent soixante lignes par mois,
+ * elles noyaient les notes, les maintenances et les réparations, c'est-à-dire
+ * tout ce que cette page est censée rendre lisible.
+ *
+ * L'exclusion est **serveur** (`exclude_type`) : la page est paginée par huit,
+ * un filtrage après coup afficherait une page vide sous un compteur qui en
+ * annonce huit. Leur fiche reste accessible (`/app/interactions/:id`), c'est la
+ * liste qui cesse de les mélanger.
+ */
+const EXCLUDED_TYPES = 'expense';
+
 const TYPE_OPTIONS = [
   'note',
-  'expense',
   'maintenance',
   'repair',
   'installation',
@@ -51,6 +65,7 @@ export default function InteractionsPage() {
 
   const filters = React.useMemo(
     () => ({
+      exclude_type: EXCLUDED_TYPES,
       ...(search ? { search } : {}),
       ...(type ? { type } : {}),
       ...(zone ? { zone } : {}),

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -102,6 +102,13 @@ export interface LinkDocumentToInteractionInput {
 interface FetchInteractionsOptions {
   search?: string;
   type?: string;
+  /**
+   * Types à retirer, séparés par des virgules. **Filtre serveur**, jamais un
+   * `.filter()` sur le résultat : la liste est paginée par huit, donc écarter
+   * des lignes après coup afficherait une page vide sous un compteur qui en
+   * annonce huit.
+   */
+  exclude_type?: string;
   zone?: string;
   contact?: string;
   structure?: string;
@@ -167,6 +174,7 @@ export async function fetchInteractions(
   const {
     search,
     type,
+    exclude_type,
     zone,
     contact,
     structure,
@@ -183,6 +191,7 @@ export async function fetchInteractions(
   const params: Record<string, string | number> = { ordering: '-occurred_at' };
   if (search) params.search = search;
   if (type) params.type = type;
+  if (exclude_type) params.exclude_type = exclude_type;
   if (zone) params.zone = zone;
   if (contact) params.contact = contact;
   if (structure) params.structure = structure;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1452,15 +1452,15 @@
       },
       "interactions": {
         "title": "Das Haushaltsjournal führen",
-        "intro": "Das Journal hält alles fest: Notizen, Ausgaben, Wartungen…",
+        "intro": "Das Journal hält fest, was im Haushalt passiert: Notizen, Wartungen, Reparaturen, Einsätze. Ausgaben haben ein eigenes Modul.",
         "steps": {
           "log": {
             "title": "Einen Eintrag hinzufügen",
-            "body": "Erstellen Sie in Sekunden eine Notiz oder Ausgabe über die Journal-Seite."
+            "body": "Halten Sie eine Notiz oder einen Einsatz in Sekunden auf der Seite Aktivität fest."
           },
           "types": {
             "title": "Den richtigen Typ wählen",
-            "body": "Notiz, Ausgabe, Wartung… der Typ bestimmt, wo der Eintrag erscheint (Ausgaben-Seite, Aktivitätsverlauf)."
+            "body": "Notiz, Wartung, Reparatur, Garantie… der Typ sagt, worum es geht, und dient als Filter. Ausgaben erscheinen hier nicht: sie leben im Modul Geld, mit ihrem Budget und dem Kontoauszug, der sie belegt."
           },
           "link": {
             "title": "Mit dem Kontext verknüpfen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1452,15 +1452,15 @@
       },
       "interactions": {
         "title": "Keep the household journal",
-        "intro": "The journal records everything that happens: notes, expenses, maintenance…",
+        "intro": "The log records what happens to the household: notes, maintenance, repairs, callouts. Expenses have a module of their own.",
         "steps": {
           "log": {
             "title": "Add an entry",
-            "body": "Create a note or an expense in seconds from the Journal page."
+            "body": "Record a note or a callout in seconds from the Activity page."
           },
           "types": {
             "title": "Pick the right type",
-            "body": "Note, expense, maintenance… the type decides where the entry shows up (Expenses page, activity feed)."
+            "body": "Note, maintenance, repair, warranty… the type says what it is and acts as a filter. Expenses do not appear here: they live in the Money module, where they carry a budget and the statement that accounts for them."
           },
           "link": {
             "title": "Link to context",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1452,15 +1452,15 @@
       },
       "interactions": {
         "title": "Llevar el diario del hogar",
-        "intro": "El diario registra todo lo que pasa: notas, gastos, mantenimientos…",
+        "intro": "El diario registra lo que le ocurre al hogar: notas, mantenimientos, reparaciones, intervenciones. Los gastos tienen su propio módulo.",
         "steps": {
           "log": {
             "title": "Añadir una entrada",
-            "body": "Crea una nota o un gasto en segundos desde la página del Diario."
+            "body": "Anota una nota o una intervención en segundos desde la página Actividad."
           },
           "types": {
             "title": "Elegir el tipo adecuado",
-            "body": "Nota, gasto, mantenimiento… el tipo decide dónde aparece la entrada (página de Gastos, hilo de actividad)."
+            "body": "Nota, mantenimiento, reparación, garantía… el tipo dice de qué se trata y sirve de filtro. Los gastos no aparecen aquí: viven en el módulo Dinero, con su presupuesto y el extracto que los justifica."
           },
           "link": {
             "title": "Enlazar con el contexto",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1452,15 +1452,15 @@
       },
       "interactions": {
         "title": "Tenir le journal du foyer",
-        "intro": "Le journal enregistre tout ce qui se passe : notes, dépenses, maintenances…",
+        "intro": "Le journal enregistre ce qui arrive au foyer : notes, maintenances, réparations, interventions. Les dépenses, elles, ont leur propre module.",
         "steps": {
           "log": {
             "title": "Ajouter une entrée",
-            "body": "Créez une note ou une dépense en quelques secondes depuis la page Journal."
+            "body": "Consignez une note ou une intervention en quelques secondes depuis la page Activité."
           },
           "types": {
             "title": "Choisir le bon type",
-            "body": "Note, dépense, maintenance… le type détermine où l'entrée apparaît (page Dépenses, fil d'activité)."
+            "body": "Note, maintenance, réparation, garantie… le type dit de quoi il s'agit et sert de filtre. Les dépenses n'apparaissent pas ici : elles vivent dans le module Argent, où elles portent un budget et le relevé qui les justifie."
           },
           "link": {
             "title": "Relier au contexte",


### PR DESCRIPTION
## Ce que ça change

`/app/interactions` et le fil « Activité récente » du dashboard ne montrent plus
les dépenses. Elles ont leur module — onglet Dépenses, avec leur période, leur
budget et leur badge de rapprochement. Dans le journal, à ~160 lignes par mois,
elles noyaient les notes, maintenances et réparations.

**La fiche d'une dépense est inchangée** et reste accessible : c'est la liste qui
cesse de les mélanger, pas la donnée qui disparaît.

## Un filtre serveur, pas un `.filter()`

La liste est paginée par **huit**. Écarter les dépenses côté client aurait
affiché une page vide sous un compteur annonçant huit résultats. D'où
`?exclude_type=`, le pendant de `?type=`. C'est un choix d'écran, pas une règle
du modèle : sans le paramètre rien n'est masqué, l'onglet Dépenses et l'onglet
d'un projet lisent le même endpoint.

Tests : `test_api_interactions.py::TestExcludingTypesFromTheList` — dont un qui
tient la pagination (neuf dépenses + une note ⇒ `count == 1`) et un qui vérifie
que sans le paramètre rien ne change.

## Trois conséquences traitées ici

Sans elles le changement fabrique ses propres incohérences :

- **le fil du dashboard** applique la même exclusion — son lien « Toute
  l'activité » mène à cette page ;
- **le filtre « Type »** perd l'option *Dépense*, qui ne ramènerait plus rien ;
- **le badge de rapprochement d'`InteractionCard`** (#422, mergée ce matin)
  devient du code mort : cette carte ne sert qu'à cette page. Retiré — c'est le
  changement qui le rend inutile qui doit le nettoyer.

## ⚠️ Un défaut trouvé en chemin, et corrigé par le retrait

`InteractionNewPage` ne propose plus le type `expense`. Ce n'était pas qu'une
question de cohérence d'écran : **ce formulaire écrivait `amount` et `supplier`
dans `metadata`**, où plus rien ne les lit depuis leur promotion en colonnes
(`interactions.0024`). Une dépense saisie par ce chemin valait **0 €** dans tous
les budgets et tous les totaux, sans que rien ne le signale.

`InteractionEditPage` écrit bien les colonnes — c'était la seule voie fautive.
La saisie ad hoc passe par le module Argent (`CashExpenseDialog`).

**À décider séparément** : si des dépenses ont été saisies par ce chemin, elles
sont en base avec `amount IS NULL` et la vraie valeur dans `metadata`. Elles sont
détectables, et réparables par une data migration — je n'en ai pas écrit une sans
ton accord.

## Vérification

- `pytest` : **3450 passed, 2 skipped**
- `tsc -b` : 0 erreur — `npm run lint` : 0 erreur (5 warnings antérieurs)
- vitest : 22 passed (garde-fou i18n compris)
- tutoriel « Tenir le journal du foyer » repris ×4 : il annonçait « notes,
  dépenses, maintenances » et proposait de créer une dépense