### PR TITLE
feat(money): rattacher depuis la dépense, et réparer celles restées à 0 €

### DIFF
--- a/apps/banking/tests/test_expense_marker.py
+++ b/apps/banking/tests/test_expense_marker.py
@@ -41,7 +41,9 @@ EXPENSES_URL = "/api/interactions/interactions/?type=expense"
 _counter = itertools.count()
 
 
-def make_txn(account, *, amount, booked_on=date(2026, 3, 10), label="CB LECLERC"):
+def make_txn(
+    account, *, amount, booked_on=date(2026, 3, 10), label="CB LECLERC", internal=False
+):
     value = Decimal(amount)
     return BankTransaction.objects.create(
         household=account.household,
@@ -50,6 +52,7 @@ def make_txn(account, *, amount, booked_on=date(2026, 3, 10), label="CB LECLERC"
         label_raw=label,
         label_norm=label.upper(),
         amount=value,
+        is_internal=internal,
         direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
         dedup_hash=compute_dedup_hash(
             account_id=account.id,
@@ -320,3 +323,68 @@ class TestItStaysCheap:
         # Trois : la fenêtre du compte (deux agrégats) et la liste des comptes.
         # Les lignes elles-mêmes arrivent jointes à la requête des interactions.
         assert self._banking_queries(many.captured_queries) <= 4
+
+
+@pytest.mark.django_db
+class TestWhichLinesCouldCarryThisExpense:
+    """`?fits=` — « quelles opérations ont la place pour cette dépense ? ».
+
+    Le pendant, depuis la dépense, de la file « À ranger » qui part de la ligne.
+    Le matcher automatique ne répondra jamais à ça : 90 € face à une ligne de
+    150 € est rejeté par `score_pair`, à raison. Mais c'est un cas réel, et le
+    seul qui puisse trancher est l'utilisateur — on lui montre donc ce qui a
+    matériellement la place, et rien d'autre.
+    """
+
+    URL = "/api/banking/transactions/"
+
+    def labels(self, client, amount):
+        body = client.get(f"{self.URL}?fits={amount}").json()
+        return [r["label_raw"] for r in body["results"]]
+
+    def test_a_line_too_small_is_not_proposed(self, ctx):
+        """Proposer un bouton que le serveur refusera est pire que ne rien proposer."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="-50.00", label="PETITE")
+        make_txn(account, amount="-200.00", label="GRANDE")
+
+        assert self.labels(client, "90.00") == ["GRANDE"]
+
+    def test_a_partly_split_line_offers_only_what_is_left(self, ctx):
+        """150 € dont 90 € déjà ventilés : il reste 60 €, pas 150."""
+        household, user, account, budget, client = ctx
+        txn = make_txn(account, amount="-150.00", label="LEROY MERLIN")
+        create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Carrelage",
+            amount=Decimal("90.00"),
+            budget_id=budget.id,
+        )
+
+        assert self.labels(client, "60.00") == ["LEROY MERLIN"]
+        assert self.labels(client, "61.00") == []
+
+    def test_an_expense_can_cover_part_of_a_line(self, ctx):
+        """Le cas qui motive tout : 90 € sur une ligne de 150 €."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="-150.00", label="LEROY MERLIN")
+
+        assert self.labels(client, "90.00") == ["LEROY MERLIN"]
+
+    def test_receipts_and_internal_movements_are_never_proposed(self, ctx):
+        """Une recette n'a rien à ventiler ; un retrait est compté ailleurs."""
+        _, _, account, _, client = ctx
+        make_txn(account, amount="900.00", label="VIR SALAIRE")
+        make_txn(account, amount="-300.00", internal=True, label="RETRAIT DAB")
+        make_txn(account, amount="-300.00", label="CB VRAIE DEPENSE")
+
+        assert self.labels(client, "50.00") == ["CB VRAIE DEPENSE"]
+
+    def test_a_malformed_amount_is_a_400(self, ctx):
+        """Un paramètre illisible est une erreur, jamais un filtre ignoré."""
+        _, _, account, _, client = ctx
+
+        assert client.get(f"{self.URL}?fits=beaucoup").status_code == 400
+        assert client.get(f"{self.URL}?fits=-10").status_code == 400

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -1,7 +1,9 @@
 """Banking REST API views."""
 import json
 from datetime import date
-from decimal import InvalidOperation
+from decimal import Decimal, InvalidOperation
+
+from django.db.models import F, Value
 
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
@@ -48,7 +50,7 @@ from .models import (
     TransactionDirection,
 )
 from . import queries
-from .queries import search
+from .queries import AMOUNT_FIELD, search
 from .validators import allocated_total, remaining_to_allocate
 from .serializers import (
     BalanceAnchorInputSerializer,
@@ -376,6 +378,28 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
         date_to = _parse_date_param(params.get("date_to"), "date_to")
         if date_to:
             qs = qs.filter(booked_on__lte=date_to)
+
+        # « Quelles lignes pourraient porter cette dépense ? » — le pendant, depuis
+        # la dépense, de la file « À ranger » qui part de la ligne.
+        #
+        # Le matcher automatique ne répondra jamais à ça : un achat de 90 € face à
+        # une ligne de 150 € est rejeté par ``score_pair``, à raison — 60 € d'écart
+        # n'est pas un appariement plausible. Mais c'est un cas réel, et le seul
+        # qui sache trancher est l'utilisateur. On lui montre donc ce qui a
+        # *matériellement* la place : le reste à ventiler doit couvrir le montant.
+        fits = params.get("fits")
+        if fits:
+            try:
+                needed = Decimal(fits)
+            except (InvalidOperation, TypeError):
+                raise ValidationError({"fits": "Expected a decimal amount."})
+            if needed <= 0:
+                raise ValidationError({"fits": "Expected a positive amount."})
+            qs = qs.filter(
+                direction=TransactionDirection.OUT,
+                is_internal=False,
+                transfer_counterpart__isnull=True,
+            ).filter(outflow_value__gte=F("allocated") + Value(needed, output_field=AMOUNT_FIELD))
 
         # Les remboursements d'une enveloppe — ce qui permet à la page d'un budget
         # d'afficher la ligne qui lui a rendu de l'argent, à côté des dépenses qui

--- a/apps/interactions/migrations/0028_promote_misplaced_expense_fields.py
+++ b/apps/interactions/migrations/0028_promote_misplaced_expense_fields.py
@@ -1,0 +1,41 @@
+"""Remonter en colonnes les montants restés dans ``metadata``.
+
+L'ancien formulaire du journal (`InteractionNewPage`, type `expense`, retiré en
+juillet 2026) écrivait `amount` et `supplier` dans `metadata`, alors que ce sont
+des colonnes depuis `0023`/`0024`. Rien ne lisait plus ces clés : une dépense
+saisie par ce chemin valait **0 €** dans tous les budgets et tous les totaux.
+
+La règle vit dans `interactions.repairs`, pour être testable ailleurs qu'en
+rejouant la migration.
+"""
+from django.db import migrations
+
+from interactions.repairs import promote_misplaced_expense_fields
+
+
+def promote(apps, schema_editor):
+    stats = promote_misplaced_expense_fields(apps.get_model("interactions", "Interaction"))
+    if stats["scanned"]:
+        print(
+            f"  interactions.0028: {stats['scanned']} dépense(s) portant des clés "
+            f"déplacées — {stats['amount_promoted']} montant(s) et "
+            f"{stats['supplier_promoted']} fournisseur(s) remontés en colonne, "
+            f"{stats['unreadable']} illisible(s) laissé(s) tels quels."
+        )
+
+
+def noop(apps, schema_editor):
+    # Irréversible par construction : les colonnes sont la vérité, et
+    # re-matérialiser les clés JSON recréerait le double stockage qu'on supprime.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("interactions", "0027_backfill_recurring_expense"),
+    ]
+
+    operations = [
+        migrations.RunPython(promote, noop),
+    ]

--- a/apps/interactions/repairs.py
+++ b/apps/interactions/repairs.py
@@ -1,0 +1,73 @@
+"""Réparations de données ponctuelles, testables hors migration.
+
+Une migration de données qui contient sa propre logique ne se teste qu'en la
+rejouant. En la sortant ici, la règle se teste comme n'importe quel service, et
+la migration n'est plus qu'un appel.
+"""
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+
+#: Clés que l'ancien formulaire du journal écrivait dans ``metadata`` alors que
+#: ce sont des colonnes depuis ``interactions.0023`` / ``0024``.
+_MISPLACED = ("amount", "supplier")
+
+
+def promote_misplaced_expense_fields(Interaction) -> dict[str, int]:
+    """Remonter en colonnes le montant et le fournisseur restés dans ``metadata``.
+
+    ``InteractionNewPage`` a écrit ``metadata.amount`` / ``metadata.supplier``
+    jusqu'en juillet 2026, alors que ces champs sont des colonnes depuis la
+    promotion documentée dans ``CARTOGRAPHIE_DEPENSES.md``. Rien ne lisait plus
+    ces clés : une dépense saisie par ce chemin valait **0 €** dans tous les
+    budgets, tous les totaux et tous les bilans, sans que rien ne le signale.
+
+    Trois précautions :
+
+    - **la colonne gagne toujours.** Si ``amount`` est déjà renseignée, la clé
+      JSON est un résidu de l'ancien double stockage, pas une correction en
+      attente — on la retire sans rien réécrire ;
+    - **une valeur illisible est laissée telle quelle** plutôt que forcée à
+      zéro : un montant faux est pire qu'un montant absent, qui lui se voit ;
+    - **les clés sont retirées dans tous les cas**, comme l'a fait ``0024`` :
+      les laisser garderait vivante la source du malentendu.
+
+    Renvoie le compte de ce qui a été fait, pour que le journal de déploiement
+    dise ce qui s'est passé plutôt que de rester muet.
+    """
+    stats = {"scanned": 0, "amount_promoted": 0, "supplier_promoted": 0, "unreadable": 0}
+    batch = []
+
+    for expense in Interaction.objects.filter(type="expense").iterator():
+        meta = expense.metadata or {}
+        if not any(key in meta for key in _MISPLACED):
+            continue
+
+        stats["scanned"] += 1
+
+        raw_amount = meta.pop("amount", None)
+        if expense.amount is None and raw_amount not in (None, ""):
+            try:
+                expense.amount = Decimal(str(raw_amount))
+                stats["amount_promoted"] += 1
+            except (InvalidOperation, TypeError, ValueError):
+                stats["unreadable"] += 1
+
+        raw_supplier = meta.pop("supplier", None)
+        if not expense.supplier and raw_supplier:
+            expense.supplier = str(raw_supplier)[:255]
+            stats["supplier_promoted"] += 1
+
+        # L'écriture n'est pas conditionnée à une promotion : même quand la
+        # colonne gagnait déjà, les clés retirées doivent être persistées.
+        expense.metadata = meta
+        batch.append(expense)
+
+        if len(batch) >= 500:
+            Interaction.objects.bulk_update(batch, ["amount", "supplier", "metadata"])
+            batch = []
+
+    if batch:
+        Interaction.objects.bulk_update(batch, ["amount", "supplier", "metadata"])
+
+    return stats

--- a/apps/interactions/tests/test_repairs.py
+++ b/apps/interactions/tests/test_repairs.py
@@ -1,0 +1,159 @@
+# interactions/tests/test_repairs.py
+"""La réparation des dépenses restées à 0 €.
+
+L'ancien formulaire du journal écrivait le montant dans `metadata` alors que
+c'est une colonne depuis `0023`/`0024`. Rien ne lisait plus cette clé : la
+dépense valait **0 €** dans tous les budgets, tous les totaux et tous les
+bilans, sans que rien ne le signale. C'est le pire genre de défaut — il ne
+produit pas d'erreur, il produit un chiffre faux.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from django.utils import timezone
+
+from households.models import Household
+from interactions.models import Interaction
+from interactions.repairs import promote_misplaced_expense_fields
+
+from accounts.tests.factories import UserFactory
+
+
+@pytest.fixture
+def household(db):
+    return Household.objects.create(name="Repairs House")
+
+
+def make(household, **kwargs):
+    defaults = {
+        "subject": "Restaurant",
+        "type": "expense",
+        "occurred_at": timezone.now(),
+    }
+    return Interaction.objects.create(household=household, **{**defaults, **kwargs})
+
+
+def run():
+    return promote_misplaced_expense_fields(Interaction)
+
+
+@pytest.mark.django_db
+class TestPromotingWhatWasMisplaced:
+    def test_a_zero_euro_expense_recovers_its_amount(self, household):
+        expense = make(household, metadata={"amount": "32.00", "supplier": "Le Bistrot"})
+
+        stats = run()
+        expense.refresh_from_db()
+
+        assert expense.amount == Decimal("32.00")
+        assert expense.supplier == "Le Bistrot"
+        assert stats["amount_promoted"] == 1
+        assert stats["supplier_promoted"] == 1
+
+    def test_the_keys_are_removed_afterwards(self, household):
+        """Les laisser garderait vivante la source du malentendu."""
+        expense = make(household, metadata={"amount": "32.00", "supplier": "Le Bistrot"})
+
+        run()
+        expense.refresh_from_db()
+
+        assert "amount" not in expense.metadata
+        assert "supplier" not in expense.metadata
+
+    def test_the_column_always_wins(self, household):
+        """Une clé JSON à côté d'une colonne renseignée est un résidu, pas une correction."""
+        expense = make(
+            household,
+            amount=Decimal("50.00"),
+            supplier="Vrai",
+            metadata={"amount": "9999.00", "supplier": "Faux"},
+        )
+
+        run()
+        expense.refresh_from_db()
+
+        assert expense.amount == Decimal("50.00")
+        assert expense.supplier == "Vrai"
+        assert expense.metadata == {}
+
+    def test_an_unreadable_amount_is_left_absent(self, household):
+        """Un montant faux est pire qu'un montant absent — celui-là, au moins, se voit."""
+        expense = make(household, metadata={"amount": "beaucoup"})
+
+        stats = run()
+        expense.refresh_from_db()
+
+        assert expense.amount is None
+        assert stats["unreadable"] == 1
+
+    def test_other_metadata_survives(self, household):
+        expense = make(
+            household,
+            metadata={"amount": "12.00", "source_name": "Stock", "unit_price": "3.00"},
+        )
+
+        run()
+        expense.refresh_from_db()
+
+        assert expense.metadata == {"source_name": "Stock", "unit_price": "3.00"}
+
+    def test_a_renovation_entry_is_never_touched(self, household):
+        """Le carnet de rénovation garde ses clés — elles ne sont pas des colonnes.
+
+        Une entrée de carnet porte un ``type`` curaté (ici ``installation``) et
+        son discriminateur en ``metadata.kind`` : la réparation ne filtre que
+        ``type='expense'``, exactement comme ``0024``.
+        """
+        note = make(
+            household,
+            type="installation",
+            subject="Fenêtres",
+            metadata={"kind": "renovation", "amount": "800.00"},
+        )
+
+        run()
+        note.refresh_from_db()
+
+        assert note.metadata == {"kind": "renovation", "amount": "800.00"}
+
+    def test_running_it_twice_changes_nothing(self, household):
+        expense = make(household, metadata={"amount": "32.00"})
+
+        run()
+        second = run()
+        expense.refresh_from_db()
+
+        assert expense.amount == Decimal("32.00")
+        assert second == {
+            "scanned": 0,
+            "amount_promoted": 0,
+            "supplier_promoted": 0,
+            "unreadable": 0,
+        }
+
+    def test_a_healthy_expense_is_not_even_scanned(self, household):
+        make(household, amount=Decimal("20.00"), metadata={"source_name": "Stock"})
+
+        assert run()["scanned"] == 0
+
+
+@pytest.mark.django_db
+class TestItActuallyFixesTheFigures:
+    """La preuve qui compte : le budget cesse d'ignorer la dépense."""
+
+    def test_the_expense_summary_counts_it_again(self, household):
+        from interactions.aggregations import compute_expense_summary
+
+        user = UserFactory()
+        make(household, created_by=user, metadata={"amount": "32.00"})
+
+        before = compute_expense_summary(
+            household_id=household.id, from_dt=None, to_dt=None
+        )
+        run()
+        after = compute_expense_summary(household_id=household.id, from_dt=None, to_dt=None)
+
+        assert before["total"] == "0.00"
+        assert after["total"] == "32.00"

--- a/docs/MODULES/interactions.md
+++ b/docs/MODULES/interactions.md
@@ -46,4 +46,15 @@
   dans tous les budgets et tous les totaux. `InteractionEditPage` écrit bien les
   colonnes ; c'était la seule voie fautive. La saisie ad hoc passe désormais par le
   module Argent (`CashExpenseDialog`).
+- **Réparation des dépenses restées à 0 € (`interactions.0028`, 2026-07)** : les
+  dépenses saisies par l'ancien formulaire portaient leur montant dans
+  `metadata`, où plus rien ne le lit — elles valaient **0 €** dans tous les
+  budgets, tous les totaux et tous les bilans. La migration remonte
+  `metadata.amount` / `metadata.supplier` en colonnes et retire les clés, comme
+  `0024`. La règle vit dans `interactions/repairs.py` (testable hors migration) :
+  la **colonne gagne toujours** (une clé JSON à côté d'une colonne renseignée est
+  un résidu, pas une correction), une valeur illisible est **laissée absente**
+  plutôt que forcée à zéro (un montant faux est pire qu'un montant manquant, qui
+  lui se voit), et les clés sont retirées dans tous les cas. Tests :
+  `interactions/tests/test_repairs.py`.
 - **Carnet de rénovation par zone (parcours 13, 2026-07)** : une entrée de carnet est une `Interaction` discriminée par `metadata.kind == "renovation"` — **aucun nouveau modèle**. Elle porte un `type` curaté (installation/replacement/upgrade/repair/maintenance) et des champs structurés en `metadata` (`element`, `product`, `brand`, `reference`), et s'appuie sur le M2M zones (une entrée peut couvrir N pièces — cas « toutes les menuiseries de la maison »). Services : `create_renovation_interaction` / `update_renovation_interaction` / `delete_renovation_interaction` (`services.py`), avec le builder `_build_renovation_metadata`. Endpoints : `POST /api/interactions/interactions/renovation/` + `PATCH .../{id}/renovation/`. UI : onglet « Rénovation » du détail zone (`ui/src/features/renovation/`). Agent : `WritableSpec(entity_type='renovation')` (create + undo) — l'**édition agent est volontairement hors périmètre** car le snapshot d'undo d'`update_entity` lit des attributs modèle, pas les clés `metadata` ; l'édition passe par l'UI/REST. Cadrage : `docs/parcours/PARCOURS_13_CARNET_DE_RENOVATION_PAR_ZONE.md`.

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -343,6 +343,30 @@ Côté écran : le budget se choisit dans `ClassifyInflowDialog` quand la nature
 page d'un budget liste ses remboursements sous ses dépenses — « avoir la ligne sous
 les yeux » était la moitié de la demande.
 
+### Rattacher une dépense à une opération, depuis la dépense
+
+Le rapprochement manuel n'existait que **depuis la ligne** (`UnreconciledPicker`,
+action « Rapprocher » du journal). Or on part souvent de l'autre bout : on lit
+« En attente de rapprochement » sur une dépense et on veut désigner l'opération.
+Le constat était posé partout sans l'action à côté.
+
+`AttachToTransactionDialog` est le miroir exact : au lieu de chercher une dépense
+pour une ligne, il cherche une ligne pour une dépense.
+
+- **Les candidates viennent du serveur** (`?fits=<montant>`) : seules les sorties
+  non internes dont le **reste à ventiler** couvre le montant. Le reste est une
+  annotation — le client ne peut pas le calculer — et proposer une ligne trop
+  petite offrirait un bouton que `assert_allocation_fits` refuse, ce qui est pire
+  que ne rien proposer.
+- **Une dépense peut ne couvrir qu'une partie d'une ligne** : 90 € sur 150 €, les
+  60 € restants attendent leur propre affectation. C'est précisément ce que le
+  matcher automatique refuse de deviner (`score_pair` rejette au-delà de la
+  tolérance, à raison), et le seul qui puisse trancher est l'utilisateur.
+- Le tri est l'**écart en jours** avec la date de la dépense : à montants
+  compatibles, c'est la seule indication qui distingue deux lignes plausibles.
+
+Tests : `banking/tests/test_expense_marker.py::TestWhichLinesCouldCarryThisExpense`.
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/ui/src/features/banking/AttachToTransactionDialog.tsx
+++ b/ui/src/features/banking/AttachToTransactionDialog.tsx
@@ -1,0 +1,132 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Button } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import { formatAmount, formatDate } from '@/lib/format';
+import { useLinkInteraction, useTransactions } from './hooks';
+
+interface AttachToTransactionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  expense: { id: string; subject: string; amount: string | null; occurred_at: string };
+}
+
+/** Écart en jours entre la dépense et la ligne — le seul tri qui aide vraiment. */
+function dayGap(a: string, b: string): number {
+  const ms = Math.abs(new Date(a).getTime() - new Date(b).getTime());
+  return Math.round(ms / 86_400_000);
+}
+
+/**
+ * Rattacher cette dépense à une opération — le sens inverse d'`UnreconciledPicker`.
+ *
+ * Le rapprochement se faisait uniquement depuis la ligne : on partait du relevé
+ * et on cherchait la dépense. Mais l'utilisateur part souvent de l'autre bout —
+ * il lit « En attente de rapprochement » sur une dépense et veut désigner
+ * l'opération. Sans ce dialogue, le constat était posé partout sans l'action à
+ * côté.
+ *
+ * Les candidates viennent du serveur avec `fits` : seules les lignes dont le
+ * **reste à ventiler** couvre le montant. Le calculer ici serait impossible — le
+ * reste est une annotation — et proposer une ligne trop petite offrirait un
+ * bouton qui échoue (`assert_allocation_fits`), ce qui est pire que ne rien
+ * proposer.
+ *
+ * Une dépense de 90 € peut ainsi se rattacher à une ligne de 150 € : elle en
+ * couvre *une partie*, et les 60 € restants restent à ventiler. C'est
+ * exactement ce que le matcher automatique refuse de deviner.
+ */
+export default function AttachToTransactionDialog({
+  open,
+  onOpenChange,
+  expense,
+}: AttachToTransactionDialogProps) {
+  const { t } = useTranslation();
+  const linkMutation = useLinkInteraction();
+
+  const amount = expense.amount ?? '0';
+  const query = useTransactions(
+    React.useMemo(() => ({ fits: amount }), [amount]),
+    50,
+    { enabled: open && Number(amount) > 0 },
+  );
+
+  // Le plus proche en date d'abord : à montant égal, c'est la seule indication
+  // qui distingue deux lignes plausibles.
+  const candidates = React.useMemo(() => {
+    const rows = query.data?.results ?? [];
+    return [...rows].sort(
+      (a, b) =>
+        dayGap(a.booked_on, expense.occurred_at) - dayGap(b.booked_on, expense.occurred_at),
+    );
+  }, [query.data, expense.occurred_at]);
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.attach.title')}>
+      <div className="mt-4 space-y-4">
+        <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
+          <p className="font-medium text-foreground">{expense.subject}</p>
+          <p className="text-xs text-muted-foreground">
+            {formatDate(expense.occurred_at)} · {formatAmount(expense.amount)}
+          </p>
+        </div>
+
+        <p className="text-xs text-muted-foreground">{t('banking.attach.hint')}</p>
+
+        {query.isLoading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
+            ))}
+          </div>
+        ) : candidates.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('banking.attach.none')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {candidates.map((line) => (
+              <li key={line.id}>
+                <Card className="flex items-center gap-2 p-2 text-sm">
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-foreground">{line.label_raw}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {formatDate(line.booked_on)}
+                      {Number(line.remaining_amount) > Number(amount)
+                        ? ` · ${t('banking.attach.remaining', {
+                            amount: formatAmount(line.remaining_amount),
+                          })}`
+                        : ''}
+                    </p>
+                  </div>
+                  <span className="shrink-0 tabular-nums text-foreground">
+                    {formatAmount(line.amount)}
+                  </span>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    disabled={linkMutation.isPending}
+                    onClick={() =>
+                      linkMutation.mutate(
+                        { transactionId: line.id, interactionId: expense.id },
+                        { onSuccess: () => onOpenChange(false) },
+                      )
+                    }
+                  >
+                    {t('banking.reconcile.attach')}
+                  </Button>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className="flex justify-end pt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.close')}
+          </Button>
+        </div>
+      </div>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { FileText, Pencil, Trash2 } from 'lucide-react';
+import { FileText, Link2, Pencil, Trash2 } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
@@ -15,6 +15,7 @@ import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { formatAmount, formatDateTime } from '@/lib/format';
 import ReconciliationBadge from '@/features/money/ReconciliationBadge';
+import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
 import { useInteraction, useDeleteInteraction } from './hooks';
 
 // ── Main page ──────────────────────────────────────────────
@@ -27,6 +28,7 @@ export default function InteractionDetailPage() {
   const navigateBack = useNavigateBack('/app/interactions');
 
   const [deleteOpen, setDeleteOpen] = React.useState(false);
+  const [attachOpen, setAttachOpen] = React.useState(false);
 
   const { data: interaction, isLoading, error } = useInteraction(id ?? '');
   const deleteMutation = useDeleteInteraction();
@@ -145,7 +147,21 @@ export default function InteractionDetailPage() {
                   <p className="text-xs text-muted-foreground">
                     {interaction.bank_line.account_name} · {interaction.bank_line.label}
                   </p>
-                ) : null}
+                ) : (
+                  /* Le constat sans le geste à côté n'aide personne : c'est ici
+                     qu'on lit « en attente », donc c'est ici qu'on doit pouvoir
+                     désigner l'opération. */
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => setAttachOpen(true)}
+                    disabled={!amount}
+                  >
+                    <Link2 className="mr-1.5 h-3 w-3" />
+                    {t('banking.attach.action')}
+                  </Button>
+                )}
               </div>
             </InfoField>
           ) : null}
@@ -248,6 +264,19 @@ export default function InteractionDetailPage() {
           </div>
         ) : null}
       </div>
+
+      {isExpense && amount ? (
+        <AttachToTransactionDialog
+          open={attachOpen}
+          onOpenChange={setAttachOpen}
+          expense={{
+            id: interaction.id,
+            subject: interaction.subject,
+            amount,
+            occurred_at: interaction.occurred_at,
+          }}
+        />
+      ) : null}
 
       <ConfirmDialog
         open={deleteOpen}

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -276,6 +276,12 @@ export interface TransactionFilters {
   allocation?: 'todo' | '';
   /** Id du budget qu'un remboursement recrédite — pour la page d'un budget. */
   refund_budget?: string;
+  /**
+   * Ne garder que les sorties dont le reste à ventiler couvre ce montant —
+   * « quelles lignes pourraient porter cette dépense ? ». Filtre serveur : le
+   * reste est une annotation, il n'existe pas côté client avant la réponse.
+   */
+  fits?: string;
   q?: string;
 }
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3544,6 +3544,13 @@
       "allocatedOf": "{{allocated}} von {{total}} zugeordnet",
       "noAllocation": "Dieser Buchung ist noch nichts zugeordnet.",
       "remaining": "Noch {{amount}} zuzuordnen"
+    },
+    "attach": {
+      "title": "Einer Buchung zuordnen",
+      "action": "Einer Buchung zuordnen",
+      "hint": "Es werden nur Buchungen angezeigt, deren Restbetrag diesen Betrag abdeckt. Eine Ausgabe kann nur einen Teil einer Zeile abdecken: der Rest wartet auf seine eigene Zuordnung.",
+      "none": "Keine Buchung hat Platz für diesen Betrag. Importieren Sie den Auszug des Zeitraums, oder prüfen Sie den Betrag.",
+      "remaining": "noch {{amount}}"
     }
   },
   "pwa": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3544,6 +3544,13 @@
       "allocatedOf": "{{allocated}} allocated out of {{total}}",
       "noAllocation": "Nothing is attached to this operation yet.",
       "remaining": "{{amount}} left to allocate"
+    },
+    "attach": {
+      "title": "Attach to an operation",
+      "action": "Attach to an operation",
+      "hint": "Only operations whose remaining amount covers this expense are listed. An expense may cover just part of a line: the rest will wait for its own allocation.",
+      "none": "No operation has room for this amount. Import the period's statement, or check the expense amount.",
+      "remaining": "{{amount}} left"
     }
   },
   "pwa": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3544,6 +3544,13 @@
       "allocatedOf": "{{allocated}} asignados de {{total}}",
       "noAllocation": "Todavía no hay nada vinculado a esta operación.",
       "remaining": "Quedan {{amount}} por asignar"
+    },
+    "attach": {
+      "title": "Vincular a una operación",
+      "action": "Vincular a una operación",
+      "hint": "Solo se muestran las operaciones cuyo importe restante cubre este gasto. Un gasto puede cubrir solo una parte de una línea: el resto esperará su propia asignación.",
+      "none": "Ninguna operación tiene espacio para este importe. Importa el extracto del periodo, o revisa el importe del gasto.",
+      "remaining": "quedan {{amount}}"
     }
   },
   "pwa": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3544,6 +3544,13 @@
       "allocatedOf": "{{allocated}} ventilés sur {{total}}",
       "noAllocation": "Rien n'est encore rattaché à cette opération.",
       "remaining": "Reste {{amount}} à ventiler"
+    },
+    "attach": {
+      "title": "Rattacher à une opération",
+      "action": "Rattacher à une opération",
+      "hint": "Seules les opérations dont le reste à ventiler couvre ce montant sont proposées. Une dépense peut ne couvrir qu'une partie d'une ligne : le reste attendra sa propre affectation.",
+      "none": "Aucune opération n'a la place pour ce montant. Importez le relevé de la période, ou vérifiez le montant de la dépense.",
+      "remaining": "reste {{amount}}"
     }
   },
   "pwa": {


### PR DESCRIPTION
Deux points du backlog, indépendants mais tous deux de la même famille : de
l'argent que l'app connaît mal.

## 1. Rattacher une dépense à une opération, depuis la dépense

Le rapprochement manuel n'existait que **depuis la ligne**. Or on part souvent de
l'autre bout : on lit « En attente de rapprochement » sur une dépense — le badge
posé par #422 — et on veut désigner l'opération. Le constat était partout, l'action
nulle part.

`AttachToTransactionDialog` est le miroir d'`UnreconciledPicker`.

- **Les candidates viennent du serveur** (`?fits=<montant>`) : seules les sorties
  non internes dont le **reste à ventiler** couvre le montant. Le reste est une
  annotation — le client ne peut pas le calculer — et proposer une ligne trop
  petite offrirait un bouton que `assert_allocation_fits` refuse.
- **Une dépense peut ne couvrir qu'une partie d'une ligne** : 90 € sur 150 €, les
  60 € restants attendent leur propre affectation. C'est exactement ce que le
  matcher refuse de deviner (`score_pair` rejette 60 € d'écart, à raison).
- Tri par écart en jours : à montants compatibles, c'est la seule indication qui
  distingue deux lignes.

## 2. Les dépenses restées à 0 €

Défaut trouvé en #423 : l'ancien formulaire du journal écrivait `amount` et
`supplier` dans `metadata`, alors que ce sont des colonnes depuis `0023`/`0024`.
Plus rien ne lisait ces clés — **une dépense saisie par ce chemin valait 0 €**
dans tous les budgets, tous les totaux et tous les bilans. Pas d'erreur, juste un
chiffre faux.

Le formulaire est parti en #423 ; il restait les données. Migration `0028`, avec
la règle sortie dans `interactions/repairs.py` pour être testable autrement qu'en
rejouant la migration :

- **la colonne gagne toujours** (une clé JSON à côté d'une colonne renseignée est
  un résidu, pas une correction en attente) ;
- **une valeur illisible est laissée absente** plutôt que forcée à zéro — un
  montant faux est pire qu'un montant manquant, qui lui se voit ;
- **les clés sont retirées dans tous les cas**, sinon la source du malentendu
  reste vivante ;
- la migration **imprime son bilan** : le log de déploiement dira combien de
  dépenses étaient concernées. C'est aussi la réponse au « combien y en a-t-il ? »
  que je ne pouvais pas trancher depuis un poste de dev.

Le test qui compte : `TestItActuallyFixesTheFigures` — le total des dépenses passe
de `0.00` à `32.00` après réparation.

## Vérification

- `pytest` : **3485 passed, 2 skipped** — 14 nouveaux (5 sur `fits`, 9 sur la réparation)
- `tsc -b` : 0 erreur — `npm run lint` : 0 erreur (5 warnings antérieurs)
- vitest : 22 passed — i18n ×4, docs `money.md` + `interactions.md`

## Suite

Reste du backlog : le **coût projet net des remboursements** (bloqué par une
décision, voir mon message) et l'**issue #410** (E2E).