### PR TITLE
fix(money): le rattachement était devenu inatteignable

### DIFF
--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -1,9 +1,13 @@
+import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Link2 } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
+import { Button } from '@/design-system/button';
 import { formatAmount, formatDate } from '@/lib/format';
 import ReconciliationBadge from '@/features/money/ReconciliationBadge';
+import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
 import type { InteractionListItem } from '@/lib/api/interactions';
 
 interface ExpenseListProps {
@@ -13,48 +17,84 @@ interface ExpenseListProps {
 export default function ExpenseList({ items }: ExpenseListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const [attachTarget, setAttachTarget] = React.useState<InteractionListItem | null>(null);
 
   return (
-    <ul className="space-y-2">
-      {items.map((item) => {
-        const amount = item.amount ? formatAmount(item.amount) : null;
-        return (
-          <li key={item.id}>
-            <Card
-              className="cursor-pointer p-3 transition-shadow hover:shadow-md"
-              onClick={() => navigate(`/app/interactions/${item.id}/edit`)}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <CardTitle>{item.subject}</CardTitle>
-                    {item.kind ? (
-                      <Badge variant="outline" className="text-xs">
-                        {t(`expenses.kind.${item.kind}`)}
-                      </Badge>
-                    ) : null}
-                    <ReconciliationBadge
-                      state={item.reconciliation_state}
-                      line={item.bank_line}
-                    />
+    <>
+      <ul className="space-y-2">
+        {items.map((item) => {
+          const amount = item.amount ? formatAmount(item.amount) : null;
+          // Le geste va là où le constat s'affiche. Il vivait sur la fiche d'une
+          // dépense — devenue inatteignable depuis que les dépenses ont quitté la
+          // page Activité, qui était le seul chemin vers elle. Une action qu'on ne
+          // peut pas atteindre n'existe pas.
+          const canAttach = !item.bank_line && Boolean(item.amount);
+
+          return (
+            <li key={item.id}>
+              <Card
+                className="cursor-pointer p-3 transition-shadow hover:shadow-md"
+                onClick={() => navigate(`/app/interactions/${item.id}/edit`)}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <CardTitle>{item.subject}</CardTitle>
+                      {item.kind ? (
+                        <Badge variant="outline" className="text-xs">
+                          {t(`expenses.kind.${item.kind}`)}
+                        </Badge>
+                      ) : null}
+                      <ReconciliationBadge
+                        state={item.reconciliation_state}
+                        line={item.bank_line}
+                      />
+                    </div>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+                      <span>{formatDate(item.occurred_at)}</span>
+                      {item.supplier ? <span>{item.supplier}</span> : null}
+                      {canAttach ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="h-6 px-2 text-xs"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setAttachTarget(item);
+                          }}
+                        >
+                          <Link2 className="mr-1 h-3 w-3" />
+                          {t('banking.attach.action')}
+                        </Button>
+                      ) : null}
+                    </div>
                   </div>
-                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
-                    <span>{formatDate(item.occurred_at)}</span>
-                    {item.supplier ? <span>{item.supplier}</span> : null}
-                  </div>
+                  {amount ? (
+                    <p className="shrink-0 text-base font-semibold tabular-nums">{amount}</p>
+                  ) : (
+                    <p className="shrink-0 text-xs italic text-muted-foreground">
+                      {t('expenses.list.noAmount')}
+                    </p>
+                  )}
                 </div>
-                {amount ? (
-                  <p className="shrink-0 text-base font-semibold tabular-nums">{amount}</p>
-                ) : (
-                  <p className="shrink-0 text-xs italic text-muted-foreground">
-                    {t('expenses.list.noAmount')}
-                  </p>
-                )}
-              </div>
-            </Card>
-          </li>
-        );
-      })}
-    </ul>
+              </Card>
+            </li>
+          );
+        })}
+      </ul>
+
+      {attachTarget ? (
+        <AttachToTransactionDialog
+          open
+          onOpenChange={(next) => !next && setAttachTarget(null)}
+          expense={{
+            id: attachTarget.id,
+            subject: attachTarget.subject,
+            amount: attachTarget.amount ?? null,
+            occurred_at: attachTarget.occurred_at,
+          }}
+        />
+      ) : null}
+    </>
   );
 }


### PR DESCRIPTION
## Le défaut

Signalé en recette : « je ne vois pas dans l'interface, à partir d'une dépense,
rattacher une ligne ». C'est exact, et c'est un **effet de composition** de trois
PR justes isolément :

| PR | Ce qu'elle a fait |
|---|---|
| #422 | pose le champ « Rapprochement » sur la **fiche** d'une dépense |
| #425 | y ajoute le bouton « Rattacher à une opération » |
| #423 | retire les dépenses de la page Activité — **le seul écran qui menait à cette fiche** |

Depuis l'onglet Dépenses, cliquer une dépense ouvre `/app/interactions/:id/edit`,
pas `/app/interactions/:id`. Le bouton existait donc sur une page qu'on ne pouvait
plus atteindre. **Une action inatteignable n'existe pas.**

## Le correctif

Le geste rejoint le constat, dans la liste : sur toute dépense qu'aucune ligne ne
justifie, un bouton « Rattacher à une opération » à côté du badge qui l'annonce.
Même principe que partout ailleurs dans ce module — le reproche et le moyen de le
lever au même endroit.

Le dialogue est le même qu'en #425 (`AttachToTransactionDialog`) : les candidates
viennent du serveur avec `?fits=`, une dépense peut ne couvrir qu'une partie d'une
ligne, tri par écart de dates.

## Ce qu'il reste à décider (inchangé)

La fiche d'une dépense reste peu atteignable. Deux options, à trancher : faire
pointer la liste vers la fiche plutôt que vers l'édition (un clic de plus pour
éditer), ou assumer que l'édition est la destination normale et que la fiche ne
sert qu'aux liens venus d'ailleurs. Je n'ai pas tranché seul — c'est un choix de
navigation.

## Vérification

- `tsc -b` : 0 erreur — `npm run lint` : 0 erreur (5 warnings antérieurs)
- vitest : 22 passed
- Aucun changement backend, aucune nouvelle clé i18n (`banking.attach.action` existe déjà)