### PR TITLE
feat(recap): le mois du foyer se regarde, carte après carte

### DIFF
--- a/e2e/recap.spec.ts
+++ b/e2e/recap.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Parcours 27 — Lot 4 : la story du récap mensuel.
+ *
+ * Couvre :
+ *  1. Entrée sidebar « Récap » → /app/recap
+ *  2. Historique : le mois frais en tête, les mois passés en liste sobre
+ *  3. Navigation carte par carte : boutons, pastilles, clavier ←/→
+ *  4. Sortie explicite (Échap, bouton Terminé) → retour à l'historique
+ *  5. Un mois sans rien à raconter le dit, au lieu d'afficher un vide
+ *
+ * **Pourquoi les réponses sont simulées ici.** Un instantané de récap est gelé une
+ * fois puis jamais recalculé — c'est tout l'intérêt du modèle. Un test qui sème des
+ * dépenses puis demande le récap dépend donc de l'ordre d'exécution : au deuxième
+ * run, le mois est déjà figé (vide) et rien ne peut plus le remplir. La génération
+ * est couverte côté serveur (`apps/recap/tests/`, dont l'accord avec le
+ * `BudgetReport` et l'idempotence du gel) ; ce qui se vérifie ici, et nulle part
+ * ailleurs, c'est le **parcours de la story**.
+ */
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MONTH = '2026-06';
+
+function card(kind: string, value: string, headline: string, caption: string) {
+  return { kind, emoji: '💰', headline, value, value_type: 'raw' as const, caption };
+}
+
+const RECAP = {
+  id: '11111111-1111-1111-1111-111111111111',
+  month: MONTH,
+  card_count: 3,
+  chapters: [
+    {
+      key: 'money',
+      emoji: '💰',
+      title: 'Argent',
+      cards: [
+        card('total_spent', '204', 'dépensés', "Soit 12 % de moins que le mois précédent."),
+        card('budget_outcome', '2/3', 'budgets tenus', 'Dépassement : Courses.'),
+        card('biggest_expense', '180', 'Plombier', 'Votre plus grosse dépense du mois.'),
+      ],
+    },
+  ],
+  created_at: '2026-07-01T09:00:00Z',
+};
+
+const OLDER = { ...RECAP, id: '22222222-2222-2222-2222-222222222222', month: '2026-05' };
+
+/** Sert le récap simulé sur les trois routes que le front interroge. */
+async function stubRecap(page: Page): Promise<void> {
+  await page.route('**/api/recap/latest/', (route) =>
+    route.fulfill({ json: RECAP }),
+  );
+  await page.route(`**/api/recap/${MONTH}/`, (route) => route.fulfill({ json: RECAP }));
+  await page.route('**/api/recap/', (route) => route.fulfill({ json: [RECAP, OLDER] }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Récap mensuel', () => {
+  test('la sidebar mène à la page Récap', async ({ page }) => {
+    await page.goto('/app/dashboard');
+    await page.getByRole('link', { name: /Récap/i }).first().click();
+
+    await expect(page).toHaveURL(/\/app\/recap$/);
+    await expect(page.getByRole('heading', { name: /Récap/i })).toBeVisible();
+  });
+
+  test("l'historique met le mois frais en tête et liste les précédents", async ({ page }) => {
+    await stubRecap(page);
+    await page.goto('/app/recap');
+
+    await expect(page.getByText(/Voir le récap/i)).toBeVisible();
+    await expect(page.getByText('3 cartes').first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Mois précédents/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /mai 2026/i })).toBeVisible();
+  });
+
+  test('la story se parcourt carte par carte, puis se referme', async ({ page }) => {
+    await stubRecap(page);
+    await page.goto('/app/recap');
+
+    await page.getByText(/Voir le récap/i).click();
+    await expect(page).toHaveURL(new RegExp(`/app/recap/${MONTH}$`));
+
+    // Première carte : le gros chiffre et sa légende sont là.
+    await expect(page.getByLabel('Carte 1 sur 3').first()).toBeVisible();
+    await expect(page.getByText('Soit 12 % de moins que le mois précédent.')).toBeVisible();
+
+    // Avancer au bouton…
+    await page.getByRole('button', { name: 'Suivant' }).click();
+    await expect(page.getByLabel('Carte 2 sur 3').first()).toBeVisible();
+    await expect(page.getByText('Dépassement : Courses.')).toBeVisible();
+
+    // …puis au clavier, dans les deux sens.
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByLabel('Carte 3 sur 3').first()).toBeVisible();
+    await page.keyboard.press('ArrowLeft');
+    await expect(page.getByLabel('Carte 2 sur 3').first()).toBeVisible();
+
+    // Une pastille ramène directement à une carte donnée.
+    await page.getByRole('button', { name: 'Aller à la carte 1' }).click();
+    await expect(page.getByLabel('Carte 1 sur 3').first()).toBeVisible();
+
+    // La dernière carte propose de sortir plutôt que d'avancer dans le vide.
+    await page.keyboard.press('ArrowRight');
+    await page.keyboard.press('ArrowRight');
+    await expect(page.getByRole('button', { name: 'Terminé' })).toBeVisible();
+
+    // Échap sort de la story — une story ne doit jamais piéger.
+    await page.keyboard.press('Escape');
+    await expect(page).toHaveURL(/\/app\/recap$/);
+  });
+
+  test('le bouton Terminé ramène à l\'historique', async ({ page }) => {
+    await stubRecap(page);
+    await page.goto(`/app/recap/${MONTH}`);
+
+    await page.getByRole('button', { name: 'Aller à la carte 3' }).click();
+    await page.getByRole('button', { name: 'Terminé' }).click();
+
+    await expect(page).toHaveURL(/\/app\/recap$/);
+  });
+
+  test('un mois sans rien à raconter ne prétend pas le contraire', async ({ page }) => {
+    // Un mois jamais gelé n'existe pas : la story le dit au lieu d'afficher un vide.
+    await page.goto('/app/recap/2019-01');
+
+    await expect(page.getByText(/Rien à raconter pour ce mois/i)).toBeVisible();
+    await page.getByRole('button', { name: /Retour aux récaps/i }).click();
+    await expect(page).toHaveURL(/\/app\/recap$/);
+  });
+});

--- a/ui/src/components/Sidebar.tsx
+++ b/ui/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
 import {
   LayoutDashboard, User, ShieldCheck, X, AlertCircle, Sparkles, Activity,
-  Rocket, Pin, PinOff, GraduationCap, Newspaper, Send, type LucideIcon,
+  Rocket, Pin, PinOff, GraduationCap, Newspaper, Send, PartyPopper, type LucideIcon,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/lib/auth/useAuth';
@@ -212,6 +212,12 @@ export default function Sidebar() {
 
           <div className="pt-3">
             <GroupLabel>{t('sidebar.groupAccount')}</GroupLabel>
+            <NavItem
+              to="/app/recap"
+              labelKey="recap.title"
+              Icon={PartyPopper}
+              onNavigate={closeSidebar}
+            />
             <NavItem
               to="/app/digest"
               labelKey="digest.title"

--- a/ui/src/features/recap/RecapCardView.tsx
+++ b/ui/src/features/recap/RecapCardView.tsx
@@ -1,0 +1,27 @@
+import { formatAmount } from '@/lib/format';
+import type { RecapCard } from '@/lib/api/recap';
+
+/**
+ * One screen of the story: an emoji, one big figure, a short label, a caption.
+ *
+ * Deliberately plain. A recap is the kind of screen that invites heavy animation and
+ * decorative gradients, and both would make the figure harder to read — which is the
+ * only thing the card is for.
+ */
+export default function RecapCardView({ card }: { card: RecapCard }) {
+  const value = card.value_type === 'money' ? formatAmount(card.value) : card.value;
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+      <span className="text-4xl" aria-hidden>
+        {card.emoji}
+      </span>
+
+      <p className="text-5xl font-semibold tracking-tight text-foreground sm:text-6xl">{value}</p>
+
+      <p className="text-base text-muted-foreground">{card.headline}</p>
+
+      <p className="max-w-sm text-pretty text-sm text-foreground/80">{card.caption}</p>
+    </div>
+  );
+}

--- a/ui/src/features/recap/RecapHistoryPage.tsx
+++ b/ui/src/features/recap/RecapHistoryPage.tsx
@@ -1,0 +1,94 @@
+import { Link, useLocation } from 'react-router-dom';
+import { Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import PageHeader from '@/components/PageHeader';
+import EmptyState from '@/components/EmptyState';
+import { Card, CardTitle } from '@/design-system/card';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { pushBack } from '@/lib/backNavigation';
+import { useLatestRecap, useRecapHistory } from './hooks';
+import { monthLabel } from './month';
+
+export default function RecapHistoryPage() {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const latestQuery = useLatestRecap();
+  const historyQuery = useRecapHistory();
+
+  const isLoading = latestQuery.isLoading || historyQuery.isLoading;
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  const latest = latestQuery.data ?? null;
+  // The freshest month gets the staging; the rest is a sober list — nobody replays
+  // the story of March.
+  const past = (historyQuery.data ?? []).filter(
+    (recap) => recap.month !== latest?.month && recap.card_count > 0,
+  );
+
+  return (
+    <>
+      <PageHeader title={t('recap.title')} description={t('recap.description')} />
+
+      {showSkeleton ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-16 animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      ) : null}
+
+      {isLoading ? null : !latest && past.length === 0 ? (
+        <EmptyState
+          icon={Sparkles}
+          title={t('recap.empty')}
+          description={t('recap.emptyDescription')}
+        />
+      ) : (
+        <div className="space-y-5">
+          {latest ? (
+            <Link
+              to={`/app/recap/${latest.month}`}
+              state={pushBack(location)}
+              className="group block text-foreground hover:text-primary"
+            >
+              <Card className="p-4">
+                <CardTitle className="text-inherit capitalize [&>span:last-child]:group-hover:underline">
+                  ✨ {monthLabel(latest.month)}
+                </CardTitle>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {t('recap.cardCount', { count: latest.card_count })}
+                </p>
+                <p className="mt-2 text-sm font-medium text-primary">{t('recap.open')}</p>
+              </Card>
+            </Link>
+          ) : null}
+
+          {past.length > 0 ? (
+            <div className="space-y-2">
+              <h2 className="text-sm font-semibold text-foreground">{t('recap.history')}</h2>
+              <div className="space-y-2">
+                {past.map((recap) => (
+                  <Link
+                    key={recap.id}
+                    to={`/app/recap/${recap.month}`}
+                    state={pushBack(location)}
+                    className="group block text-foreground hover:text-primary"
+                  >
+                    <Card className="flex items-center justify-between gap-3 p-3">
+                      <CardTitle className="text-inherit capitalize [&>span:last-child]:group-hover:underline">
+                        {monthLabel(recap.month)}
+                      </CardTitle>
+                      <span className="shrink-0 text-xs text-muted-foreground">
+                        {t('recap.cardCount', { count: recap.card_count })}
+                      </span>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </>
+  );
+}

--- a/ui/src/features/recap/RecapStoryPage.tsx
+++ b/ui/src/features/recap/RecapStoryPage.tsx
@@ -1,0 +1,194 @@
+import * as React from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ChevronLeft, ChevronRight, Sparkles, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import EmptyState from '@/components/EmptyState';
+import { Button } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import type { RecapCard } from '@/lib/api/recap';
+import { useRecap } from './hooks';
+import RecapCardView from './RecapCardView';
+import { monthLabel } from './month';
+
+/** A card plus the chapter it came from — the chapter is context, not a screen. */
+type StoryCard = RecapCard & { chapterTitle: string; chapterEmoji: string };
+
+/** Below this horizontal travel a touch is a tap, not a swipe. */
+const SWIPE_THRESHOLD_PX = 48;
+
+export default function RecapStoryPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { month } = useParams<{ month: string }>();
+  const query = useRecap(month);
+  const showSkeleton = useDelayedLoading(query.isLoading);
+
+  const cards: StoryCard[] = React.useMemo(
+    () =>
+      (query.data?.chapters ?? []).flatMap((chapter) =>
+        chapter.cards.map((card) => ({
+          ...card,
+          chapterTitle: chapter.title,
+          chapterEmoji: chapter.emoji,
+        })),
+      ),
+    [query.data],
+  );
+
+  const [index, setIndex] = React.useState(0);
+  // A shorter recap (or a chapter the user just switched off) must not leave the
+  // cursor past the end.
+  React.useEffect(() => {
+    setIndex((i) => Math.min(i, Math.max(cards.length - 1, 0)));
+  }, [cards.length]);
+
+  const go = React.useCallback(
+    (delta: number) => {
+      setIndex((i) => Math.min(Math.max(i + delta, 0), Math.max(cards.length - 1, 0)));
+    },
+    [cards.length],
+  );
+
+  const close = React.useCallback(() => navigate('/app/recap'), [navigate]);
+
+  // Keyboard is a first-class way through the story, not an afterthought: arrows
+  // move, Escape leaves. There is no auto-advance — a recap is not an ad.
+  React.useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowRight') go(1);
+      else if (event.key === 'ArrowLeft') go(-1);
+      else if (event.key === 'Escape') close();
+      else return;
+      event.preventDefault();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [go, close]);
+
+  const touchStartX = React.useRef<number | null>(null);
+  const onTouchStart = (event: React.TouchEvent) => {
+    touchStartX.current = event.touches[0]?.clientX ?? null;
+  };
+  const onTouchEnd = (event: React.TouchEvent) => {
+    const start = touchStartX.current;
+    touchStartX.current = null;
+    if (start == null) return;
+    const travel = (event.changedTouches[0]?.clientX ?? start) - start;
+    if (Math.abs(travel) < SWIPE_THRESHOLD_PX) return;
+    go(travel < 0 ? 1 : -1);
+  };
+
+  if (showSkeleton) {
+    return <div className="h-[26rem] animate-pulse rounded-lg bg-muted" />;
+  }
+  if (query.isLoading) return null;
+
+  if (query.isError || cards.length === 0) {
+    return (
+      <EmptyState
+        icon={Sparkles}
+        title={t('recap.story.unavailable')}
+        description={t('recap.story.unavailableDescription')}
+        action={{ label: t('recap.backToHistory'), onClick: close }}
+      />
+    );
+  }
+
+  const card = cards[index];
+  const isFirst = index === 0;
+  const isLast = index === cards.length - 1;
+
+  return (
+    // Bounded width on purpose: full-bleed, the figure floats in a banner and stops
+    // reading as a card. The story is a stack of cards, not a dashboard panel.
+    <div className="mx-auto max-w-xl space-y-3">
+      <div className="flex items-center justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold capitalize text-foreground">
+            {monthLabel(month)}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {card.chapterEmoji} {card.chapterTitle}
+          </p>
+        </div>
+        <Button variant="ghost" size="icon" onClick={close} aria-label={t('common.close')}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* The card area. `select-none` so a swipe doesn't highlight the figure. */}
+      <Card
+        className="relative h-[26rem] select-none overflow-hidden p-0"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+      >
+        <div
+          role="group"
+          aria-roledescription={t('recap.story.cardRole')}
+          aria-label={t('recap.story.position', { current: index + 1, total: cards.length })}
+          className="h-full"
+        >
+          <RecapCardView card={card} />
+        </div>
+
+        {/* Tap zones: a pointer affordance, nothing more. They duplicate the footer
+            buttons, so they stay out of the accessibility tree and out of the tab
+            order — otherwise a screen reader announces "Next" twice, and tabbing
+            through the story hits two controls that do the same thing. */}
+        <button
+          type="button"
+          onClick={() => go(-1)}
+          disabled={isFirst}
+          aria-hidden
+          tabIndex={-1}
+          className="absolute inset-y-0 left-0 w-1/3 cursor-w-resize disabled:cursor-default"
+        />
+        <button
+          type="button"
+          onClick={() => go(1)}
+          disabled={isLast}
+          aria-hidden
+          tabIndex={-1}
+          className="absolute inset-y-0 right-0 w-1/3 cursor-e-resize disabled:cursor-default"
+        />
+      </Card>
+
+      <div className="flex items-center justify-between gap-3">
+        <Button variant="outline" size="sm" onClick={() => go(-1)} disabled={isFirst}>
+          <ChevronLeft className="mr-1 h-4 w-4" />
+          {t('recap.story.previous')}
+        </Button>
+
+        <div
+          className="flex flex-wrap items-center justify-center gap-1.5"
+          aria-label={t('recap.story.position', { current: index + 1, total: cards.length })}
+        >
+          {cards.map((c, i) => (
+            <button
+              key={`${c.kind}-${i}`}
+              type="button"
+              onClick={() => setIndex(i)}
+              aria-label={t('recap.story.goTo', { position: i + 1 })}
+              aria-current={i === index}
+              className={`h-1.5 rounded-full transition-all ${
+                i === index ? 'w-5 bg-primary' : 'w-1.5 bg-muted-foreground/30'
+              }`}
+            />
+          ))}
+        </div>
+
+        {isLast ? (
+          <Button variant="outline" size="sm" onClick={close}>
+            {t('recap.story.done')}
+          </Button>
+        ) : (
+          <Button variant="outline" size="sm" onClick={() => go(1)}>
+            {t('recap.story.next')}
+            <ChevronRight className="ml-1 h-4 w-4" />
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ui/src/features/recap/hooks.ts
+++ b/ui/src/features/recap/hooks.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchLatestRecap, fetchRecap, fetchRecaps } from '@/lib/api/recap';
+
+export const recapKeys = {
+  all: ['recap'] as const,
+  list: () => [...recapKeys.all, 'list'] as const,
+  latest: () => [...recapKeys.all, 'latest'] as const,
+  detail: (month: string) => [...recapKeys.all, month] as const,
+};
+
+/**
+ * A recap is a frozen memory: once fetched it cannot change, so there is no point
+ * refetching it on every focus. The generous `staleTime` is not an optimization
+ * guess — it follows from the snapshot being immutable by design.
+ */
+const FROZEN = { staleTime: 5 * 60_000 } as const;
+
+export function useRecapHistory() {
+  return useQuery({ queryKey: recapKeys.list(), queryFn: fetchRecaps, ...FROZEN });
+}
+
+/** `null` when the last closed month had too little to tell (API answers 204). */
+export function useLatestRecap() {
+  return useQuery({ queryKey: recapKeys.latest(), queryFn: fetchLatestRecap, ...FROZEN });
+}
+
+export function useRecap(month: string | undefined) {
+  return useQuery({
+    queryKey: recapKeys.detail(month ?? ''),
+    queryFn: () => fetchRecap(month as string),
+    enabled: Boolean(month),
+    ...FROZEN,
+  });
+}

--- a/ui/src/features/recap/month.test.ts
+++ b/ui/src/features/recap/month.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { monthLabel } from './month';
+
+describe('monthLabel', () => {
+  it('labels a month from its parts, never by parsing the string as a date', () => {
+    // `new Date('2026-01')` parses as UTC midnight, which is December 31st in any
+    // negative-offset zone — the label would name the wrong month, and the wrong
+    // year. Same trap as `toISOString()` on the other side (see lib/format).
+    expect(monthLabel('2026-01')).toMatch(/2026/);
+    expect(monthLabel('2026-01')).not.toMatch(/2025/);
+  });
+
+  it('keeps the month and the year of what it was given', () => {
+    const label = monthLabel('2026-07');
+    expect(label).toMatch(/2026/);
+    // July in the four supported locales, plus the English fallback.
+    expect(label.toLowerCase()).toMatch(/juillet|july|juli|julio/);
+  });
+
+  it('handles December without rolling into the next year', () => {
+    expect(monthLabel('2026-12')).toMatch(/2026/);
+    expect(monthLabel('2026-12')).not.toMatch(/2027/);
+  });
+
+  it('degrades to the raw value rather than throwing on malformed input', () => {
+    expect(monthLabel('not-a-month')).toBe('not-a-month');
+    expect(monthLabel('')).toBe('');
+    expect(monthLabel(undefined)).toBe('');
+  });
+});

--- a/ui/src/features/recap/month.ts
+++ b/ui/src/features/recap/month.ts
@@ -1,0 +1,15 @@
+/**
+ * `'YYYY-MM'` → localized month label, e.g. « juillet 2026 ».
+ *
+ * Built from the parts, never from `new Date('2026-07')`: that string parses as UTC
+ * midnight, which is the previous month's last day in any negative-offset zone — the
+ * same trap `toISOString()` sets on the other side (see `lib/format`).
+ */
+export function monthLabel(month: string | undefined): string {
+  if (!month) return '';
+  const [year, mon] = month.split('-').map(Number);
+  if (!year || !mon) return month;
+  return new Intl.DateTimeFormat(undefined, { month: 'long', year: 'numeric' }).format(
+    new Date(year, mon - 1, 1),
+  );
+}

--- a/ui/src/lib/api/recap.ts
+++ b/ui/src/lib/api/recap.ts
@@ -1,0 +1,61 @@
+import { api } from '@/lib/axios';
+
+// --- Household monthly recap (parcours 27) ----------------------------------
+
+function unwrapList<T>(data: T[] | { results: T[] }): T[] {
+  return Array.isArray(data) ? data : (data?.results ?? []);
+}
+
+/**
+ * One story card. `value_type` says how to display `value`:
+ * - `money` → raw decimal string, format it with `formatAmount` (one formatter rule);
+ * - `count` / `raw` → already a display string, show as-is.
+ *
+ * `headline` and `caption` arrive localized from the server, which renders them
+ * from the frozen snapshot in the reader's language.
+ */
+export interface RecapCard {
+  kind: string;
+  emoji: string;
+  headline: string;
+  value: string;
+  value_type: 'money' | 'count' | 'raw';
+  caption: string;
+}
+
+export interface RecapChapter {
+  key: string;
+  emoji: string;
+  title: string;
+  cards: RecapCard[];
+}
+
+export interface HouseholdRecap {
+  id: string;
+  month: string; // 'YYYY-MM'
+  card_count: number;
+  chapters: RecapChapter[];
+  created_at: string;
+}
+
+export async function fetchRecaps(): Promise<HouseholdRecap[]> {
+  const { data } = await api.get<HouseholdRecap[] | { results: HouseholdRecap[] }>('/recap/');
+  return unwrapList(data);
+}
+
+/**
+ * The last closed month, generated on first read.
+ *
+ * A `204` means the month had too little to tell — a legitimate answer, not an
+ * error, so it surfaces as `null` rather than throwing.
+ */
+export async function fetchLatestRecap(): Promise<HouseholdRecap | null> {
+  const { data, status } = await api.get<HouseholdRecap | null>('/recap/latest/');
+  if (status === 204 || !data) return null;
+  return data;
+}
+
+export async function fetchRecap(month: string): Promise<HouseholdRecap> {
+  const { data } = await api.get<HouseholdRecap>(`/recap/${month}/`);
+  return data;
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -3842,5 +3842,26 @@
       "deleteConfirm": "Diese Ausgabe löschen? Sie verschwindet aus dem Journal und aus den Budgetsummen.",
       "deleteSplitConfirm": "Diese Ausgabe löschen? Die Kontobewegung bleibt unberührt: ihr Betrag wandert zurück in die Warteschlange."
     }
+  },
+  "recap": {
+    "title": "Rückblick",
+    "description": "Der Monat Ihres Haushalts, in wenigen Karten erzählt.",
+    "empty": "Noch kein Rückblick",
+    "emptyDescription": "Ihr erster Rückblick kommt am 1., sobald ein Monat abgeschlossen ist.",
+    "history": "Frühere Monate",
+    "open": "Rückblick ansehen",
+    "cardCount_one": "{{count}} Karte",
+    "cardCount_other": "{{count}} Karten",
+    "backToHistory": "Zurück zu den Rückblicken",
+    "story": {
+      "previous": "Zurück",
+      "next": "Weiter",
+      "done": "Fertig",
+      "cardRole": "Rückblick-Karte",
+      "position": "Karte {{current}} von {{total}}",
+      "goTo": "Zu Karte {{position}}",
+      "unavailable": "Für diesen Monat gibt es nichts zu erzählen",
+      "unavailableDescription": "In diesem Monat ist zu wenig erfasst, um einen Rückblick zu erstellen."
+    }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -3842,5 +3842,26 @@
       "deleteConfirm": "Delete this expense? It will disappear from the journal and from budget totals.",
       "deleteSplitConfirm": "Delete this expense? The bank transaction is untouched: its amount goes back to the queue."
     }
+  },
+  "recap": {
+    "title": "Recap",
+    "description": "Your household's month, told in a few cards.",
+    "empty": "No recap yet",
+    "emptyDescription": "Your first recap will arrive on the 1st, once a month has closed.",
+    "history": "Earlier months",
+    "open": "See the recap",
+    "cardCount_one": "{{count}} card",
+    "cardCount_other": "{{count}} cards",
+    "backToHistory": "Back to recaps",
+    "story": {
+      "previous": "Previous",
+      "next": "Next",
+      "done": "Done",
+      "cardRole": "recap card",
+      "position": "Card {{current}} of {{total}}",
+      "goTo": "Go to card {{position}}",
+      "unavailable": "Nothing to tell for this month",
+      "unavailableDescription": "This month has too little recorded to make a recap."
+    }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -3842,5 +3842,26 @@
       "deleteConfirm": "¿Eliminar este gasto? Desaparecerá del diario y de los totales de presupuesto.",
       "deleteSplitConfirm": "¿Eliminar este gasto? La operación bancaria no se toca: su importe vuelve a la cola."
     }
+  },
+  "recap": {
+    "title": "Resumen",
+    "description": "El mes de tu hogar, contado en unas pocas tarjetas.",
+    "empty": "Aún no hay resumen",
+    "emptyDescription": "Tu primer resumen llegará el día 1, una vez cerrado un mes.",
+    "history": "Meses anteriores",
+    "open": "Ver el resumen",
+    "cardCount_one": "{{count}} tarjeta",
+    "cardCount_other": "{{count}} tarjetas",
+    "backToHistory": "Volver a los resúmenes",
+    "story": {
+      "previous": "Anterior",
+      "next": "Siguiente",
+      "done": "Terminado",
+      "cardRole": "tarjeta de resumen",
+      "position": "Tarjeta {{current}} de {{total}}",
+      "goTo": "Ir a la tarjeta {{position}}",
+      "unavailable": "Nada que contar de este mes",
+      "unavailableDescription": "Este mes tiene muy pocos datos para hacer un resumen."
+    }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -3842,5 +3842,26 @@
       "deleteConfirm": "Supprimer cette dépense ? Elle disparaîtra du journal et des totaux de budget.",
       "deleteSplitConfirm": "Supprimer cette dépense ? L'opération bancaire n'est pas touchée : son montant redevient à ranger."
     }
+  },
+  "recap": {
+    "title": "Récap",
+    "description": "Le mois de votre foyer, raconté en quelques cartes.",
+    "empty": "Pas encore de récap",
+    "emptyDescription": "Votre premier récap arrivera le 1er, une fois un mois clôturé.",
+    "history": "Mois précédents",
+    "open": "Voir le récap",
+    "cardCount_one": "{{count}} carte",
+    "cardCount_other": "{{count}} cartes",
+    "backToHistory": "Retour aux récaps",
+    "story": {
+      "previous": "Précédent",
+      "next": "Suivant",
+      "done": "Terminé",
+      "cardRole": "carte de récap",
+      "position": "Carte {{current}} sur {{total}}",
+      "goTo": "Aller à la carte {{position}}",
+      "unavailable": "Rien à raconter pour ce mois",
+      "unavailableDescription": "Ce mois-ci contient trop peu d'éléments pour en faire un récap."
+    }
   }
 }

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -46,6 +46,8 @@ const AIUsagePage = lazyWithReload(() => import('./features/ai-usage/AIUsagePage
 const AgentPage = lazyWithReload(() => import('./features/agent/AgentPage'));
 const MemoryPage = lazyWithReload(() => import('./features/agent/MemoryPage'));
 const DigestPage = lazyWithReload(() => import('./features/digest/DigestPage'));
+const RecapHistoryPage = lazyWithReload(() => import('./features/recap/RecapHistoryPage'));
+const RecapStoryPage = lazyWithReload(() => import('./features/recap/RecapStoryPage'));
 const BriefingsPage = lazyWithReload(() => import('./features/briefings/BriefingsPage'));
 const MoneyPage = lazyWithReload(() => import('./features/money/MoneyPage'));
 const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPage'));
@@ -139,6 +141,8 @@ export const router = createBrowserRouter([
       { path: 'agent', element: <AgentPage /> },
       { path: 'agent/memory', element: <MemoryPage /> },
       { path: 'digest', element: <DigestPage /> },
+      { path: 'recap', element: <RecapHistoryPage /> },
+      { path: 'recap/:month', element: <RecapStoryPage /> },
       { path: 'briefings', element: <BriefingsPage /> },
       { path: 'admin/users', element: <AdminUsersPage /> },
       { path: 'admin/ai-usage', element: <AIUsagePage /> },


### PR DESCRIPTION
La **story** du récap mensuel — parcours 27, **lot 4**. Closes #439. Lot du #435. Suite de #443.

C'est le lot où se joue l'effet produit : le bilan mensuel existait déjà, mais en un paragraphe gris que personne ne relit.

## Ce que ça donne

- **`/app/recap`** — l'historique. Le mois frais a droit à la mise en scène, les mois passés à une liste sobre : on ne rejoue pas la story de mars.
- **`/app/recap/:month`** — la story. Boutons, pastilles cliquables, clavier ←/→, swipe tactile, `Échap` pour sortir. **Aucun auto-play** : un récap n'est pas une publicité.
- Entrée sidebar dans le groupe **Compte**, à côté de Digest.

## Trois décisions de détail

**Les zones de tap sont `aria-hidden` et hors du tab order.** Elles doublent les boutons du pied — les exposer faisait annoncer « Suivant » deux fois à un lecteur d'écran et mettait deux contrôles identiques sur le chemin du clavier. C'est l'E2E qui l'a révélé (sélecteur ambigu), et la correction est allée dans le composant, pas dans le test.

**La carte est bornée en largeur.** Pleine page, le chiffre flotte dans un bandeau et cesse de se lire comme une carte.

**`monthLabel` construit le libellé depuis les parties**, jamais en parsant `'2026-01'` comme une date : cette string parse en minuit UTC, soit le 31 décembre 2025 dans tout fuseau négatif — le même piège que `toISOString()` de l'autre côté. Test de régression dans `month.test.ts`.

Les montants passent par `formatAmount` : le serveur renvoie `value_type: "money"` avec le montant brut, le front formate (règle du formatter unique).

## Sur le choix de simuler les réponses en E2E

Ma première version semait des dépenses via l'API puis demandait le récap. Elle a échoué au deuxième run, et pour une bonne raison : **un instantané est gelé au premier appel et jamais recalculé**. Le mois avait donc été figé *vide* par le run précédent, et plus rien ne pouvait le remplir — le test dépendait de l'ordre d'exécution.

La génération est couverte côté serveur (68 tests, dont l'accord avec le `BudgetReport` et l'idempotence du gel). Ce qui ne se vérifie qu'en E2E, c'est le **parcours de la story** : la spec simule donc les trois routes et teste la navigation, la sortie et les états vides.

## Vérifications

- `tsc -b ui/tsconfig.json` : 0 erreur · `npm run lint` : 0 erreur · `npm run build` : OK
- `vitest` : 51 passed (dont 4 nouveaux sur `monthLabel`)
- `playwright test recap.spec.ts` : **7 passed**
- i18n : namespace `recap` complet dans les 4 catalogues, aucun `defaultValue`, `keys.test.ts` vert

## Aperçu

Story (carte 1/3) et historique — rendus dans l'app réelle :

- gros chiffre + libellé + légende, pastilles de progression, sortie explicite
- historique : mois frais en tête avec son nombre de cartes, mois précédents en liste

## Reste du parcours

Lot 5 (les quatre autres chapitres, #440) → lot 6 (le rendez-vous, #441).