### PR TITLE
feat(money): les recettes entrent dans la file « À ranger », même geste

### DIFF
--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -548,6 +548,33 @@ Tests : `banking/tests/test_refund_allocations.py` (14 cas) et
 `budget/tests/test_refunds.py`, dont les 22 cas de netting tournent inchangés sur
 le nouveau mécanisme — c'est ce qui prouve qu'aucun total n'a bougé.
 
+### Les recettes entrent dans la file — même geste, pastilles différentes
+
+« D'abord les recettes doivent être considérées comme des dépenses, ensuite un
+seul endroit où l'on dispatch. » La file traite désormais **cinq** détecteurs :
+les deux sorties, plus `inflow_unclassified`, `refund_without_budget` et
+`refund_partially_allocated`. Les lignes se mélangent, triées par date — c'est le
+relevé, pas deux listes, et deux écrans obligeaient à se souvenir lequel on avait
+vidé.
+
+⚠️ **Mêmes issues, pastilles différentes.** Ce qu'on demande à une recette n'est
+pas un budget mais une **nature** : salaire, transfert interne, autre se règlent
+d'un clic, et le remboursement ouvre son dialogue parce que lui seul demande de
+désigner des enveloppes *et* des montants. Offrir des pastilles de budget sur une
+recette aurait laissé croire qu'on la ventile comme une dépense — alors qu'elle ne
+consomme rien, elle rend.
+
+- **Actions groupées séparées par sens** : quinze virements internes se classent
+  d'un geste (le cas réel après un import). Une barre commune aurait proposé des
+  actions inapplicables à la moitié de la sélection.
+- `PENDING_KINDS` se scinde en `PENDING_OUTFLOW_KINDS` / `PENDING_INFLOW_KINDS`.
+  Le badge de la coque lit l'union ; **le Contrôle lit les sorties seules**, sans
+  quoi il proposerait « Ventiler » sur un virement reçu — un éditeur qui ne sait
+  pas les traiter.
+- `PendingRow.outflow` devient `amount` (magnitude), le sens porté par
+  `direction` : la file range des lignes, elle n'a pas à connaître la convention
+  de signe des détecteurs (`outflow` pour les uns, `amount` pour les autres).
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -20,7 +20,11 @@ import EmptyState from '@/components/EmptyState';
 import type { ComplianceFinding, ComplianceGroup, ComplianceSeverity } from '@/lib/api/banking';
 import { useComplianceGroup, useComplianceSummary, useRevokeWaiver } from './hooks';
 import { blockingPrerequisite } from './prerequisites';
-import { ACCOUNT_ANCHOR_STALE, ACCOUNT_WITHOUT_WINDOW, PENDING_KINDS } from './keys';
+import {
+  ACCOUNT_ANCHOR_STALE,
+  ACCOUNT_WITHOUT_WINDOW,
+  PENDING_OUTFLOW_KINDS,
+} from './keys';
 import { useBankAccounts } from '@/features/banking/hooks';
 import AccountDialog from '@/features/banking/AccountDialog';
 import BalanceAnchorDialog from '@/features/banking/BalanceAnchorDialog';
@@ -378,8 +382,12 @@ function GroupDetail({
                   ? () => onAnchorAccount(finding.object_id)
                   : undefined
               }
+              // ⚠️ `PENDING_OUTFLOW_KINDS`, pas `PENDING_KINDS` : depuis que la
+              // file traite aussi les recettes, ce dernier en contient, et
+              // l'éditeur de ventilation ne sait pas les traiter — il aurait
+              // proposé de ventiler un virement reçu.
               onAllocate={
-                (PENDING_KINDS as readonly string[]).includes(group.kind)
+                (PENDING_OUTFLOW_KINDS as readonly string[]).includes(group.kind)
                   ? () => onAllocate(finding.object_id)
                   : undefined
               }

--- a/ui/src/features/money/PendingCard.tsx
+++ b/ui/src/features/money/PendingCard.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Split } from 'lucide-react';
+import { ArrowDownLeft, Split, Tag } from 'lucide-react';
 import { Card } from '@/design-system/card';
 import { Button } from '@/design-system/button';
 import { CheckboxField } from '@/design-system/checkbox-field';
 import { formatAmount } from '@/lib/format';
-import { useSetAllocations } from '@/features/banking/hooks';
+import { useQualifyTransaction, useSetAllocations } from '@/features/banking/hooks';
 import type { PendingRow } from './PendingQueue';
 
 interface PendingCardProps {
@@ -17,6 +17,8 @@ interface PendingCardProps {
   onSplit: () => void;
   onPostpone: () => void;
   onWaive: () => void;
+  /** Ouvre le dialogue de qualification — le seul chemin d'un remboursement. */
+  onClassify: () => void;
 }
 
 /**
@@ -33,6 +35,14 @@ interface PendingCardProps {
  * l'enregistrement d'une ventilation est un remplacement complet, donc imputer
  * d'un clic une ligne déjà partagée écraserait le travail déjà fait. Sur une ligne
  * partielle, le seul chemin est le dialog, qui part de l'existant.
+ *
+ * ⚠️ **Une recette a les mêmes issues, mais pas les mêmes pastilles.** Ce qu'on lui
+ * demande n'est pas un budget mais une **nature** : salaire, remboursement,
+ * transfert interne, autre. Trois d'entre elles se règlent d'un clic ; le
+ * remboursement ouvre son dialogue, parce que lui seul demande de désigner des
+ * enveloppes *et* des montants. Offrir des pastilles de budget sur une recette
+ * aurait laissé croire qu'on peut la ventiler comme une dépense — alors qu'elle
+ * ne consomme rien, elle rend.
  */
 export default function PendingCard({
   row,
@@ -42,17 +52,29 @@ export default function PendingCard({
   onSplit,
   onPostpone,
   onWaive,
+  onClassify,
 }: PendingCardProps) {
   const { t } = useTranslation();
   const setAllocationsMutation = useSetAllocations();
+  const qualify = useQualifyTransaction();
   const [pending, setPending] = React.useState(false);
+  const isInflow = row.direction === 'in';
+
+  async function classify(nature: 'salary' | 'transfer' | 'other') {
+    setPending(true);
+    try {
+      await qualify.mutateAsync({ id: row.transactionId, payload: { inflow_nature: nature } });
+    } finally {
+      setPending(false);
+    }
+  }
 
   async function assignWhole(budgetId: string) {
     setPending(true);
     try {
       await setAllocationsMutation.mutateAsync({
         transactionId: row.transactionId,
-        lines: [{ subject: row.label, amount: row.outflow, budget_id: budgetId || null }],
+        lines: [{ subject: row.label, amount: row.amount, budget_id: budgetId || null }],
       });
     } finally {
       setPending(false);
@@ -82,14 +104,19 @@ export default function PendingCard({
                 {row.accountName ? ` · ${row.accountName}` : ''}
               </p>
             </div>
-            <span className="shrink-0 text-sm font-semibold tabular-nums text-foreground">
-              {formatAmount(row.outflow)}
+            <span
+              className={`flex shrink-0 items-center gap-1 text-sm font-semibold tabular-nums ${
+                isInflow ? 'text-primary' : 'text-foreground'
+              }`}
+            >
+              {isInflow ? <ArrowDownLeft className="h-3.5 w-3.5" aria-hidden /> : null}
+              {formatAmount(row.amount)}
             </span>
           </div>
 
           {row.isPartial ? (
             <p className="mt-1 text-xs text-warning">
-              {t('money.pending.partial', {
+              {t(isInflow ? 'money.pending.partialRefund' : 'money.pending.partial', {
                 allocated: formatAmount(row.allocated),
                 remaining: formatAmount(row.remaining),
               })}
@@ -103,25 +130,64 @@ export default function PendingCard({
           ) : null}
 
           <div className="mt-2 flex flex-wrap items-center gap-1.5">
-            {!row.isPartial
-              ? budgets.map((budget) => (
+            {/* Une recette : sa nature. Une sortie : son budget. Même geste,
+                même place, mais la question posée n'est pas la même. */}
+            {isInflow ? (
+              <>
+                {(['salary', 'transfer', 'other'] as const).map((nature) => (
                   <Button
-                    key={budget.id}
+                    key={nature}
                     type="button"
                     variant="outline"
                     size="sm"
                     disabled={pending}
-                    onClick={() => assignWhole(budget.id)}
+                    onClick={() => classify(nature)}
                   >
-                    {budget.name}
+                    {t(`banking.inflow.natures.${nature}`)}
                   </Button>
-                ))
-              : null}
+                ))}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onClassify}
+                  disabled={pending}
+                >
+                  <Tag className="mr-1 h-3.5 w-3.5" aria-hidden />
+                  {row.isPartial
+                    ? t('money.pending.completeRefund')
+                    : t('banking.inflow.natures.refund')}
+                </Button>
+              </>
+            ) : (
+              <>
+                {!row.isPartial
+                  ? budgets.map((budget) => (
+                      <Button
+                        key={budget.id}
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={pending}
+                        onClick={() => assignWhole(budget.id)}
+                      >
+                        {budget.name}
+                      </Button>
+                    ))
+                  : null}
 
-            <Button type="button" variant="ghost" size="sm" onClick={onSplit} disabled={pending}>
-              <Split className="mr-1 h-3.5 w-3.5" aria-hidden />
-              {row.isPartial ? t('money.pending.complete') : t('money.pending.split')}
-            </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={onSplit}
+                  disabled={pending}
+                >
+                  <Split className="mr-1 h-3.5 w-3.5" aria-hidden />
+                  {row.isPartial ? t('money.pending.complete') : t('money.pending.split')}
+                </Button>
+              </>
+            )}
 
             <Button type="button" variant="ghost" size="sm" onClick={onWaive} disabled={pending}>
               {row.isStale

--- a/ui/src/features/money/PendingQueue.tsx
+++ b/ui/src/features/money/PendingQueue.tsx
@@ -9,9 +9,16 @@ import EmptyState from '@/components/EmptyState';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useBudgets } from '@/features/budget/hooks';
 import AllocationDialog from '@/features/banking/AllocationDialog';
-import { useSetAllocations } from '@/features/banking/hooks';
+import ClassifyInflowDialog from '@/features/banking/ClassifyInflowDialog';
+import { useAllocations, useQualifyTransaction, useSetAllocations } from '@/features/banking/hooks';
 import type { ComplianceFinding } from '@/lib/api/banking';
-import { TRANSACTION_PARTIAL, TRANSACTION_UNALLOCATED } from './keys';
+import {
+  INFLOW_UNCLASSIFIED,
+  REFUND_PARTIALLY_ALLOCATED,
+  REFUND_WITHOUT_BUDGET,
+  TRANSACTION_PARTIAL,
+  TRANSACTION_UNALLOCATED,
+} from './keys';
 import { useComplianceGroup, useComplianceSummary } from './hooks';
 import { householdBlocker } from './prerequisites';
 import PendingCard from './PendingCard';
@@ -24,15 +31,22 @@ export interface PendingRow {
   label: string;
   accountName: string;
   bookedOn: string;
-  outflow: string;
+  /** Magnitude, toujours positive — le sens est porté par `direction`. */
+  amount: string;
   allocated: string;
   remaining: string;
+  /** `in` = une recette à qualifier, `out` = une sortie à ventiler. */
+  direction: 'in' | 'out';
+  /** Sortie à moitié ventilée, ou remboursement à moitié attribué. */
   isPartial: boolean;
   isStale: boolean;
   waiverReason: string;
 }
 
-function toRow(finding: ComplianceFinding, isPartial: boolean): PendingRow {
+function toRow(
+  finding: ComplianceFinding,
+  { direction, isPartial }: { direction: 'in' | 'out'; isPartial: boolean },
+): PendingRow {
   const detail = finding.detail as Record<string, string | undefined>;
   return {
     kind: finding.kind,
@@ -40,9 +54,12 @@ function toRow(finding: ComplianceFinding, isPartial: boolean): PendingRow {
     label: detail.label ?? finding.label,
     accountName: detail.account_name ?? '',
     bookedOn: detail.booked_on ?? '',
-    outflow: detail.outflow ?? '0',
-    allocated: detail.allocated ?? '0',
+    // Les détecteurs de sortie nomment `outflow`, ceux de recette `amount` : la
+    // file n'a pas à connaître cette différence, elle range des lignes.
+    amount: detail.outflow ?? detail.amount ?? '0',
+    allocated: detail.allocated ?? detail.credited ?? '0',
     remaining: detail.remaining ?? '0',
+    direction,
     isPartial,
     isStale: finding.is_stale,
     waiverReason: finding.waiver_reason,
@@ -74,26 +91,62 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
   const { limit, loadMore, maxLimit } = useLoadMore(50);
   const unallocatedQuery = useComplianceGroup(TRANSACTION_UNALLOCATED, { limit });
   const partialQuery = useComplianceGroup(TRANSACTION_PARTIAL, { limit });
+  // Les recettes, dans la même file et au même titre : une recette non classée
+  // est du rangement, exactement comme une sortie non ventilée.
+  const unclassifiedQuery = useComplianceGroup(INFLOW_UNCLASSIFIED, { limit });
+  const refundNoBudgetQuery = useComplianceGroup(REFUND_WITHOUT_BUDGET, { limit });
+  const refundPartialQuery = useComplianceGroup(REFUND_PARTIALLY_ALLOCATED, { limit });
+
+  const inflowQueries = [unclassifiedQuery, refundNoBudgetQuery, refundPartialQuery];
+  const allQueries = [unallocatedQuery, partialQuery, ...inflowQueries];
   const summaryQuery = useComplianceSummary();
   const budgetsQuery = useBudgets();
 
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [postponed, setPostponed] = React.useState<Set<string>>(new Set());
   const [splitting, setSplitting] = React.useState<string | null>(null);
+  const [classifying, setClassifying] = React.useState<string | null>(null);
+  const classifyQuery = useAllocations(classifying ?? undefined);
+  const classifyTarget = classifyQuery.data?.transaction ?? null;
   const [waiving, setWaiving] = React.useState<WaiverTarget | null>(null);
 
-  const isLoading = unallocatedQuery.isLoading || partialQuery.isLoading;
+  const isLoading = allQueries.some((q) => q.isLoading);
   const showSkeleton = useDelayedLoading(isLoading);
 
   const rows = React.useMemo(() => {
-    const unallocated = (unallocatedQuery.data?.results ?? []).map((f) => toRow(f, false));
-    const partial = (partialQuery.data?.results ?? []).map((f) => toRow(f, true));
+    const out = [
+      ...(unallocatedQuery.data?.results ?? []).map((f) =>
+        toRow(f, { direction: 'out', isPartial: false }),
+      ),
+      ...(partialQuery.data?.results ?? []).map((f) =>
+        toRow(f, { direction: 'out', isPartial: true }),
+      ),
+    ];
+    const inn = [
+      ...(unclassifiedQuery.data?.results ?? []).map((f) =>
+        toRow(f, { direction: 'in', isPartial: false }),
+      ),
+      ...(refundNoBudgetQuery.data?.results ?? []).map((f) =>
+        toRow(f, { direction: 'in', isPartial: false }),
+      ),
+      ...(refundPartialQuery.data?.results ?? []).map((f) =>
+        toRow(f, { direction: 'in', isPartial: true }),
+      ),
+    ];
     // Les plus anciennes d'abord : ranger dans l'ordre du relevé est le seul ordre
-    // qui laisse une chance de se souvenir de ce qu'était une ligne.
-    return [...unallocated, ...partial]
+    // qui laisse une chance de se souvenir de ce qu'était une ligne. Recettes et
+    // sorties se mélangent — c'est le relevé, pas deux listes.
+    return [...out, ...inn]
       .filter((row) => !postponed.has(row.transactionId))
       .sort((a, b) => a.bookedOn.localeCompare(b.bookedOn));
-  }, [unallocatedQuery.data, partialQuery.data, postponed]);
+  }, [
+    unallocatedQuery.data,
+    partialQuery.data,
+    unclassifiedQuery.data,
+    refundNoBudgetQuery.data,
+    refundPartialQuery.data,
+    postponed,
+  ]);
 
   // Pastilles, pas options : on garde des `Budget`, mais un groupe n'est pas
   // plus une cible ici qu'ailleurs — le serveur refuserait la ventilation.
@@ -102,8 +155,7 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
     [budgetsQuery.data],
   );
 
-  const totalOpen =
-    (unallocatedQuery.data?.open ?? 0) + (partialQuery.data?.open ?? 0);
+  const totalOpen = allQueries.reduce((sum, q) => sum + (q.data?.open ?? 0), 0);
 
   function toggleSelected(id: string) {
     setSelected((prev) => {
@@ -168,12 +220,22 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
     );
   }
 
-  // Une sélection ne peut porter que sur des lignes entièrement non ventilées :
+  // Une sélection ne peut porter que sur des sorties entièrement non ventilées :
   // imputer en masse une ligne déjà partiellement ventilée écraserait sa
   // ventilation existante (le PUT est un « set »). Les lignes partielles se
   // complètent une par une, dans le dialog.
-  const selectableRows = rows.filter((row) => !row.isPartial);
-  const selectedRows = rows.filter((row) => selected.has(row.transactionId));
+  //
+  // Les **recettes** ont leur propre lot, séparé : leur action groupée n'est pas
+  // un budget mais une nature, et mélanger les deux sélections produirait une
+  // barre d'actions dont la moitié ne s'applique pas à la moitié de la sélection.
+  const selectableRows = rows.filter((row) => !row.isPartial && row.direction === 'out');
+  const selectableInflows = rows.filter((row) => row.direction === 'in');
+  const selectedRows = rows.filter(
+    (row) => selected.has(row.transactionId) && row.direction === 'out',
+  );
+  const selectedInflows = rows.filter(
+    (row) => selected.has(row.transactionId) && row.direction === 'in',
+  );
 
   return (
     <div className="space-y-3">
@@ -181,25 +243,31 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
         <p className="text-sm text-muted-foreground">
           {t('money.pending.count', { count: totalOpen })}
         </p>
-        {selectableRows.length > 0 ? (
+        {selectableRows.length + selectableInflows.length > 0 ? (
           <Button
             type="button"
             variant="ghost"
             size="sm"
             onClick={() =>
               setSelected((prev) =>
-                prev.size === selectableRows.length
+                prev.size === selectableRows.length + selectableInflows.length
                   ? new Set()
-                  : new Set(selectableRows.map((r) => r.transactionId)),
+                  : new Set(
+                      [...selectableRows, ...selectableInflows].map((r) => r.transactionId),
+                    ),
               )
             }
           >
-            {selected.size === selectableRows.length
+            {selected.size === selectableRows.length + selectableInflows.length
               ? t('money.pending.clearSelection')
               : t('money.pending.selectAll')}
           </Button>
         ) : null}
       </div>
+
+      {selectedInflows.length > 0 ? (
+        <InflowBulkBar rows={selectedInflows} onDone={() => setSelected(new Set())} />
+      ) : null}
 
       {selectedRows.length > 0 ? (
         <BulkBar
@@ -223,8 +291,13 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
             row={row}
             budgets={budgets}
             selected={selected.has(row.transactionId)}
-            onToggleSelected={row.isPartial ? undefined : () => toggleSelected(row.transactionId)}
+            onToggleSelected={
+              row.isPartial && row.direction === 'out'
+                ? undefined
+                : () => toggleSelected(row.transactionId)
+            }
             onSplit={() => setSplitting(row.transactionId)}
+            onClassify={() => setClassifying(row.transactionId)}
             onPostpone={() => postpone(row.transactionId)}
             onWaive={() =>
               setWaiving({
@@ -242,13 +315,11 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
           on compte donc ce qui a été chargé, pas ce qui reste affiché, sinon
           reporter trois lignes ferait réapparaître un bouton qui ne charge rien. */}
       <LoadMore
-        shown={
-          (unallocatedQuery.data?.results.length ?? 0) + (partialQuery.data?.results.length ?? 0)
-        }
+        shown={allQueries.reduce((sum, q) => sum + (q.data?.results.length ?? 0), 0)}
         total={totalOpen}
         max={maxLimit}
         onLoadMore={loadMore}
-        isFetching={unallocatedQuery.isFetching || partialQuery.isFetching}
+        isFetching={allQueries.some((q) => q.isFetching)}
         className="flex flex-col items-center gap-1 pt-2"
       />
 
@@ -260,8 +331,70 @@ export default function PendingQueue({ onGoToControl }: PendingQueueProps) {
         />
       ) : null}
 
+      {/* Le dialogue de qualification veut la ligne complète, pas son id : la file
+          ne connaît que des écarts (voir `AllocationDialog`, même contrainte
+          inversée). On la relit par l'endpoint que toute cette famille de
+          dialogues utilise déjà, plutôt que d'inventer un second chemin. */}
+      {classifyTarget ? (
+        <ClassifyInflowDialog
+          open
+          onOpenChange={(next) => !next && setClassifying(null)}
+          transaction={classifyTarget}
+        />
+      ) : null}
+
       <WaiverDialog target={waiving} onClose={() => setWaiving(null)} />
     </div>
+  );
+}
+
+/**
+ * Le lot des recettes : une **nature** pour toute la sélection.
+ *
+ * Quinze virements internes se classent d'un geste — c'est le cas réel après un
+ * import : les allers-retours entre comptes arrivent en paquet. « Remboursement »
+ * n'y figure pas : il demande de désigner des enveloppes et des montants, donc il
+ * se traite ligne à ligne, dans son dialogue.
+ */
+function InflowBulkBar({ rows, onDone }: { rows: PendingRow[]; onDone: () => void }) {
+  const { t } = useTranslation();
+  const [pending, setPending] = React.useState(false);
+  const qualify = useQualifyTransaction();
+
+  async function classifyAll(nature: 'salary' | 'transfer' | 'other') {
+    setPending(true);
+    try {
+      // Séquentiel, comme pour les sorties : quinze lignes ne doivent pas partir
+      // en quinze requêtes concurrentes qui verrouillent chacune leur ligne.
+      for (const row of rows) {
+        await qualify.mutateAsync({ id: row.transactionId, payload: { inflow_nature: nature } });
+      }
+      onDone();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <Card className="space-y-2 border-primary/40 bg-primary/5 p-3">
+      <p className="text-sm font-medium text-foreground">
+        {t('money.pending.bulkSelectedInflows', { count: rows.length })}
+      </p>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {(['salary', 'transfer', 'other'] as const).map((nature) => (
+          <Button
+            key={nature}
+            type="button"
+            variant="outline"
+            size="sm"
+            disabled={pending}
+            onClick={() => classifyAll(nature)}
+          >
+            {t(`banking.inflow.natures.${nature}`)}
+          </Button>
+        ))}
+      </div>
+    </Card>
   );
 }
 
@@ -288,7 +421,7 @@ function BulkBar({
       for (const row of rows) {
         await setAllocationsMutation.mutateAsync({
           transactionId: row.transactionId,
-          lines: [{ subject: row.label, amount: row.outflow, budget_id: budgetId || null }],
+          lines: [{ subject: row.label, amount: row.amount, budget_id: budgetId || null }],
         });
       }
       onDone();

--- a/ui/src/features/money/keys.ts
+++ b/ui/src/features/money/keys.ts
@@ -42,6 +42,26 @@ export const EXPENSE_UNRECONCILED = 'expense_unreconciled';
 export const ACCOUNT_WITHOUT_WINDOW = 'account_without_window';
 export const ACCOUNT_CHAIN_BROKEN = 'account_chain_broken';
 export const ACCOUNT_ANCHOR_STALE = 'account_anchor_stale';
+export const INFLOW_UNCLASSIFIED = 'inflow_unclassified';
+export const REFUND_WITHOUT_BUDGET = 'refund_without_budget';
+export const REFUND_PARTIALLY_ALLOCATED = 'refund_partially_allocated';
 
-/** Les deux écarts que la file « À ranger » traite — même geste de résolution. */
-export const PENDING_KINDS = [TRANSACTION_UNALLOCATED, TRANSACTION_PARTIAL] as const;
+/** Ce qui est sorti et que personne n'a affecté — pastilles de budget. */
+export const PENDING_OUTFLOW_KINDS = [TRANSACTION_UNALLOCATED, TRANSACTION_PARTIAL] as const;
+
+/**
+ * Ce qui est **entré** et que personne n'a qualifié — pastilles de nature.
+ *
+ * Même file et même geste que les sorties, décidé en recette : « d'abord les
+ * recettes doivent être considérées comme des dépenses ». Une recette non classée
+ * est du travail de rangement au même titre qu'une sortie non ventilée, et les
+ * séparer en deux écrans obligeait à se souvenir lequel on avait vidé.
+ */
+export const PENDING_INFLOW_KINDS = [
+  INFLOW_UNCLASSIFIED,
+  REFUND_WITHOUT_BUDGET,
+  REFUND_PARTIALLY_ALLOCATED,
+] as const;
+
+/** Tout ce que la file traite — ce que compte le badge de la coque. */
+export const PENDING_KINDS = [...PENDING_OUTFLOW_KINDS, ...PENDING_INFLOW_KINDS] as const;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3774,6 +3774,11 @@
           "title": "Erstattungen ohne Umschlag",
           "hint": "Dieses Geld kam zurück, aber kein Budget nimmt es auf: der Monatszähler bleibt um diesen Betrag zu hoch.",
           "resolution": "Wählen Sie im Bankjournal das gutgeschriebene Budget, oder entscheiden Sie, dass die Erstattung keinen Umschlag betrifft."
+        },
+        "refund_partially_allocated": {
+          "title": "Teilweise zugeordnete Rückzahlungen",
+          "hint": "Ein Teil des zurückgekommenen Geldes erstattet kein Budget: deren Zähler bleiben um diesen Betrag zu hoch.",
+          "resolution": "Vervollständigen Sie die Aufteilung in der Warteschlange, oder begründen Sie den Rest."
         }
       },
       "blocked": "Kontrolle nicht bewertbar",
@@ -3807,7 +3812,10 @@
       "nothingLeftHint": "Zurückgestellte Buchungen erscheinen beim nächsten Besuch wieder.",
       "blocked": "Noch nichts bewertbar",
       "blockedHint": "Eine Voraussetzung blockiert die Kontrolle: {{prerequisite}}. Ihre Buchungen existieren, aber keine Regel kann sie erfassen.",
-      "blockedAction": "Kontrolle öffnen"
+      "blockedAction": "Kontrolle öffnen",
+      "bulkSelectedInflows": "{{count}} Einnahmen ausgewählt",
+      "partialRefund": "{{allocated}} erstattet, {{remaining}} ohne Budget",
+      "completeRefund": "Aufteilung vervollständigen"
     },
     "reconciliation": {
       "label": "Abgleich",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3774,6 +3774,11 @@
           "title": "Refunds crediting no envelope",
           "hint": "This money came back, but no budget takes it: the month's counter stays inflated by that much.",
           "resolution": "Pick the budget credited back from the bank journal, or arbitrate if this refund concerns no envelope."
+        },
+        "refund_partially_allocated": {
+          "title": "Partially credited refunds",
+          "hint": "Part of what came back credits no envelope: those budgets' counters stay inflated by that much.",
+          "resolution": "Complete the split from the queue, or arbitrate if the remainder concerns no envelope."
         }
       },
       "blocked": "Control cannot be evaluated",
@@ -3807,7 +3812,10 @@
       "nothingLeftHint": "Postponed operations will be back on your next visit.",
       "blocked": "Nothing evaluable yet",
       "blockedHint": "A prerequisite blocks the control: {{prerequisite}}. Your operations exist, but no rule can cover them yet.",
-      "blockedAction": "Open the control"
+      "blockedAction": "Open the control",
+      "bulkSelectedInflows": "{{count}} receipts selected",
+      "partialRefund": "{{allocated}} credited, {{remaining}} with no envelope",
+      "completeRefund": "Complete the split"
     },
     "reconciliation": {
       "label": "Reconciliation",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3774,6 +3774,11 @@
           "title": "Reembolsos sin sobre",
           "hint": "Este dinero volvió, pero ningún presupuesto lo recupera: el contador del mes sigue inflado por ese importe.",
           "resolution": "Elige el presupuesto acreditado desde el diario bancario, o arbitra si el reembolso no afecta a ningún sobre."
+        },
+        "refund_partially_allocated": {
+          "title": "Reembolsos parcialmente asignados",
+          "hint": "Una parte de lo devuelto no acredita ningún presupuesto: sus contadores siguen inflados en ese importe.",
+          "resolution": "Completa el reparto desde la cola, o justifica el resto si no corresponde a ningún presupuesto."
         }
       },
       "blocked": "Control no evaluable",
@@ -3807,7 +3812,10 @@
       "nothingLeftHint": "Las operaciones postergadas volverán en su próxima visita.",
       "blocked": "Nada evaluable por ahora",
       "blockedHint": "Un requisito bloquea el control: {{prerequisite}}. Sus operaciones existen, pero ninguna regla puede cubrirlas todavía.",
-      "blockedAction": "Ver el control"
+      "blockedAction": "Ver el control",
+      "bulkSelectedInflows": "{{count}} ingresos seleccionados",
+      "partialRefund": "{{allocated}} devueltos, {{remaining}} sin presupuesto",
+      "completeRefund": "Completar el reparto"
     },
     "reconciliation": {
       "label": "Conciliación",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3774,6 +3774,11 @@
           "title": "Remboursements sans enveloppe",
           "hint": "Cet argent est revenu, mais aucun budget ne le récupère : le compteur du mois reste gonflé d'autant.",
           "resolution": "Choisissez le budget recrédité depuis le journal bancaire, ou arbitrez si ce remboursement ne concerne aucune enveloppe."
+        },
+        "refund_partially_allocated": {
+          "title": "Remboursements partiellement attribués",
+          "hint": "Une part de ce qui est revenu ne recrédite aucune enveloppe : les compteurs de ces budgets restent gonflés d'autant.",
+          "resolution": "Complétez la répartition depuis « À ranger », ou arbitrez si le reste ne concerne aucune enveloppe."
         }
       },
       "blocked": "Contrôle non évaluable",
@@ -3807,7 +3812,10 @@
       "nothingLeftHint": "Les opérations reportées reviendront à votre prochaine visite.",
       "blocked": "Rien d'évaluable pour l'instant",
       "blockedHint": "Un prérequis bloque le contrôle : {{prerequisite}}. Tes opérations existent, mais aucune règle ne peut encore porter sur elles.",
-      "blockedAction": "Voir le contrôle"
+      "blockedAction": "Voir le contrôle",
+      "bulkSelectedInflows": "{{count}} recettes sélectionnées",
+      "partialRefund": "{{allocated}} rendus, {{remaining}} sans enveloppe",
+      "completeRefund": "Compléter la répartition"
     },
     "reconciliation": {
       "label": "Rapprochement",


### PR DESCRIPTION
Lot B du chantier « recettes ». Suite de #433.

La promesse de la recette était : « d'abord les recettes doivent être considérées comme des dépenses, ensuite un seul endroit où l'on dispatch ». Une recette non classée est du rangement au même titre qu'une sortie non ventilée ; les séparer en deux écrans obligeait à se souvenir lequel on avait vidé.

## Ce que la file traite

Cinq détecteurs au lieu de deux : les deux sorties, plus `inflow_unclassified`, `refund_without_budget`, `refund_partially_allocated`. Les lignes se **mélangent**, triées par date — c'est le relevé, pas deux listes.

## ⚠️ Mêmes issues, pastilles différentes

Ce qu'on demande à une recette n'est pas un budget mais une **nature** :

| | Pastilles | Le cas particulier |
|---|---|---|
| Sortie | les budgets | « Ventiler en plusieurs » |
| Recette | Revenu / Transfert / Autre | « Remboursement » ouvre son dialogue |

Le remboursement passe par son dialogue parce que lui seul demande de désigner des enveloppes **et** des montants. Des pastilles de budget sur une recette auraient laissé croire qu'on la ventile comme une dépense — alors qu'elle ne consomme rien, elle rend.

## Trois détails qui comptent

- **Actions groupées séparées par sens** : quinze virements internes se classent d'un geste, ce qui est le cas réel après un import. Une barre commune aurait offert des actions inapplicables à la moitié de la sélection.
- `PENDING_KINDS` se scinde en `PENDING_OUTFLOW_KINDS` / `PENDING_INFLOW_KINDS`. Le badge de la coque lit l'union ; **le Contrôle lit les sorties seules** — sinon il proposait « Ventiler » sur un virement reçu, un éditeur qui ne sait pas les traiter. Trouvé par le typage, pas en recette.
- `PendingRow.outflow` devient `amount` (magnitude), le sens porté par `direction` : la file range des lignes, elle n'a pas à connaître la convention de signe des détecteurs (`outflow` chez les uns, `amount` chez les autres).

## Vérification

- `pytest` complet : **3 528 passed**, 2 skipped (aucun changement serveur dans ce lot).
- `vitest` 41/41, `tsc -b ui` propre, `eslint` 0 erreur, i18n ×4 — dont les libellés du nouveau détecteur.
- `docs/MODULES/money.md` : nouvelle section.