### PR TITLE
fix(money): détacher une dépense de son opération, depuis la dépense

### DIFF
--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -367,6 +367,28 @@ pour une ligne, il cherche une ligne pour une dépense.
 
 Tests : `banking/tests/test_expense_marker.py::TestWhichLinesCouldCarryThisExpense`.
 
+### …et s'en dédire au même endroit
+
+Le détachement existait côté relevé (bloc « Dépenses déjà rattachées ») et nulle
+part côté dépense : on pouvait donc désigner la mauvaise opération d'un clic sans
+pouvoir revenir en arrière depuis l'écran où l'erreur se lit. **Un geste réversible
+dont l'annulation vit dans un autre module n'est pas réversible en pratique.**
+`DetachFromTransactionButton` est posé partout où le badge s'affiche avec une
+opération : liste des dépenses, fiche d'une dépense.
+
+⚠️ **Sauf sur une dépense `kind='bank'`**, et c'est la seule subtilité. Celle-là
+n'a pas été rapprochée : elle **est** la ventilation de l'opération. La détacher
+ne libère rien — elle fabrique d'un seul geste une dépense que plus rien ne
+justifie *et* une sortie redevenue partiellement ventilée : deux écarts pour le
+même argent, exactement ce que le module existe pour supprimer. Le bouton ne s'y
+affiche pas ; le badge mène à l'opération, où la retirer veut dire quelque chose.
+
+La règle de propriété est donc désormais déclarée **une fois** côté front
+(`banking/ownership.ts`, miroir de `interactions/kinds.py::OWNED_BY_ALLOCATION_EDITOR`)
+et consommée par l'éditeur de ventilation comme par le bouton — elle était recopiée
+dans `AllocationDialog`, et une règle recopiée est une règle qui divergera.
+Régression : `ui/src/features/banking/DetachFromTransactionButton.test.tsx`.
+
 ### Le doublon de ventilation, et pourquoi le sélecteur a changé de source
 
 Cas vécu en recette : une dépense saisie et jamais reliée ; au moment de ventiler

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -14,6 +14,7 @@ import { useBudgets } from '@/features/budget/hooks';
 import { useAllocations, useSetAllocations, useUnlinkAllocation } from './hooks';
 import AllocationSourceSelect from './AllocationSourceSelect';
 import { NO_SOURCE, type AllocationSource } from './allocationSource';
+import { isOwnedByAllocationEditor } from './ownership';
 
 interface AllocationDialogProps {
   open: boolean;
@@ -36,16 +37,6 @@ interface DraftLine {
   source: AllocationSource;
   zoneIds: string[];
 }
-
-/**
- * Le `kind` que cet éditeur possède — miroir de
- * `interactions/kinds.py::OWNED_BY_ALLOCATION_EDITOR`.
- *
- * Tout le reste (un achat de projet, une occurrence de récurrence) a été
- * rapproché ailleurs, délibérément : l'éditeur l'affiche, le compte contre le
- * montant de l'opération, et n'y touche pas.
- */
-const OWNED_KIND = 'bank';
 
 let lineCounter = 0;
 function blankLine(
@@ -86,7 +77,7 @@ export default function AllocationDialog({
   const total = Math.abs(Number(transaction?.amount ?? 0));
 
   // Les dépenses rapprochées ailleurs : affichées, comptées, jamais réécrites.
-  const linked = (allocationsQuery.data?.allocations ?? []).filter((a) => a.kind !== OWNED_KIND);
+  const linked = (allocationsQuery.data?.allocations ?? []).filter((a) => !isOwnedByAllocationEditor(a.kind));
   const linkedTotal = linked.reduce((sum, a) => sum + Number(a.amount ?? 0), 0);
   /** Ce que cette ventilation peut se partager : l'opération moins les rattachements. */
   const editable = total - linkedTotal;
@@ -95,9 +86,9 @@ export default function AllocationDialog({
     if (!open || !allocationsQuery.data) return;
     setError(null);
     const rows = allocationsQuery.data.allocations;
-    const owned = rows.filter((a) => a.kind === OWNED_KIND);
+    const owned = rows.filter((a) => isOwnedByAllocationEditor(a.kind));
     const free =
-      total - rows.filter((a) => a.kind !== OWNED_KIND).reduce((s, a) => s + Number(a.amount ?? 0), 0);
+      total - rows.filter((a) => !isOwnedByAllocationEditor(a.kind)).reduce((s, a) => s + Number(a.amount ?? 0), 0);
     setLines(
       owned.length > 0
         ? owned.map((a) =>

--- a/ui/src/features/banking/DetachFromTransactionButton.test.tsx
+++ b/ui/src/features/banking/DetachFromTransactionButton.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DetachFromTransactionButton from './DetachFromTransactionButton';
+
+const mutate = vi.fn();
+
+vi.mock('./hooks', () => ({
+  useUnlinkAllocation: () => ({ mutate, isPending: false }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+describe('DetachFromTransactionButton', () => {
+  beforeEach(() => mutate.mockClear());
+
+  it('détache la dépense de son opération', async () => {
+    const user = userEvent.setup();
+    render(
+      <DetachFromTransactionButton expenseId="exp-1" kind="manual" transactionId="txn-9" />,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(mutate).toHaveBeenCalledWith({ transactionId: 'txn-9', interactionId: 'exp-1' });
+  });
+
+  it.each(['project_purchase', 'recurring', 'stock_purchase', undefined])(
+    'reste offert sur une dépense rapprochée ailleurs (kind=%s)',
+    (kind) => {
+      render(<DetachFromTransactionButton expenseId="exp-1" kind={kind} transactionId="txn-9" />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    },
+  );
+
+  it("ne s'affiche pas sur une dépense née de la ventilation", () => {
+    // ⚠️ Le cœur de la règle. Détacher une dépense `kind='bank'` ne libère rien :
+    // elle *est* la ventilation. Le geste produirait d'un coup une dépense que
+    // plus rien ne justifie et une sortie redevenue partiellement ventilée —
+    // deux écarts pour le même argent, exactement ce que le module supprime.
+    render(<DetachFromTransactionButton expenseId="exp-1" kind="bank" transactionId="txn-9" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/banking/DetachFromTransactionButton.tsx
+++ b/ui/src/features/banking/DetachFromTransactionButton.tsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+import { Link2Off } from 'lucide-react';
+import { Button } from '@/design-system/button';
+import { useUnlinkAllocation } from './hooks';
+import { isOwnedByAllocationEditor } from './ownership';
+
+interface DetachFromTransactionButtonProps {
+  expenseId: string;
+  /** Discriminateur de la dépense — décide si le geste lui est applicable. */
+  kind?: string | null;
+  /** L'opération dont on la détache (`bank_line.id`). */
+  transactionId: string;
+  className?: string;
+}
+
+/**
+ * Détacher une dépense de l'opération qui la justifiait — l'inverse exact du
+ * rattachement, au même endroit que lui.
+ *
+ * Le geste existait déjà côté relevé (bloc « Dépenses déjà rattachées » de
+ * l'éditeur de ventilation), mais nulle part côté dépense : on pouvait donc
+ * rattacher la mauvaise ligne depuis la liste des dépenses sans pouvoir s'en
+ * dédire depuis le même écran. Un geste réversible dont l'annulation vit dans un
+ * autre module n'est pas réversible en pratique.
+ *
+ * Ne rend rien sur une dépense née de la ventilation (voir `ownership.ts`) : là,
+ * le badge mène déjà à l'opération, seul endroit où la retirer a un sens.
+ */
+export default function DetachFromTransactionButton({
+  expenseId,
+  kind,
+  transactionId,
+  className = 'h-6 px-2 text-xs',
+}: DetachFromTransactionButtonProps) {
+  const { t } = useTranslation();
+  const mutation = useUnlinkAllocation();
+
+  if (isOwnedByAllocationEditor(kind)) return null;
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className={className}
+      disabled={mutation.isPending}
+      title={t('banking.allocation.linked.detach')}
+      onClick={(e) => {
+        e.stopPropagation();
+        mutation.mutate({ transactionId, interactionId: expenseId });
+      }}
+    >
+      <Link2Off className="mr-1 h-3 w-3" />
+      {t('banking.attach.detach')}
+    </Button>
+  );
+}

--- a/ui/src/features/banking/ownership.ts
+++ b/ui/src/features/banking/ownership.ts
@@ -1,0 +1,20 @@
+/**
+ * Ce que l'éditeur de ventilation **possède** — miroir de
+ * `apps/interactions/kinds.py::OWNED_BY_ALLOCATION_EDITOR`.
+ *
+ * Une dépense `kind='bank'` n'existe que parce qu'on a ventilé une ligne : elle
+ * est *la ventilation*, pas un fait rapproché après coup. La détacher ne libère
+ * rien — elle fabrique deux écarts d'un seul geste (une dépense que plus rien ne
+ * justifie, et une sortie redevenue partiellement ventilée) pour le même argent.
+ * Ce qu'on veut dans ce cas, c'est modifier ou supprimer la ventilation, depuis
+ * l'opération.
+ *
+ * Tout le reste (un achat de projet, une occurrence de récurrence, une dépense
+ * saisie à la main) a été rapproché délibérément : détacher est alors le geste
+ * inverse exact du rattachement, et il doit exister des deux côtés.
+ */
+const OWNED_KINDS = new Set(['bank']);
+
+export function isOwnedByAllocationEditor(kind: string | null | undefined): boolean {
+  return OWNED_KINDS.has(kind ?? '');
+}

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/design-system/button';
 import { formatAmount, formatDate } from '@/lib/format';
 import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
+import DetachFromTransactionButton from '@/features/banking/DetachFromTransactionButton';
 import type { InteractionListItem } from '@/lib/api/interactions';
 
 interface ExpenseListProps {
@@ -66,6 +67,16 @@ export default function ExpenseList({ items }: ExpenseListProps) {
                           <Link2 className="mr-1 h-3 w-3" />
                           {t('banking.attach.action')}
                         </Button>
+                      ) : null}
+                      {/* Et son inverse, à la même place : rattacher la mauvaise
+                          ligne est une erreur d'un clic, s'en dédire ne doit pas
+                          demander d'aller la chercher dans l'autre module. */}
+                      {item.bank_line ? (
+                        <DetachFromTransactionButton
+                          expenseId={item.id}
+                          kind={item.kind}
+                          transactionId={item.bank_line.id}
+                        />
                       ) : null}
                     </div>
                   </div>

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -16,6 +16,8 @@ import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { formatAmount, formatDateTime } from '@/lib/format';
 import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
+import DetachFromTransactionButton from '@/features/banking/DetachFromTransactionButton';
+import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
 import { useInteraction, useDeleteInteraction } from './hooks';
 
 // ── Main page ──────────────────────────────────────────────
@@ -144,9 +146,27 @@ export default function InteractionDetailPage() {
                   line={interaction.bank_line}
                 />
                 {interaction.bank_line ? (
-                  <p className="text-xs text-muted-foreground">
-                    {interaction.bank_line.account_name} · {interaction.bank_line.label}
-                  </p>
+                  <>
+                    <p className="text-xs text-muted-foreground">
+                      {interaction.bank_line.account_name} · {interaction.bank_line.label}
+                    </p>
+                    {isOwnedByAllocationEditor(interaction.kind) ? (
+                      /* Née de la ventilation : la détacher ici fabriquerait une
+                         dépense que plus rien ne justifie **et** une sortie
+                         redevenue incomplète. Le badge mène à l'opération, où la
+                         retirer veut dire quelque chose. */
+                      <p className="text-xs text-muted-foreground">
+                        {t('banking.attach.ownedHint')}
+                      </p>
+                    ) : (
+                      <DetachFromTransactionButton
+                        expenseId={interaction.id}
+                        kind={interaction.kind}
+                        transactionId={interaction.bank_line.id}
+                        className="h-7 px-2 text-xs"
+                      />
+                    )}
+                  </>
                 ) : (
                   /* Le constat sans le geste à côté n'aide personne : c'est ici
                      qu'on lit « en attente », donc c'est ici qu'on doit pouvoir

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3552,7 +3552,9 @@
       "action": "Einer Buchung zuordnen",
       "hint": "Es werden nur Buchungen angezeigt, deren Restbetrag diesen Betrag abdeckt. Eine Ausgabe kann nur einen Teil einer Zeile abdecken: der Rest wartet auf seine eigene Zuordnung.",
       "none": "Keine Buchung hat Platz für diesen Betrag. Importieren Sie den Auszug des Zeitraums, oder prüfen Sie den Betrag.",
-      "remaining": "noch {{amount}}"
+      "remaining": "noch {{amount}}",
+      "detach": "Lösen",
+      "ownedHint": "Diese Ausgabe ist die Aufteilung der Buchung: Um sie zu entfernen, bearbeiten Sie die Aufteilung in der Buchung."
     }
   },
   "pwa": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3552,7 +3552,9 @@
       "action": "Attach to an operation",
       "hint": "Only operations whose remaining amount covers this expense are listed. An expense may cover just part of a line: the rest will wait for its own allocation.",
       "none": "No operation has room for this amount. Import the period's statement, or check the expense amount.",
-      "remaining": "{{amount}} left"
+      "remaining": "{{amount}} left",
+      "detach": "Detach",
+      "ownedHint": "This expense *is* the operation's allocation: to remove it, edit the allocation from the operation."
     }
   },
   "pwa": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3552,7 +3552,9 @@
       "action": "Vincular a una operación",
       "hint": "Solo se muestran las operaciones cuyo importe restante cubre este gasto. Un gasto puede cubrir solo una parte de una línea: el resto esperará su propia asignación.",
       "none": "Ninguna operación tiene espacio para este importe. Importa el extracto del periodo, o revisa el importe del gasto.",
-      "remaining": "quedan {{amount}}"
+      "remaining": "quedan {{amount}}",
+      "detach": "Desvincular",
+      "ownedHint": "Este gasto es la asignación de la operación: para quitarlo, edita la asignación desde la operación."
     }
   },
   "pwa": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3552,7 +3552,9 @@
       "action": "Rattacher à une opération",
       "hint": "Seules les opérations dont le reste à ventiler couvre ce montant sont proposées. Une dépense peut ne couvrir qu'une partie d'une ligne : le reste attendra sa propre affectation.",
       "none": "Aucune opération n'a la place pour ce montant. Importez le relevé de la période, ou vérifiez le montant de la dépense.",
-      "remaining": "reste {{amount}}"
+      "remaining": "reste {{amount}}",
+      "detach": "Détacher",
+      "ownedHint": "Cette dépense est la ventilation de l'opération : pour la retirer, modifiez la ventilation depuis l'opération."
     }
   },
   "pwa": {


### PR DESCRIPTION
## Ce que ça corrige

Question de recette : « je ne peux pas enlever l'affectation d'une ligne sur une dépense ? » — non, et c'était un trou.

Le rattachement manuel se fait depuis les deux rives (#422, #427). Son inverse n'existait que d'un côté : le bloc « Dépenses déjà rattachées » de l'éditeur de ventilation, atteignable seulement depuis le relevé. Désigner la mauvaise opération est une erreur d'un clic ; s'en dédire imposait d'aller la chercher dans l'autre module.

## Ce que ça fait

- Bouton **Détacher** partout où le badge s'affiche avec une opération : liste des dépenses, fiche d'une dépense.
- **Aucun changement serveur** — `DELETE /api/banking/transactions/{id}/unlink/{interaction}/` existait déjà, testé.
- La règle de propriété (`kind='bank'`) était recopiée dans `AllocationDialog` ; elle est déclarée une fois dans `banking/ownership.ts` et consommée par les deux.

## Le seul point de conception

Une dépense `kind='bank'` n'a pas été rapprochée : elle **est** la ventilation de la ligne. La détacher ne libère rien — elle produit d'un seul geste une dépense que plus rien ne justifie *et* une sortie redevenue partiellement ventilée : deux écarts pour le même argent, ce que le module existe pour supprimer. Le bouton ne s'y affiche pas, et la fiche dit pourquoi en une ligne plutôt que de laisser un bouton manquant sans motif. Le badge mène à l'opération, où retirer la ligne veut dire quelque chose.

Ça couvre aussi les dépenses en espèces : `record_cash_expense` passe par `set_allocations`, donc `kind='bank'` — détacher une dépense espèces de sa propre ligne espèces n'aurait jamais de sens.

## Vérification

- `DetachFromTransactionButton.test.tsx` — 6 cas, dont la non-apparition sur `kind='bank'`.
- `vitest` : 28/28. `tsc -b ui` : propre. `eslint` : 0 erreur.
- i18n ×4 (`banking.attach.detach`, `banking.attach.ownedHint`).
- `docs/MODULES/money.md` : section « …et s'en dédire au même endroit ».