### PR TITLE
feat(money): un budget sur tous les formulaires de dépense, création comme édition

### DIFF
--- a/apps/chickens/serializers.py
+++ b/apps/chickens/serializers.py
@@ -123,6 +123,12 @@ class ChickenPurchaseSerializer(serializers.Serializer):
     supplier = serializers.CharField(max_length=255, required=False, allow_blank=True, default='')
     occurred_at = serializers.DateTimeField(required=False, allow_null=True)
     notes = serializers.CharField(required=False, allow_blank=True, default='')
+    # Enveloppe à laquelle imputer l'achat. Facultative, mais son absence est
+    # l'écart `expense_without_budget` : sans budget, un euro n'est classé par
+    # aucun axe (projet et zone disent *sur quoi* et *où*, pas *de quelle
+    # nature*). L'offrir à la saisie évite de fabriquer l'écart puis de le
+    # réparer.
+    budget_id = serializers.UUIDField(required=False, allow_null=True)
 
 
 class ChickenSettingsSerializer(serializers.ModelSerializer):

--- a/apps/chickens/views.py
+++ b/apps/chickens/views.py
@@ -13,7 +13,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 
 from core.permissions import IsHouseholdMember
 from documents.mixins import DocumentLinkActionsMixin
-from interactions.services import create_expense_interaction
+from interactions.services import create_expense_interaction, validate_expense_budget
 
 from . import services
 from .models import Chicken, ChickenEvent, EggLog
@@ -87,6 +87,10 @@ class ChickenViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
         serializer = ChickenPurchaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
+        budget_id = validate_expense_budget(
+            chicken.household_id, serializer.validated_data.get('budget_id')
+        )
+
         interaction = create_expense_interaction(
             source=chicken,
             user=request.user,
@@ -95,6 +99,7 @@ class ChickenViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
             occurred_at=serializer.validated_data.get('occurred_at') or timezone.now(),
             notes=serializer.validated_data.get('notes', '') or '',
             kind='chickens_purchase',
+            budget_id=budget_id,
         )
 
         payload = ChickenSerializer(chicken, context=self.get_serializer_context()).data

--- a/apps/equipment/serializers.py
+++ b/apps/equipment/serializers.py
@@ -16,6 +16,12 @@ class EquipmentPurchaseSerializer(serializers.Serializer):
     supplier = serializers.CharField(required=False, allow_blank=True, default="")
     occurred_at = serializers.DateTimeField(required=False, allow_null=True)
     notes = serializers.CharField(required=False, allow_blank=True, default="")
+    # Enveloppe à laquelle imputer l'achat. Facultative, mais son absence est
+    # l'écart `expense_without_budget` : sans budget, un euro n'est classé par
+    # aucun axe (projet et zone disent *sur quoi* et *où*, pas *de quelle
+    # nature*). L'offrir à la saisie évite de fabriquer l'écart puis de le
+    # réparer.
+    budget_id = serializers.UUIDField(required=False, allow_null=True)
 
 
 class EquipmentSerializer(serializers.ModelSerializer):

--- a/apps/equipment/views.py
+++ b/apps/equipment/views.py
@@ -11,7 +11,7 @@ from rest_framework.response import Response
 from core.permissions import IsHouseholdMember
 from documents.mixins import DocumentLinkActionsMixin
 from interactions.models import Interaction
-from interactions.services import create_expense_interaction
+from interactions.services import create_expense_interaction, validate_expense_budget
 from .models import Equipment, EquipmentInteraction
 from .serializers import (
     EquipmentInteractionSerializer,
@@ -60,6 +60,9 @@ class EquipmentViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
         supplier = serializer.validated_data.get("supplier", "") or ""
         occurred_at = serializer.validated_data.get("occurred_at") or timezone.now()
         notes = serializer.validated_data.get("notes", "") or ""
+        budget_id = validate_expense_budget(
+            equipment.household_id, serializer.validated_data.get("budget_id")
+        )
 
         with transaction.atomic():
             # Equipment-specific snapshot of the most recent purchase
@@ -82,6 +85,7 @@ class EquipmentViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
                 occurred_at=occurred_at,
                 notes=notes,
                 kind="equipment_purchase",
+                budget_id=budget_id,
                 extra_metadata={"equipment_name": equipment.name},
             )
 

--- a/apps/interactions/services.py
+++ b/apps/interactions/services.py
@@ -164,6 +164,27 @@ def _resolve_expense_budget(household_id, budget_id):
     return budget
 
 
+def validate_expense_budget(household_id, budget_id):
+    """Check a client-supplied budget id, as a **400** rather than a 500.
+
+    Every purchase endpoint now accepts a budget, and the resolver signals a
+    foreign or global budget with ``ValueError`` — which, raised from inside a
+    view, is a server error on what is a plain client mistake. Same reasoning
+    as ``banking.services.set_allocations``, and one message instead of five.
+
+    Returns the id unchanged so the caller can pass it straight on: the
+    resolution itself happens once, inside the creator, in the same
+    transaction.
+    """
+    from rest_framework.exceptions import ValidationError
+
+    try:
+        _resolve_expense_budget(household_id, budget_id)
+    except ValueError as exc:
+        raise ValidationError({"budget_id": str(exc)})
+    return budget_id
+
+
 def _resolve_household_zones(household, zone_ids) -> list[Zone]:
     """Resolve zone ids to Zone instances scoped to the household, order preserved.
 

--- a/apps/interactions/tests/test_purchase_budget.py
+++ b/apps/interactions/tests/test_purchase_budget.py
@@ -1,0 +1,238 @@
+# interactions/tests/test_purchase_budget.py
+"""Le budget se saisit sur **tous** les formulaires d'achat.
+
+`Interaction.budget` est le seul axe qui classe un euro (projet et zone disent
+*sur quoi* et *où*, pas *de quelle nature*), et le détecteur
+`expense_without_budget` en réclame un sur chaque dépense de la fenêtre. Or les
+cinq chemins d'achat de l'app — stock, équipement, projet, poule, liste de
+courses — créaient jusqu'ici des dépenses sans budget, **sans même offrir le
+champ**. L'app fabriquait donc ses propres écarts, un par achat, à charge de
+l'utilisateur d'aller tous les réparer ailleurs.
+
+Ces tests tiennent les deux moitiés de la correction : le budget arrive bien
+jusqu'à l'interaction, et un budget qui n'est pas au foyer est un **400**, pas
+un 500 — la résolution lève un `ValueError`, qui sorti d'une vue est une erreur
+serveur sur une simple erreur client.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.models import User
+from budget.models import Budget
+from chickens.models import Chicken
+from equipment.models import Equipment
+from households.models import Household, HouseholdMember
+from interactions.models import Interaction
+from projects.models import Project
+from shopping.models import ShoppingListItem
+from stock.models import StockCategory, StockItem
+from zones.models import Zone
+
+_counter = itertools.count()
+
+
+def make_household_user():
+    household = Household.objects.create(name=f"Budget forms {next(_counter)}")
+    user = User.objects.create_user(email=f"u-{next(_counter)}@example.com", password="pass1234")
+    HouseholdMember.objects.create(
+        household=household, user=user, role=HouseholdMember.Role.MEMBER
+    )
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return household, user
+
+
+def make_budget(household, name="Bricolage", *, is_global=False):
+    return Budget.objects.create(
+        household=household,
+        name=name,
+        monthly_amount=Decimal("400.00"),
+        is_global=is_global,
+    )
+
+
+def api(user):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def context(db):
+    household, user = make_household_user()
+    return {
+        "household": household,
+        "user": user,
+        "budget": make_budget(household),
+        "client": api(user),
+    }
+
+
+def zone_of(household):
+    return Zone.objects.create(household=household, name="Maison")
+
+
+# --- Un budget par chemin d'achat --------------------------------------------
+
+
+class TestEveryPurchaseFormCarriesItsBudget:
+    """Cinq chemins, une seule attente : l'enveloppe choisie arrive à l'écriture."""
+
+    def test_stock_purchase(self, context):
+        category = StockCategory.objects.create(
+            household=context["household"], name="Consommables"
+        )
+        item = StockItem.objects.create(
+            household=context["household"], category=category, name="Vis", unit="boîte", quantity=0
+        )
+
+        response = context["client"].post(
+            f"/api/stock/{item.id}/purchase/",
+            {"delta": "2", "amount": "19.90", "budget_id": str(context["budget"].id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        expense = Interaction.objects.get(id=response.data["interaction_id"])
+        assert expense.budget_id == context["budget"].id
+
+    def test_equipment_purchase(self, context):
+        equipment = Equipment.objects.create(
+            household=context["household"], name="Perceuse", zone=zone_of(context["household"])
+        )
+
+        response = context["client"].post(
+            f"/api/equipment/{equipment.id}/register-purchase/",
+            {"amount": "89.00", "budget_id": str(context["budget"].id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        expense = Interaction.objects.get(id=response.data["interaction_id"])
+        assert expense.budget_id == context["budget"].id
+
+    def test_project_purchase(self, context):
+        project = Project.objects.create(household=context["household"], title="Salle de bain")
+
+        response = context["client"].post(
+            f"/api/projects/projects/{project.id}/register-purchase/",
+            {"amount": "150.00", "budget_id": str(context["budget"].id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        expense = Interaction.objects.get(id=response.data["interaction_id"])
+        assert expense.budget_id == context["budget"].id
+
+    def test_chicken_purchase(self, context):
+        chicken = Chicken.objects.create(household=context["household"], name="Roussette")
+
+        response = context["client"].post(
+            f"/api/chickens/{chicken.id}/purchase/",
+            {"amount": "24.00", "budget_id": str(context["budget"].id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        expense = Interaction.objects.get(id=response.data["interaction_id"])
+        assert expense.budget_id == context["budget"].id
+
+    def test_shopping_commit(self, context):
+        line = ShoppingListItem.objects.create(
+            household=context["household"], label="Farine", quantity=1
+        )
+        StockCategory.objects.create(household=context["household"], name="Épicerie")
+
+        response = context["client"].post(
+            f"/api/shopping/items/{line.id}/commit-to-stock/",
+            {
+                "delta": "1",
+                "amount": "3.20",
+                "category": "Épicerie",
+                "budget_id": str(context["budget"].id),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        expense = Interaction.objects.filter(type="expense").latest("created_at")
+        assert expense.budget_id == context["budget"].id
+
+
+# --- Et l'erreur client reste une erreur client -------------------------------
+
+
+class TestABadBudgetIsA400:
+    """Le résolveur lève un ``ValueError`` ; sorti d'une vue, c'est un 500.
+
+    C'est exactement la régression que `set_allocations` avait déjà connue : un
+    mauvais id renvoyé par un client donnait une erreur serveur sur ce qui est
+    une faute de saisie. Le garde-fou vaut pour les cinq chemins, il est testé
+    sur deux — l'un qui passe par une vue, l'autre par un service intermédiaire.
+    """
+
+    def test_a_budget_from_another_household_is_refused(self, context):
+        other_household, _ = make_household_user()
+        stranger = make_budget(other_household, name="Chez le voisin")
+        project = Project.objects.create(household=context["household"], title="Terrasse")
+
+        response = context["client"].post(
+            f"/api/projects/projects/{project.id}/register-purchase/",
+            {"amount": "10.00", "budget_id": str(stranger.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "budget_id" in response.data
+        assert not Interaction.objects.filter(type="expense").exists()
+
+    def test_the_global_budget_is_refused(self, context):
+        """Le plafond global couvre tout : il n'est la catégorie de rien."""
+        overall = make_budget(context["household"], name="Global", is_global=True)
+        category = StockCategory.objects.create(
+            household=context["household"], name="Consommables"
+        )
+        item = StockItem.objects.create(
+            household=context["household"], category=category, name="Vis", unit="boîte", quantity=0
+        )
+
+        response = context["client"].post(
+            f"/api/stock/{item.id}/purchase/",
+            {"delta": "1", "amount": "5.00", "budget_id": str(overall.id)},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        # ⚠️ L'achat est refusé **en entier** : le budget est validé avant que
+        # quoi que ce soit ne soit écrit. Incrémenter le stock puis échouer sur
+        # l'enveloppe laisserait une quantité fausse et aucune dépense.
+        item.refresh_from_db()
+        assert item.quantity == 0
+
+
+class TestTheBudgetStaysOptional:
+    """Ne pas choisir reste possible — le Contrôle le signalera, pas le formulaire.
+
+    Exiger un budget à la saisie transformerait chaque achat pressé en cul-de-sac.
+    L'écart `expense_without_budget` existe précisément pour rattraper ça plus tard.
+    """
+
+    def test_a_purchase_without_budget_still_works(self, context):
+        project = Project.objects.create(household=context["household"], title="Jardin")
+
+        response = context["client"].post(
+            f"/api/projects/projects/{project.id}/register-purchase/",
+            {"amount": "42.00"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        expense = Interaction.objects.get(id=response.data["interaction_id"])
+        assert expense.budget_id is None

--- a/apps/projects/serializers.py
+++ b/apps/projects/serializers.py
@@ -22,6 +22,12 @@ class ProjectPurchaseSerializer(serializers.Serializer):
     supplier = serializers.CharField(required=False, allow_blank=True, default="")
     occurred_at = serializers.DateTimeField(required=False, allow_null=True)
     notes = serializers.CharField(required=False, allow_blank=True, default="")
+    # Enveloppe à laquelle imputer l'achat. Facultative, mais son absence est
+    # l'écart `expense_without_budget` : sans budget, un euro n'est classé par
+    # aucun axe (projet et zone disent *sur quoi* et *où*, pas *de quelle
+    # nature*). L'offrir à la saisie évite de fabriquer l'écart puis de le
+    # réparer.
+    budget_id = serializers.UUIDField(required=False, allow_null=True)
 
 
 class ProjectGroupPickerSerializer(serializers.ModelSerializer):

--- a/apps/projects/views.py
+++ b/apps/projects/views.py
@@ -7,7 +7,7 @@ from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
 from documents.mixins import DocumentLinkActionsMixin
-from interactions.services import create_expense_interaction
+from interactions.services import create_expense_interaction, validate_expense_budget
 from .models import (
     Project,
     ProjectGroup,
@@ -103,6 +103,10 @@ class ProjectViewSet(DocumentLinkActionsMixin, _HouseholdScopedViewSet):
         serializer = ProjectPurchaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
+        budget_id = validate_expense_budget(
+            project.household_id, serializer.validated_data.get("budget_id")
+        )
+
         interaction = create_expense_interaction(
             source=project,
             user=request.user,
@@ -111,6 +115,7 @@ class ProjectViewSet(DocumentLinkActionsMixin, _HouseholdScopedViewSet):
             occurred_at=serializer.validated_data.get("occurred_at") or timezone.now(),
             notes=serializer.validated_data.get("notes", "") or "",
             kind="project_purchase",
+            budget_id=budget_id,
             extra_metadata={"project_title": project.title},
         )
 

--- a/apps/shopping/services.py
+++ b/apps/shopping/services.py
@@ -226,6 +226,7 @@ def commit_item_to_stock(
     notes: str = "",
     category=None,
     unit: str | None = None,
+    budget_id=None,
 ) -> StockItem:
     """Turn a shopping line into a stock purchase (Lot 4), then remove the line.
 
@@ -267,6 +268,7 @@ def commit_item_to_stock(
         supplier=supplier or "",
         occurred_at=occurred_at,
         notes=notes or "",
+        budget_id=budget_id,
     )
     item.delete()
     return stock_item

--- a/apps/shopping/views.py
+++ b/apps/shopping/views.py
@@ -5,6 +5,7 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
+from interactions.services import validate_expense_budget
 from stock.models import StockItem
 
 from .models import ShoppingListItem
@@ -134,6 +135,9 @@ class ShoppingListItemViewSet(viewsets.ModelViewSet):
         On success the line is removed and the stock item is returned.
         """
         item = self.get_object()
+        budget_id = validate_expense_budget(
+            request.household.id, request.data.get("budget_id")
+        )
         stock_item = commit_item_to_stock(
             request.household,
             request.user,
@@ -145,6 +149,7 @@ class ShoppingListItemViewSet(viewsets.ModelViewSet):
             notes=request.data.get("notes") or "",
             category=request.data.get("category"),
             unit=request.data.get("unit"),
+            budget_id=budget_id,
         )
         return Response({"stock_item": str(stock_item.id)}, status=status.HTTP_200_OK)
 

--- a/apps/stock/serializers.py
+++ b/apps/stock/serializers.py
@@ -152,6 +152,12 @@ class StockPurchaseSerializer(serializers.Serializer):
         max_digits=12, decimal_places=3, required=False, allow_null=True, min_value=Decimal("0")
     )
     occurred_at = serializers.DateTimeField(required=False, allow_null=True)
+    # Enveloppe à laquelle imputer l'achat. Facultative, mais son absence est
+    # l'écart `expense_without_budget` : sans budget, un euro n'est classé par
+    # aucun axe (projet et zone disent *sur quoi* et *où*, pas *de quelle
+    # nature*). L'offrir à la saisie évite de fabriquer l'écart puis de le
+    # réparer.
+    budget_id = serializers.UUIDField(required=False, allow_null=True)
     notes = serializers.CharField(required=False, allow_blank=True, default="")
 
 

--- a/apps/stock/services.py
+++ b/apps/stock/services.py
@@ -79,6 +79,7 @@ def purchase_stock_item(
     remaining_before: Decimal | None = None,
     occurred_at: datetime | None = None,
     notes: str = "",
+    budget_id=None,
 ):
     """Compose an inbound stock movement with an expense interaction.
 
@@ -139,6 +140,7 @@ def purchase_stock_item(
         occurred_at=occurred_at,
         notes=notes,
         kind="stock_purchase",
+        budget_id=budget_id,
         extra_metadata={
             "stock_item_name": item.name,
             "brand": brand,

--- a/apps/stock/views.py
+++ b/apps/stock/views.py
@@ -10,6 +10,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from core.permissions import IsHouseholdMember
+from interactions.services import validate_expense_budget
 
 from .models import StockCategory, StockItem
 from .notifications import notify_stock_status_change
@@ -140,6 +141,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
         serializer = StockPurchaseSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
+        budget_id = validate_expense_budget(item.household_id, data.get("budget_id"))
 
         item, interaction = purchase_stock_item(
             item=item,
@@ -151,6 +153,7 @@ class StockItemViewSet(viewsets.ModelViewSet):
             remaining_before=data.get("remaining_before"),
             occurred_at=data.get("occurred_at"),
             notes=data.get("notes", "") or "",
+            budget_id=budget_id,
         )
 
         payload = StockItemSerializer(item, context={"request": request}).data

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -435,6 +435,41 @@ de re-créer — n'était pas proposée. **« Qu'est-ce qui existe déjà ? » n
 jamais. Régression :
 `banking/tests/test_expense_marker.py::TestTheForgottenExpenseIsOffered`.
 
+### Le budget se saisit sur *tous* les formulaires de dépense
+
+`Interaction.budget` est le seul axe qui classe un euro, et le détecteur
+`expense_without_budget` en réclame un sur chaque dépense de la fenêtre. Or
+**aucun** des cinq chemins d'achat ne proposait le champ : stock, équipement,
+projet, poule, liste de courses créaient toutes des dépenses sans enveloppe. Ce
+n'était pas un oubli d'ergonomie mais une **fabrique d'écarts** : chaque achat
+naissait non conforme, et l'utilisateur devait aller réparer ailleurs ce que la
+saisie venait de casser. Le formulaire d'édition, seul endroit où corriger après
+coup, ne le proposait pas non plus — on pouvait donc lire « hors budget » sur une
+dépense sans pouvoir y remédier depuis la page ouverte pour ça.
+
+- Le champ vit dans **`PurchaseForm`**, le formulaire partagé, au même titre que
+  le prix : c'est un champ générique de dépense, pas une particularité de
+  feature. Les deux dialogs qui en avaient bricolé un (`ExpenseAdHocDialog`,
+  `CashExpenseDialog`) l'ont perdu au profit du champ commun — deux sélecteurs
+  pour une enveloppe, c'était la duplication qui allait diverger.
+- Il reste **facultatif**. Exiger une enveloppe transformerait un achat pressé en
+  cul-de-sac, et le Contrôle existe précisément pour rattraper ce qu'on n'a pas
+  classé sur le coup.
+- Le **plafond global n'est jamais proposé** : il couvre tout, donc il n'est la
+  catégorie de rien, et le serveur le refuse. Offrir une option qui produit un
+  400 est pire que ne pas l'offrir.
+- Côté serveur, un budget étranger au foyer est un **400 nommé**, pas un 500 :
+  `interactions.services.validate_expense_budget` traduit le `ValueError` du
+  résolveur, une fois pour les cinq chemins. Même correction que
+  `set_allocations` en son temps.
+- L'édition envoie `budget_id: null` **explicitement** quand on retire
+  l'enveloppe : omettre la clé laisserait l'ancienne en place, et « retirer le
+  budget » serait un geste sans effet.
+
+Tests : `interactions/tests/test_purchase_budget.py` — un cas par chemin, plus le
+budget étranger, le budget global (qui ne doit **rien** écrire du tout, pas même
+la quantité de stock) et l'achat sans budget qui reste permis.
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/e2e/budget.spec.ts
+++ b/e2e/budget.spec.ts
@@ -271,10 +271,10 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
     const dialog = await openCashDialog(page);
 
     // Le select "Budget" doit être présent
-    await expect(dialog.locator('#cash-budget')).toBeVisible();
+    await expect(dialog.locator('#purchase-budget')).toBeVisible();
 
     // L'option "Courses Tests" doit être disponible dans le select
-    const select = dialog.locator('#cash-budget');
+    const select = dialog.locator('#purchase-budget');
     await expect(select.locator('option', { hasText: 'Courses Tests' })).toHaveCount(1);
   });
 
@@ -285,7 +285,7 @@ test.describe('Budgets — intégration dépenses ad-hoc', () => {
     await dialog.locator('#cash-label').fill(subject);
 
     // Sélectionner le budget "Courses Tests"
-    await dialog.locator('#cash-budget').selectOption({ label: 'Courses Tests' });
+    await dialog.locator('#purchase-budget').selectOption({ label: 'Courses Tests' });
 
     await page.locator('#purchase-price').fill('85');
     await dialog.getByRole('button', { name: "Enregistrer l'achat" }).click();

--- a/ui/src/features/chickens/ChickenPurchaseDialog.tsx
+++ b/ui/src/features/chickens/ChickenPurchaseDialog.tsx
@@ -33,6 +33,7 @@ export default function ChickenPurchaseDialog({ open, onOpenChange, chicken }: C
           supplier: payload.supplier,
           occurred_at: payload.occurred_at,
           notes: payload.notes,
+          budget_id: payload.budget_id,
         },
       });
       onOpenChange(false);

--- a/ui/src/features/equipment/EquipmentPurchaseDialog.tsx
+++ b/ui/src/features/equipment/EquipmentPurchaseDialog.tsx
@@ -37,6 +37,7 @@ export default function EquipmentPurchaseDialog({
           supplier: payload.supplier,
           occurred_at: payload.occurred_at,
           notes: payload.notes,
+          budget_id: payload.budget_id,
         },
       });
       onOpenChange(false);

--- a/ui/src/features/expenses/ExpenseAdHocDialog.tsx
+++ b/ui/src/features/expenses/ExpenseAdHocDialog.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
-import { Select } from '@/design-system/select';
 import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
-import { useBudgets } from '@/features/budget/hooks';
 import { useCreateManualExpense } from './hooks';
 
 interface ExpenseAdHocDialogProps {
@@ -16,23 +14,12 @@ interface ExpenseAdHocDialogProps {
 export default function ExpenseAdHocDialog({ open, onOpenChange }: ExpenseAdHocDialogProps) {
   const { t } = useTranslation();
   const mutation = useCreateManualExpense();
-  const { data: budgets } = useBudgets();
   const [subject, setSubject] = React.useState('');
-  const [budgetId, setBudgetId] = React.useState('');
   const [error, setError] = React.useState<string | null>(null);
-
-  const budgetOptions = React.useMemo(
-    () =>
-      (budgets ?? [])
-        .filter((b) => !b.is_global)
-        .map((b) => ({ value: b.id, label: b.name })),
-    [budgets],
-  );
 
   React.useEffect(() => {
     if (!open) {
       setSubject('');
-      setBudgetId('');
       setError(null);
     }
   }, [open]);
@@ -50,7 +37,10 @@ export default function ExpenseAdHocDialog({ open, onOpenChange }: ExpenseAdHocD
         supplier: payload.supplier,
         occurred_at: payload.occurred_at,
         notes: payload.notes,
-        budget_id: budgetId || null,
+        // Le budget vient du form partagé : il y est devenu un champ générique
+        // de dépense, au même titre que le prix. Le garder ici en double aurait
+        // affiché deux sélecteurs pour une seule enveloppe.
+        budget_id: payload.budget_id,
       });
       onOpenChange(false);
     } catch {
@@ -74,18 +64,6 @@ export default function ExpenseAdHocDialog({ open, onOpenChange }: ExpenseAdHocD
             required
           />
         </FormField>
-
-        {budgetOptions.length > 0 ? (
-          <FormField label={t('expenses.adhoc.budget')} htmlFor="adhoc-budget">
-            <Select
-              id="adhoc-budget"
-              value={budgetId}
-              onChange={(e) => setBudgetId(e.target.value)}
-              placeholder={t('expenses.adhoc.budgetNone')}
-              options={budgetOptions}
-            />
-          </FormField>
-        ) : null}
 
         <PurchaseForm
           isPending={mutation.isPending}

--- a/ui/src/features/interactions/ExpenseFields.tsx
+++ b/ui/src/features/interactions/ExpenseFields.tsx
@@ -1,7 +1,11 @@
+import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/design-system/input';
 import { Badge } from '@/design-system/badge';
+import { Select } from '@/design-system/select';
+import { FormField } from '@/design-system/form-field';
+import { useBudgets } from '@/features/budget/hooks';
 import LinkedLineActions from '@/features/banking/LinkedLineActions';
 import type { BankLineRef } from '@/lib/api/interactions';
 
@@ -22,6 +26,9 @@ interface ExpenseFieldsProps {
   bankLine?: BankLineRef | null;
   /** Sortie du formulaire quand la dépense vient d'être supprimée d'ici. */
   onDeleted?: () => void;
+  /** Enveloppe actuelle (id), et son écriture. */
+  budgetId: string;
+  onBudgetChange: (value: string) => void;
   /** Read-only unit_price displayed when filled (computed for stock purchases from delta×amount). */
   unitPrice?: string | null;
   unit?: string | null;
@@ -47,10 +54,18 @@ export default function ExpenseFields({
   expenseId,
   bankLine,
   onDeleted,
+  budgetId,
+  onBudgetChange,
   unitPrice,
   unit,
 }: ExpenseFieldsProps) {
   const { t } = useTranslation();
+  const budgetsQuery = useBudgets();
+  // Le plafond global n'est la catégorie de rien : le serveur le refuse.
+  const budgetOptions = React.useMemo(
+    () => (budgetsQuery.data ?? []).filter((b) => !b.is_global),
+    [budgetsQuery.data],
+  );
   const hasSource = Boolean(sourceLabel && sourceType);
   const link = sourceLink(sourceType, sourceId);
 
@@ -127,6 +142,24 @@ export default function ExpenseFields({
           />
         </div>
       </div>
+
+      {/* Le budget se corrige ici, et pas seulement à la création : c'est le
+          seul axe qui classe un euro, et l'écran d'édition était le seul à ne
+          pas le proposer — on pouvait donc lire « hors budget » sur une dépense
+          sans pouvoir y remédier depuis la page ouverte pour ça. */}
+      {budgetOptions.length > 0 ? (
+        <FormField label={t('purchase.fields.budget')} htmlFor="expense-budget">
+          <Select
+            id="expense-budget"
+            value={budgetId}
+            onChange={(e) => onBudgetChange(e.target.value)}
+            options={[
+              { value: '', label: t('purchase.fields.budget_none') },
+              ...budgetOptions.map((b) => ({ value: b.id, label: b.name })),
+            ]}
+          />
+        </FormField>
+      ) : null}
 
       {unitPrice ? (
         <p className="text-xs text-muted-foreground">

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -75,6 +75,7 @@ export default function InteractionEditPage() {
   const [equipmentList, setEquipmentList] = React.useState<EquipmentListItem[]>([]);
   const [amount, setAmount] = React.useState('');
   const [supplier, setSupplier] = React.useState('');
+  const [budgetId, setBudgetId] = React.useState('');
   const [formError, setFormError] = React.useState<string | null>(null);
   const [submitting, setSubmitting] = React.useState(false);
   const [initialised, setInitialised] = React.useState(false);
@@ -101,6 +102,7 @@ export default function InteractionEditPage() {
     setTagsInput((interaction.tags ?? []).join(', '));
     setAmount(interaction.amount ?? '');
     setSupplier(interaction.supplier ?? '');
+    setBudgetId(interaction.budget?.id ?? '');
     setContactId(interaction.contacts?.[0]?.id ?? '');
     setStructureId(interaction.structures?.[0]?.id ?? '');
     setEquipmentId(interaction.equipments?.[0]?.id ?? '');
@@ -145,7 +147,14 @@ export default function InteractionEditPage() {
     // (no metadata round-trip). kind stays as-is; unit_price and other extras
     // remain in metadata and are left untouched by omitting `metadata` here.
     const expenseFields = isExpense
-      ? { amount: amount.trim() ? amount.trim() : null, supplier: supplier.trim() }
+      ? {
+          amount: amount.trim() ? amount.trim() : null,
+          supplier: supplier.trim(),
+          // `null` explicite, jamais l'omission : ne pas envoyer la clé
+          // laisserait l'ancienne enveloppe en place, donc « retirer le budget »
+          // serait un geste sans effet.
+          budget_id: budgetId || null,
+        }
       : {};
 
     try {
@@ -273,6 +282,8 @@ export default function InteractionEditPage() {
             expenseId={interaction.id}
             bankLine={interaction.bank_line}
             onDeleted={navigateBackAfterDelete}
+            budgetId={budgetId}
+            onBudgetChange={setBudgetId}
             unitPrice={(metadata.unit_price ?? null) as string | null}
             unit={(metadata.unit ?? null) as string | null}
           />

--- a/ui/src/features/interactions/PurchaseForm.tsx
+++ b/ui/src/features/interactions/PurchaseForm.tsx
@@ -4,7 +4,9 @@ import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
+import { Select } from '@/design-system/select';
 import { todayISO } from '@/lib/format';
+import { useBudgets } from '@/features/budget/hooks';
 
 export interface PurchaseFormPayload {
   delta?: number;
@@ -15,6 +17,8 @@ export interface PurchaseFormPayload {
   remaining_before: number | null;
   occurred_at: string | null;
   notes: string;
+  /** Enveloppe à laquelle imputer l'achat. `null` = non classé. */
+  budget_id: string | null;
 }
 
 interface PurchaseFormProps {
@@ -30,6 +34,8 @@ interface PurchaseFormProps {
   onCancel: () => void;
   /** Optional submit-time error message to display above the buttons. */
   externalError?: string | null;
+  /** Enveloppe pré-sélectionnée (une dépense créée depuis un contexte connu). */
+  initialBudgetId?: string;
 }
 
 type PriceMode = 'total' | 'unit';
@@ -43,13 +49,14 @@ interface FormState {
   remaining: string;
   occurredAt: string;
   notes: string;
+  budgetId: string;
 }
 
 function todayIsoDate(): string {
   return todayISO();
 }
 
-function emptyState(currentQuantity?: number): FormState {
+function emptyState(currentQuantity?: number, budgetId = ''): FormState {
   return {
     delta: '',
     priceMode: 'total',
@@ -59,6 +66,7 @@ function emptyState(currentQuantity?: number): FormState {
     remaining: currentQuantity != null ? String(currentQuantity) : '',
     occurredAt: todayIsoDate(),
     notes: '',
+    budgetId,
   };
 }
 
@@ -77,9 +85,19 @@ export default function PurchaseForm({
   onSubmit,
   onCancel,
   externalError,
+  initialBudgetId = '',
 }: PurchaseFormProps) {
   const { t } = useTranslation();
-  const [form, setForm] = React.useState<FormState>(() => emptyState(currentQuantity));
+  const [form, setForm] = React.useState<FormState>(() =>
+    emptyState(currentQuantity, initialBudgetId),
+  );
+  const budgetsQuery = useBudgets();
+  // Le plafond global couvre tout : il n'est la catégorie de rien, et le serveur
+  // le refuse. L'offrir ici serait offrir une erreur.
+  const budgetOptions = React.useMemo(
+    () => (budgetsQuery.data ?? []).filter((b) => !b.is_global),
+    [budgetsQuery.data],
+  );
   const [internalError, setInternalError] = React.useState<string | null>(null);
 
   const error = externalError ?? internalError;
@@ -142,6 +160,7 @@ export default function PurchaseForm({
       remaining_before: isRecalibrating ? parsedRemaining : null,
       occurred_at: occurredAt,
       notes: form.notes.trim(),
+      budget_id: form.budgetId || null,
     });
   }
 
@@ -254,6 +273,26 @@ export default function PurchaseForm({
           />
         </FormField>
       </div>
+
+      {/* Le budget est le **seul** axe qui classe un euro : projet et zone disent
+          sur quoi et où, pas de quelle nature. Sans lui, chaque achat naissait
+          en écart `expense_without_budget`, à réparer plus tard ailleurs — l'app
+          fabriquait son propre travail. Il reste facultatif : exiger une
+          enveloppe transformerait un achat pressé en cul-de-sac, et le Contrôle
+          est précisément là pour rattraper ce qu'on n'a pas classé sur le coup. */}
+      {budgetOptions.length > 0 ? (
+        <FormField label={t('purchase.fields.budget')} htmlFor="purchase-budget">
+          <Select
+            id="purchase-budget"
+            value={form.budgetId}
+            onChange={(e) => updateField('budgetId', e.target.value)}
+            options={[
+              { value: '', label: t('purchase.fields.budget_none') },
+              ...budgetOptions.map((b) => ({ value: b.id, label: b.name })),
+            ]}
+          />
+        </FormField>
+      ) : null}
 
       <FormField label={t('purchase.fields.notes')} htmlFor="purchase-notes">
         <Textarea

--- a/ui/src/features/money/CashExpenseDialog.tsx
+++ b/ui/src/features/money/CashExpenseDialog.tsx
@@ -7,7 +7,6 @@ import { Input } from '@/design-system/input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import PurchaseForm, { type PurchaseFormPayload } from '@/features/interactions/PurchaseForm';
-import { useBudgets } from '@/features/budget/hooks';
 import { todayISO } from '@/lib/format';
 import {
   useBankAccounts,
@@ -38,13 +37,11 @@ interface CashExpenseDialogProps {
 export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDialogProps) {
   const { t } = useTranslation();
   const accountsQuery = useBankAccounts();
-  const { data: budgets } = useBudgets();
   const mutation = useRecordCashExpense();
   const createAccount = useCreateBankAccount();
 
   const [label, setLabel] = React.useState('');
   const [accountId, setAccountId] = React.useState('');
-  const [budgetId, setBudgetId] = React.useState('');
   const [error, setError] = React.useState<string | null>(null);
 
   const cashAccounts = React.useMemo(
@@ -52,15 +49,9 @@ export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDia
     [accountsQuery.data],
   );
 
-  const budgetOptions = React.useMemo(
-    () => (budgets ?? []).filter((b) => !b.is_global).map((b) => ({ value: b.id, label: b.name })),
-    [budgets],
-  );
-
   React.useEffect(() => {
     if (!open) {
       setLabel('');
-      setBudgetId('');
       setError(null);
       return;
     }
@@ -94,7 +85,9 @@ export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDia
         // `occurred_at` du form est un datetime ; l'opération de compte est datée
         // au jour, comme toute ligne de relevé.
         booked_on: payload.occurred_at ? payload.occurred_at.slice(0, 10) : undefined,
-        budget_id: budgetId || null,
+        // Le budget vient du form partagé, où il est devenu un champ générique
+        // de dépense. En garder une copie ici afficherait deux sélecteurs.
+        budget_id: payload.budget_id,
         notes: payload.notes,
       });
       onOpenChange(false);
@@ -173,18 +166,6 @@ export default function CashExpenseDialog({ open, onOpenChange }: CashExpenseDia
                 value={accountId}
                 onChange={(e) => setAccountId(e.target.value)}
                 options={cashAccounts.map((a) => ({ value: a.id, label: a.name }))}
-              />
-            </FormField>
-          ) : null}
-
-          {budgetOptions.length > 0 ? (
-            <FormField label={t('banking.cash.budget')} htmlFor="cash-budget">
-              <Select
-                id="cash-budget"
-                value={budgetId}
-                onChange={(e) => setBudgetId(e.target.value)}
-                placeholder={t('banking.cash.budgetNone')}
-                options={budgetOptions}
               />
             </FormField>
           ) : null}

--- a/ui/src/features/projects/ProjectPurchaseDialog.tsx
+++ b/ui/src/features/projects/ProjectPurchaseDialog.tsx
@@ -37,6 +37,7 @@ export default function ProjectPurchaseDialog({
           supplier: payload.supplier,
           occurred_at: payload.occurred_at,
           notes: payload.notes,
+          budget_id: payload.budget_id,
         },
       });
       onOpenChange(false);

--- a/ui/src/features/shopping/ShoppingCommitDialog.tsx
+++ b/ui/src/features/shopping/ShoppingCommitDialog.tsx
@@ -50,6 +50,7 @@ export default function ShoppingCommitDialog({ open, onOpenChange, item }: Props
           supplier: payload.supplier,
           occurred_at: payload.occurred_at,
           notes: payload.notes,
+          budget_id: payload.budget_id,
           category: isFreeText ? category : undefined,
           unit: item.unit || undefined,
         },

--- a/ui/src/features/stock/StockPurchaseDialog.tsx
+++ b/ui/src/features/stock/StockPurchaseDialog.tsx
@@ -36,6 +36,7 @@ export default function StockPurchaseDialog({ open, onOpenChange, item }: StockP
           remaining_before: payload.remaining_before,
           occurred_at: payload.occurred_at,
           notes: payload.notes,
+          budget_id: payload.budget_id,
         },
       });
       onOpenChange(false);

--- a/ui/src/lib/api/chickens.ts
+++ b/ui/src/lib/api/chickens.ts
@@ -161,6 +161,8 @@ export interface ChickenPurchasePayload {
   supplier?: string;
   occurred_at?: string | null;
   notes?: string;
+  /** Enveloppe à laquelle imputer la dépense créée. `null` = non classée. */
+  budget_id?: string | null;
 }
 
 export interface ChickenPurchaseResponse extends Chicken {

--- a/ui/src/lib/api/equipment.ts
+++ b/ui/src/lib/api/equipment.ts
@@ -188,6 +188,8 @@ export interface EquipmentPurchasePayload {
   supplier?: string;
   occurred_at?: string | null;
   notes?: string;
+  /** Enveloppe à laquelle imputer la dépense créée. `null` = non classée. */
+  budget_id?: string | null;
 }
 
 export interface EquipmentPurchaseResponse extends EquipmentListItem {

--- a/ui/src/lib/api/interactions.ts
+++ b/ui/src/lib/api/interactions.ts
@@ -60,6 +60,8 @@ export interface InteractionListItem {
   source_type?: string | null;
   source_id?: string | null;
   source_label?: string | null;
+  /** Enveloppe qui classe cette dépense — le seul axe qui dit *de quelle nature*. */
+  budget?: { id: string; name: string } | null;
   /** Ligne de relevé dont cette dépense est une ventilation (parcours 25). */
   bank_transaction?: string | null;
   /** `auto` | `manual` | `''` — comment le rapprochement s'est fait. */
@@ -84,6 +86,8 @@ export interface CreateInteractionInput {
   amount?: string | null;
   kind?: string;
   supplier?: string;
+  /** Enveloppe de la dépense ; `null` la retire. Omettre la clé ne change rien. */
+  budget_id?: string | null;
   document_ids?: string[];
   source_type?: string | null;
   source_id?: string | null;

--- a/ui/src/lib/api/projects.ts
+++ b/ui/src/lib/api/projects.ts
@@ -89,6 +89,8 @@ export interface ProjectPurchasePayload {
   supplier?: string;
   occurred_at?: string | null;
   notes?: string;
+  /** Enveloppe à laquelle imputer la dépense créée. `null` = non classée. */
+  budget_id?: string | null;
 }
 
 interface PaginatedResponse<T> {

--- a/ui/src/lib/api/shopping.ts
+++ b/ui/src/lib/api/shopping.ts
@@ -125,6 +125,8 @@ export interface CommitToStockPayload {
   /** Required only for a free-text line (creates the stock item). */
   category?: string;
   unit?: string;
+  /** Enveloppe à laquelle imputer la dépense créée. `null` = non classée. */
+  budget_id?: string | null;
 }
 
 export async function commitShoppingItemToStock(
@@ -139,6 +141,7 @@ export async function commitShoppingItemToStock(
     notes: payload.notes ?? '',
     category: payload.category ?? undefined,
     unit: payload.unit ?? undefined,
+    budget_id: payload.budget_id ?? null,
   });
   return data as { stock_item: string };
 }

--- a/ui/src/lib/api/stock.ts
+++ b/ui/src/lib/api/stock.ts
@@ -165,6 +165,8 @@ export interface StockPurchasePayload {
   remaining_before?: number | null;
   occurred_at?: string | null;
   notes?: string;
+  /** Enveloppe à laquelle imputer la dépense créée. `null` = non classée. */
+  budget_id?: string | null;
 }
 
 export interface StockPurchaseResponse extends StockItem {

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2420,7 +2420,9 @@
       "remaining_before_hint": "Optional — wie viel vor dem Auffüllen übrig war. Fließt in deinen Verbrauchsverlauf ein.",
       "remaining_adjusted": "Bestand von {{from}} auf {{to}} {{unit}} angepasst",
       "occurred_at": "Kaufdatum",
-      "notes": "Notizen"
+      "notes": "Notizen",
+      "budget": "Budget",
+      "budget_none": "Kein Budget"
     },
     "price_mode": {
       "total": "Gesamt",
@@ -3038,9 +3040,7 @@
       "created": "Ausgabe erfasst",
       "actions": {
         "add": "Neue Ausgabe"
-      },
-      "budget": "Budget",
-      "budgetNone": "Kein Budget"
+      }
     }
   },
   "aiUsage": {
@@ -3402,8 +3402,6 @@
       "account": "Barkonto",
       "accountRequired": "Wählen Sie ein Barkonto.",
       "amountRequired": "Geben Sie einen positiven Betrag ein.",
-      "budget": "Budget",
-      "budgetNone": "Ohne Budget",
       "recorded": "Ausgabe auf dem Barkonto erfasst.",
       "noAccount": "Kein Barkonto",
       "noAccountHint": "Legen Sie im Reiter Konten ein Konto „Bargeld“ an: eine Barausgabe wird dann eine Kontobuchung wie jede andere.",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2420,7 +2420,9 @@
       "remaining_before_hint": "Optional — how much was left before restocking. Feeds your consumption history.",
       "remaining_adjusted": "Stock adjusted from {{from}} to {{to}} {{unit}}",
       "occurred_at": "Purchase date",
-      "notes": "Notes"
+      "notes": "Notes",
+      "budget": "Budget",
+      "budget_none": "No budget"
     },
     "price_mode": {
       "total": "Total",
@@ -3038,9 +3040,7 @@
       "created": "Expense recorded",
       "actions": {
         "add": "New expense"
-      },
-      "budget": "Budget",
-      "budgetNone": "No budget"
+      }
     }
   },
   "aiUsage": {
@@ -3402,8 +3402,6 @@
       "account": "Cash account",
       "accountRequired": "Pick a cash account.",
       "amountRequired": "Enter a positive amount.",
-      "budget": "Budget",
-      "budgetNone": "No budget",
       "recorded": "Expense recorded on the cash account.",
       "noAccount": "No cash account",
       "noAccountHint": "Declare a “Cash” account in the Accounts tab: a cash spend then becomes an account operation, like every other.",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2420,7 +2420,9 @@
       "remaining_before_hint": "Opcional — cuánto quedaba antes de reabastecer. Alimenta tu historial de consumo.",
       "remaining_adjusted": "Existencias ajustadas de {{from}} a {{to}} {{unit}}",
       "occurred_at": "Fecha de compra",
-      "notes": "Notas"
+      "notes": "Notas",
+      "budget": "Presupuesto",
+      "budget_none": "Sin presupuesto"
     },
     "price_mode": {
       "total": "Total",
@@ -3038,9 +3040,7 @@
       "created": "Gasto registrado",
       "actions": {
         "add": "Nuevo gasto"
-      },
-      "budget": "Presupuesto",
-      "budgetNone": "Sin presupuesto"
+      }
     }
   },
   "aiUsage": {
@@ -3402,8 +3402,6 @@
       "account": "Cuenta de efectivo",
       "accountRequired": "Elija una cuenta de efectivo.",
       "amountRequired": "Indique un importe positivo.",
-      "budget": "Presupuesto",
-      "budgetNone": "Sin presupuesto",
       "recorded": "Gasto registrado en la cuenta de efectivo.",
       "noAccount": "Sin cuenta de efectivo",
       "noAccountHint": "Declare una cuenta «Efectivo» en la pestaña Cuentas: un gasto en metálico pasa entonces a ser una operación de cuenta, como las demás.",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2420,7 +2420,9 @@
       "remaining_before_hint": "Optionnel — combien il restait avant de réapprovisionner. Alimente ton historique de consommation.",
       "remaining_adjusted": "Stock ajusté de {{from}} à {{to}} {{unit}}",
       "occurred_at": "Date d'achat",
-      "notes": "Notes"
+      "notes": "Notes",
+      "budget": "Budget",
+      "budget_none": "Aucun budget"
     },
     "price_mode": {
       "total": "Total",
@@ -3038,9 +3040,7 @@
       "created": "Dépense enregistrée",
       "actions": {
         "add": "Nouvelle dépense"
-      },
-      "budget": "Budget",
-      "budgetNone": "Aucun budget"
+      }
     }
   },
   "aiUsage": {
@@ -3402,8 +3402,6 @@
       "account": "Compte espèces",
       "accountRequired": "Choisissez un compte espèces.",
       "amountRequired": "Indiquez un montant positif.",
-      "budget": "Budget",
-      "budgetNone": "Hors budget",
       "recorded": "Dépense enregistrée sur le compte espèces.",
       "noAccount": "Aucun compte espèces",
       "noAccountHint": "Déclarez un compte « Espèces » dans l'onglet Comptes : une dépense en liquide devient alors une opération de compte, comme les autres.",


### PR DESCRIPTION
Demandé en recette : « il faudrait mettre le budget dans tout formulaire de dépense, le edit ». Le manque était plus large que l'édition.

## Le problème

`Interaction.budget` est le seul axe qui classe un euro, et `expense_without_budget` en réclame un sur chaque dépense de la fenêtre. Or **aucun** des cinq chemins d'achat ne proposait le champ :

| Chemin | Avant | Après |
|---|---|---|
| Achat de stock | pas de budget | ✅ |
| Achat d'équipement | pas de budget | ✅ |
| Achat de projet | pas de budget | ✅ |
| Achat sur une poule | pas de budget | ✅ |
| Liste de courses → stock | pas de budget | ✅ |
| **Édition d'une dépense** | pas de budget | ✅ |

Ce n'était pas un défaut d'ergonomie mais une **fabrique d'écarts** : chaque achat naissait non conforme, et l'utilisateur devait aller réparer ailleurs ce que la saisie venait de casser. Le formulaire d'édition, seul endroit où corriger après coup, ne l'offrait pas non plus — on lisait « hors budget » sans pouvoir y remédier depuis la page ouverte pour ça.

## Les choix

- **Le champ vit dans `PurchaseForm`**, avec le prix et le fournisseur : c'est un champ générique de dépense. `ExpenseAdHocDialog` et `CashExpenseDialog` s'en étaient bricolé un chacun ; ils le perdent au profit du champ commun. Deux sélecteurs pour une enveloppe, c'est la duplication qui diverge.
- **Facultatif.** Exiger une enveloppe transformerait un achat pressé en cul-de-sac ; le Contrôle existe pour rattraper ce qu'on n'a pas classé sur le coup.
- **Le plafond global n'est jamais proposé** — il couvre tout, il n'est la catégorie de rien, le serveur le refuse. Offrir une option qui produit un 400 est pire que ne pas l'offrir.
- **Un budget étranger au foyer est un 400 nommé, pas un 500.** Le résolveur lève un `ValueError` ; sorti d'une vue c'est une erreur serveur sur une faute de saisie. `validate_expense_budget` le traduit, une fois pour les cinq chemins — même correction que `set_allocations` en son temps.
- **L'édition envoie `budget_id: null` explicitement** pour retirer l'enveloppe : omettre la clé la laisserait en place, et « retirer le budget » serait un geste sans effet.

## Vérification

- `interactions/tests/test_purchase_budget.py` — 8 cas : un par chemin, le budget étranger, le budget global (qui ne doit **rien** écrire, pas même la quantité de stock), et l'achat sans budget qui reste permis.
- `pytest` complet : **3 497 passed**, 2 skipped.
- `vitest` 29/29, `tsc -b ui` propre, `eslint` 0 erreur, i18n ×4 (clés mortes `expenses.adhoc.budget*` / `banking.cash.budget*` retirées).
- `e2e/budget.spec.ts` suit le champ à son nouvel id (`#purchase-budget`).
- `docs/MODULES/money.md` : nouvelle section.