### PR TITLE
fix(money): montrer les dépenses déjà saisies avant d'en faire créer une

### DIFF
--- a/apps/banking/tests/test_expense_marker.py
+++ b/apps/banking/tests/test_expense_marker.py
@@ -388,3 +388,72 @@ class TestWhichLinesCouldCarryThisExpense:
 
         assert client.get(f"{self.URL}?fits=beaucoup").status_code == 400
         assert client.get(f"{self.URL}?fits=-10").status_code == 400
+
+
+@pytest.mark.django_db
+class TestTheForgottenExpenseIsOffered:
+    """Le doublon vécu en recette : une dépense saisie, oubliée, puis re-créée.
+
+    L'utilisateur avait saisi une dépense sans la relier. Au moment de ventiler la
+    ligne il en a créé une **nouvelle**, la ligne est devenue pleine, et l'ancienne
+    ne pouvait plus s'y rattacher : le même argent compté deux fois, et un écart
+    « dépense non rapprochée » insoluble.
+
+    Le correctif est en amont — montrer l'existant avant d'offrir d'en fabriquer.
+    Ces tests tiennent la source de cette liste.
+    """
+
+    URL = "/api/interactions/interactions/"
+
+    def subjects(self, client, **params):
+        query = "&".join(f"{k}={v}" for k, v in params.items())
+        body = client.get(f"{self.URL}?{query}").json()
+        items = body["results"] if isinstance(body, dict) else body
+        return [row["subject"] for row in items]
+
+    def test_it_lists_expenses_no_line_justifies(self, ctx):
+        household, user, account, budget, client = ctx
+        loose_expense(household, user, subject="Carrelage oublié")
+        txn = make_txn(account, amount="-90.00")
+        create_bank_expense_interaction(
+            household=household,
+            user=user,
+            transaction=txn,
+            subject="Déjà rapprochée",
+            amount=Decimal("90.00"),
+            budget_id=budget.id,
+        )
+
+        assert self.subjects(client, unreconciled="true") == ["Carrelage oublié"]
+
+    def test_it_ignores_the_conformity_window(self, ctx):
+        """Le piège de la première version, et la raison même du doublon.
+
+        Le sélecteur lisait le détecteur `expense_unreconciled`, borné par la
+        fenêtre. Une dépense saisie **après** le dernier relevé importé — celle
+        qu'on vient de créer, donc celle qu'on risque de re-créer — n'était pas
+        proposée. « Qu'est-ce qui existe déjà » n'est pas « qu'est-ce que je dois
+        réclamer ».
+        """
+        household, user, _, _, client = ctx
+        loose_expense(household, user, day=date(2026, 6, 1), subject="Saisie hier")
+
+        from banking.compliance import summary
+        from banking.detectors import EXPENSE_UNRECONCILED
+
+        flagged = {g.spec.kind: g.open for g in summary(household)}[EXPENSE_UNRECONCILED]
+
+        assert flagged == 0, "hors fenêtre : le contrôle ne la réclame pas, et c'est normal"
+        assert self.subjects(client, unreconciled="true") == ["Saisie hier"]
+
+    def test_it_never_offers_more_than_the_line_can_hold(self, ctx):
+        household, user, _, _, client = ctx
+        loose_expense(household, user, amount="40.00", subject="Tient")
+        loose_expense(household, user, amount="300.00", subject="Trop grosse")
+
+        assert self.subjects(client, unreconciled="true", max_amount="60.00") == ["Tient"]
+
+    def test_a_malformed_ceiling_is_a_400(self, ctx):
+        _, _, _, _, client = ctx
+
+        assert client.get(f"{self.URL}?max_amount=beaucoup").status_code == 400

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -2,6 +2,7 @@
 Interaction views for REST API.
 """
 import uuid
+from decimal import Decimal, InvalidOperation
 from datetime import datetime, timedelta
 
 from django.contrib.contenttypes.models import ContentType
@@ -130,6 +131,26 @@ class InteractionViewSet(viewsets.ModelViewSet):
             excluded = [value.strip() for value in exclude_type.split(',') if value.strip()]
             if excluded:
                 queryset = queryset.exclude(type__in=excluded)
+
+        # « Quelles dépenses déjà saisies pourraient être celle-ci ? » — le vivier
+        # du rattachement manuel, dans les deux sens.
+        #
+        # ⚠️ Volontairement **hors fenêtre de conformité**, contrairement au
+        # détecteur `expense_unreconciled` : celui-ci répond « qu'est-ce que je
+        # dois réclamer ? », celui-là « qu'est-ce qui existe déjà ? ». Une dépense
+        # postérieure au dernier relevé n'est pas un écart, mais elle est
+        # exactement celle qu'on vient de saisir et qu'on risque de re-créer en
+        # double au moment de ventiler.
+        if self.request.query_params.get('unreconciled') == 'true':
+            queryset = queryset.filter(type='expense', bank_transaction__isnull=True)
+
+        # Plafond de montant — ce qui tient dans le reste à ventiler d'une ligne.
+        max_amount = self.request.query_params.get('max_amount')
+        if max_amount:
+            try:
+                queryset = queryset.filter(amount__lte=Decimal(max_amount))
+            except (InvalidOperation, TypeError):
+                raise ValidationError({'max_amount': 'Expected a decimal amount.'})
 
         # Filter by zone
         zone_id = self.request.query_params.get('zone')

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -367,6 +367,27 @@ pour une ligne, il cherche une ligne pour une dépense.
 
 Tests : `banking/tests/test_expense_marker.py::TestWhichLinesCouldCarryThisExpense`.
 
+### Le doublon de ventilation, et pourquoi le sélecteur a changé de source
+
+Cas vécu en recette : une dépense saisie et jamais reliée ; au moment de ventiler
+la ligne, l'utilisateur en crée une **nouvelle**, ayant oublié la première. La
+ligne devient pleine, l'ancienne dépense ne peut plus s'y rattacher
+(`assert_allocation_fits` refuse, à raison), et le même argent est compté deux
+fois — plus un écart « dépense non rapprochée » que rien ne permet de résoudre.
+
+Le correctif est **en amont** : `AllocationDialog` affiche, avant les lignes de
+brouillon, les dépenses déjà saisies qui tiennent dans la ligne. Créer reste
+possible, mais après avoir vu.
+
+⚠️ **`UnreconciledPicker` ne lit plus le détecteur de conformité** mais
+`?unreconciled=true&max_amount=`. C'était le piège, et il expliquait le doublon :
+le détecteur est borné par la fenêtre, donc une dépense saisie *après* le dernier
+relevé importé — celle qu'on vient de créer, donc précisément celle qu'on risque
+de re-créer — n'était pas proposée. **« Qu'est-ce qui existe déjà ? » n'est pas
+« qu'est-ce que je dois réclamer ? »** : la seconde question se borne, la première
+jamais. Régression :
+`banking/tests/test_expense_marker.py::TestTheForgottenExpenseIsOffered`.
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/e2e/expense-adhoc.spec.ts
+++ b/e2e/expense-adhoc.spec.ts
@@ -44,9 +44,11 @@ test('dépense en espèces — Marché 32 €, opération et ventilation ensembl
   // La dépense apparaît dans l'onglet Dépenses — le libellé est saisi tel quel.
   await expect(page.getByText(label).first()).toBeVisible();
 
-  // Et dans le journal du foyer, comme toute dépense.
+  // Et **pas** dans la page Activité : les dépenses en sont sorties, elles ont
+  // leur module. Leur fiche reste accessible, c'est la liste qui ne les mélange
+  // plus aux notes et aux maintenances.
   await page.goto('/app/interactions');
-  await expect(page.getByText(label).first()).toBeVisible();
+  await expect(page.getByText(label)).toHaveCount(0);
 });
 
 test('dépense en espèces — la ligne apparaît dans le journal bancaire', async ({ page }) => {

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link2Off, Plus, Trash2 } from 'lucide-react';
+import UnreconciledPicker from './UnreconciledPicker';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
@@ -197,6 +198,19 @@ export default function AllocationDialog({
             </p>
           ) : null}
         </div>
+
+        {/* ⚠️ Avant de faire créer quoi que ce soit : ce qui existe déjà.
+            Sans ce bloc, on ventile en créant une dépense alors qu'on l'avait
+            saisie la veille — la ligne devient pleine, l'ancienne dépense ne peut
+            plus s'y rattacher, et le même argent est compté deux fois. Le geste
+            de rangement doit montrer l'existant *avant* d'offrir d'en fabriquer. */}
+        {remaining > 0 ? (
+          <UnreconciledPicker
+            transactionId={transactionId}
+            remaining={remaining.toFixed(2)}
+            defaultOpen
+          />
+        ) : null}
 
         {/* Ce que l'éditeur ne possède pas — un achat de projet rapproché à la
             main, une occurrence de récurrence. Enregistrer la ventilation les

--- a/ui/src/features/banking/UnreconciledPicker.tsx
+++ b/ui/src/features/banking/UnreconciledPicker.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
 import { Card } from '@/design-system/card';
 import { Button } from '@/design-system/button';
-import { formatAmount } from '@/lib/format';
-import { useComplianceGroup } from '@/features/money/hooks';
-import { EXPENSE_UNRECONCILED } from '@/features/money/keys';
+import { formatAmount, formatDate } from '@/lib/format';
+import { fetchInteractions } from '@/lib/api/interactions';
+import { interactionKeys } from '@/features/interactions/hooks';
 import { useLinkInteraction } from './hooks';
 
 interface UnreconciledPickerProps {
@@ -12,7 +13,9 @@ interface UnreconciledPickerProps {
   /** Montant encore libre sur la ligne, en string décimale. */
   remaining: string;
   /** Ids déjà proposés par le matcher — on ne les répète pas. */
-  excludeIds: string[];
+  excludeIds?: string[];
+  /** Déplié d'emblée : au moment de ventiler, la question doit se poser seule. */
+  defaultOpen?: boolean;
   onLinked?: () => void;
 }
 
@@ -27,41 +30,45 @@ interface UnreconciledPickerProps {
  * ligne. D'où ce sélecteur explicite, qui assume ce que le matcher refuse de
  * deviner.
  *
- * La liste vient du détecteur `expense_unreconciled` : c'est déjà l'inventaire des
- * dépenses que la banque n'a jamais confirmées, donc exactement le vivier. Les
- * candidates plus grosses que le reste à ventiler sont masquées — le serveur les
- * refuserait (`assert_allocation_fits`), et proposer un bouton qui échoue est pire
- * que ne rien proposer.
+ * ⚠️ La liste vient de `?unreconciled=true&max_amount=`, **pas** du détecteur de
+ * conformité. Elle en venait, et c'était un piège : le détecteur est borné par la
+ * fenêtre de conformité, donc une dépense saisie après le dernier relevé importé
+ * — celle qu'on vient justement de créer et qu'on risque de re-créer en double —
+ * n'était pas proposée. « Qu'est-ce qui existe déjà ? » n'est pas la même question
+ * que « qu'est-ce que je dois réclamer ? ».
+ *
+ * Les candidates plus grosses que le reste à ventiler sont exclues côté serveur :
+ * le serveur les refuserait (`assert_allocation_fits`), et proposer un bouton qui
+ * échoue est pire que ne rien proposer.
  */
 export default function UnreconciledPicker({
   transactionId,
   remaining,
-  excludeIds,
+  excludeIds = [],
+  defaultOpen = false,
   onLinked,
 }: UnreconciledPickerProps) {
   const { t } = useTranslation();
-  const [open, setOpen] = React.useState(false);
-  const groupQuery = useComplianceGroup(open ? EXPENSE_UNRECONCILED : undefined, { limit: 50 });
+  const [open, setOpen] = React.useState(defaultOpen);
   const linkMutation = useLinkInteraction();
 
-  const remainingValue = Number(remaining);
-  const excluded = React.useMemo(() => new Set(excludeIds), [excludeIds]);
+  const filters = React.useMemo(
+    () => ({ unreconciled: true, max_amount: remaining, limit: 50 }),
+    [remaining],
+  );
+  const query = useQuery({
+    queryKey: interactionKeys.list(filters),
+    queryFn: () => fetchInteractions(filters),
+    enabled: Number(remaining) > 0,
+  });
 
-  const candidates = React.useMemo(() => {
-    const rows = groupQuery.data?.results ?? [];
-    return rows
-      .filter((finding) => !excluded.has(finding.object_id))
-      .map((finding) => {
-        const detail = finding.detail as Record<string, string | undefined>;
-        return {
-          id: finding.object_id,
-          subject: detail.subject ?? finding.label,
-          amount: detail.amount ?? '0',
-          occurredAt: detail.occurred_at ?? '',
-        };
-      })
-      .filter((row) => Number(row.amount) <= remainingValue + 0.001);
-  }, [groupQuery.data, excluded, remainingValue]);
+  const excluded = React.useMemo(() => new Set(excludeIds), [excludeIds]);
+  const candidates = React.useMemo(
+    () => (query.data?.items ?? []).filter((item) => !excluded.has(item.id)),
+    [query.data, excluded],
+  );
+
+  if (candidates.length === 0) return null;
 
   if (!open) {
     return (
@@ -72,50 +79,44 @@ export default function UnreconciledPicker({
   }
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 rounded-lg border border-warning/40 bg-warning/5 p-3">
+      <p className="text-xs font-medium text-foreground">
+        {t('banking.reconcile.alreadyTyped', { count: candidates.length })}
+      </p>
       <p className="text-xs text-muted-foreground">
         {t('banking.reconcile.pickExistingHint', { amount: formatAmount(remaining) })}
       </p>
 
-      {groupQuery.isLoading ? (
-        <div className="h-16 animate-pulse rounded-lg bg-muted" />
-      ) : candidates.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          {t('banking.reconcile.noUnreconciled')}
-        </p>
-      ) : (
-        <div className="space-y-1.5">
-          {candidates.map((candidate) => (
-            <Card key={candidate.id} className="flex items-center gap-2 p-2 text-sm">
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-foreground">{candidate.subject}</p>
-                <p className="text-xs text-muted-foreground">
-                  {candidate.occurredAt
-                    ? new Date(candidate.occurredAt).toLocaleDateString()
-                    : ''}
-                </p>
-              </div>
-              <span className="shrink-0 tabular-nums text-foreground">
-                {formatAmount(candidate.amount)}
-              </span>
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                disabled={linkMutation.isPending}
-                onClick={() =>
-                  linkMutation.mutate(
-                    { transactionId, interactionId: candidate.id },
-                    { onSuccess: () => onLinked?.() },
-                  )
-                }
-              >
-                {t('banking.reconcile.attach')}
-              </Button>
-            </Card>
-          ))}
-        </div>
-      )}
+      <div className="space-y-1.5">
+        {candidates.map((candidate) => (
+          <Card key={candidate.id} className="flex items-center gap-2 p-2 text-sm">
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-foreground">{candidate.subject}</p>
+              <p className="text-xs text-muted-foreground">
+                {formatDate(candidate.occurred_at)}
+                {candidate.supplier ? ` · ${candidate.supplier}` : ''}
+              </p>
+            </div>
+            <span className="shrink-0 tabular-nums text-foreground">
+              {formatAmount(candidate.amount)}
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={linkMutation.isPending}
+              onClick={() =>
+                linkMutation.mutate(
+                  { transactionId, interactionId: candidate.id },
+                  { onSuccess: () => onLinked?.() },
+                )
+              }
+            >
+              {t('banking.reconcile.attach')}
+            </Button>
+          </Card>
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/src/features/interactions/hooks.ts
+++ b/ui/src/features/interactions/hooks.ts
@@ -22,7 +22,7 @@ interface InteractionFilters {
   end_date?: string;
   limit?: number;
   offset?: number;
-  [key: string]: string | number | undefined;
+  [key: string]: string | number | boolean | undefined;
 }
 
 export const interactionKeys = {

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -109,6 +109,15 @@ interface FetchInteractionsOptions {
    * annonce huit.
    */
   exclude_type?: string;
+  /**
+   * `true` = les dépenses qu'aucune ligne ne justifie encore — le vivier du
+   * rattachement manuel. **Hors fenêtre de conformité**, contrairement au
+   * détecteur : ici la question est « qu'est-ce qui existe déjà ? », pas
+   * « qu'est-ce que je dois réclamer ? ».
+   */
+  unreconciled?: boolean;
+  /** Plafond de montant : ce qui tient dans le reste à ventiler d'une ligne. */
+  max_amount?: string;
   zone?: string;
   contact?: string;
   structure?: string;
@@ -175,6 +184,8 @@ export async function fetchInteractions(
     search,
     type,
     exclude_type,
+    unreconciled,
+    max_amount,
     zone,
     contact,
     structure,
@@ -192,6 +203,8 @@ export async function fetchInteractions(
   if (search) params.search = search;
   if (type) params.type = type;
   if (exclude_type) params.exclude_type = exclude_type;
+  if (unreconciled) params.unreconciled = 'true';
+  if (max_amount) params.max_amount = max_amount;
   if (zone) params.zone = zone;
   if (contact) params.contact = contact;
   if (structure) params.structure = structure;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3485,7 +3485,9 @@
       "noUnreconciled": "Keine nicht abgeglichene Ausgabe passt in den Rest.",
       "attach": "Verknüpfen",
       "recurringConfirmed": "{{count}} Fälligkeit bestätigt",
-      "recurringConfirmed_other": "{{count}} Fälligkeiten bestätigt"
+      "recurringConfirmed_other": "{{count}} Fälligkeiten bestätigt",
+      "alreadyTyped_one": "1 bereits erfasste Ausgabe passt in diese Zeile",
+      "alreadyTyped_other": "{{count}} bereits erfasste Ausgaben passen in diese Zeile"
     },
     "inflow": {
       "title": "Diese Einnahme einordnen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3485,7 +3485,9 @@
       "noUnreconciled": "No unreconciled expense fits in what is left.",
       "attach": "Attach",
       "recurringConfirmed": "{{count}} recurrence confirmed",
-      "recurringConfirmed_other": "{{count}} recurrences confirmed"
+      "recurringConfirmed_other": "{{count}} recurrences confirmed",
+      "alreadyTyped_one": "1 expense already typed fits in this line",
+      "alreadyTyped_other": "{{count}} expenses already typed fit in this line"
     },
     "inflow": {
       "title": "Classify this receipt",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3485,7 +3485,9 @@
       "noUnreconciled": "Ningún gasto sin conciliar cabe en lo que queda.",
       "attach": "Vincular",
       "recurringConfirmed": "{{count}} vencimiento confirmado",
-      "recurringConfirmed_other": "{{count}} vencimientos confirmados"
+      "recurringConfirmed_other": "{{count}} vencimientos confirmados",
+      "alreadyTyped_one": "1 gasto ya registrado cabe en esta línea",
+      "alreadyTyped_other": "{{count}} gastos ya registrados caben en esta línea"
     },
     "inflow": {
       "title": "Clasificar este ingreso",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3485,7 +3485,9 @@
       "noUnreconciled": "Aucune dépense non rapprochée ne tient dans le reste.",
       "attach": "Rattacher",
       "recurringConfirmed": "{{count}} échéance confirmée",
-      "recurringConfirmed_other": "{{count}} échéances confirmées"
+      "recurringConfirmed_other": "{{count}} échéances confirmées",
+      "alreadyTyped_one": "1 dépense déjà saisie tient dans cette ligne",
+      "alreadyTyped_other": "{{count}} dépenses déjà saisies tiennent dans cette ligne"
     },
     "inflow": {
       "title": "Classer cette recette",


### PR DESCRIPTION
## Le doublon que tu as vécu

Une dépense saisie et jamais reliée ; au moment de ventiler la ligne, tu en crées
une **nouvelle** en ayant oublié la première. La ligne devient pleine, l'ancienne
ne peut plus s'y rattacher — `assert_allocation_fits` refuse, à raison — et le
même argent est compté deux fois, avec en prime un écart « dépense non
rapprochée » que plus rien ne permet de résoudre.

La sortie existait (rouvrir la ventilation, supprimer la ligne créée, rattacher
l'ancienne) mais elle était invisible. Donc elle n'existait pas.

**Le correctif est en amont** : le dialogue de ventilation affiche les dépenses
déjà saisies qui tiennent dans la ligne, avant les lignes de brouillon. Créer
reste possible, mais après avoir vu.

## ⚠️ Et le sélecteur change de source — c'est ça qui expliquait le doublon

`UnreconciledPicker` lisait le **détecteur de conformité**. Or celui-ci est borné
par la fenêtre : une dépense saisie *après* le dernier relevé importé — celle
qu'on vient de créer, donc précisément celle qu'on risque de re-créer — n'était
pas proposée.

> « Qu'est-ce qui existe déjà ? » n'est pas « qu'est-ce que je dois réclamer ? ».
> La seconde question se borne, la première jamais.

Nouvelle source : `?unreconciled=true&max_amount=`. Régression :
`TestTheForgottenExpenseIsOffered`, dont un test vérifie explicitement qu'une
dépense **hors fenêtre** (que le Contrôle ne réclame pas) est bien proposée.

## Un échec E2E réparé, et le décompte de #410

J'ai lancé la suite complète : **54 échecs / 267 passés**. Un seul nous est
imputable — `expense-adhoc.spec.ts:35` affirmait qu'une dépense en espèces se lit
« dans le journal du foyer, comme toute dépense », ce que #423 a supprimé.
L'assertion est **inversée** plutôt que retirée : que les dépenses ne soient plus
dans cette liste est la règle, et une règle sans test se perd.

Les 53 autres correspondent au périmètre décrit dans #410 (electricity 12,
weather 8, project-detail-tabs 6, chickens 5, shopping-list 4, recurring 4…).
Je n'ai pas rejoué la base de référence, donc je ne l'affirme pas : je constate
que le total colle.

## Vérification

- `pytest` : **3489 passed, 2 skipped** — 4 nouveaux sur la source des candidates
- `tsc -b` : 0 erreur — `npm run lint` : 0 erreur (5 warnings antérieurs)
- E2E `expense-adhoc.spec.ts` : **6 passed**
- i18n ×4 (pluriels), doc `money.md`