### PR TITLE
feat(money): une dépense a sa propre fiche, et se supprime d'où on la lit

### DIFF
--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -123,7 +123,7 @@ l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
 `/app/money/transactions/:id`, `/app/money/analysis`, `/app/money/budgets/:id`,
-`/app/money/recurring`, `/app/money/reports`.
+`/app/money/expenses/:id`, `/app/money/recurring`, `/app/money/reports`.
 
 Les deux dernières ont rejoint la famille en juillet 2026 ; `/app/budget/recurring`
 et `/app/budget/reports` redirigent via `PreserveQueryRedirect`, qui conserve la
@@ -574,6 +574,48 @@ consomme rien, elle rend.
 - `PendingRow.outflow` devient `amount` (magnitude), le sens porté par
   `direction` : la file range des lignes, elle n'a pas à connaître la convention
   de signe des détecteurs (`outflow` pour les uns, `amount` pour les autres).
+
+### Une dépense a sa propre fiche
+
+`/app/money/expenses/:id` (`money/ExpenseDetailPage.tsx`). Sous le capot c'est
+toujours une `Interaction` — mais **la fiche générique du journal ne répondait à
+aucune des questions qu'une dépense pose**. Elle affichait un montant et un
+fournisseur, et taisait le budget : le seul axe qui classe un euro. D'où l'écran
+d'édition comme unique endroit habitable, donc comme destination du clic : un
+formulaire, ouvert pour lire.
+
+La fiche répond aux trois seules questions d'une dépense, dans cet ordre :
+**combien / où est-ce classé / qu'est-ce qui la justifie**.
+
+- **`/app/interactions/:id` redirige** quand le type est `expense`, en recopiant
+  `location.state` — sans quoi le lien retour de la fiche oublierait d'où l'on
+  vient. Les liens qui *savent* pointer une dépense (liste des dépenses, dépenses
+  d'une opération) visent directement la nouvelle URL : une redirection rattrape un
+  ancien lien, elle ne justifie pas d'en produire.
+- **Les dépenses sœurs sont affichées** (`useAllocations` sur la ligne, la dépense
+  courante retirée). 90 € lus sur une sortie de 150 € sans trace des 60 autres
+  ressemblent à une erreur de saisie ; le total de la ligne et son reste sont
+  rappelés dessous.
+- **Sans budget, la fiche le dit et propose d'y remédier.** C'est l'écart le plus
+  courant du foyer (`expense_without_budget`) et le résoudre demandait de deviner
+  qu'il faut passer par l'édition.
+- **Un seul geste de suppression par écran.** `InteractionDeleteAction` porte la
+  confirmation et la sortie pour les trois écrans (fiche, fiche de dépense,
+  édition) — l'édition ne l'offrait pas du tout, alors que c'est là qu'on découvre
+  qu'une entrée n'a rien à faire dans le journal. Corollaire : `ExpenseFields` ne
+  garde que le **détachement**, qui n'existe nulle part ailleurs sur ce
+  formulaire ; sur une dépense `kind='bank'`, deux boutons rouges au même endroit
+  ne se distinguaient pas l'un de l'autre.
+- Le libellé de confirmation **change de sens** sur une dépense née d'une
+  ventilation : elle ne disparaît pas, son montant retourne dans « À ranger ».
+- Les justificatifs se lisent via `?linked_to=interaction:{id}` (`DocumentLink`,
+  pas la FK legacy) et s'ajoutent en un geste — photographier un ticket depuis la
+  fiche d'une dépense le rattache forcément à elle. La section reste visible même
+  vide : une section qui n'apparaît qu'une fois remplie n'apprend à personne
+  qu'on peut la remplir.
+
+Régression : `ui/src/features/money/ExpenseDetailPage.test.tsx` (dont la
+redirection, et le fait que la fiche générique reste celle d'une note).
 
 ### Reste ouvert
 

--- a/ui/src/features/banking/TransactionDetailPage.tsx
+++ b/ui/src/features/banking/TransactionDetailPage.tsx
@@ -222,7 +222,7 @@ function AllocationLine({ expense }: { expense: AllocatedExpense }) {
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <Link
-              to={`/app/interactions/${expense.id}`}
+              to={`/app/money/expenses/${expense.id}`}
               state={pushBack(location)}
               className="group text-foreground hover:text-primary"
             >

--- a/ui/src/features/documents/DocumentDetailPage.tsx
+++ b/ui/src/features/documents/DocumentDetailPage.tsx
@@ -268,9 +268,9 @@ export default function DocumentDetailPage() {
                                 </Badge>
                               )}
                               <Link
-                                to={`/app/interactions/${item.id}/edit`}
+                                to={`/app/interactions/${item.id}`}
                                 className="ml-1 inline-flex items-center text-xs text-muted-foreground hover:text-foreground"
-                                aria-label={t('common.edit')}
+                                aria-label={t('common.view')}
                               >
                                 <ExternalLink className="h-3.5 w-3.5" />
                               </Link>

--- a/ui/src/features/documents/hooks.ts
+++ b/ui/src/features/documents/hooks.ts
@@ -45,10 +45,16 @@ export function useDetachEntityDocument(entityType: string, objectId: string) {
   });
 }
 
-export function useDocuments(filters: DocumentFilters = {}) {
+/**
+ * `enabled: false` compte : un filtre d'entité dont l'id est vide est **retiré**
+ * de la requête (voir `fetchDocuments`), donc la liste vide qu'on croit demander
+ * revient en réalité avec *tous* les documents du foyer.
+ */
+export function useDocuments(filters: DocumentFilters = {}, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: documentKeys.list(filters),
     queryFn: () => fetchDocuments(filters),
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Link2 } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { formatAmount, formatDate } from '@/lib/format';
+import { pushBack } from '@/lib/backNavigation';
 import ReconciliationBadge from '@/features/money/ReconciliationBadge';
 import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
 import LinkedLineActions from '@/features/banking/LinkedLineActions';
@@ -18,6 +19,7 @@ interface ExpenseListProps {
 export default function ExpenseList({ items }: ExpenseListProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   const [attachTarget, setAttachTarget] = React.useState<InteractionListItem | null>(null);
 
   return (
@@ -35,7 +37,11 @@ export default function ExpenseList({ items }: ExpenseListProps) {
             <li key={item.id}>
               <Card
                 className="cursor-pointer p-3 transition-shadow hover:shadow-md"
-                onClick={() => navigate(`/app/interactions/${item.id}/edit`)}
+                /* Cliquer une dépense ouvre sa **fiche**, plus un formulaire :
+                   on clique pour lire, et un champ de saisie ne se lit pas. */
+                onClick={() =>
+                  navigate(`/app/money/expenses/${item.id}`, { state: pushBack(location) })
+                }
               >
                 <div className="flex items-start justify-between gap-3">
                   <div className="min-w-0 flex-1">

--- a/ui/src/features/interactions/ExpenseFields.tsx
+++ b/ui/src/features/interactions/ExpenseFields.tsx
@@ -8,6 +8,7 @@ import { FormField } from '@/design-system/form-field';
 import { useBudgets } from '@/features/budget/hooks';
 import { selectableBudgets } from '@/features/budget/tree';
 import LinkedLineActions from '@/features/banking/LinkedLineActions';
+import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
 import type { BankLineRef } from '@/lib/api/interactions';
 
 interface ExpenseFieldsProps {
@@ -96,21 +97,28 @@ export default function ExpenseFields({
         </div>
       ) : null}
 
-      {/* Le rapprochement se lit et se défait **ici aussi**, parce que c'est ici
-          qu'on atterrit : cliquer une dépense de la liste ouvre ce formulaire, pas
-          sa fiche. Le geste posé sur la liste et sur la fiche restait donc
-          introuvable pour qui passe par le chemin le plus courant. */}
+      {/* L'opération qui justifie la dépense, et le lien pour aller la voir.
+          ⚠️ **Un seul geste par écran** : sur une dépense née de la ventilation,
+          « défaire » veut dire *supprimer*, et l'en-tête de la page le propose
+          déjà — deux boutons de suppression sur le même formulaire ne se
+          distinguent pas l'un de l'autre. Ne reste donc ici que le détachement,
+          qui n'existe nulle part ailleurs sur cet écran. */}
       {bankLine ? (
         <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-          <span>
+          <Link
+            to={`/app/money/transactions/${bankLine.id}`}
+            className="font-medium text-foreground underline-offset-2 hover:underline"
+          >
             {bankLine.account_name} · {bankLine.label}
-          </span>
-          <LinkedLineActions
-            expenseId={expenseId}
-            kind={kind}
-            transactionId={bankLine.id}
-            onDeleted={onDeleted}
-          />
+          </Link>
+          {!isOwnedByAllocationEditor(kind) ? (
+            <LinkedLineActions
+              expenseId={expenseId}
+              kind={kind}
+              transactionId={bankLine.id}
+              onDeleted={onDeleted}
+            />
+          ) : null}
         </div>
       ) : null}
 

--- a/ui/src/features/interactions/InteractionDeleteAction.tsx
+++ b/ui/src/features/interactions/InteractionDeleteAction.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Trash2 } from 'lucide-react';
+import { Button } from '@/design-system/button';
+import ConfirmDialog from '@/components/ConfirmDialog';
+import { useDeleteInteraction } from './hooks';
+
+interface InteractionDeleteActionProps {
+  id: string;
+  /** Où aller ensuite — la page courante éditerait sinon un objet disparu. */
+  onDeleted: () => void;
+  /** Texte de confirmation ; par défaut celui du journal. */
+  description?: string;
+  className?: string;
+  label?: string;
+}
+
+/**
+ * Supprimer une entrée du journal — **un seul geste, trois écrans**.
+ *
+ * La fiche, la fiche de dépense et le formulaire d'édition posent la même
+ * question, avec la même confirmation et la même sortie. Le formulaire d'édition
+ * ne l'offrait pas du tout : on y arrive pour corriger un montant, on y découvre
+ * que la dépense n'a rien à faire là, et il fallait ressortir pour la supprimer.
+ *
+ * Pas d'undo ici, contrairement aux listes : une page ne peut pas afficher une
+ * suppression optimiste puisqu'elle disparaît avec son objet. La confirmation
+ * joue ce rôle, et c'est le seul endroit du projet où elle le joue.
+ */
+export default function InteractionDeleteAction({
+  id,
+  onDeleted,
+  description,
+  className = 'h-8 px-3 text-sm',
+  label,
+}: InteractionDeleteActionProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+  const deleteMutation = useDeleteInteraction();
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="destructive"
+        className={className}
+        onClick={() => setOpen(true)}
+      >
+        <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+        {label ?? t('common.delete')}
+      </Button>
+
+      <ConfirmDialog
+        open={open}
+        onOpenChange={setOpen}
+        title={t('common.confirmDelete')}
+        description={description ?? t('interactions.delete_confirm')}
+        onConfirm={() => deleteMutation.mutate(id, { onSuccess: onDeleted })}
+        loading={deleteMutation.isPending}
+      />
+    </>
+  );
+}

--- a/ui/src/features/interactions/InteractionDetailPage.tsx
+++ b/ui/src/features/interactions/InteractionDetailPage.tsx
@@ -1,11 +1,9 @@
-import * as React from 'react';
-import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
+import { useParams, Link, useLocation, useNavigate, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { FileText, Link2, Pencil, Trash2 } from 'lucide-react';
+import { FileText, Pencil } from 'lucide-react';
 import { Badge } from '@/design-system/badge';
 import { Button } from '@/design-system/button';
 import { Card, CardContent } from '@/design-system/card';
-import ConfirmDialog from '@/components/ConfirmDialog';
 import BackLink from '@/components/BackLink';
 import PageHeader from '@/components/PageHeader';
 import InfoField from '@/components/InfoField';
@@ -13,15 +11,24 @@ import LoadError from '@/components/LoadError';
 import ListSkeleton from '@/components/ListSkeleton';
 import { pushBack, useNavigateBack } from '@/lib/backNavigation';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
-import { formatAmount, formatDateTime } from '@/lib/format';
-import ReconciliationBadge from '@/features/money/ReconciliationBadge';
-import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
-import LinkedLineActions from '@/features/banking/LinkedLineActions';
-import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
-import { useInteraction, useDeleteInteraction } from './hooks';
+import { formatDateTime } from '@/lib/format';
+import InteractionDeleteAction from './InteractionDeleteAction';
+import { useInteraction } from './hooks';
 
 // ── Main page ──────────────────────────────────────────────
 
+/**
+ * La fiche d'une entrée du journal — note, entretien, réparation, rénovation.
+ *
+ * ⚠️ **Une dépense a la sienne** (`/app/money/expenses/:id`) : les questions
+ * qu'elle pose — quelle enveloppe, quelle ligne de relevé, quelles dépenses
+ * sœurs — n'ont pas d'équivalent sur une note, et les traiter ici obligeait à
+ * cacher la moitié de l'écran une fois sur deux. Cette page **redirige** donc les
+ * dépenses au lieu de les rendre : les liens génériques (fil d'activité, fiche
+ * projet, tâche) n'ont pas à connaître le type de ce qu'ils pointent, mais un
+ * lien qui *sait* pointer sur une dépense doit viser directement la bonne page —
+ * une redirection rattrape un ancien lien, elle ne justifie pas d'en produire.
+ */
 export default function InteractionDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
@@ -29,20 +36,9 @@ export default function InteractionDetailPage() {
   const location = useLocation();
   const navigateBack = useNavigateBack('/app/interactions');
 
-  const [deleteOpen, setDeleteOpen] = React.useState(false);
-  const [attachOpen, setAttachOpen] = React.useState(false);
-
   const { data: interaction, isLoading, error } = useInteraction(id ?? '');
-  const deleteMutation = useDeleteInteraction();
 
   const showSkeleton = useDelayedLoading(isLoading);
-
-  function handleDelete() {
-    if (!id) return;
-    deleteMutation.mutate(id, {
-      onSuccess: () => navigateBack(),
-    });
-  }
 
   if (!id) return null;
 
@@ -60,9 +56,11 @@ export default function InteractionDetailPage() {
     );
   }
 
-  const amount = interaction.amount;
-  const supplier = interaction.supplier;
-  const isExpense = interaction.type === 'expense';
+  if (interaction.type === 'expense') {
+    // `state` recopié tel quel : la pile de retour doit survivre au saut, sinon
+    // le lien « retour » de la fiche de dépense oublierait d'où l'on vient.
+    return <Navigate to={`/app/money/expenses/${id}`} replace state={location.state} />;
+  }
 
   return (
     <>
@@ -86,15 +84,7 @@ export default function InteractionDetailPage() {
             <Pencil className="mr-1.5 h-3.5 w-3.5" />
             {t('common.edit')}
           </Button>
-          <Button
-            type="button"
-            variant="destructive"
-            className="h-8 px-3 text-sm"
-            onClick={() => setDeleteOpen(true)}
-          >
-            <Trash2 className="mr-1.5 h-3.5 w-3.5" />
-            {t('common.delete')}
-          </Button>
+          <InteractionDeleteAction id={interaction.id} onDeleted={navigateBack} />
         </PageHeader>
 
         {/* Info grid */}
@@ -127,64 +117,6 @@ export default function InteractionDetailPage() {
             </InfoField>
           )}
 
-          {isExpense && amount ? (
-            <InfoField label={t('interactions.expense_amount_label')}>{formatAmount(amount)}</InfoField>
-          ) : null}
-
-          {isExpense && supplier ? (
-            <InfoField label={t('interactions.contact_label')}>{supplier}</InfoField>
-          ) : null}
-
-          {/* Rapprochée ou non — et si oui, l'opération qui le prouve. C'est ici
-              que la question se pose vraiment : sur la page d'une dépense, « la
-              banque l'a-t-elle vue passer ? » n'a pas d'autre endroit où être lue. */}
-          {isExpense ? (
-            <InfoField label={t('money.reconciliation.label')}>
-              <div className="space-y-1.5">
-                <ReconciliationBadge
-                  state={interaction.reconciliation_state}
-                  line={interaction.bank_line}
-                />
-                {interaction.bank_line ? (
-                  <>
-                    <p className="text-xs text-muted-foreground">
-                      {interaction.bank_line.account_name} · {interaction.bank_line.label}
-                    </p>
-                    {/* Née de la ventilation : le geste n'est pas « détacher »
-                        mais « supprimer », puisque la dépense *est* la
-                        ventilation. Le composant tranche ; ici on ajoute le
-                        pourquoi, que seule une fiche a la place de dire. */}
-                    {isOwnedByAllocationEditor(interaction.kind) ? (
-                      <p className="text-xs text-muted-foreground">
-                        {t('banking.attach.ownedHint')}
-                      </p>
-                    ) : null}
-                    <LinkedLineActions
-                      expenseId={interaction.id}
-                      kind={interaction.kind}
-                      transactionId={interaction.bank_line.id}
-                      onDeleted={navigateBack}
-                      className="h-7 px-2 text-xs"
-                    />
-                  </>
-                ) : (
-                  /* Le constat sans le geste à côté n'aide personne : c'est ici
-                     qu'on lit « en attente », donc c'est ici qu'on doit pouvoir
-                     désigner l'opération. */
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="h-7 px-2 text-xs"
-                    onClick={() => setAttachOpen(true)}
-                    disabled={!amount}
-                  >
-                    <Link2 className="mr-1.5 h-3 w-3" />
-                    {t('banking.attach.action')}
-                  </Button>
-                )}
-              </div>
-            </InfoField>
-          ) : null}
         </dl>
 
         {/* Content */}
@@ -285,27 +217,6 @@ export default function InteractionDetailPage() {
         ) : null}
       </div>
 
-      {isExpense && amount ? (
-        <AttachToTransactionDialog
-          open={attachOpen}
-          onOpenChange={setAttachOpen}
-          expense={{
-            id: interaction.id,
-            subject: interaction.subject,
-            amount,
-            occurred_at: interaction.occurred_at,
-          }}
-        />
-      ) : null}
-
-      <ConfirmDialog
-        open={deleteOpen}
-        onOpenChange={setDeleteOpen}
-        title={t('common.confirmDelete')}
-        description={t('interactions.delete_confirm')}
-        onConfirm={handleDelete}
-        loading={deleteMutation.isPending}
-      />
     </>
   );
 }

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -13,6 +13,8 @@ import { fetchEquipmentList, type EquipmentListItem } from '@/lib/api/equipment'
 import { updateInteraction } from '@/lib/api/interactions';
 import { fetchHouseholdMembers, type HouseholdMember } from '@/lib/api/tasks';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
+import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
+import InteractionDeleteAction from './InteractionDeleteAction';
 import { useInteraction } from './hooks';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useNavigateBack } from '@/lib/backNavigation';
@@ -217,6 +219,19 @@ export default function InteractionEditPage() {
         >
           {t('common.cancel')}
         </Button>
+        {/* Supprimer depuis le formulaire : on y arrive pour corriger un montant,
+            on y découvre parfois que l'entrée n'a rien à faire là. Le geste vivait
+            seulement sur la fiche, qu'il fallait donc rouvrir pour l'atteindre. */}
+        <InteractionDeleteAction
+          id={id ?? ''}
+          onDeleted={navigateBackAfterDelete}
+          className="h-10 px-4 text-sm"
+          description={
+            isExpense && isOwnedByAllocationEditor(interaction.kind)
+              ? t('money.expense.deleteSplitConfirm')
+              : t('interactions.delete_confirm')
+          }
+        />
       </PageHeader>
 
       <NewTaskDialog

--- a/ui/src/features/interactions/hooks.ts
+++ b/ui/src/features/interactions/hooks.ts
@@ -1,12 +1,14 @@
-import { useQuery, useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   fetchInteractions,
   createInteraction,
   deleteInteraction,
   fetchInteraction,
   updateInteraction,
+  linkDocumentToInteraction,
   type CreateInteractionInput,
 } from '@/lib/api/interactions';
+import { documentKeys } from '@/features/documents/hooks';
 import { INTERACTIONS_ROOT } from '@/features/money/keys';
 import { useInvalidateMoney } from '@/features/money/invalidate';
 
@@ -60,6 +62,22 @@ export function useInteraction(id: string) {
     queryKey: interactionKeys.detail(id),
     queryFn: () => fetchInteraction(id),
     enabled: !!id,
+  });
+}
+
+/**
+ * Joindre un document à une entrée du journal — le justificatif d'une dépense.
+ *
+ * Le lien vit dans `DocumentLink` (table polymorphe), donc la liste se relit par
+ * `?linked_to=interaction:{id}` : c'est le cache `documents` qu'il faut invalider,
+ * pas celui de l'interaction, qui ne porte pas ses pièces.
+ */
+export function useAttachDocumentToInteraction(interactionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (documentId: string) =>
+      linkDocumentToInteraction({ interactionId, documentId }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: documentKeys.all }),
   });
 }
 

--- a/ui/src/features/money/ExpenseDetailPage.test.tsx
+++ b/ui/src/features/money/ExpenseDetailPage.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { InteractionListItem } from '@/lib/api/interactions';
+import ExpenseDetailPage from './ExpenseDetailPage';
+import InteractionDetailPage from '@/features/interactions/InteractionDetailPage';
+
+/**
+ * Ce que ces tests tiennent, et pourquoi :
+ *
+ * 1. **Une dépense a sa propre page**, et la fiche générique y renvoie. Sans la
+ *    redirection, les liens du fil d'activité et de la fiche projet continueraient
+ *    d'ouvrir un écran qui ne dit pas dans quelle enveloppe l'euro tombe.
+ * 2. **Le classement se lit sur la fiche.** Le budget est le seul axe qui classe un
+ *    euro : une fiche de dépense qui ne l'affiche pas manque son seul sujet.
+ * 3. **Les dépenses sœurs sont visibles.** 90 € lus sur une sortie de 150 € sans
+ *    trace des 60 autres ressemblent à une erreur de saisie.
+ */
+
+const expense: Partial<InteractionListItem> = {
+  id: 'exp-1',
+  subject: 'MAGASIN U',
+  type: 'expense',
+  content: '',
+  occurred_at: '2026-07-10T12:00:00Z',
+  tags: [],
+  zone_names: [],
+  amount: '90.00',
+  kind: 'bank',
+  supplier: 'Magasin U',
+  budget: { id: 'b-1', name: 'Courses' },
+  reconciliation_state: 'attested',
+  bank_line: {
+    id: 'txn-9',
+    label: 'CB MAGASIN U',
+    booked_on: '2026-07-10',
+    account_name: 'Compte courant',
+  },
+};
+
+let current: Partial<InteractionListItem> = expense;
+
+vi.mock('@/features/interactions/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/features/interactions/hooks')>(
+    '@/features/interactions/hooks',
+  );
+  return {
+    ...actual,
+    useInteraction: () => ({ data: current, isLoading: false, error: null }),
+    useDeleteInteraction: () => ({ mutate: vi.fn(), isPending: false }),
+    useAttachDocumentToInteraction: () => ({ mutate: vi.fn() }),
+  };
+});
+
+vi.mock('@/features/banking/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/features/banking/hooks')>(
+    '@/features/banking/hooks',
+  );
+  return {
+    ...actual,
+    useAllocations: () => ({
+      data: {
+        transaction: { id: 'txn-9' },
+        allocations: [
+          { id: 'exp-1', subject: 'MAGASIN U', amount: '90.00', budget: { id: 'b-1', name: 'Courses' } },
+          { id: 'exp-2', subject: 'Bricolage', amount: '60.00', budget: { id: 'b-2', name: 'Travaux' } },
+        ],
+        allocated: '150.00',
+        remaining: '0.00',
+      },
+    }),
+  };
+});
+
+vi.mock('@/features/documents/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/features/documents/hooks')>(
+    '@/features/documents/hooks',
+  );
+  return { ...actual, useDocuments: () => ({ data: [] }) };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+function renderAt(path: string) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route path="/app/interactions/:id" element={<InteractionDetailPage />} />
+          <Route path="/app/money/expenses/:id" element={<ExpenseDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('la fiche dédiée à une dépense', () => {
+  beforeAll(() => {
+    // jsdom n'implémente pas matchMedia, utilisé par useIsMobile (SheetDialog).
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    current = expense;
+  });
+
+  it('affiche le montant, le fournisseur et l’enveloppe', () => {
+    renderAt('/app/money/expenses/exp-1');
+
+    // `formatAmount` suit la locale du système : on n'y compare ni le séparateur
+    // décimal ni la place du symbole.
+    expect(screen.getByText(/90[.,]00/)).toBeTruthy();
+    expect(screen.getByText('Courses')).toBeTruthy();
+    expect(screen.getByText(/Magasin U/)).toBeTruthy();
+  });
+
+  it('nomme les dépenses sœurs de la même opération, sans se compter elle-même', () => {
+    renderAt('/app/money/expenses/exp-1');
+
+    expect(screen.getByText(/Travaux/)).toBeTruthy();
+    const links = screen
+      .getAllByRole('link')
+      .map((a) => a.getAttribute('href'))
+      .filter((href) => href?.startsWith('/app/money/expenses/'));
+    // La sœur est atteignable, et la dépense courante ne se lie pas à elle-même.
+    expect(links).toContain('/app/money/expenses/exp-2');
+    expect(links).not.toContain('/app/money/expenses/exp-1');
+  });
+
+  it('dit qu’une dépense sans enveloppe n’est classée nulle part, et propose d’y remédier', () => {
+    current = { ...expense, budget: null };
+    renderAt('/app/money/expenses/exp-1');
+
+    expect(screen.getByText('money.expense.noBudget')).toBeTruthy();
+    expect(screen.getByText('money.expense.pickBudget')).toBeTruthy();
+  });
+
+  it('mène à l’opération qui la justifie', () => {
+    renderAt('/app/money/expenses/exp-1');
+
+    const link = screen.getByText('CB MAGASIN U').closest('a');
+    expect(link?.getAttribute('href')).toBe('/app/money/transactions/txn-9');
+  });
+
+  it('renvoie la fiche générique d’une dépense vers sa page dédiée', () => {
+    renderAt('/app/interactions/exp-1');
+
+    // La page de dépense a rendu : son bloc « classement » n'existe nulle part ailleurs.
+    expect(screen.getByText('money.expense.classification')).toBeTruthy();
+  });
+
+  it('garde la fiche générique pour ce qui n’est pas une dépense', () => {
+    current = {
+      ...expense,
+      type: 'note',
+      subject: 'Réunion syndic',
+      amount: null,
+      kind: '',
+      bank_line: null,
+      budget: null,
+    };
+    renderAt('/app/interactions/exp-1');
+
+    expect(screen.getByText('Réunion syndic')).toBeTruthy();
+    expect(screen.queryByText('money.expense.classification')).toBeNull();
+  });
+});

--- a/ui/src/features/money/ExpenseDetailPage.tsx
+++ b/ui/src/features/money/ExpenseDetailPage.tsx
@@ -1,0 +1,410 @@
+import * as React from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { FileText, Link2, Paperclip, Pencil, Receipt, Wallet } from 'lucide-react';
+import { Badge } from '@/design-system/badge';
+import { Button } from '@/design-system/button';
+import { Card, CardContent } from '@/design-system/card';
+import BackLink from '@/components/BackLink';
+import PageHeader from '@/components/PageHeader';
+import InfoField from '@/components/InfoField';
+import LoadError from '@/components/LoadError';
+import ListSkeleton from '@/components/ListSkeleton';
+import { pushBack, useNavigateBack } from '@/lib/backNavigation';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { formatAmount, formatDate, formatDateTime } from '@/lib/format';
+import { useInteraction, useAttachDocumentToInteraction } from '@/features/interactions/hooks';
+import InteractionDeleteAction from '@/features/interactions/InteractionDeleteAction';
+import DocumentUploadDialog from '@/features/documents/DocumentUploadDialog';
+import AttachToTransactionDialog from '@/features/banking/AttachToTransactionDialog';
+import LinkedLineActions from '@/features/banking/LinkedLineActions';
+import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
+import { useAllocations } from '@/features/banking/hooks';
+import { useDocuments } from '@/features/documents/hooks';
+import ReconciliationBadge from './ReconciliationBadge';
+
+/** Vers quoi pointe l'objet auquel la dépense est rattachée, quand il en a un. */
+function sourceLink(sourceType: string | null | undefined, sourceId: string | null | undefined) {
+  if (!sourceType || !sourceId) return null;
+  if (sourceType === 'projects.project') return `/app/projects/${sourceId}`;
+  if (sourceType === 'equipment.equipment') return `/app/equipment/${sourceId}`;
+  if (sourceType === 'stock.stockitem') return '/app/stock';
+  return null;
+}
+
+/**
+ * La fiche d'une **dépense** — pas celle d'une activité.
+ *
+ * Sous le capot c'est la même `Interaction` que la note ou l'entretien : un fait
+ * daté du journal du foyer. Mais les questions qu'on pose à une dépense n'ont
+ * rien à voir avec celles qu'on pose à une note, et la fiche générique n'en
+ * répondait à aucune — elle affichait un montant et s'arrêtait là, sans dire dans
+ * quelle enveloppe l'euro tombe. Ce qui a rendu l'écran d'édition le seul endroit
+ * habitable, donc le seul endroit où l'on atterrissait : un formulaire, pour lire.
+ *
+ * Cette page répond aux trois seules questions qu'une dépense pose :
+ *
+ * 1. **Combien, quand, à qui** — l'en-tête et le montant.
+ * 2. **Où est-ce classé** — le budget (le seul axe qui classe un euro), l'objet
+ *    rattaché, les zones. Sans budget, la fiche le dit et propose d'y remédier :
+ *    c'est l'écart que le Contrôle réclame, autant le résoudre là où on le lit.
+ * 3. **Qu'est-ce qui la justifie** — le rapprochement, l'opération de relevé, et
+ *    les **autres** dépenses qui se partagent la même ligne : sur une sortie de
+ *    150 € ventilée 90/60, lire 90 € sans savoir où sont passés les 60 autres
+ *    laisse croire à une erreur.
+ *
+ * Les gestes vivent à côté du constat qu'ils corrigent, jamais dans un autre
+ * écran : éditer, supprimer, rattacher, détacher, joindre un justificatif.
+ */
+export default function ExpenseDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const navigateBack = useNavigateBack('/app/money?tab=expenses');
+
+  const [attachOpen, setAttachOpen] = React.useState(false);
+  const [uploadOpen, setUploadOpen] = React.useState(false);
+
+  const { data: expense, isLoading, error } = useInteraction(id ?? '');
+  const attachDocument = useAttachDocumentToInteraction(id ?? '');
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  const bankLine = expense?.bank_line ?? null;
+  // Les dépenses sœurs de la même opération. Requêtée seulement quand une ligne
+  // existe : une dépense en espèces ou non rapprochée n'a rien à partager.
+  const allocationsQuery = useAllocations(bankLine?.id);
+  const documentsQuery = useDocuments(
+    React.useMemo(() => ({ linked_to: `interaction:${id ?? ''}` }), [id]),
+    { enabled: Boolean(id) },
+  );
+
+  if (!id) return null;
+  if (showSkeleton) return <ListSkeleton className="space-y-2 p-4" />;
+  if (isLoading) return null;
+
+  if (error || !expense) {
+    return (
+      <LoadError
+        message={t('interactions.error_load_failed')}
+        link={{ to: '/app/money?tab=expenses', label: t('money.tabs.expenses') }}
+      />
+    );
+  }
+
+  const amount = expense.amount ?? null;
+  const budget = expense.budget ?? null;
+  const link = sourceLink(expense.source_type, expense.source_id);
+  const siblings = (allocationsQuery.data?.allocations ?? []).filter((row) => row.id !== expense.id);
+  const documents = documentsQuery.data ?? [];
+  const isOwnedSplit = isOwnedByAllocationEditor(expense.kind);
+
+  return (
+    <>
+      <div className="space-y-6">
+        <PageHeader
+          backLink={
+            <BackLink fallback="/app/money?tab=expenses" fallbackLabel={t('money.tabs.expenses')} />
+          }
+          title={expense.subject}
+          titleSuffix={
+            expense.kind ? (
+              <Badge variant="outline">{t(`expenses.kind.${expense.kind}`)}</Badge>
+            ) : null
+          }
+          description={
+            <span className="flex flex-wrap items-center gap-x-2 gap-y-1">
+              <span>{formatDateTime(expense.occurred_at)}</span>
+              {expense.supplier ? <span>· {expense.supplier}</span> : null}
+            </span>
+          }
+        >
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 px-3 text-sm"
+            onClick={() => navigate(`/app/interactions/${id}/edit`, { state: pushBack(location) })}
+          >
+            <Pencil className="mr-1.5 h-3.5 w-3.5" />
+            {t('common.edit')}
+          </Button>
+          {/* Une dépense née d'une ventilation ne « disparaît » pas quand on la
+              supprime : son argent retourne dans « À ranger ». Le dire dans la
+              confirmation évite d'avoir à le deviner. */}
+          <InteractionDeleteAction
+            id={expense.id}
+            onDeleted={navigateBack}
+            description={
+              isOwnedSplit ? t('money.expense.deleteSplitConfirm') : t('money.expense.deleteConfirm')
+            }
+          />
+        </PageHeader>
+
+        {/* 1. Combien — le chiffre d'abord, c'est ce qu'on vient lire. */}
+        <Card>
+          <CardContent className="flex flex-wrap items-baseline justify-between gap-3 pt-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                {t('interactions.expense_amount_label')}
+              </p>
+              <p className="mt-1 text-3xl font-semibold tabular-nums text-foreground">
+                {amount ? formatAmount(amount) : t('expenses.list.noAmount')}
+              </p>
+            </div>
+            <ReconciliationBadge state={expense.reconciliation_state} line={bankLine} />
+          </CardContent>
+        </Card>
+
+        {/* 2. Où est-ce classé */}
+        <section className="space-y-3">
+          <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+            <Wallet className="h-4 w-4 text-muted-foreground" />
+            {t('money.expense.classification')}
+          </h2>
+          <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoField label={t('purchase.fields.budget')}>
+              {budget ? (
+                <Link
+                  to="/app/money?tab=budgets"
+                  state={pushBack(location)}
+                  className="font-medium text-primary hover:underline"
+                >
+                  {budget.name}
+                </Link>
+              ) : (
+                /* « Hors budget » est l'écart le plus courant du foyer, et le
+                   résoudre demandait de deviner qu'il faut passer par l'édition. */
+                <div className="space-y-1.5">
+                  <p className="text-sm text-warning">{t('money.expense.noBudget')}</p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    onClick={() =>
+                      navigate(`/app/interactions/${id}/edit`, { state: pushBack(location) })
+                    }
+                  >
+                    {t('money.expense.pickBudget')}
+                  </Button>
+                </div>
+              )}
+            </InfoField>
+
+            {expense.source_label ? (
+              <InfoField label={t('money.expense.attachedTo')}>
+                {link ? (
+                  <Link
+                    to={link}
+                    state={pushBack(location)}
+                    className="font-medium text-primary hover:underline"
+                  >
+                    {expense.source_label}
+                  </Link>
+                ) : (
+                  expense.source_label
+                )}
+              </InfoField>
+            ) : null}
+
+            {expense.zone_names.length > 0 ? (
+              <InfoField label={t('interactions.zone_label')}>
+                {expense.zone_names.join(', ')}
+              </InfoField>
+            ) : null}
+
+            {expense.created_by_name ? (
+              <InfoField label={t('interactions.detail_created_by')}>
+                {expense.created_by_name}
+              </InfoField>
+            ) : null}
+          </dl>
+        </section>
+
+        {/* 3. Qu'est-ce qui la justifie */}
+        <section className="space-y-3">
+          <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+            <Receipt className="h-4 w-4 text-muted-foreground" />
+            {t('money.reconciliation.label')}
+          </h2>
+
+          <Card>
+            <CardContent className="space-y-3 pt-4">
+              {bankLine ? (
+                <>
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="min-w-0">
+                      {/* « Rapprochée » sans pouvoir aller voir à quoi est
+                          invérifiable : le lien mène à l'opération. */}
+                      <Link
+                        to={`/app/money/transactions/${bankLine.id}`}
+                        state={pushBack(location)}
+                        className="font-medium text-primary hover:underline"
+                      >
+                        {bankLine.label}
+                      </Link>
+                      <p className="text-xs text-muted-foreground">
+                        {bankLine.account_name} · {formatDate(bankLine.booked_on)}
+                      </p>
+                    </div>
+                    <LinkedLineActions
+                      expenseId={expense.id}
+                      kind={expense.kind}
+                      transactionId={bankLine.id}
+                      onDeleted={navigateBack}
+                      className="h-7 px-2 text-xs"
+                    />
+                  </div>
+
+                  {isOwnedSplit ? (
+                    <p className="text-xs text-muted-foreground">{t('banking.attach.ownedHint')}</p>
+                  ) : null}
+
+                  {/* Les dépenses sœurs : le reste de l'argent de la même ligne.
+                      Sans elles, 90 € lus sur une sortie de 150 € ressemblent à
+                      une erreur de saisie. */}
+                  {siblings.length > 0 ? (
+                    <div className="space-y-1.5 border-t border-border/60 pt-3">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {t('money.expense.sharedLine', { count: siblings.length })}
+                      </p>
+                      <ul className="space-y-1">
+                        {siblings.map((row) => (
+                          <li key={row.id} className="flex items-center justify-between gap-2 text-sm">
+                            <Link
+                              to={`/app/money/expenses/${row.id}`}
+                              state={pushBack(location)}
+                              className="min-w-0 truncate text-foreground hover:text-primary hover:underline"
+                            >
+                              {row.subject}
+                              {row.budget ? (
+                                <span className="text-muted-foreground"> · {row.budget.name}</span>
+                              ) : null}
+                            </Link>
+                            <span className="shrink-0 tabular-nums text-muted-foreground">
+                              {row.amount ? formatAmount(row.amount) : ''}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                      {allocationsQuery.data ? (
+                        <p className="text-xs text-muted-foreground">
+                          {t('money.expense.lineRemaining', {
+                            allocated: formatAmount(allocationsQuery.data.allocated),
+                            remaining: formatAmount(allocationsQuery.data.remaining),
+                          })}
+                        </p>
+                      ) : null}
+                    </div>
+                  ) : null}
+                </>
+              ) : (
+                <div className="space-y-2">
+                  <p className="text-sm text-muted-foreground">
+                    {t('money.expense.notReconciled')}
+                  </p>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="h-7 px-2 text-xs"
+                    onClick={() => setAttachOpen(true)}
+                    disabled={!amount}
+                  >
+                    <Link2 className="mr-1.5 h-3 w-3" />
+                    {t('banking.attach.action')}
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </section>
+
+        {/* Le justificatif — la pièce qu'on cherche six mois plus tard. Le bloc
+            s'affiche même vide : une section qui n'apparaît qu'une fois remplie
+            n'apprend à personne qu'on peut la remplir. */}
+        <section className="space-y-2">
+          <div className="flex items-center justify-between gap-2">
+            <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+              <Paperclip className="h-4 w-4 text-muted-foreground" />
+              {t('money.expense.receipts')}
+            </h2>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-7 px-2 text-xs"
+              onClick={() => setUploadOpen(true)}
+            >
+              {t('money.expense.addReceipt')}
+            </Button>
+          </div>
+          {documents.length > 0 ? (
+            <ul className="space-y-1.5">
+              {documents.map((doc) => (
+                <li key={doc.id}>
+                  <Link
+                    to={`/app/documents/${doc.id}`}
+                    state={pushBack(location)}
+                    className="flex items-center gap-2 text-sm text-foreground hover:text-primary hover:underline"
+                  >
+                    <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+                    <span className="truncate">{doc.name}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">{t('money.expense.noReceipt')}</p>
+          )}
+        </section>
+
+        {/* Les notes en dernier : elles précisent, elles ne portent pas le sens. */}
+        {expense.content ? (
+          <section className="space-y-2">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('interactions.description_label')}
+            </h2>
+            <p className="whitespace-pre-line text-sm leading-relaxed text-foreground">
+              {expense.content}
+            </p>
+          </section>
+        ) : null}
+
+        {expense.tags.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {expense.tags.map((tag) => (
+              <span
+                key={tag}
+                className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {/* L'upload et le lien sont un seul geste vu de l'utilisateur : un ticket
+          photographié depuis la fiche d'une dépense y est *forcément* rattaché. */}
+      <DocumentUploadDialog
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        onSaved={(created) => {
+          if (created) attachDocument.mutate(created.id);
+          setUploadOpen(false);
+        }}
+      />
+
+      {amount ? (
+        <AttachToTransactionDialog
+          open={attachOpen}
+          onOpenChange={setAttachOpen}
+          expense={{
+            id: expense.id,
+            subject: expense.subject,
+            amount,
+            occurred_at: expense.occurred_at,
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/ui/src/features/stock/StockItemDetailPage.tsx
+++ b/ui/src/features/stock/StockItemDetailPage.tsx
@@ -267,7 +267,9 @@ export default function StockItemDetailPage() {
                         <li key={entry.id}>
                           <Card
                             className="cursor-pointer p-3 text-sm transition-shadow hover:shadow-md"
-                            onClick={() => navigate(`/app/interactions/${entry.id}/edit`)}
+                            /* L'historique mêle achats et notes : on ouvre la
+                               fiche, qui aiguille une dépense vers la sienne. */
+                            onClick={() => navigate(`/app/interactions/${entry.id}`)}
                           >
                             <div className="flex items-start justify-between gap-2">
                               <span className="font-medium">{entry.subject || '—'}</span>

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -83,7 +83,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   // fenêtre qui exclut volontairement des données, un zéro qui peut vouloir dire
   // « non évaluable ») qu'aucun parcours procédural ne fait comprendre.
   { key: 'money', moduleKey: 'money', Icon: ShieldCheck, to: '/app/money?tab=control', stepIds: ['source', 'allocation', 'axes', 'window', 'arbitrate', 'notEvaluable', 'cash'] },
-  { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'trace', 'review'] },
+  { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'sheet', 'trace', 'review'] },
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'analysis', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1519,6 +1519,10 @@
           "trace": {
             "title": "Zur Buchung zurückgehen",
             "body": "Jede Ausgabe zeigt, ob eine Kontoauszugszeile sie belegt. „Kontoauszug vom 12. Juli“ ist ein Link: Sie landen auf der Buchung, mit Betrag, Konto und den weiteren Ausgaben, die sie abdeckt. „Abgleich ausstehend“ bedeutet das Gegenteil — eine Ausgabe, die die Bank nie gesehen hat, also eine Abweichung, die das Kontrollregister zählt. Außerhalb des geprüften Zeitraums erscheint nichts: dort kann die App nichts verlangen."
+          },
+          "sheet": {
+            "title": "Die Ausgabenseite",
+            "body": "Klicken Sie eine Ausgabe an: ihre Seite öffnet sich. Sie beantwortet drei Fragen — wie viel und an wen, in welches Budget der Euro fällt, und was ihn belegt. Eine Ausgabe ohne Budget sagt es und bietet an, eines zu wählen. Eine aus einem Kontoauszug entstandene Ausgabe zeigt die übrigen Ausgaben derselben Buchung, damit 90 € bei einem Abgang von 150 € nicht wie ein Fehler aussehen. Bearbeiten, löschen, zuordnen, Beleg anhängen: alles von dort."
           }
         }
       },
@@ -3823,6 +3827,20 @@
       "cash": "Bargeld vom {{date}}",
       "pending": "Abgleich ausstehend",
       "out_of_scope": "Außerhalb des geprüften Zeitraums"
+    },
+    "expense": {
+      "classification": "Einordnung",
+      "attachedTo": "Verknüpft mit",
+      "noBudget": "Kein Budget — diese Ausgabe zählt in keiner Kategorie.",
+      "pickBudget": "Budget wählen",
+      "notReconciled": "Noch keine Kontobewegung belegt diese Ausgabe.",
+      "sharedLine": "Der Rest dieser Buchung ({{count}})",
+      "lineRemaining": "{{allocated}} auf der Buchung zugeordnet, {{remaining}} offen",
+      "receipts": "Belege",
+      "addReceipt": "Hinzufügen",
+      "noReceipt": "Kein Beleg angehängt.",
+      "deleteConfirm": "Diese Ausgabe löschen? Sie verschwindet aus dem Journal und aus den Budgetsummen.",
+      "deleteSplitConfirm": "Diese Ausgabe löschen? Die Kontobewegung bleibt unberührt: ihr Betrag wandert zurück in die Warteschlange."
     }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1519,6 +1519,10 @@
           "trace": {
             "title": "Trace it back to the operation",
             "body": "Every expense shows whether a statement line accounts for it. “Statement of 12 July” is a link: it takes you to the operation, with its amount, its account, and the other expenses it covers. “Awaiting reconciliation” means the opposite — an expense the bank never saw, which is a discrepancy the Control tab counts. Nothing shows outside the checked period: there, the app cannot require anything."
+          },
+          "sheet": {
+            "title": "An expense's sheet",
+            "body": "Click an expense: its sheet opens. It answers three questions — how much and to whom, which envelope the euro falls into, and what justifies it. An expense with no envelope says so and offers to pick one. An expense born from a statement shows the other expenses on the same transaction, so €90 on a €150 outflow doesn't look like a mistake. Edit, delete, attach to a line, add a receipt: all from there."
           }
         }
       },
@@ -3823,6 +3827,20 @@
       "cash": "Cash on {{date}}",
       "pending": "Awaiting reconciliation",
       "out_of_scope": "Outside the checked period"
+    },
+    "expense": {
+      "classification": "Classification",
+      "attachedTo": "Attached to",
+      "noBudget": "No envelope — this expense counts in no category.",
+      "pickBudget": "Pick an envelope",
+      "notReconciled": "No statement line justifies this expense yet.",
+      "sharedLine": "The rest of this transaction ({{count}})",
+      "lineRemaining": "{{allocated}} allocated on the line, {{remaining}} left",
+      "receipts": "Receipts",
+      "addReceipt": "Add",
+      "noReceipt": "No receipt attached.",
+      "deleteConfirm": "Delete this expense? It will disappear from the journal and from budget totals.",
+      "deleteSplitConfirm": "Delete this expense? The bank transaction is untouched: its amount goes back to the queue."
     }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1519,6 +1519,10 @@
           "trace": {
             "title": "Remontar hasta la operación",
             "body": "Cada gasto indica si una línea del extracto lo justifica. «Extracto del 12 de julio» es un enlace: llegas a la operación, con su importe, su cuenta y los demás gastos que cubre. «Pendiente de conciliación» significa lo contrario — un gasto que el banco nunca vio, es decir una discrepancia que la pestaña Control cuenta. Fuera del periodo controlado no aparece nada: ahí la app no puede exigir nada."
+          },
+          "sheet": {
+            "title": "La ficha de un gasto",
+            "body": "Haga clic en un gasto: se abre su ficha. Responde a tres preguntas — cuánto y a quién, en qué sobre cae el euro, y qué lo justifica. Un gasto sin sobre lo dice y propone elegir uno. Un gasto nacido de un extracto muestra los demás gastos de la misma operación, para que 90 € en una salida de 150 € no parezcan un error. Editar, eliminar, vincular, adjuntar un justificante: todo desde ahí."
           }
         }
       },
@@ -3823,6 +3827,20 @@
       "cash": "Efectivo del {{date}}",
       "pending": "Pendiente de conciliación",
       "out_of_scope": "Fuera del periodo controlado"
+    },
+    "expense": {
+      "classification": "Clasificación",
+      "attachedTo": "Vinculada a",
+      "noBudget": "Sin sobre — este gasto no cuenta en ninguna categoría.",
+      "pickBudget": "Elegir un sobre",
+      "notReconciled": "Ningún movimiento del extracto justifica todavía este gasto.",
+      "sharedLine": "El resto de esta operación ({{count}})",
+      "lineRemaining": "{{allocated}} asignados en la línea, quedan {{remaining}}",
+      "receipts": "Justificantes",
+      "addReceipt": "Añadir",
+      "noReceipt": "Ningún justificante adjunto.",
+      "deleteConfirm": "¿Eliminar este gasto? Desaparecerá del diario y de los totales de presupuesto.",
+      "deleteSplitConfirm": "¿Eliminar este gasto? La operación bancaria no se toca: su importe vuelve a la cola."
     }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1519,6 +1519,10 @@
           "trace": {
             "title": "Remonter à l'opération",
             "body": "Chaque dépense affiche si une ligne de relevé la justifie. « Relevé du 12 juillet » est cliquable : vous arrivez sur l'opération, avec son montant, son compte, et les autres dépenses qu'elle couvre. « En attente de rapprochement » signale au contraire une dépense que la banque n'a jamais vue — c'est un écart, et le Contrôle la compte. Rien n'apparaît hors de la période contrôlée : là, l'app ne peut rien exiger."
+          },
+          "sheet": {
+            "title": "La fiche d'une dépense",
+            "body": "Cliquez une dépense : sa fiche s'ouvre. Elle répond à trois questions — combien et à qui, dans quelle enveloppe l'euro tombe, et ce qui la justifie. Une dépense sans enveloppe le dit et propose d'en choisir une. Une dépense née d'un relevé montre les autres dépenses de la même opération, pour que 90 € sur une sortie de 150 € ne ressemblent pas à une erreur. Éditer, supprimer, rattacher, joindre un justificatif : tout se fait depuis là."
           }
         }
       },
@@ -3823,6 +3827,20 @@
       "cash": "Espèces du {{date}}",
       "pending": "En attente de rapprochement",
       "out_of_scope": "Hors période contrôlée"
+    },
+    "expense": {
+      "classification": "Classement",
+      "attachedTo": "Rattachée à",
+      "noBudget": "Aucune enveloppe — cette dépense ne compte dans aucune catégorie.",
+      "pickBudget": "Choisir une enveloppe",
+      "notReconciled": "Aucune opération de relevé ne justifie encore cette dépense.",
+      "sharedLine": "Le reste de cette opération ({{count}})",
+      "lineRemaining": "{{allocated}} affectés sur la ligne, reste {{remaining}}",
+      "receipts": "Justificatifs",
+      "addReceipt": "Ajouter",
+      "noReceipt": "Aucun justificatif joint.",
+      "deleteConfirm": "Supprimer cette dépense ? Elle disparaîtra du journal et des totaux de budget.",
+      "deleteSplitConfirm": "Supprimer cette dépense ? L'opération bancaire n'est pas touchée : son montant redevient à ranger."
     }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -52,6 +52,7 @@ const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPa
 const ReportsPage = lazyWithReload(() => import('./features/budget/ReportsPage'));
 const MoneyAnalysisPage = lazyWithReload(() => import('./features/money/AnalysisPage'));
 const BudgetDetailPage = lazyWithReload(() => import('./features/money/BudgetDetailPage'));
+const ExpenseDetailPage = lazyWithReload(() => import('./features/money/ExpenseDetailPage'));
 const BankingTransactionsPage = lazyWithReload(
   () => import('./features/banking/TransactionsPage'),
 );
@@ -94,6 +95,9 @@ export const router = createBrowserRouter([
       { path: 'money/transactions/:id', element: <BankingTransactionDetailPage /> },
       { path: 'money/analysis', element: <MoneyAnalysisPage /> },
       { path: 'money/budgets/:id', element: <BudgetDetailPage /> },
+      // Une dépense est une `Interaction`, mais sa fiche appartient à la famille
+      // argent : elle vit donc sous `/app/money`, comme toute URL de la famille.
+      { path: 'money/expenses/:id', element: <ExpenseDetailPage /> },
       { path: 'money/recurring', element: <RecurringPage /> },
       { path: 'money/reports', element: <ReportsPage /> },
       // Anciennes URLs (parcours 26, lot 2) : les favoris, les liens de l'agent et


### PR DESCRIPTION
## Le problème

Cliquer une dépense ouvrait `/app/interactions/:id/edit`. On clique pour **lire**,
et un formulaire ne se lit pas. La fiche générique du journal existait, mais elle
ne répondait à aucune des questions qu'une dépense pose : elle affichait un montant
et un fournisseur, et **taisait le budget** — le seul axe qui classe un euro. C'est
ce qui a fait du formulaire le seul écran habitable, donc la destination du clic.

Et la suppression n'existait nulle part sur ce formulaire, alors que c'est là qu'on
découvre qu'une entrée n'a rien à faire dans le journal.

## La page

`/app/money/expenses/:id` (`money/ExpenseDetailPage.tsx`) — sous le capot toujours
une `Interaction`, mais une page personnalisée à la dépense, dans l'ordre des trois
seules questions qu'elle pose :

1. **Combien, quand, à qui** — le montant en grand, le badge de rapprochement.
2. **Où est-ce classé** — budget, objet rattaché, zones. Sans budget, la fiche le
   dit et propose d'en choisir un.
3. **Qu'est-ce qui la justifie** — l'opération de relevé (cliquable), les gestes
   (rattacher / détacher / supprimer), et **les dépenses sœurs** de la même ligne.

Plus les justificatifs, joints en un geste depuis la fiche.

## Décisions

- **`/app/interactions/:id` redirige** un `type=expense`, en recopiant
  `location.state` — sans quoi le lien retour oublierait d'où l'on vient. Les liens
  qui *savent* pointer une dépense (liste, dépenses d'une opération) visent la
  nouvelle URL : une redirection rattrape un ancien lien, elle ne justifie pas d'en
  produire.
- **Les dépenses sœurs sont affichées.** 90 € lus sur une sortie de 150 € sans
  trace des 60 autres ressemblent à une erreur de saisie.
- **Un seul geste de suppression par écran.** `InteractionDeleteAction` sert les
  trois écrans (fiche, fiche de dépense, édition). Corollaire : `ExpenseFields` ne
  garde que le **détachement** — sur une dépense `kind='bank'`, deux boutons rouges
  au même endroit ne se distinguaient pas l'un de l'autre.
- **La confirmation change de sens** sur une dépense née d'une ventilation : elle
  ne disparaît pas, son montant retourne dans « À ranger ».
- `useDocuments` prend un `enabled` : un filtre d'entité à id vide est *retiré* de
  la requête, donc la liste vide qu'on croit demander revient avec **tous** les
  documents du foyer.

## Vérification

- `ui/src/features/money/ExpenseDetailPage.test.tsx` — 6 tests, dont la redirection
  et le fait que la fiche générique reste celle d'une note.
- `vitest` 47/47, `tsc -b ui` propre, `npm run lint` 0 erreur (5 warnings
  préexistants), garde i18n verte sur les 4 catalogues.
- Aucun changement serveur.
- Tutoriel « Suivre les dépenses » : nouvelle étape `sheet` (règle CLAUDE.md).
- `docs/MODULES/money.md` à jour.