### PR TITLE
fix(money): aucune liste ne se termine plus par un mur

### DIFF
--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -470,6 +470,40 @@ Tests : `interactions/tests/test_purchase_budget.py` — un cas par chemin, plus
 budget étranger, le budget global (qui ne doit **rien** écrire du tout, pas même
 la quantité de stock) et l'achat sans budget qui reste permis.
 
+### Aucune liste ne se termine par un mur
+
+Les quatre listes du module s'arrêtaient à un plafond en dur — 50 pour le journal,
+les dépenses et la file, 25 pour un groupe du Contrôle — **sans aucun moyen d'aller
+plus loin**. Sur un relevé réel de 116 lignes, les deux tiers du travail étaient
+hors d'atteinte, et le Contrôle allait jusqu'à afficher « et 66 de plus… » sans
+offrir de les voir. **Un compteur qui nomme ce qu'il cache est pire qu'un compteur
+muet.**
+
+Deux mécanismes, et la distinction n'est pas cosmétique :
+
+| Liste | Mécanisme | Pourquoi |
+|---|---|---|
+| Journal, Dépenses | **Pages** (`usePager` + `Pager`) | Ce sont des registres qu'on consulte : ils grandissent sans fin, leur parcours doit être sans plafond |
+| À ranger, groupe du Contrôle | **« Voir plus »** (`useLoadMore` + `LoadMore`) | Ce sont des piles qu'on vide : les lignes disparaissent à mesure, et changer de page pendant que la précédente se vide fait sauter des lignes |
+
+- **L'agrandissement de fenêtre ne pouvait pas servir aux registres** : le serveur
+  plafonne à 100 (dépenses) et 200 (journal), donc le bouton aurait cessé
+  d'avancer sans le dire — le mur déplacé, pas supprimé.
+- **Et là où il sert, il ne ment pas non plus** : `LoadMore` reçoit le plafond
+  serveur et, une fois atteint, remplace le bouton par une phrase (« 200 sur
+  1 043 — traitez ces lignes pour voir la suite »).
+- On agrandit la fenêtre plutôt que d'empiler des pages (`useInfiniteQuery`) pour
+  deux raisons concrètes : la forme du cache reste `{items, count}`, celle que le
+  retrait optimiste manipule (`LinkedLineActions`), et une invalidation rafraîchit
+  *toute* la liste visible d'un coup — sur de l'argent, une page fraîche et trois
+  périmées serait un piège.
+- Le `Pager` annonce des **bornes** (« 51–100 sur 260 »), pas un numéro de page :
+  c'est ce qui permet de dire « j'ai traité jusqu'au centième » et de reprendre.
+- Une page vidée sous les doigts **ramène à la première** : rester sur une page
+  vide afficherait « aucune dépense » à un foyer qui en a deux cents.
+
+Tests : `ui/src/components/listNavigation.test.tsx`.
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/ui/src/components/LoadMore.tsx
+++ b/ui/src/components/LoadMore.tsx
@@ -1,0 +1,61 @@
+import { useTranslation } from 'react-i18next';
+import { ChevronDown } from 'lucide-react';
+import { Button } from '@/design-system/button';
+
+interface LoadMoreProps {
+  /** Nombre de lignes actuellement affichées. */
+  shown: number;
+  /** Nombre total côté serveur. */
+  total: number;
+  onLoadMore: () => void;
+  /** Vrai pendant le rechargement — le bouton reste lisible, il ne disparaît pas. */
+  isFetching?: boolean;
+  /**
+   * Plafond que le serveur ne dépassera pas en une requête. Atteint, le bouton
+   * cède la place à une phrase : un bouton qui n'avance plus est exactement le
+   * mur qu'on supprime ici, déplacé cinquante lignes plus loin.
+   */
+  max?: number;
+  className?: string;
+}
+
+/**
+ * « Voir plus », avec le compte exact de ce qui reste.
+ *
+ * Le libellé porte les deux nombres (`12 sur 116`) parce que le bouton seul ne
+ * dit pas s'il reste trois lignes ou trois cents — or c'est ce qui décide si on
+ * clique ou si on affine un filtre.
+ *
+ * Ne rend rien quand tout est affiché : un bouton qui ne fait rien apprend à
+ * ignorer les boutons.
+ */
+export default function LoadMore({
+  shown,
+  total,
+  onLoadMore,
+  isFetching = false,
+  max,
+  className,
+}: LoadMoreProps) {
+  const { t } = useTranslation();
+
+  if (shown >= total) return null;
+
+  if (max !== undefined && shown >= max) {
+    return (
+      <p className={className ?? 'pt-2 text-center text-xs text-muted-foreground'}>
+        {t('common.cappedAtMax', { shown, total })}
+      </p>
+    );
+  }
+
+  return (
+    <div className={className ?? 'flex flex-col items-center gap-1 pt-1'}>
+      <Button type="button" variant="outline" size="sm" onClick={onLoadMore} disabled={isFetching}>
+        <ChevronDown className="mr-1.5 h-4 w-4" />
+        {t('common.loadMore')}
+      </Button>
+      <p className="text-xs text-muted-foreground">{t('common.shownOfTotal', { shown, total })}</p>
+    </div>
+  );
+}

--- a/ui/src/components/Pager.tsx
+++ b/ui/src/components/Pager.tsx
@@ -1,0 +1,78 @@
+import { useTranslation } from 'react-i18next';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { Button } from '@/design-system/button';
+
+interface PagerProps {
+  /** Index de la première ligne affichée (0-based). */
+  offset: number;
+  /** Taille de page demandée. */
+  limit: number;
+  /** Nombre de lignes réellement rendues sur cette page. */
+  shown: number;
+  /** Total côté serveur. */
+  total: number;
+  onPrevious: () => void;
+  onNext: () => void;
+  isFetching?: boolean;
+}
+
+/**
+ * « 51–100 sur 260 », avec les deux flèches.
+ *
+ * Les bornes sont affichées, pas seulement un numéro de page : sur un registre
+ * d'argent, savoir *où* on est dans la liste vaut mieux que savoir sur quelle
+ * page — c'est ce qui permet de dire « j'ai traité jusqu'au 100e » et de
+ * reprendre.
+ *
+ * Ne rend rien quand tout tient sur une page.
+ */
+export default function Pager({
+  offset,
+  limit,
+  shown,
+  total,
+  onPrevious,
+  onNext,
+  isFetching = false,
+}: PagerProps) {
+  const { t } = useTranslation();
+
+  if (total <= limit) return null;
+
+  const hasPrevious = offset > 0;
+  const hasNext = offset + shown < total;
+
+  return (
+    <div className="flex items-center justify-between gap-3 pt-3">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onPrevious}
+        disabled={!hasPrevious || isFetching}
+      >
+        <ChevronLeft className="mr-1 h-4 w-4" />
+        {t('common.previous')}
+      </Button>
+
+      <p className="text-xs text-muted-foreground">
+        {t('common.rangeOfTotal', {
+          from: shown === 0 ? 0 : offset + 1,
+          to: offset + shown,
+          total,
+        })}
+      </p>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={onNext}
+        disabled={!hasNext || isFetching}
+      >
+        {t('common.next')}
+        <ChevronRight className="ml-1 h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/ui/src/components/listNavigation.test.tsx
+++ b/ui/src/components/listNavigation.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LoadMore from './LoadMore';
+import Pager from './Pager';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key}:${JSON.stringify(vars)}` : key,
+  }),
+}));
+
+describe('LoadMore', () => {
+  it('propose la suite tant qu’il en reste', async () => {
+    const onLoadMore = vi.fn();
+    const user = userEvent.setup();
+    render(<LoadMore shown={50} total={116} onLoadMore={onLoadMore} />);
+
+    expect(screen.getByText(/50.*116/)).toBeInTheDocument();
+    await user.click(screen.getByRole('button'));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+
+  it('disparaît quand tout est affiché', () => {
+    const { container } = render(<LoadMore shown={12} total={12} onLoadMore={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('dit pourquoi il s’arrête au plafond du serveur', () => {
+    // ⚠️ Le cœur du correctif. Un bouton qui n'avance plus est le mur d'origine
+    // déplacé de cinquante lignes : au plafond, la phrase remplace le bouton.
+    render(<LoadMore shown={200} total={1043} max={200} onLoadMore={vi.fn()} />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByText(/cappedAtMax/)).toBeInTheDocument();
+  });
+});
+
+describe('Pager', () => {
+  const base = { shown: 50, total: 260, onPrevious: vi.fn(), onNext: vi.fn() };
+
+  it('ne s’affiche pas quand tout tient sur une page', () => {
+    const { container } = render(<Pager {...base} offset={0} limit={50} shown={30} total={30} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('annonce les bornes, pas un numéro de page', () => {
+    // « 51–100 sur 260 » permet de dire « j'ai traité jusqu'au centième » et de
+    // reprendre là ; un numéro de page ne le permet pas.
+    render(<Pager {...base} offset={50} limit={50} />);
+    expect(screen.getByText(/"from":51.*"to":100.*"total":260/)).toBeInTheDocument();
+  });
+
+  it('bloque le retour sur la première page et la suite sur la dernière', () => {
+    const first = render(<Pager {...base} offset={0} limit={50} />);
+    const [previous, next] = screen.getAllByRole('button');
+    expect(previous).toBeDisabled();
+    expect(next).toBeEnabled();
+    first.unmount();
+
+    render(<Pager {...base} offset={250} limit={50} shown={10} />);
+    const [prev2, next2] = screen.getAllByRole('button');
+    expect(prev2).toBeEnabled();
+    expect(next2).toBeDisabled();
+  });
+});

--- a/ui/src/features/banking/TransactionsPage.tsx
+++ b/ui/src/features/banking/TransactionsPage.tsx
@@ -3,6 +3,8 @@ import { Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/PageHeader';
 import BackLink from '@/components/BackLink';
+import Pager from '@/components/Pager';
+import { usePager } from '@/lib/usePager';
 import { Button } from '@/design-system/button';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
@@ -34,7 +36,10 @@ export default function TransactionsPage() {
   const [filters, setFilters] = useSessionState<Filters>('banking.journal.filters', NO_FILTERS);
 
   const accountsQuery = useBankAccounts();
-  const transactionsQuery = useTransactions(filters, PAGE_SIZE);
+  // Un registre se parcourt : 116 lignes par relevé mensuel, et un plafond muet
+  // à 50 mettait les deux tiers du journal hors d'atteinte.
+  const pager = usePager(PAGE_SIZE, filters);
+  const transactionsQuery = useTransactions(filters, pager.limit, { offset: pager.offset });
   const flowQuery = useAccountFlow(filters);
   const qualifyMutation = useQualifyTransaction();
   const unlinkCashMutation = useUnlinkCashCounterpart();
@@ -71,6 +76,13 @@ export default function TransactionsPage() {
   }
 
   const page = transactionsQuery.data;
+
+  // Même garde que l'onglet Dépenses : une page vidée ramène à la première.
+  React.useEffect(() => {
+    if (!transactionsQuery.isFetching && page && page.results.length === 0 && pager.offset > 0) {
+      pager.reset();
+    }
+  }, [transactionsQuery.isFetching, page, pager]);
 
   return (
     <>
@@ -121,6 +133,16 @@ export default function TransactionsPage() {
           onClassify={setClassifyTarget}
         />
       )}
+
+      <Pager
+        offset={pager.offset}
+        limit={pager.limit}
+        shown={page?.results.length ?? 0}
+        total={page?.count ?? 0}
+        onPrevious={pager.previous}
+        onNext={pager.next}
+        isFetching={transactionsQuery.isFetching}
+      />
 
       {suggestTarget ? (
         <SuggestionsDialog

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -178,11 +178,14 @@ export function useImportStatementFile() {
 export function useTransactions(
   filters: TransactionFilters,
   limit = 50,
-  options: { enabled?: boolean } = {},
+  options: { enabled?: boolean; offset?: number } = {},
 ) {
+  const offset = options.offset ?? 0;
   return useQuery({
-    queryKey: bankingKeys.transactions(filters, limit),
-    queryFn: () => fetchTransactions(filters, limit),
+    // L'offset entre dans la clé : sans lui, la page 2 servirait le cache de la
+    // page 1 et le journal paraîtrait bloqué sur ses cinquante premières lignes.
+    queryKey: [...bankingKeys.transactions(filters, limit), offset],
+    queryFn: () => fetchTransactions(filters, limit, offset),
     enabled: options.enabled ?? true,
   });
 }

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -10,6 +10,8 @@ import {
   ShieldAlert,
   Undo2,
 } from 'lucide-react';
+import LoadMore from '@/components/LoadMore';
+import { useLoadMore } from '@/lib/useLoadMore';
 import { Card } from '@/design-system/card';
 import { Button } from '@/design-system/button';
 import { Badge } from '@/design-system/badge';
@@ -322,10 +324,14 @@ function GroupDetail({
 }) {
   const { t } = useTranslation();
   const [showWaived, setShowWaived] = React.useState(false);
-  const openQuery = useComplianceGroup(group.kind, { limit: 25 });
+  // Les deux listes s'agrandissent séparément : ouvrir la liste d'audit ne doit
+  // pas recharger la liste actionnable, et inversement.
+  const openWindow = useLoadMore(25, group.kind);
+  const waivedWindow = useLoadMore(25, group.kind);
+  const openQuery = useComplianceGroup(group.kind, { limit: openWindow.limit });
   const waivedQuery = useComplianceGroup(showWaived ? group.kind : undefined, {
     waived: true,
-    limit: 25,
+    limit: waivedWindow.limit,
   });
   const revoke = useRevokeWaiver();
 
@@ -390,11 +396,13 @@ function GroupDetail({
         </ul>
       )}
 
-      {group.open > openRows.length && openRows.length > 0 ? (
-        <p className="text-xs text-muted-foreground">
-          {t('money.compliance.andMore', { count: group.open - openRows.length })}
-        </p>
-      ) : null}
+      <LoadMore
+        shown={openRows.length}
+        total={group.open}
+        max={openWindow.maxLimit}
+        onLoadMore={openWindow.loadMore}
+        isFetching={openQuery.isFetching}
+      />
 
       {/* La liste d'audit. Repliée parce qu'elle n'appelle pas à l'action — mais
           présente, parce qu'un arbitrage qu'on ne peut pas relire ne vaut rien. */}
@@ -436,6 +444,17 @@ function GroupDetail({
                 </li>
               ))}
             </ul>
+          ) : null}
+
+          {showWaived ? (
+            <LoadMore
+              shown={waivedQuery.data?.results.length ?? 0}
+              total={group.waived}
+              max={waivedWindow.maxLimit}
+              onLoadMore={waivedWindow.loadMore}
+              isFetching={waivedQuery.isFetching}
+              className="flex flex-col items-center gap-1 pt-2"
+            />
           ) : null}
         </div>
       ) : null}

--- a/ui/src/features/money/ExpensesPanel.tsx
+++ b/ui/src/features/money/ExpensesPanel.tsx
@@ -3,9 +3,11 @@ import { Plus, Receipt } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import EmptyState from '@/components/EmptyState';
+import Pager from '@/components/Pager';
 import { Button } from '@/design-system/button';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useSessionState } from '@/lib/useSessionState';
+import { usePager } from '@/lib/usePager';
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
 import { interactionKeys } from '@/features/interactions/hooks';
 import { useExpenseSummary } from '@/features/expenses/hooks';
@@ -51,6 +53,11 @@ export default function ExpensesPanel() {
     ),
   );
 
+  // Même mécanique que le journal, et pour la même raison : c'est un registre,
+  // il grandit sans fin. Le serveur plafonne d'ailleurs cette liste à 100 par
+  // requête — une fenêtre qu'on agrandit s'y serait arrêtée sans le dire.
+  const pager = usePager(50, `${kind}|${supplier}|${range.from}|${range.to}`);
+
   const listFilters = React.useMemo(
     () => ({
       type: 'expense' as const,
@@ -61,9 +68,10 @@ export default function ExpensesPanel() {
       // The list endpoint filter param is `start_date`/`end_date` per views.py:71.
       ...(range.from ? { start_date: range.from } : {}),
       ...(range.to ? { end_date: range.to } : {}),
-      limit: 50,
+      limit: pager.limit,
+      offset: pager.offset,
     }),
-    [kind, supplier, range.from, range.to],
+    [kind, supplier, range.from, range.to, pager.limit, pager.offset],
   );
 
   const listQuery = useQuery({
@@ -72,6 +80,13 @@ export default function ExpensesPanel() {
   });
 
   const items: InteractionListItem[] = listQuery.data?.items ?? [];
+
+  // Une page qui s'est vidée sous les doigts (dépenses supprimées pendant la
+  // lecture) ramène à la première : rester sur une page vide afficherait « aucune
+  // dépense » à un foyer qui en a deux cents.
+  React.useEffect(() => {
+    if (!listQuery.isFetching && items.length === 0 && pager.offset > 0) pager.reset();
+  }, [listQuery.isFetching, items.length, pager]);
   const isLoading = summaryQuery.isLoading || listQuery.isLoading;
   const showSkeleton = useDelayedLoading(isLoading);
   const summary = summaryQuery.data;
@@ -135,7 +150,18 @@ export default function ExpensesPanel() {
                 action={{ label: t('expenses.adhoc.actions.add'), onClick: () => setAdhocOpen(true) }}
               />
             ) : (
-              <ExpenseList items={items} />
+              <>
+                <ExpenseList items={items} />
+                <Pager
+                  offset={pager.offset}
+                  limit={pager.limit}
+                  shown={items.length}
+                  total={listQuery.data?.count ?? items.length}
+                  onPrevious={pager.previous}
+                  onNext={pager.next}
+                  isFetching={listQuery.isFetching}
+                />
+              </>
             )}
           </>
         ) : null}

--- a/ui/src/features/money/PendingQueue.tsx
+++ b/ui/src/features/money/PendingQueue.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, Inbox, ShieldAlert } from 'lucide-react';
+import LoadMore from '@/components/LoadMore';
+import { useLoadMore } from '@/lib/useLoadMore';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
 import EmptyState from '@/components/EmptyState';
@@ -66,8 +68,12 @@ interface PendingQueueProps {
 
 export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
   const { t } = useTranslation();
-  const unallocatedQuery = useComplianceGroup(TRANSACTION_UNALLOCATED, { limit: 50 });
-  const partialQuery = useComplianceGroup(TRANSACTION_PARTIAL, { limit: 50 });
+  // Une seule fenêtre pour les deux détecteurs : la file les présente comme une
+  // liste unique triée par date, donc agrandir l'une sans l'autre ferait
+  // apparaître des lignes au milieu de ce qu'on vient de lire.
+  const { limit, loadMore, maxLimit } = useLoadMore(50);
+  const unallocatedQuery = useComplianceGroup(TRANSACTION_UNALLOCATED, { limit });
+  const partialQuery = useComplianceGroup(TRANSACTION_PARTIAL, { limit });
   const summaryQuery = useComplianceSummary();
   const budgetsQuery = useBudgets();
 
@@ -229,6 +235,20 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
           />
         ))}
       </div>
+
+      {/* Le « reporté » de la session est retiré de `rows` sans l'être du total :
+          on compte donc ce qui a été chargé, pas ce qui reste affiché, sinon
+          reporter trois lignes ferait réapparaître un bouton qui ne charge rien. */}
+      <LoadMore
+        shown={
+          (unallocatedQuery.data?.results.length ?? 0) + (partialQuery.data?.results.length ?? 0)
+        }
+        total={totalOpen}
+        max={maxLimit}
+        onLoadMore={loadMore}
+        isFetching={unallocatedQuery.isFetching || partialQuery.isFetching}
+        className="flex flex-col items-center gap-1 pt-2"
+      />
 
       {splitting ? (
         <AllocationDialog

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -316,9 +316,10 @@ function cleanParams(filters: TransactionFilters): Record<string, string> {
 export async function fetchTransactions(
   filters: TransactionFilters = {},
   limit = 50,
+  offset = 0,
 ): Promise<TransactionPage> {
   const { data } = await api.get<TransactionPage>('/banking/transactions/', {
-    params: { ...cleanParams(filters), limit },
+    params: { ...cleanParams(filters), limit, offset },
   });
   return data;
 }

--- a/ui/src/lib/useLoadMore.ts
+++ b/ui/src/lib/useLoadMore.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+/**
+ * Une liste plafonnée qui sait s'agrandir.
+ *
+ * Le module argent affichait ses quatre listes avec un `limit` en dur — 50 pour
+ * le journal, les dépenses et la file, 25 pour un groupe du Contrôle — et **aucun
+ * moyen d'aller plus loin**. Sur un relevé réel de 116 lignes, deux tiers du
+ * travail étaient hors d'atteinte, et le Contrôle allait jusqu'à annoncer « et 66
+ * de plus… » sans offrir de les voir. Un compteur qui nomme ce qu'il cache est
+ * pire qu'un compteur muet.
+ *
+ * On agrandit la fenêtre plutôt que d'empiler des pages (`useInfiniteQuery`) pour
+ * deux raisons concrètes : la forme du cache reste `{items, count}`, celle que le
+ * retrait optimiste d'une dépense manipule (`LinkedLineActions`), et une
+ * invalidation continue de rafraîchir *toute* la liste visible d'un coup — sur
+ * de l'argent, une page rafraîchie et trois périmées serait un piège.
+ *
+ * `resetKey` remet la fenêtre à sa taille de départ quand les filtres changent :
+ * garder 300 lignes de large après avoir filtré sur un compte ne servirait qu'à
+ * ralentir la requête suivante.
+ */
+export function useLoadMore(pageSize = 50, resetKey?: unknown, maxLimit = 200) {
+  const [limit, setLimit] = React.useState(pageSize);
+
+  React.useEffect(() => {
+    setLimit(pageSize);
+  }, [pageSize, resetKey]);
+
+  const loadMore = React.useCallback(() => {
+    // Borné au plafond du serveur : demander 250 quand il en rend 200 ferait un
+    // bouton qui ne bouge plus, sans rien dire.
+    setLimit((current) => Math.min(current + pageSize, maxLimit));
+  }, [pageSize, maxLimit]);
+
+  return { limit, loadMore, maxLimit };
+}

--- a/ui/src/lib/usePager.ts
+++ b/ui/src/lib/usePager.ts
@@ -1,0 +1,37 @@
+import * as React from 'react';
+
+/**
+ * Une liste qu'on **parcourt**, par pages.
+ *
+ * Deux mécanismes coexistent dans le module argent, et la différence n'est pas
+ * cosmétique :
+ *
+ * - le journal et les dépenses sont des registres qu'on **consulte** : ils
+ *   grandissent sans fin (116 lignes par relevé mensuel), donc leur parcours doit
+ *   être sans plafond. C'est ce hook.
+ * - la file « À ranger » et un groupe du Contrôle sont des piles qu'on **vide** :
+ *   les lignes disparaissent à mesure qu'on les traite, et changer de page pendant
+ *   que la précédente se vide fait sauter des lignes. C'est `useLoadMore`.
+ *
+ * L'agrandissement de fenêtre, lui, ne pouvait pas servir aux registres : le
+ * serveur plafonne à 100 (dépenses) et 200 (journal), donc le bouton aurait cessé
+ * d'avancer sans le dire — un mur déplacé plus loin, pas un mur supprimé.
+ *
+ * `resetKey` ramène à la première page quand les filtres changent : rester
+ * page 4 d'une liste qui n'en a plus qu'une afficherait un vide inexplicable.
+ */
+export function usePager(pageSize: number, resetKey?: unknown) {
+  const [offset, setOffset] = React.useState(0);
+
+  React.useEffect(() => {
+    setOffset(0);
+  }, [resetKey, pageSize]);
+
+  return {
+    limit: pageSize,
+    offset,
+    reset: React.useCallback(() => setOffset(0), []),
+    next: React.useCallback(() => setOffset((o) => o + pageSize), [pageSize]),
+    previous: React.useCallback(() => setOffset((o) => Math.max(0, o - pageSize)), [pageSize]),
+  };
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -171,7 +171,13 @@
     "create": "Erstellen",
     "showMore": "Mehr anzeigen",
     "close": "Schließen",
-    "clear": "Löschen"
+    "clear": "Löschen",
+    "loadMore": "Mehr anzeigen",
+    "shownOfTotal": "{{shown}} von {{total}}",
+    "previous": "Zurück",
+    "next": "Weiter",
+    "rangeOfTotal": "{{from}}–{{to}} von {{total}}",
+    "cappedAtMax": "{{shown}} von {{total}} — bearbeiten Sie diese, um den Rest zu sehen."
   },
   "errors": {
     "notFoundTitle": "Seite nicht gefunden",
@@ -3660,7 +3666,6 @@
       "waivedShort": "{{count}} abgelegt",
       "waivedShort_other": "{{count}} abgelegt",
       "blockedBy": "Diese Prüfung gilt nur für Konten, deren Voraussetzung „{{prerequisite}}“ erfüllt ist.",
-      "andMore": "und {{count}} weitere…",
       "showArbitrated": "{{count}} Ablagen anzeigen",
       "hideArbitrated": "Ablagen ausblenden",
       "revoke": "Widerrufen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -171,7 +171,13 @@
     "create": "Create",
     "showMore": "Show more",
     "close": "Close",
-    "clear": "Clear"
+    "clear": "Clear",
+    "loadMore": "Show more",
+    "shownOfTotal": "{{shown}} of {{total}}",
+    "previous": "Previous",
+    "next": "Next",
+    "rangeOfTotal": "{{from}}–{{to}} of {{total}}",
+    "cappedAtMax": "{{shown}} of {{total}} — clear these to see the rest."
   },
   "errors": {
     "notFoundTitle": "Page not found",
@@ -3660,7 +3666,6 @@
       "waivedShort": "{{count}} arbitrated",
       "waivedShort_other": "{{count}} arbitrated",
       "blockedBy": "This check only covers accounts whose “{{prerequisite}}” prerequisite is cleared.",
-      "andMore": "and {{count}} more…",
       "showArbitrated": "Show the {{count}} arbitrations",
       "hideArbitrated": "Hide arbitrations",
       "revoke": "Revoke",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -171,7 +171,13 @@
     "create": "Crear",
     "showMore": "Mostrar más",
     "close": "Cerrar",
-    "clear": "Borrar"
+    "clear": "Borrar",
+    "loadMore": "Ver más",
+    "shownOfTotal": "{{shown}} de {{total}}",
+    "previous": "Anterior",
+    "next": "Siguiente",
+    "rangeOfTotal": "{{from}}–{{to}} de {{total}}",
+    "cappedAtMax": "{{shown}} de {{total}} — resuelve estas para ver el resto."
   },
   "errors": {
     "notFoundTitle": "Página no encontrada",
@@ -3660,7 +3666,6 @@
       "waivedShort": "{{count}} justificada",
       "waivedShort_other": "{{count}} justificadas",
       "blockedBy": "Este control solo cubre las cuentas cuyo requisito «{{prerequisite}}» está resuelto.",
-      "andMore": "y {{count}} más…",
       "showArbitrated": "Ver las {{count}} justificaciones",
       "hideArbitrated": "Ocultar las justificaciones",
       "revoke": "Revocar",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -171,7 +171,13 @@
     "create": "Créer",
     "showMore": "Afficher plus",
     "close": "Fermer",
-    "clear": "Effacer"
+    "clear": "Effacer",
+    "loadMore": "Voir plus",
+    "shownOfTotal": "{{shown}} sur {{total}}",
+    "previous": "Précédent",
+    "next": "Suivant",
+    "rangeOfTotal": "{{from}}–{{to}} sur {{total}}",
+    "cappedAtMax": "{{shown}} sur {{total}} — traitez ces lignes pour voir la suite."
   },
   "errors": {
     "notFoundTitle": "Page introuvable",
@@ -3660,7 +3666,6 @@
       "waivedShort": "{{count}} arbitré",
       "waivedShort_other": "{{count}} arbitrés",
       "blockedBy": "Ce contrôle ne porte que sur les comptes dont le prérequis « {{prerequisite}} » est levé.",
-      "andMore": "et {{count}} de plus…",
       "showArbitrated": "Voir les {{count}} arbitrages",
       "hideArbitrated": "Masquer les arbitrages",
       "revoke": "Révoquer",


### PR DESCRIPTION
Recette : « je suis bloqué à cet endroit, il n'y a pas de pagination ou voir plus, je ne peux pas tout consulter ».

## Ce n'était pas un écran, c'était les quatre

| Liste | Plafond | Suite |
|---|---|---|
| Journal des opérations | 50 | ❌ |
| Onglet Dépenses | 50 | ❌ |
| À ranger | 50 | ❌ |
| Un groupe du Contrôle | 25 | ❌ |

Sur un relevé réel de 116 lignes, les deux tiers du travail étaient hors d'atteinte. Et le Contrôle affichait **« et 66 de plus… »** sans offrir de les voir : un compteur qui nomme ce qu'il cache est pire qu'un compteur muet.

## Deux mécanismes, parce que ce ne sont pas les mêmes listes

| Liste | Mécanisme | Pourquoi |
|---|---|---|
| Journal, Dépenses | **Pages** (`usePager` + `Pager`) | Des registres qu'on consulte : ils grandissent sans fin, le parcours doit être sans plafond |
| À ranger, Contrôle | **« Voir plus »** (`useLoadMore` + `LoadMore`) | Des piles qu'on vide : les lignes disparaissent à mesure, et changer de page pendant que la précédente se vide fait sauter des lignes |

**L'agrandissement de fenêtre ne pouvait pas servir aux registres** : le serveur plafonne à 100 (dépenses) et 200 (journal), donc le bouton aurait cessé d'avancer sans le dire — le mur déplacé de cinquante lignes, pas supprimé. C'est le piège que j'ai failli livrer.

**Et là où il sert, il ne ment pas non plus** : `LoadMore` reçoit le plafond serveur et, une fois atteint, remplace le bouton par une phrase — « 200 sur 1 043 — traitez ces lignes pour voir la suite ».

## Détails qui comptent

- Le `Pager` annonce des **bornes** (« 51–100 sur 260 »), pas un numéro de page : c'est ce qui permet de dire « j'ai traité jusqu'au centième » et de reprendre.
- Une **page vidée sous les doigts ramène à la première** — rester sur une page vide afficherait « aucune dépense » à un foyer qui en a deux cents.
- On agrandit la fenêtre plutôt que d'empiler des pages react-query : la forme du cache reste `{items, count}`, celle dont dépend le retrait optimiste d'une dépense (#429), et une invalidation rafraîchit toute la liste visible d'un coup. Sur de l'argent, une page fraîche et trois périmées serait un piège.
- `offset` entre dans la clé de cache du journal — sans lui la page 2 servait le cache de la page 1.

## Vérification

- `ui/src/components/listNavigation.test.tsx` — 6 cas, dont le plafond serveur et les bornes.
- `vitest` 35/35, `tsc -b ui` propre, `eslint` 0 erreur, i18n ×4 (clé morte `money.compliance.andMore` retirée).
- `pytest apps/banking apps/interactions` : 701 passed. Aucun changement serveur.