### PR TITLE
feat(money): les espèces entrent par la porte, et le retrait partiel ne se perd plus

### DIFF
--- a/apps/banking/detectors.py
+++ b/apps/banking/detectors.py
@@ -12,6 +12,7 @@ would therefore never ask:
 - a cash account in the red, which is physically impossible (``account_cash_negative``);
 - a receipt nobody classified (``inflow_unclassified``);
 - an internal movement whose other leg is missing (``internal_without_counterpart``);
+- a withdrawal only partly poured into the cash pot (``cash_mirror_partial``);
 - a recurrence past due with nothing recorded (``recurring_overdue``);
 - a recurrence confirmed twice for the same day (``recurring_double_confirmed``);
 - a period nobody ever imported (``statement_period_gap``);
@@ -66,6 +67,7 @@ INFLOW_UNCLASSIFIED = "inflow_unclassified"
 REFUND_WITHOUT_BUDGET = "refund_without_budget"
 REFUND_PARTIALLY_ALLOCATED = "refund_partially_allocated"
 INTERNAL_WITHOUT_COUNTERPART = "internal_without_counterpart"
+CASH_MIRROR_PARTIAL = "cash_mirror_partial"
 RECURRING_OVERDUE = "recurring_overdue"
 RECURRING_DOUBLE_CONFIRMED = "recurring_double_confirmed"
 STATEMENT_PERIOD_GAP = "statement_period_gap"
@@ -532,6 +534,63 @@ def _find_internal_without_counterpart(household, **window) -> list[Finding]:
         )
         for txn in apply_window(_internal_without_counterpart_qs(household), **window)
     ]
+
+
+def _cash_mirror_partial_qs(household):
+    """Withdrawals only **partly** poured into the cash account.
+
+    The last silent orphan of the money model, and the subtlest: 100 € withdrawn,
+    60 € declared as entering the cash pot. The withdrawal line is flagged
+    ``is_internal`` **as a whole**, so its 40 € remainder is excluded from spending
+    by the internal rule — and no cash line ever claims it either. Nothing is
+    arithmetically wrong: the bank balance is right, the cash balance is right, and
+    40 € belong nowhere. Precisely the state the whole module exists to abolish.
+
+    Its sibling ``internal_without_counterpart`` cannot see it: there *is* a
+    counterpart, it is simply too small. And ``account_cash_negative`` cannot
+    either — under-declaring cash makes the pot look *richer*, never negative.
+
+    Waivable, unlike the negative cash balance: keeping part of a withdrawal out
+    of the household's common pot is a legitimate choice ("40 € stayed in my
+    pocket"), not an impossibility. The fingerprint carries the **missing amount**,
+    so declaring more of it later makes the arbitration stale.
+    """
+    return (
+        _scoped_lines(household)
+        .filter(amount__lt=0, transfer_counterpart__isnull=False)
+        .annotate(mirrored=F("transfer_counterpart__amount"))
+        # `amount` is negative, `mirrored` positive: their sum is what is missing,
+        # expressed as a negative. One comparison, no Python, no CASE.
+        .annotate(gap=F("amount") + F("transfer_counterpart__amount"))
+        .filter(gap__lt=0)
+    )
+
+
+def _count_cash_mirror_partial(household) -> int:
+    return _cash_mirror_partial_qs(household).count()
+
+
+def _find_cash_mirror_partial(household, **window) -> list[Finding]:
+    findings = []
+    for txn in apply_window(_cash_mirror_partial_qs(household), **window):
+        missing = -txn.gap
+        findings.append(
+            Finding(
+                kind=CASH_MIRROR_PARTIAL,
+                object_id=str(txn.pk),
+                label=f"{txn.booked_on.isoformat()} · {txn.label_raw[:80]}",
+                fingerprint=fingerprint_of(CASH_MIRROR_PARTIAL, missing),
+                detail={
+                    "account_name": txn.account.name,
+                    "booked_on": txn.booked_on.isoformat(),
+                    "label": txn.label_raw,
+                    "outflow": str(txn.outflow),
+                    "mirrored": str(txn.mirrored),
+                    "missing": str(missing),
+                },
+            )
+        )
+    return findings
 
 
 # --- Statement continuity and provenance (lot 7) ------------------------------
@@ -1059,6 +1118,16 @@ def _specs() -> list[DetectorSpec]:
             model=BankTransaction,
             count=_count_internal_without_counterpart,
             findings=_find_internal_without_counterpart,
+            blocked_by=ACCOUNT_WITHOUT_WINDOW,
+        ),
+        DetectorSpec(
+            kind=CASH_MIRROR_PARTIAL,
+            severity=ERROR,
+            label="Withdrawal only partly declared as entering the cash pot",
+            target="transaction",
+            model=BankTransaction,
+            count=_count_cash_mirror_partial,
+            findings=_find_cash_mirror_partial,
             blocked_by=ACCOUNT_WITHOUT_WINDOW,
         ),
         DetectorSpec(

--- a/apps/banking/services.py
+++ b/apps/banking/services.py
@@ -470,6 +470,55 @@ def record_cash_withdrawal(*, user, transaction, cash_account, amount=None):
     return mirror
 
 
+def adjust_cash_mirror(*, user, transaction, amount) -> "object":
+    """Change **how much** of a withdrawal is declared as entering the cash pot.
+
+    The resolution gesture of ``cash_mirror_partial``. Declaring 60 € of a 100 €
+    withdrawal was possible from the start; correcting it to 100 € was not — the
+    only way out was to unlink and redo, which destroys and recreates the cash line
+    (and with it, anything already spent against that line's balance history).
+
+    Only the leg **we** generated is adjustable, recognised exactly as
+    ``unlink_counterpart`` recognises it: no ``source_import`` and living on a cash
+    account. An imported line's amount is a fact from a statement and is never
+    rewritten here.
+
+    ⚠️ ``dedup_hash`` embeds the amount, so it is recomputed. Leaving the old hash
+    would make the row claim an identity it no longer has — and a re-import could
+    then land a *second* line for the same money.
+    """
+    from .models import BankAccount
+
+    mirror = transaction.transfer_counterpart
+    if mirror is None:
+        raise ValidationError({"transaction": "This operation has no cash counterpart."})
+    if mirror.source_import_id is not None or mirror.account.kind != BankAccount.Kind.CASH:
+        raise ValidationError(
+            {"transaction": "Only a generated cash counterpart can be adjusted."}
+        )
+
+    value = abs(Decimal(str(amount)))
+    if value <= 0:
+        raise ValidationError({"amount": "Amount must be positive."})
+    if value > transaction.outflow:
+        raise ValidationError({"amount": "Amount cannot exceed the withdrawal."})
+
+    with atomic():
+        mirror.amount = value
+        mirror.dedup_hash = compute_dedup_hash(
+            account_id=mirror.account_id,
+            booked_on=mirror.booked_on,
+            label_norm=mirror.label_norm,
+            amount=value,
+            currency=mirror.currency,
+            discriminant=f"cash-of:{transaction.id}",
+        )
+        mirror.updated_by = user
+        mirror.save(update_fields=["amount", "dedup_hash", "updated_by", "updated_at"])
+
+    return mirror
+
+
 def unlink_counterpart(*, user, transaction) -> None:
     """Undo a cash counterpart.
 
@@ -959,3 +1008,78 @@ def record_cash_expense(
         )
 
     return transaction_row, allocations
+
+
+def record_cash_deposit(
+    *,
+    household,
+    user,
+    account,
+    booked_on,
+    label: str,
+    amount: Decimal,
+    inflow_nature: str,
+    refund_lines: list[dict] | None = None,
+    notes: str = "",
+):
+    """Cash that came in from outside the tracked world.
+
+    The missing half of the cash story. ``record_cash_withdrawal`` covers money
+    that *left a bank account*, and it is the only way cash could ever enter — so
+    a note handed over at a family lunch, a bike sold for cash, a flatmate paying
+    their share in coins had **no representation at all**. The advice one could
+    give was to inflate the opening balance, which rewrites history to record a
+    dated fact: exactly the kind of lie the module refuses elsewhere.
+
+    Born classified, like ``record_cash_expense`` is born allocated: an
+    ``inflow_nature`` is **required**, so the line never lands in the queue as
+    ``inflow_unclassified``. The app does not create its own work.
+
+    ``transfer`` is refused here on purpose. An internal movement promises a
+    counterpart on another tracked account; cash arriving from a withdrawal already
+    has its own path (``record_cash_withdrawal``), and declaring one by hand would
+    leave an internal leg whose other half nothing will ever supply — the écart
+    ``internal_without_counterpart``, manufactured by the very gesture meant to
+    resolve a gap.
+    """
+    from .models import BankAccount, InflowNature
+
+    if account.kind != BankAccount.Kind.CASH:
+        raise ValidationError({"account": "Target account must be a cash account."})
+
+    nature = (inflow_nature or "").strip()
+    allowed = {c for c in InflowNature.values if c and c != InflowNature.TRANSFER}
+    if nature not in allowed:
+        raise ValidationError(
+            {"inflow_nature": f"Pick one of: {', '.join(sorted(allowed))}."}
+        )
+
+    value = abs(Decimal(str(amount)))
+    if value <= 0:
+        raise ValidationError({"amount": "Amount must be positive."})
+
+    with atomic():
+        transaction_row = create_manual_transaction(
+            household=household,
+            user=user,
+            account=account,
+            booked_on=booked_on,
+            label=label,
+            amount=value,
+            notes=notes,
+        )
+        transaction_row.inflow_nature = nature
+        transaction_row.updated_by = user
+        transaction_row.save(update_fields=["inflow_nature", "updated_by", "updated_at"])
+
+        # Un remboursement en espèces recrédite une enveloppe comme n'importe quel
+        # autre : sans ses parts, il resterait l'écart `refund_without_budget`.
+        if nature == InflowNature.REFUND and refund_lines:
+            set_refund_allocations(
+                household=household,
+                user=user,
+                transaction=transaction_row,
+                lines=refund_lines,
+            )
+
+    return transaction_row

--- a/apps/banking/tests/test_cash_gap.py
+++ b/apps/banking/tests/test_cash_gap.py
@@ -1,0 +1,405 @@
+# banking/tests/test_cash_gap.py
+"""Les deux trous restants de l'argent liquide.
+
+**Le retrait partiellement versé** — 100 € retirés, 60 € déclarés entrés dans la
+caisse. Rien n'est faux arithmétiquement : le solde bancaire est juste, le solde
+espèces est juste, et 40 € n'appartiennent à rien. La ligne de retrait est
+`is_internal` **en entier**, donc son reste est exclu des dépenses par la règle des
+mouvements internes, et aucune ligne espèces ne le réclame. C'était le dernier
+orphelin silencieux du modèle, et le plus discret : ses deux voisins ne peuvent pas
+le voir (il *a* une contrepartie, elle est juste trop petite ; et sous-déclarer les
+espèces fait paraître la caisse plus riche, jamais négative).
+
+**La rentrée d'espèces** — l'autre moitié de l'histoire. Jusqu'ici les espèces ne
+pouvaient entrer qu'en miroir d'un retrait bancaire : un billet donné à un repas de
+famille, un vélo vendu, une part payée en pièces n'avaient aucune représentation.
+Le seul conseil possible était de gonfler le solde d'ouverture — réécrire
+l'histoire pour enregistrer un fait daté.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from rest_framework.exceptions import ValidationError
+
+from banking.balances import compute_balance
+from banking.compliance import summary
+from banking.dedup import compute_dedup_hash
+from banking.detectors import (
+    ACCOUNT_CASH_NEGATIVE,
+    CASH_MIRROR_PARTIAL,
+    INFLOW_UNCLASSIFIED,
+    INTERNAL_WITHOUT_COUNTERPART,
+    REFUND_WITHOUT_BUDGET,
+)
+from banking.models import (
+    BankAccount,
+    BankTransaction,
+    ImportStatus,
+    InflowNature,
+    StatementImport,
+    TransactionDirection,
+)
+from banking.services import (
+    adjust_cash_mirror,
+    record_cash_deposit,
+    record_cash_withdrawal,
+    waive_finding,
+)
+from budget.models import Budget
+
+from .factories import BankAccountFactory, HouseholdFactory, UserFactory
+
+_counter = itertools.count()
+
+
+def make_txn(account, *, amount, booked_on=date(2026, 2, 10), label="RETRAIT DAB", **extra):
+    value = Decimal(amount)
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+        **extra,
+    )
+
+
+@pytest.fixture
+def ctx(db):
+    household = HouseholdFactory()
+    user = UserFactory()
+    bank = BankAccountFactory(
+        household=household, name="Courant", opening_balance_date=date(2026, 1, 1)
+    )
+    cash = BankAccountFactory(
+        household=household,
+        name="Espèces",
+        kind=BankAccount.Kind.CASH,
+        bank_label="",
+        opening_balance=Decimal("0.00"),
+        opening_balance_date=date(2026, 1, 1),
+    )
+    for account in (bank, cash):
+        StatementImport.objects.create(
+            household=household,
+            account=account,
+            provider="generic_csv",
+            status=ImportStatus.COMPLETED,
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 3, 31),
+        )
+    return {"household": household, "user": user, "bank": bank, "cash": cash}
+
+
+def open_count(household, kind):
+    return {g.spec.kind: g.open for g in summary(household)}.get(kind)
+
+
+# --- Le retrait partiellement versé ------------------------------------------
+
+
+class TestTheUnpouredRemainderIsSeen:
+    def test_sixty_of_a_hundred_leaves_forty_reported(self, ctx):
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        assert open_count(ctx["household"], CASH_MIRROR_PARTIAL) == 1
+
+    def test_a_full_pour_is_clean(self, ctx):
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"], transaction=withdrawal, cash_account=ctx["cash"]
+        )
+
+        assert open_count(ctx["household"], CASH_MIRROR_PARTIAL) == 0
+
+    def test_the_finding_names_what_is_missing(self, ctx):
+        from banking.compliance import get_detector, open_findings
+
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        (finding,) = open_findings(ctx["household"], get_detector(CASH_MIRROR_PARTIAL))
+        assert finding.detail["outflow"] == "100.00"
+        assert finding.detail["mirrored"] == "60.00"
+        assert finding.detail["missing"] == "40.00"
+
+    def test_neither_neighbour_could_have_caught_it(self, ctx):
+        """Les deux détecteurs voisins sont aveugles à ce cas, chacun pour sa raison.
+
+        `internal_without_counterpart` voit une contrepartie et se taît ; le solde
+        espèces sous-déclaré est *plus riche*, donc `account_cash_negative` n'a rien
+        à dire. Sans un détecteur propre, personne ne parle.
+        """
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        assert open_count(ctx["household"], INTERNAL_WITHOUT_COUNTERPART) == 0
+        assert open_count(ctx["household"], ACCOUNT_CASH_NEGATIVE) == 0
+
+    def test_an_over_poured_mirror_is_not_this_ecart(self, ctx):
+        """Verser plus que le retrait est refusé à l'écriture, pas signalé après."""
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+
+        with pytest.raises(ValidationError):
+            record_cash_withdrawal(
+                user=ctx["user"],
+                transaction=withdrawal,
+                cash_account=ctx["cash"],
+                amount=Decimal("140.00"),
+            )
+
+
+class TestCompletingThePour:
+    def test_raising_the_mirror_closes_the_ecart(self, ctx):
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        mirror = record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        adjust_cash_mirror(
+            user=ctx["user"], transaction=withdrawal, amount=Decimal("100.00")
+        )
+
+        mirror.refresh_from_db()
+        assert mirror.amount == Decimal("100.00")
+        assert open_count(ctx["household"], CASH_MIRROR_PARTIAL) == 0
+
+    def test_the_cash_balance_follows(self, ctx):
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        adjust_cash_mirror(
+            user=ctx["user"], transaction=withdrawal, amount=Decimal("100.00")
+        )
+
+        assert compute_balance(account=ctx["cash"]).amount == Decimal("100.00")
+
+    def test_the_dedup_hash_is_recomputed(self, ctx):
+        """Sinon la ligne revendique une identité qu'elle n'a plus — et un
+        ré-import pourrait déposer une **seconde** ligne pour le même argent."""
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        mirror = record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+        before = mirror.dedup_hash
+
+        adjust_cash_mirror(
+            user=ctx["user"], transaction=withdrawal, amount=Decimal("100.00")
+        )
+
+        mirror.refresh_from_db()
+        assert mirror.dedup_hash != before
+
+    def test_it_cannot_exceed_the_withdrawal(self, ctx):
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+
+        with pytest.raises(ValidationError):
+            adjust_cash_mirror(
+                user=ctx["user"], transaction=withdrawal, amount=Decimal("120.00")
+            )
+
+    def test_an_imported_counterpart_is_never_rewritten(self, ctx):
+        """Le montant d'une ligne importée est un fait du relevé.
+
+        Même règle que `unlink_counterpart`, qui ne détruit que la jambe qu'on a
+        générée : ici on ne réécrit que celle-là non plus.
+        """
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        other_bank = BankAccountFactory(
+            household=ctx["household"], name="Livret", opening_balance_date=date(2026, 1, 1)
+        )
+        real = make_txn(other_bank, amount="60.00", label="VIR RECU")
+        withdrawal.transfer_counterpart = real
+        withdrawal.is_internal = True
+        withdrawal.save(update_fields=["transfer_counterpart", "is_internal"])
+
+        with pytest.raises(ValidationError):
+            adjust_cash_mirror(
+                user=ctx["user"], transaction=withdrawal, amount=Decimal("100.00")
+            )
+
+    def test_the_arbitration_expires_when_the_remainder_moves(self, ctx):
+        """40 € arbitrés « restés dans ma poche », puis 20 € déclarés : l'écart
+        resurgit, parce que le motif ne parle plus de la même somme."""
+        withdrawal = make_txn(ctx["bank"], amount="-100.00")
+        record_cash_withdrawal(
+            user=ctx["user"],
+            transaction=withdrawal,
+            cash_account=ctx["cash"],
+            amount=Decimal("60.00"),
+        )
+        waive_finding(
+            household=ctx["household"],
+            user=ctx["user"],
+            finding_kind=CASH_MIRROR_PARTIAL,
+            object_id=str(withdrawal.id),
+            reason="40 € restés dans ma poche",
+        )
+        assert open_count(ctx["household"], CASH_MIRROR_PARTIAL) == 0
+
+        adjust_cash_mirror(
+            user=ctx["user"], transaction=withdrawal, amount=Decimal("80.00")
+        )
+
+        groups = {g.spec.kind: g for g in summary(ctx["household"])}
+        assert groups[CASH_MIRROR_PARTIAL].stale == 1
+
+
+# --- La rentrée d'espèces ----------------------------------------------------
+
+
+class TestCashCanComeFromOutside:
+    def test_a_gift_in_notes_becomes_a_cash_line(self, ctx):
+        row = record_cash_deposit(
+            household=ctx["household"],
+            user=ctx["user"],
+            account=ctx["cash"],
+            booked_on=date(2026, 2, 14),
+            label="Cadeau anniversaire",
+            amount=Decimal("50.00"),
+            inflow_nature=InflowNature.OTHER,
+        )
+
+        assert row.amount == Decimal("50.00")
+        assert row.direction == TransactionDirection.IN
+        assert compute_balance(account=ctx["cash"]).amount == Decimal("50.00")
+
+    def test_it_is_born_classified(self, ctx):
+        """Sinon la rentrée atterrit dans « À ranger » : l'app fabriquerait son
+        propre travail, exactement ce que la dépense en espèces évite déjà."""
+        record_cash_deposit(
+            household=ctx["household"],
+            user=ctx["user"],
+            account=ctx["cash"],
+            booked_on=date(2026, 2, 14),
+            label="Vélo vendu",
+            amount=Decimal("120.00"),
+            inflow_nature=InflowNature.OTHER,
+        )
+
+        assert open_count(ctx["household"], INFLOW_UNCLASSIFIED) == 0
+
+    def test_a_nature_is_required(self, ctx):
+        with pytest.raises(ValidationError):
+            record_cash_deposit(
+                household=ctx["household"],
+                user=ctx["user"],
+                account=ctx["cash"],
+                booked_on=date(2026, 2, 14),
+                label="Billet trouvé",
+                amount=Decimal("20.00"),
+                inflow_nature="",
+            )
+
+    def test_transfer_is_refused(self, ctx):
+        """Un mouvement interne promet une contrepartie que rien ne fournira —
+        l'écart `internal_without_counterpart`, fabriqué par le geste censé
+        combler un trou. Les espèces issues d'un retrait ont déjà leur chemin."""
+        with pytest.raises(ValidationError):
+            record_cash_deposit(
+                household=ctx["household"],
+                user=ctx["user"],
+                account=ctx["cash"],
+                booked_on=date(2026, 2, 14),
+                label="Retrait",
+                amount=Decimal("100.00"),
+                inflow_nature=InflowNature.TRANSFER,
+            )
+
+    def test_a_bank_account_is_refused(self, ctx):
+        """Une rentrée sur un compte bancaire s'importe, elle ne se saisit pas."""
+        with pytest.raises(ValidationError):
+            record_cash_deposit(
+                household=ctx["household"],
+                user=ctx["user"],
+                account=ctx["bank"],
+                booked_on=date(2026, 2, 14),
+                label="Virement reçu",
+                amount=Decimal("100.00"),
+                inflow_nature=InflowNature.OTHER,
+            )
+
+    def test_a_cash_refund_credits_its_envelope_at_once(self, ctx):
+        """Ma copine me rend 30 € en liquide sur les courses : l'enveloppe est
+        recréditée dans le même geste, sans laisser `refund_without_budget`."""
+        groceries = Budget.objects.create(
+            household=ctx["household"], name="Courses", monthly_amount=Decimal("400.00")
+        )
+
+        row = record_cash_deposit(
+            household=ctx["household"],
+            user=ctx["user"],
+            account=ctx["cash"],
+            booked_on=date(2026, 2, 14),
+            label="Part de Marie",
+            amount=Decimal("30.00"),
+            inflow_nature=InflowNature.REFUND,
+            refund_lines=[{"budget_id": str(groceries.id), "amount": "30.00"}],
+        )
+
+        assert row.refund_allocations.count() == 1
+        assert open_count(ctx["household"], REFUND_WITHOUT_BUDGET) == 0
+
+    def test_a_deposit_is_never_a_duplicate_of_itself(self, ctx):
+        """Deux billets de 20 € le même jour sont deux rentrées, et seul
+        l'utilisateur sait si c'est une erreur."""
+        for _ in range(2):
+            record_cash_deposit(
+                household=ctx["household"],
+                user=ctx["user"],
+                account=ctx["cash"],
+                booked_on=date(2026, 2, 14),
+                label="Billet",
+                amount=Decimal("20.00"),
+                inflow_nature=InflowNature.OTHER,
+            )
+
+        assert BankTransaction.objects.filter(account=ctx["cash"]).count() == 2
+        assert compute_balance(account=ctx["cash"]).amount == Decimal("40.00")

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -60,10 +60,12 @@ from .serializers import (
     StatementImportSerializer,
 )
 from .services import (
+    adjust_cash_mirror,
     apply_statement_opening_balance,
     archive_account,
     create_account,
     import_statement_file,
+    record_cash_deposit,
     record_cash_expense,
     link_interaction,
     preview_statement_file,
@@ -550,6 +552,52 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+    @action(detail=False, methods=["post"], url_path="cash-deposit")
+    def cash_deposit(self, request):
+        """Cash that came in from outside: a gift, a sale, a share paid in coins.
+
+        The missing half of the cash story — until now the only way cash could
+        enter was mirroring a bank withdrawal, so money handed over in notes had no
+        representation at all. The advice one could give was to inflate the opening
+        balance, which rewrites history to record a dated fact.
+
+        Born classified (``inflow_nature`` required), for the same reason a cash
+        spend is born allocated: the app must not create its own écart.
+        """
+        household = request.household
+        if household is None:
+            raise ValidationError({"household_id": "A valid household context is required."})
+
+        account_id = request.data.get("account")
+        if not account_id:
+            raise ValidationError({"account": "This field is required."})
+        account = BankAccount.objects.filter(household=household, pk=account_id).first()
+        if account is None:
+            raise ValidationError({"account": "Unknown account for this household."})
+
+        booked_on = _parse_date_param(
+            request.data.get("booked_on"), "booked_on"
+        ) or household_today(household)
+
+        try:
+            transaction_row = record_cash_deposit(
+                household=household,
+                user=request.user,
+                account=account,
+                booked_on=booked_on,
+                label=str(request.data.get("label") or ""),
+                amount=request.data.get("amount") or 0,
+                inflow_nature=str(request.data.get("inflow_nature") or ""),
+                refund_lines=request.data.get("refund_lines") or None,
+                notes=str(request.data.get("notes") or ""),
+            )
+        except (TypeError, ValueError, InvalidOperation):
+            raise ValidationError({"amount": "Expected a decimal amount."})
+
+        return Response(
+            self.get_serializer(transaction_row).data, status=status.HTTP_201_CREATED
+        )
+
     @action(detail=False, methods=["get"], url_path="flow")
     def flow(self, request):
         """Money in / out over a period, internal movements excluded.
@@ -603,6 +651,22 @@ class BankTransactionViewSet(viewsets.ReadOnlyModelViewSet):
             amount=request.data.get("amount"),
         )
         return Response(self.get_serializer(mirror).data, status=status.HTTP_201_CREATED)
+
+    @action(detail=True, methods=["patch"], url_path="cash-mirror")
+    def cash_mirror(self, request, pk=None):
+        """Corriger **quelle part** de ce retrait est entrée dans la caisse.
+
+        La résolution de l'écart `cash_mirror_partial`. Déclarer 60 € d'un retrait
+        de 100 € était possible dès le départ ; le corriger à 100 € ne l'était pas —
+        il fallait délier puis refaire, ce qui détruit et recrée la ligne espèces.
+        """
+        instance = self.get_object()
+        mirror = adjust_cash_mirror(
+            user=request.user,
+            transaction=instance,
+            amount=request.data.get("amount"),
+        )
+        return Response(self.get_serializer(mirror).data)
 
     @action(detail=True, methods=["delete"], url_path="unlink-cash")
     def unlink_cash(self, request, pk=None):

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -1014,6 +1014,68 @@ qui contredit le solde d'ouverture qu'elle est censée justifier.
 seul « Corriger » a un sens), l'écart `account_anchor_stale`, et le menu de la carte
 de compte.
 
+## Les deux trous restants du liquide (juillet 2026)
+
+### `cash_mirror_partial` — 40 € qui n'appartiennent à rien
+
+Le dernier orphelin silencieux du modèle, et le plus discret : **100 € retirés,
+60 € déclarés entrés dans la caisse**. Rien n'est faux arithmétiquement — le solde
+bancaire est juste, le solde espèces est juste — et 40 € n'appartiennent à rien. La
+ligne de retrait est `is_internal` **en entier**, donc son reste est exclu des
+dépenses par la règle des mouvements internes, et aucune ligne espèces ne le
+réclame.
+
+- **Ses deux voisins sont aveugles à ce cas**, et il faut le savoir avant de
+  proposer de fusionner : `internal_without_counterpart` *voit* une contrepartie et
+  se taît ; `account_cash_negative` ne peut rien dire non plus, puisque
+  sous-déclarer les espèces fait paraître la caisse **plus riche**, jamais négative.
+- **Pur SQL**, donc un `COUNT(*)` honnête pour le badge :
+  `amount + transfer_counterpart__amount < 0` — `amount` est négatif, le miroir
+  positif, leur somme est exactement ce qui manque.
+- **Arbitrable**, contrairement au solde espèces négatif : garder une partie d'un
+  retrait hors du pot commun est un **choix** (« 40 € restés dans ma poche »), pas
+  une impossibilité. Le `fingerprint` porte le **montant manquant**, donc en
+  déclarer davantage périme l'arbitrage.
+- **Hors de la file « À ranger »** (`money/keys.ts`) : ce qui le résout n'est ni une
+  ventilation ni une nature, mais la correction du montant versé. C'est le seul
+  écart d'opération dont le geste vit dans le Contrôle.
+- La résolution est `services.adjust_cash_mirror` (`PATCH
+  /banking/transactions/{id}/cash-mirror/`). Elle n'ajuste que la jambe **qu'on a
+  générée**, reconnue exactement comme `unlink_counterpart` la reconnaît (pas de
+  `source_import`, compte espèces) : le montant d'une ligne importée est un fait du
+  relevé. ⚠️ Le `dedup_hash` est **recalculé** — l'amount y entre, et laisser
+  l'ancien ferait revendiquer à la ligne une identité qu'elle n'a plus, donc un
+  ré-import pourrait déposer une **seconde** ligne pour le même argent.
+
+Avant, corriger un versement partiel demandait de délier puis refaire, ce qui
+détruit et recrée la ligne espèces.
+
+### `record_cash_deposit` — les espèces peuvent venir d'ailleurs
+
+La moitié manquante de l'histoire du liquide : jusque-là les espèces ne pouvaient
+entrer qu'**en miroir d'un retrait**. Un billet donné à un repas de famille, un vélo
+vendu, la part d'un ami payée en pièces n'avaient donc aucune représentation, et le
+seul conseil possible était de gonfler le solde d'ouverture — réécrire l'histoire
+pour enregistrer un fait daté, exactement le mensonge que le module refuse ailleurs.
+
+- `POST /banking/transactions/cash-deposit/`, compte **espèces** obligatoire : une
+  rentrée sur un compte bancaire s'importe, elle ne se saisit pas.
+- **Née classée** : `inflow_nature` est requis, comme la dépense en espèces naît
+  ventilée. Sans ça la rentrée atterrirait dans « À ranger » et l'app fabriquerait
+  son propre travail.
+- **`transfer` est refusé.** Un mouvement interne promet une contrepartie sur un
+  autre compte suivi ; les espèces issues d'un retrait ont déjà leur chemin. En
+  déclarer un à la main laisserait une jambe dont rien ne fournira jamais l'autre
+  moitié — `internal_without_counterpart`, fabriqué par le geste censé combler un
+  trou.
+- Un remboursement en espèces accepte ses `refund_lines` dans le **même** appel,
+  sinon il resterait l'écart `refund_without_budget`.
+- Le `dedup_hash` porte `manual:{uuid4}` : deux billets de 20 € le même jour sont
+  deux rentrées, et seul l'utilisateur sait si c'est une erreur.
+
+Régressions : `banking/tests/test_cash_gap.py` (18 tests, dont l'aveuglement des
+deux détecteurs voisins et la péremption de l'arbitrage).
+
 ## Règle transverse
 - On n'additionne **jamais** un total banque et un total interactions. Le pont est un
   taux de couverture, pas une somme.

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -617,6 +617,25 @@ La fiche répond aux trois seules questions d'une dépense, dans cet ordre :
 Régression : `ui/src/features/money/ExpenseDetailPage.test.tsx` (dont la
 redirection, et le fait que la fiche générique reste celle d'une note).
 
+### Les espèces, des deux côtés
+
+Deux ajouts, côté UI, pour le dernier orphelin silencieux du modèle et pour son
+symétrique (détail du modèle : `docs/MODULES/banking.md`, « Les deux trous restants
+du liquide »).
+
+- **« Rentrée d'espèces »** vit dans l'onglet **Comptes**, pas dans Dépenses : ce
+  n'est pas une dépense, c'est de l'argent qui arrive dans une caisse — donc un
+  geste de compte. Le dialogue demande une **nature** (pas de transfert interne :
+  voir la doc banking) et, sur un remboursement, ses parts d'enveloppes dans le
+  même envoi.
+- **`cash_mirror_partial` reste hors de la file** et porte son geste dans le
+  Contrôle : « Corriger le versement ». Le `detail` du finding transporte déjà
+  `outflow` et `mirrored`, donc le dialogue s'ouvre **sans une requête de plus** —
+  même principe que le reste à ventiler affiché sur une ligne partielle.
+- La ligne d'écart affiche les trois chiffres (retiré / versé / manquant). « Le
+  versement est partiel » n'apprend rien ; c'est le montant orphelin qui dit s'il
+  faut corriger une faute de frappe ou arbitrer un choix.
+
 ### Reste ouvert
 
 Un seul point, et il attend de l'usage plutôt qu'un arbitrage : les **suggestions

--- a/ui/src/features/banking/CashMirrorDialog.tsx
+++ b/ui/src/features/banking/CashMirrorDialog.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import { Button } from '@/design-system/button';
+import { formatAmount } from '@/lib/format';
+import { useAdjustCashMirror } from './hooks';
+
+interface CashMirrorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  transactionId: string;
+  /** Le retrait, en positif. */
+  outflow: string;
+  /** Ce qui a déjà été déclaré comme entré dans la caisse. */
+  mirrored: string;
+}
+
+/**
+ * Corriger **quelle part** d'un retrait est entrée dans la caisse.
+ *
+ * La résolution de l'écart `cash_mirror_partial`. Déclarer 60 € d'un retrait de
+ * 100 € était possible dès le premier jour ; le corriger ne l'était pas — il
+ * fallait délier puis refaire, ce qui détruit et recrée la ligne espèces.
+ *
+ * Le champ est **pré-rempli au montant total**, parce que c'est la correction
+ * attendue dans la grande majorité des cas : l'écart existe le plus souvent parce
+ * qu'un montant partiel a été saisi par erreur, pas par choix. Le choix, lui,
+ * s'exprime en arbitrant l'écart avec son motif.
+ */
+export default function CashMirrorDialog({
+  open,
+  onOpenChange,
+  transactionId,
+  outflow,
+  mirrored,
+}: CashMirrorDialogProps) {
+  const { t } = useTranslation();
+  const mutation = useAdjustCashMirror();
+  const [amount, setAmount] = React.useState(outflow);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setAmount(outflow);
+    setError(null);
+  }, [open, outflow]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    const parsed = Number(amount.trim().replace(',', '.'));
+    if (!Number.isFinite(parsed) || parsed <= 0 || parsed > Number(outflow)) {
+      setError(t('banking.withdraw.errors.amountInvalid', { max: formatAmount(outflow) }));
+      return;
+    }
+
+    try {
+      await mutation.mutateAsync({ transactionId, amount: parsed.toFixed(2) });
+      onOpenChange(false);
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.withdraw.completeTitle')}>
+      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+        <p className="text-sm text-muted-foreground">
+          {t('banking.withdraw.completeHint', {
+            outflow: formatAmount(outflow),
+            mirrored: formatAmount(mirrored),
+          })}
+        </p>
+
+        <FormField label={t('banking.withdraw.fields.amount')} htmlFor="cash-mirror-amount">
+          <Input
+            id="cash-mirror-amount"
+            type="number"
+            step="0.01"
+            min="0"
+            max={outflow}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            autoFocus
+          />
+        </FormField>
+
+        {error ? (
+          <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button type="submit" disabled={mutation.isPending}>
+            {t('common.save')}
+          </Button>
+        </div>
+      </form>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -7,6 +7,7 @@ import {
   fetchAllocations,
   fetchAccountFlow,
   fetchBalanceAnchor,
+  adjustCashMirror,
   fetchBankAccounts,
   fetchStatementImports,
   fetchSuggestions,
@@ -16,6 +17,7 @@ import {
   previewStatementFile,
   qualifyTransaction,
   reconcileTransactions,
+  recordCashDeposit,
   recordCashExpense,
   restoreBankAccount,
   setAllocations,
@@ -28,6 +30,7 @@ import {
   withdrawToCash,
   type AllocationLine,
   type BankAccountPayload,
+  type CashDepositPayload,
   type CashExpensePayload,
   type InflowNature,
   type StatementMapping,
@@ -409,6 +412,34 @@ export function useRecordCashExpense() {
       // doivent se rafraîchir, sinon la dépense qu'on vient de saisir n'apparaît
       // nulle part avant un reload.
       toast({ description: t('banking.cash.recorded'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+export function useRecordCashDeposit() {
+  const invalidate = useInvalidateMoney();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: (payload: CashDepositPayload) => recordCashDeposit(payload),
+    onSuccess: () => {
+      invalidate();
+      toast({ description: t('banking.cash.deposited'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/** Corriger la part d'un retrait versée en caisse — résout `cash_mirror_partial`. */
+export function useAdjustCashMirror() {
+  const invalidate = useInvalidateMoney();
+  const { t } = useTranslation();
+  return useMutation({
+    mutationFn: ({ transactionId, amount }: { transactionId: string; amount: string }) =>
+      adjustCashMirror(transactionId, { amount }),
+    onSuccess: () => {
+      invalidate();
+      toast({ description: t('banking.withdraw.adjusted'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });

--- a/ui/src/features/money/AccountsPanel.tsx
+++ b/ui/src/features/money/AccountsPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Landmark, Plus, Receipt } from 'lucide-react';
+import { Banknote, Landmark, Plus, Receipt } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import EmptyState from '@/components/EmptyState';
@@ -21,6 +21,7 @@ import BalanceAnchorDialog from '@/features/banking/BalanceAnchorDialog';
 import AccountDialog from '@/features/banking/AccountDialog';
 import ImportHistoryCard from '@/features/banking/ImportHistoryCard';
 import StatementImportDialog from '@/features/banking/StatementImportDialog';
+import CashDepositDialog from './CashDepositDialog';
 
 /**
  * Onglet « Comptes » du module Argent (parcours 26, lot 2).
@@ -44,6 +45,7 @@ export default function AccountsPanel() {
   const [editing, setEditing] = React.useState<BankAccount | undefined>(undefined);
   const [importing, setImporting] = React.useState<BankAccount | null>(null);
   const [anchoring, setAnchoring] = React.useState<BankAccount | null>(null);
+  const [depositOpen, setDepositOpen] = React.useState(false);
   const [pendingArchive, setPendingArchive] = React.useState<Set<string>>(new Set());
 
   const { deleteWithUndo } = useDeleteWithUndo({
@@ -97,6 +99,13 @@ export default function AccountsPanel() {
             <Receipt className="mr-1.5 h-4 w-4" aria-hidden />
             {t('banking.journal.title')}
           </Link>
+          {/* Une rentrée d'espèces se saisit ici et pas dans l'onglet Dépenses :
+              ce n'est pas une dépense, c'est de l'argent qui arrive dans une
+              caisse — donc un geste de compte. */}
+          <Button variant="outline" onClick={() => setDepositOpen(true)}>
+            <Banknote className="mr-1.5 h-4 w-4" aria-hidden />
+            {t('banking.deposit.action')}
+          </Button>
           <Button onClick={openCreate}>
             <Plus className="mr-1.5 h-4 w-4" aria-hidden />
             {t('banking.new.action')}
@@ -140,6 +149,8 @@ export default function AccountsPanel() {
       ) : null}
 
       <AccountDialog open={dialogOpen} onOpenChange={setDialogOpen} existing={editing} />
+
+      <CashDepositDialog open={depositOpen} onOpenChange={setDepositOpen} />
 
       {importing ? (
         <StatementImportDialog

--- a/ui/src/features/money/CashDepositDialog.tsx
+++ b/ui/src/features/money/CashDepositDialog.tsx
@@ -1,0 +1,363 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Landmark, Plus, Trash2 } from 'lucide-react';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { FormField } from '@/design-system/form-field';
+import { Input } from '@/design-system/input';
+import { Select } from '@/design-system/select';
+import { Button } from '@/design-system/button';
+import { formatAmount, todayISO } from '@/lib/format';
+import { useBudgets } from '@/features/budget/hooks';
+import { selectableBudgets } from '@/features/budget/tree';
+import {
+  useBankAccounts,
+  useCreateBankAccount,
+  useRecordCashDeposit,
+} from '@/features/banking/hooks';
+import type { CashDepositPayload } from '@/lib/api/banking';
+
+interface CashDepositDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/** `transfer` est absent : le serveur le refuse, voir plus bas. */
+const NATURES = ['other', 'refund', 'salary'] as const;
+
+interface DraftLine {
+  key: string;
+  budgetId: string;
+  amount: string;
+}
+
+let lineCounter = 0;
+function blankLine(amount = ''): DraftLine {
+  lineCounter += 1;
+  return { key: `deposit-${lineCounter}`, budgetId: '', amount };
+}
+
+/**
+ * Une **rentrée** d'espèces — la moitié manquante de l'histoire du liquide.
+ *
+ * Jusqu'ici les espèces ne pouvaient entrer qu'en miroir d'un retrait bancaire.
+ * Un billet donné à un repas de famille, un vélo vendu, la part d'un ami payée en
+ * pièces n'avaient donc **aucune représentation** : le seul conseil possible était
+ * de gonfler le solde d'ouverture du compte espèces, c'est-à-dire de réécrire
+ * l'histoire pour enregistrer un fait daté. C'est exactement le genre de mensonge
+ * que le module refuse partout ailleurs.
+ *
+ * ⚠️ **Pas de « transfert interne » ici.** Un mouvement interne promet une
+ * contrepartie sur un autre compte suivi ; les espèces venues d'un retrait ont
+ * déjà leur chemin (« Verser en caisse » sur la ligne de retrait). En déclarer un
+ * à la main laisserait une jambe dont rien ne fournira jamais l'autre moitié —
+ * l'écart `internal_without_counterpart`, fabriqué par le geste censé combler un
+ * trou.
+ *
+ * Née **classée**, comme la dépense en espèces naît ventilée : la nature est
+ * obligatoire, sinon la rentrée atterrirait dans « À ranger » et l'app se
+ * fabriquerait son propre travail.
+ */
+export default function CashDepositDialog({ open, onOpenChange }: CashDepositDialogProps) {
+  const { t } = useTranslation();
+  const accountsQuery = useBankAccounts();
+  const mutation = useRecordCashDeposit();
+  const createAccount = useCreateBankAccount();
+  const budgetsQuery = useBudgets();
+  const budgetOptions = React.useMemo(
+    () => selectableBudgets(budgetsQuery.data),
+    [budgetsQuery.data],
+  );
+
+  const [label, setLabel] = React.useState('');
+  const [amount, setAmount] = React.useState('');
+  const [bookedOn, setBookedOn] = React.useState(todayISO());
+  const [nature, setNature] = React.useState<(typeof NATURES)[number]>('other');
+  const [lines, setLines] = React.useState<DraftLine[]>([]);
+  const [accountId, setAccountId] = React.useState('');
+  const [notes, setNotes] = React.useState('');
+  const [error, setError] = React.useState<string | null>(null);
+
+  const cashAccounts = React.useMemo(
+    () => (accountsQuery.data ?? []).filter((a) => a.kind === 'cash'),
+    [accountsQuery.data],
+  );
+
+  React.useEffect(() => {
+    if (!open) return;
+    setLabel('');
+    setAmount('');
+    setBookedOn(todayISO());
+    setNature('other');
+    setLines([blankLine()]);
+    setNotes('');
+    setError(null);
+    setAccountId((prev) => prev || cashAccounts[0]?.id || '');
+  }, [open, cashAccounts]);
+
+  const total = Number(amount.replace(',', '.')) || 0;
+  const credited = lines.reduce((sum, line) => {
+    const value = Number(line.amount.replace(',', '.'));
+    return sum + (Number.isFinite(value) ? value : 0);
+  }, 0);
+  const remaining = total - credited;
+  const isRefund = nature === 'refund';
+
+  function update(key: string, patch: Partial<DraftLine>) {
+    setLines((prev) => prev.map((l) => (l.key === key ? { ...l, ...patch } : l)));
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    if (!label.trim()) {
+      setError(t('banking.cash.labelRequired'));
+      return;
+    }
+    if (!accountId) {
+      setError(t('banking.cash.accountRequired'));
+      return;
+    }
+    if (!(total > 0)) {
+      setError(t('banking.cash.amountRequired'));
+      return;
+    }
+
+    // Un remboursement en espèces recrédite une enveloppe comme n'importe quel
+    // autre : ses parts partent dans le même appel, sinon il resterait l'écart
+    // « remboursement dont le reste ne crédite rien ».
+    const refundLines: { budget_id: string; amount: string }[] = [];
+    if (isRefund) {
+      for (const line of lines) {
+        const value = Number(line.amount.replace(',', '.'));
+        if (!line.budgetId && !line.amount.trim()) continue;
+        if (!line.budgetId) {
+          setError(t('banking.inflow.errors.budgetRequired'));
+          return;
+        }
+        if (!Number.isFinite(value) || value <= 0) {
+          setError(t('banking.inflow.errors.amountInvalid'));
+          return;
+        }
+        refundLines.push({ budget_id: line.budgetId, amount: value.toFixed(2) });
+      }
+      if (credited > total + 0.001) {
+        setError(
+          t('banking.inflow.errors.overCredited', { total: formatAmount(total.toFixed(2)) }),
+        );
+        return;
+      }
+    }
+
+    const payload: CashDepositPayload = {
+      account: accountId,
+      label: label.trim(),
+      amount: total.toFixed(2),
+      booked_on: bookedOn || undefined,
+      inflow_nature: nature,
+      notes,
+    };
+    if (isRefund && refundLines.length > 0) payload.refund_lines = refundLines;
+
+    try {
+      await mutation.mutateAsync(payload);
+      onOpenChange(false);
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  async function createCashAccount() {
+    setError(null);
+    try {
+      const created = await createAccount.mutateAsync({
+        name: t('banking.cash.defaultAccountName'),
+        kind: 'cash',
+        opening_balance: '0',
+        opening_balance_date: todayISO(),
+      });
+      setAccountId(created.id);
+    } catch {
+      setError(t('common.saveFailed'));
+    }
+  }
+
+  const hasCashAccount = cashAccounts.length > 0;
+
+  return (
+    <SheetDialog open={open} onOpenChange={onOpenChange} title={t('banking.deposit.title')}>
+      {!hasCashAccount ? (
+        <div className="mt-4 space-y-4">
+          <div className="flex items-start gap-3 rounded-lg border border-border bg-muted/40 p-3">
+            <Landmark className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" aria-hidden />
+            <div className="min-w-0 text-sm">
+              <p className="font-medium text-foreground">{t('banking.cash.noAccount')}</p>
+              <p className="text-muted-foreground">{t('banking.cash.noAccountHint')}</p>
+            </div>
+          </div>
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="button" onClick={createCashAccount} disabled={createAccount.isPending}>
+              {t('banking.cash.createAccount')}
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <FormField label={`${t('banking.cash.label')} *`} htmlFor="deposit-label">
+            <Input
+              id="deposit-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder={t('banking.deposit.labelPlaceholder')}
+              autoFocus
+              required
+            />
+          </FormField>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <FormField label={`${t('banking.deposit.amount')} *`} htmlFor="deposit-amount">
+              <Input
+                id="deposit-amount"
+                type="number"
+                step="0.01"
+                min="0"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="0.00"
+                required
+              />
+            </FormField>
+            <FormField label={t('banking.deposit.date')} htmlFor="deposit-date">
+              <Input
+                id="deposit-date"
+                type="date"
+                value={bookedOn}
+                onChange={(e) => setBookedOn(e.target.value)}
+              />
+            </FormField>
+          </div>
+
+          {cashAccounts.length > 1 ? (
+            <FormField label={t('banking.cash.account')} htmlFor="deposit-account">
+              <Select
+                id="deposit-account"
+                value={accountId}
+                onChange={(e) => setAccountId(e.target.value)}
+                options={cashAccounts.map((a) => ({ value: a.id, label: a.name }))}
+              />
+            </FormField>
+          ) : null}
+
+          <FormField label={t('banking.inflow.nature')} htmlFor="deposit-nature">
+            <Select
+              id="deposit-nature"
+              value={nature}
+              onChange={(e) => setNature(e.target.value as (typeof NATURES)[number])}
+              options={NATURES.map((value) => ({
+                value,
+                label: t(`banking.inflow.natures.${value}`),
+              }))}
+            />
+            <p className="text-xs text-muted-foreground">{t('banking.deposit.natureHint')}</p>
+          </FormField>
+
+          {isRefund ? (
+            <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-foreground">
+                  {t('banking.inflow.refundBudget')}
+                </span>
+                <span
+                  className={`text-xs tabular-nums ${
+                    remaining < -0.001 ? 'text-destructive' : 'text-muted-foreground'
+                  }`}
+                >
+                  {t('banking.inflow.remaining', { amount: formatAmount(remaining.toFixed(2)) })}
+                </span>
+              </div>
+
+              {lines.map((line, index) => (
+                <div key={line.key} className="flex items-end gap-2">
+                  <div className="min-w-0 flex-1">
+                    <Select
+                      id={index === 0 ? 'deposit-refund-budget' : `deposit-refund-budget-${index}`}
+                      aria-label={t('banking.inflow.refundBudget')}
+                      value={line.budgetId}
+                      onChange={(e) => update(line.key, { budgetId: e.target.value })}
+                      options={[
+                        { value: '', label: t('banking.inflow.refundBudgetNone') },
+                        ...budgetOptions,
+                      ]}
+                    />
+                  </div>
+                  <Input
+                    className="w-28"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    aria-label={t('banking.inflow.refundAmount')}
+                    value={line.amount}
+                    onChange={(e) => update(line.key, { amount: e.target.value })}
+                  />
+                  {lines.length > 1 ? (
+                    <button
+                      type="button"
+                      onClick={() => setLines((prev) => prev.filter((l) => l.key !== line.key))}
+                      className="mb-2 text-muted-foreground hover:text-destructive"
+                      aria-label={t('banking.inflow.removeLine')}
+                    >
+                      <Trash2 className="h-4 w-4" aria-hidden />
+                    </button>
+                  ) : null}
+                </div>
+              ))}
+
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setLines((prev) => [...prev, blankLine(remaining > 0 ? remaining.toFixed(2) : '')])
+                }
+              >
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                {t('banking.inflow.addLine')}
+              </Button>
+            </div>
+          ) : null}
+
+          <FormField label={t('purchase.fields.notes')} htmlFor="deposit-notes">
+            <Input
+              id="deposit-notes"
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+            />
+          </FormField>
+
+          {error ? (
+            <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" disabled={mutation.isPending}>
+              {t('common.save')}
+            </Button>
+          </div>
+        </form>
+      )}
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/money/CompliancePanel.tsx
+++ b/ui/src/features/money/CompliancePanel.tsx
@@ -23,12 +23,14 @@ import { blockingPrerequisite } from './prerequisites';
 import {
   ACCOUNT_ANCHOR_STALE,
   ACCOUNT_WITHOUT_WINDOW,
+  CASH_MIRROR_PARTIAL,
   PENDING_OUTFLOW_KINDS,
 } from './keys';
 import { useBankAccounts } from '@/features/banking/hooks';
 import AccountDialog from '@/features/banking/AccountDialog';
 import BalanceAnchorDialog from '@/features/banking/BalanceAnchorDialog';
 import AllocationDialog from '@/features/banking/AllocationDialog';
+import CashMirrorDialog from '@/features/banking/CashMirrorDialog';
 import WaiverDialog, { type WaiverTarget } from './WaiverDialog';
 
 const SEVERITY_ORDER: Record<ComplianceSeverity, number> = { blocker: 0, error: 1, warning: 2 };
@@ -70,6 +72,12 @@ export default function CompliancePanel() {
   // la sortie de secours, et renvoyait le vrai travail vers un autre onglet — le
   // contraire de ce que le parcours 26 cherche à obtenir.
   const [allocatingId, setAllocatingId] = React.useState<string | null>(null);
+  // Même raison pour le retrait partiellement versé : ce qui le résout n'est ni
+  // une ventilation ni une nature, mais la correction du montant entré en caisse.
+  // Le détail de l'écart porte déjà les deux chiffres, donc rien à re-requêter.
+  const [pouring, setPouring] = React.useState<
+    { transactionId: string; outflow: string; mirrored: string } | null
+  >(null);
   const accountsQuery = useBankAccounts(true);
   const findAccount = React.useCallback(
     (id: string | null) => (accountsQuery.data ?? []).find((account) => account.id === id),
@@ -128,6 +136,7 @@ export default function CompliancePanel() {
               onFixAccount={setFixingAccountId}
               onAnchorAccount={setAnchoringAccountId}
               onAllocate={setAllocatingId}
+              onPour={setPouring}
             />
           ))}
         </div>
@@ -156,6 +165,16 @@ export default function CompliancePanel() {
           open
           onOpenChange={(next) => !next && setAllocatingId(null)}
           transactionId={allocatingId}
+        />
+      ) : null}
+
+      {pouring ? (
+        <CashMirrorDialog
+          open
+          onOpenChange={(next) => !next && setPouring(null)}
+          transactionId={pouring.transactionId}
+          outflow={pouring.outflow}
+          mirrored={pouring.mirrored}
         />
       ) : null}
     </div>
@@ -223,6 +242,7 @@ function GroupRow({
   onFixAccount,
   onAnchorAccount,
   onAllocate,
+  onPour,
 }: {
   group: ComplianceGroup;
   /** Prérequis encore ouvert : ce groupe n'est pas conforme, il est non évaluable. */
@@ -233,6 +253,7 @@ function GroupRow({
   onFixAccount: (accountId: string) => void;
   onAnchorAccount: (accountId: string) => void;
   onAllocate: (transactionId: string) => void;
+  onPour: (target: { transactionId: string; outflow: string; mirrored: string }) => void;
 }) {
   const { t } = useTranslation();
   const Icon = SEVERITY_ICON[group.severity];
@@ -307,6 +328,7 @@ function GroupRow({
           onFixAccount={onFixAccount}
           onAnchorAccount={onAnchorAccount}
           onAllocate={onAllocate}
+          onPour={onPour}
         />
       ) : null}
     </Card>
@@ -319,12 +341,14 @@ function GroupDetail({
   onFixAccount,
   onAnchorAccount,
   onAllocate,
+  onPour,
 }: {
   group: ComplianceGroup;
   onWaive: (target: WaiverTarget) => void;
   onFixAccount: (accountId: string) => void;
   onAnchorAccount: (accountId: string) => void;
   onAllocate: (transactionId: string) => void;
+  onPour: (target: { transactionId: string; outflow: string; mirrored: string }) => void;
 }) {
   const { t } = useTranslation();
   const [showWaived, setShowWaived] = React.useState(false);
@@ -389,6 +413,18 @@ function GroupDetail({
               onAllocate={
                 (PENDING_OUTFLOW_KINDS as readonly string[]).includes(group.kind)
                   ? () => onAllocate(finding.object_id)
+                  : undefined
+              }
+              // Le détail du finding porte `outflow` et `mirrored` : la
+              // correction se propose sans une requête de plus.
+              onPour={
+                group.kind === CASH_MIRROR_PARTIAL
+                  ? () =>
+                      onPour({
+                        transactionId: finding.object_id,
+                        outflow: String(finding.detail.outflow ?? '0'),
+                        mirrored: String(finding.detail.mirrored ?? '0'),
+                      })
                   : undefined
               }
               onWaive={() =>
@@ -477,6 +513,7 @@ function FindingRow({
   onFix,
   onAnchor,
   onAllocate,
+  onPour,
 }: {
   finding: ComplianceFinding;
   waivable: boolean;
@@ -487,6 +524,8 @@ function FindingRow({
   onAnchor?: () => void;
   /** Ventiler la ligne — la **résolution** de l'écart, pas son contournement. */
   onAllocate?: () => void;
+  /** Corriger la part d'un retrait entrée en caisse. */
+  onPour?: () => void;
 }) {
   const { t } = useTranslation();
   const reason = typeof finding.detail.reason === 'string' ? finding.detail.reason : null;
@@ -524,6 +563,15 @@ function FindingRow({
         {/* Les deux chiffres qui ne concordent plus. Sans eux « l'ancrage a dérivé »
             n'apprend rien : c'est l'écart chiffré qui dit s'il manque un relevé ou
             si la lecture était fausse. */}
+        {typeof finding.detail.missing === 'string' ? (
+          <p className="text-xs text-muted-foreground">
+            {t('money.compliance.cashMissing', {
+              outflow: finding.detail.outflow,
+              mirrored: finding.detail.mirrored,
+              missing: finding.detail.missing,
+            })}
+          </p>
+        ) : null}
         {typeof finding.detail.drift === 'string' ? (
           <p className="text-xs text-muted-foreground">
             {t('money.compliance.anchorDrift', {
@@ -540,6 +588,12 @@ function FindingRow({
       {onAllocate ? (
         <Button type="button" size="sm" onClick={onAllocate}>
           {t('money.compliance.allocate')}
+        </Button>
+      ) : null}
+
+      {onPour ? (
+        <Button type="button" size="sm" onClick={onPour}>
+          {t('money.compliance.pour')}
         </Button>
       ) : null}
 

--- a/ui/src/features/money/keys.ts
+++ b/ui/src/features/money/keys.ts
@@ -45,6 +45,13 @@ export const ACCOUNT_ANCHOR_STALE = 'account_anchor_stale';
 export const INFLOW_UNCLASSIFIED = 'inflow_unclassified';
 export const REFUND_WITHOUT_BUDGET = 'refund_without_budget';
 export const REFUND_PARTIALLY_ALLOCATED = 'refund_partially_allocated';
+/**
+ * Retrait dont une partie seulement a été déclarée entrée en caisse. **Hors de la
+ * file** : ce qui le résout n'est ni une ventilation ni une nature, mais la
+ * correction du montant versé — le seul écart d'opération dont le geste vit dans
+ * le Contrôle.
+ */
+export const CASH_MIRROR_PARTIAL = 'cash_mirror_partial';
 
 /** Ce qui est sorti et que personne n'a affecté — pastilles de budget. */
 export const PENDING_OUTFLOW_KINDS = [TRANSACTION_UNALLOCATED, TRANSACTION_PARTIAL] as const;

--- a/ui/src/gen/api/models/BankTransaction.ts
+++ b/ui/src/gen/api/models/BankTransaction.ts
@@ -56,10 +56,20 @@ export type BankTransaction = {
      */
     inflow_nature?: (InflowNatureEnum | BlankEnum);
     /**
-     * Budget this refund credits back. Only meaningful on an inflow classified `refund`: returning a 40 € item means the envelope consumed 110 € of the 150 € spent, not 150 €. Kept here rather than as a negative Interaction — `Interaction.amount` never goes negative, which is what protects the nine Sum('amount') aggregations. SET_NULL: deleting a budget must never destroy a bank line.
+     * Ce que cette recette rend, enveloppe par enveloppe.
+     *
+     * Une liste et non un champ : un virement de 70 € peut recréditer deux
+     * budgets, ce qu'une FK ne pouvait pas dire.
      */
-    readonly refund_budget: string | null;
-    readonly refund_budget_name: string;
+    readonly refund_allocations: Array<any>;
+    /**
+     * Ce qui n'est attribué à personne — le « reste » de l'éditeur.
+     *
+     * Toujours calculé, jamais dénormalisé : c'est aussi ce que le détecteur
+     * `refund_partially_allocated` réclame, et un écart ne se dit jamais deux
+     * fois avec deux voix.
+     */
+    readonly refund_remaining: string;
     /**
      * Running balance after this operation, when the bank exports it. Anchors the lot 4 balance and its chain check.
      */

--- a/ui/src/gen/api/models/Budget.ts
+++ b/ui/src/gen/api/models/Budget.ts
@@ -20,6 +20,9 @@ export type Budget = {
      * The single household-wide budget that caps all expenses (budgeted + hors budget). At most one per household.
      */
     is_global?: boolean;
+    readonly parent: string;
+    parent_id?: string | null;
+    readonly is_group: string;
     readonly created_at: string;
     readonly updated_at: string;
     readonly created_by: number | null;

--- a/ui/src/gen/api/models/PatchedBankTransaction.ts
+++ b/ui/src/gen/api/models/PatchedBankTransaction.ts
@@ -56,10 +56,20 @@ export type PatchedBankTransaction = {
      */
     inflow_nature?: (InflowNatureEnum | BlankEnum);
     /**
-     * Budget this refund credits back. Only meaningful on an inflow classified `refund`: returning a 40 € item means the envelope consumed 110 € of the 150 € spent, not 150 €. Kept here rather than as a negative Interaction — `Interaction.amount` never goes negative, which is what protects the nine Sum('amount') aggregations. SET_NULL: deleting a budget must never destroy a bank line.
+     * Ce que cette recette rend, enveloppe par enveloppe.
+     *
+     * Une liste et non un champ : un virement de 70 € peut recréditer deux
+     * budgets, ce qu'une FK ne pouvait pas dire.
      */
-    readonly refund_budget?: string | null;
-    readonly refund_budget_name?: string;
+    readonly refund_allocations?: Array<any>;
+    /**
+     * Ce qui n'est attribué à personne — le « reste » de l'éditeur.
+     *
+     * Toujours calculé, jamais dénormalisé : c'est aussi ce que le détecteur
+     * `refund_partially_allocated` réclame, et un écart ne se dit jamais deux
+     * fois avec deux voix.
+     */
+    readonly refund_remaining?: string;
     /**
      * Running balance after this operation, when the bank exports it. Anchors the lot 4 balance and its chain check.
      */

--- a/ui/src/gen/api/models/PatchedBudget.ts
+++ b/ui/src/gen/api/models/PatchedBudget.ts
@@ -20,6 +20,9 @@ export type PatchedBudget = {
      * The single household-wide budget that caps all expenses (budgeted + hors budget). At most one per household.
      */
     is_global?: boolean;
+    readonly parent?: string;
+    parent_id?: string | null;
+    readonly is_group?: string;
     readonly created_at?: string;
     readonly updated_at?: string;
     readonly created_by?: number | null;

--- a/ui/src/gen/api/services/BankingService.ts
+++ b/ui/src/gen/api/services/BankingService.ts
@@ -468,6 +468,31 @@ export class BankingService {
         });
     }
     /**
+     * Corriger **quelle part** de ce retrait est entrée dans la caisse.
+     *
+     * La résolution de l'écart `cash_mirror_partial`. Déclarer 60 € d'un retrait
+     * de 100 € était possible dès le départ ; le corriger à 100 € ne l'était pas —
+     * il fallait délier puis refaire, ce qui détruit et recrée la ligne espèces.
+     * @param id
+     * @param requestBody
+     * @returns BankTransaction
+     * @throws ApiError
+     */
+    public static bankingTransactionsCashMirrorPartialUpdate(
+        id: string,
+        requestBody?: PatchedBankTransaction,
+    ): CancelablePromise<BankTransaction> {
+        return __request(OpenAPI, {
+            method: 'PATCH',
+            url: '/api/banking/transactions/{id}/cash-mirror/',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
      * Attach an existing expense to this operation (manual reconciliation).
      * @param id
      * @param requestBody
@@ -505,6 +530,31 @@ export class BankingService {
         return __request(OpenAPI, {
             method: 'PATCH',
             url: '/api/banking/transactions/{id}/qualify/',
+            path: {
+                'id': id,
+            },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Remplacer la répartition d'un remboursement sur les enveloppes.
+     *
+     * ``PUT`` et non des CRUD par ligne, pour la raison qui vaut aussi pour les
+     * sorties : « 40/30 devient 50/20 » doit être atomique, sinon on traverse
+     * un état où la somme dépasse ce que la recette a rapporté.
+     * @param id
+     * @param requestBody
+     * @returns BankTransaction
+     * @throws ApiError
+     */
+    public static bankingTransactionsRefundAllocationsUpdate(
+        id: string,
+        requestBody?: BankTransaction,
+    ): CancelablePromise<BankTransaction> {
+        return __request(OpenAPI, {
+            method: 'PUT',
+            url: '/api/banking/transactions/{id}/refund-allocations/',
             path: {
                 'id': id,
             },
@@ -586,6 +636,30 @@ export class BankingService {
             path: {
                 'id': id,
             },
+            body: requestBody,
+            mediaType: 'application/json',
+        });
+    }
+    /**
+     * Cash that came in from outside: a gift, a sale, a share paid in coins.
+     *
+     * The missing half of the cash story — until now the only way cash could
+     * enter was mirroring a bank withdrawal, so money handed over in notes had no
+     * representation at all. The advice one could give was to inflate the opening
+     * balance, which rewrites history to record a dated fact.
+     *
+     * Born classified (``inflow_nature`` required), for the same reason a cash
+     * spend is born allocated: the app must not create its own écart.
+     * @param requestBody
+     * @returns BankTransaction
+     * @throws ApiError
+     */
+    public static bankingTransactionsCashDepositCreate(
+        requestBody?: BankTransaction,
+    ): CancelablePromise<BankTransaction> {
+        return __request(OpenAPI, {
+            method: 'POST',
+            url: '/api/banking/transactions/cash-deposit/',
             body: requestBody,
             mediaType: 'application/json',
         });

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -409,6 +409,24 @@ export async function unlinkCashCounterpart(transactionId: string): Promise<void
   await api.delete(`/banking/transactions/${transactionId}/unlink-cash/`);
 }
 
+/**
+ * Corriger **quelle part** d'un retrait est entrée dans la caisse.
+ *
+ * La résolution de l'écart `cash_mirror_partial`. Déclarer 60 € d'un retrait de
+ * 100 € était possible dès le départ ; le corriger ne l'était pas — il fallait
+ * délier puis refaire, ce qui détruit et recrée la ligne espèces.
+ */
+export async function adjustCashMirror(
+  transactionId: string,
+  payload: { amount: string },
+): Promise<BankTransaction> {
+  const { data } = await api.patch<BankTransaction>(
+    `/banking/transactions/${transactionId}/cash-mirror/`,
+    payload,
+  );
+  return data;
+}
+
 // --- Ventilation (parcours 25, lot 5) ---------------------------------------
 
 /**
@@ -687,6 +705,42 @@ export async function recordCashExpense(
 ): Promise<CashExpenseResult> {
   const { data } = await api.post<CashExpenseResult>(
     '/banking/transactions/cash-expense/',
+    payload,
+  );
+  return data;
+}
+
+export interface CashDepositPayload {
+  account: string;
+  label: string;
+  /** Positif — ce qui est entré dans la caisse. */
+  amount: string;
+  /**
+   * Requis. `transfer` est refusé côté serveur : les espèces issues d'un retrait
+   * ont leur propre chemin (`withdrawToCash`), et déclarer un mouvement interne à
+   * la main laisserait une jambe dont rien ne fournira jamais l'autre moitié.
+   */
+  inflow_nature: Exclude<InflowNature, 'transfer'>;
+  booked_on?: string;
+  /** Les parts rendues aux enveloppes, quand la nature est `refund`. */
+  refund_lines?: RefundAllocationLine[];
+  notes?: string;
+}
+
+/**
+ * Des espèces venues d'ailleurs que d'un retrait : un cadeau, une vente, une
+ * part payée en pièces.
+ *
+ * La moitié manquante de l'histoire des espèces. Sans cet endpoint, le seul
+ * conseil possible était de gonfler le solde d'ouverture — réécrire l'histoire
+ * pour enregistrer un fait daté. Née classée, comme la dépense en espèces naît
+ * ventilée : l'app ne doit pas fabriquer son propre travail.
+ */
+export async function recordCashDeposit(
+  payload: CashDepositPayload,
+): Promise<BankTransaction> {
+  const { data } = await api.post<BankTransaction>(
+    '/banking/transactions/cash-deposit/',
     payload,
   );
   return data;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1680,7 +1680,7 @@
           },
           "cash": {
             "title": "Auch Bargeld erfassen",
-            "body": "Legen Sie ein Konto vom Typ „Bargeld“ an. Es verhält sich wie ein Bankkonto: Abhebungen füllen es, und eine Barausgabe wird eine Buchung darauf — also eine Ausgabe, die die Kontrolle zuordnen kann, wie jede andere."
+            "body": "Erstelle ein Konto vom Typ „Bargeld“ für das Bargeld des Haushalts. Es funktioniert wie ein Bankkonto, und Bargeld kommt auf zwei Wegen hinein: „Kasse auffüllen“ auf einer Abhebungszeile, und „Bareingang“ im Tab Konten für Geld von außen (ein Geschenk, ein Verkauf, der Anteil einer Freundin). Eine Barausgabe wird zu einer Buchung dieses Kontos — also zu einer Ausgabe, die die Kontrolle zuordnen kann. Zahlst du nur einen Teil einer Abhebung in die Kasse ein, meldet es die Kontrolle: der Rest würde nirgendwohin gehören."
           },
           "openingBalance": {
             "title": "Anfangssaldo eintragen",
@@ -3420,7 +3420,8 @@
       "noAccount": "Kein Barkonto",
       "noAccountHint": "Legen Sie im Reiter Konten ein Konto „Bargeld“ an: eine Barausgabe wird dann eine Kontobuchung wie jede andere.",
       "createAccount": "Barkonto anlegen",
-      "defaultAccountName": "Bargeld"
+      "defaultAccountName": "Bargeld",
+      "deposited": "Bareingang erfasst."
     },
     "withdraw": {
       "title": "Auf Bargeld übertragen",
@@ -3439,7 +3440,10 @@
       "linked": "Abhebung auf Bargeld gespiegelt.",
       "unlinked": "Bargeld-Gegenbuchung entfernt.",
       "linkedBadge": "Bargeld",
-      "unlink": "Gegenbuchung entfernen"
+      "unlink": "Gegenbuchung entfernen",
+      "completeTitle": "Bareinlage vervollständigen",
+      "completeHint": "Abhebung von {{outflow}}, davon {{mirrored}} als in die Kasse eingegangen erklärt. Der Rest gehört nirgendwohin: weder Ausgabe noch Bargeld.",
+      "adjusted": "In die Kasse eingezahlter Anteil korrigiert."
     },
     "allocation": {
       "title": "Diese Buchung aufteilen",
@@ -3581,6 +3585,14 @@
       "removeSplit": "Aufteilung entfernen",
       "removeSplitHint": "Löscht diese Ausgabe; die Bankbuchung bleibt unberührt und kehrt in die Warteschlange zurück.",
       "splitRemoved": "Aufteilung entfernt"
+    },
+    "deposit": {
+      "title": "Bareingang",
+      "action": "Bareingang",
+      "labelPlaceholder": "z. B. Geschenk, Fahrrad verkauft, Maries Anteil",
+      "amount": "Erhaltener Betrag",
+      "date": "Datum",
+      "natureHint": "Eine interne Umbuchung wird hier nicht erfasst: Bargeld aus einer Abhebung wird auf der Abhebungszeile mit „Kasse auffüllen“ erklärt."
     }
   },
   "pwa": {
@@ -3783,6 +3795,11 @@
           "title": "Teilweise zugeordnete Rückzahlungen",
           "hint": "Ein Teil des zurückgekommenen Geldes erstattet kein Budget: deren Zähler bleiben um diesen Betrag zu hoch.",
           "resolution": "Vervollständigen Sie die Aufteilung in der Warteschlange, oder begründen Sie den Rest."
+        },
+        "cash_mirror_partial": {
+          "title": "Abhebungen nur teilweise in die Kasse eingezahlt",
+          "hint": "Ein Teil der Abhebung ist weder Ausgabe noch erklärtes Bargeld: dieses Geld gehört nirgendwohin.",
+          "resolution": "Korrigieren Sie den in die Kasse eingegangenen Anteil, oder entscheiden Sie begründet, wenn der Rest woanders hingegangen ist (eigene Tasche, anderer Haushalt)."
         }
       },
       "blocked": "Kontrolle nicht bewertbar",
@@ -3795,7 +3812,9 @@
       "fix": "Beheben",
       "findBalance": "Saldo ermitteln",
       "anchorDrift": "Abgelesener Saldo: {{attested}} · heute berechnet: {{computed}}",
-      "allocate": "Zuordnen"
+      "allocate": "Zuordnen",
+      "pour": "Einzahlung korrigieren",
+      "cashMissing": "Abhebung von {{outflow}}, {{mirrored}} in die Kasse — {{missing}} gehören nirgendwohin."
     },
     "pending": {
       "count": "{{count}} Buchung zuzuordnen",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1680,7 +1680,7 @@
           },
           "cash": {
             "title": "Track cash too",
-            "body": "Create a “Cash” account for the household's physical money. It behaves like a bank account: withdrawals feed it, and a cash spend becomes an operation on it — so an expense the control can account for, like any other."
+            "body": "Create a “Cash” account for the household's physical money. It works like a bank account, and cash enters it two ways: “Feed cash” on a withdrawal line, and “Cash in” on the Accounts tab for money from elsewhere (a gift, a sale, a friend's share). A cash spend becomes an operation on that account — an expense the control can reconcile, like any other. If you pour only part of a withdrawal into the pot, the Control tells you: the rest would belong nowhere."
           },
           "openingBalance": {
             "title": "Set the starting balance",
@@ -3420,7 +3420,8 @@
       "noAccount": "No cash account",
       "noAccountHint": "Declare a “Cash” account in the Accounts tab: a cash spend then becomes an account operation, like every other.",
       "createAccount": "Create my cash account",
-      "defaultAccountName": "Cash"
+      "defaultAccountName": "Cash",
+      "deposited": "Cash deposit recorded."
     },
     "withdraw": {
       "title": "Move to cash",
@@ -3439,7 +3440,10 @@
       "linked": "Withdrawal mirrored onto cash.",
       "unlinked": "Cash counterpart removed.",
       "linkedBadge": "Cash",
-      "unlink": "Remove the counterpart"
+      "unlink": "Remove the counterpart",
+      "completeTitle": "Complete the cash pour",
+      "completeHint": "{{outflow}} withdrawn, of which {{mirrored}} declared as entering the cash pot. The rest belongs nowhere: neither a spend nor cash.",
+      "adjusted": "Share poured into cash corrected."
     },
     "allocation": {
       "title": "Split this operation",
@@ -3581,6 +3585,14 @@
       "removeSplit": "Remove the allocation",
       "removeSplitHint": "Deletes this expense; the bank operation is untouched and goes back to the queue.",
       "splitRemoved": "Allocation removed"
+    },
+    "deposit": {
+      "title": "Cash coming in",
+      "action": "Cash in",
+      "labelPlaceholder": "E.g. gift, bike sold, Marie's share",
+      "amount": "Amount received",
+      "date": "Date",
+      "natureHint": "An internal transfer is not recorded here: cash from a withdrawal is declared on the withdrawal line, with “Feed cash”."
     }
   },
   "pwa": {
@@ -3783,6 +3795,11 @@
           "title": "Partially credited refunds",
           "hint": "Part of what came back credits no envelope: those budgets' counters stay inflated by that much.",
           "resolution": "Complete the split from the queue, or arbitrate if the remainder concerns no envelope."
+        },
+        "cash_mirror_partial": {
+          "title": "Withdrawals only partly poured into cash",
+          "hint": "Part of the withdrawal is neither a spend nor declared cash: that money belongs nowhere.",
+          "resolution": "Correct the share that entered the cash pot, or arbitrate if the rest went elsewhere (own pocket, another household)."
         }
       },
       "blocked": "Control cannot be evaluated",
@@ -3795,7 +3812,9 @@
       "fix": "Fix",
       "findBalance": "Find the balance",
       "anchorDrift": "Balance you read: {{attested}} · computed today: {{computed}}",
-      "allocate": "Sort it"
+      "allocate": "Sort it",
+      "pour": "Correct the pour",
+      "cashMissing": "{{outflow}} withdrawn, {{mirrored}} poured into cash — {{missing}} belongs nowhere."
     },
     "pending": {
       "count": "{{count}} operation to sort",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1680,7 +1680,7 @@
           },
           "cash": {
             "title": "Seguir también el efectivo",
-            "body": "Cree una cuenta de tipo «Efectivo» para el dinero en metálico del hogar. Funciona como una cuenta bancaria: sus retiradas la alimentan, y un gasto en metálico pasa a ser una operación de esa cuenta — por tanto un gasto que el control sabe vincular, como los demás."
+            "body": "Crea una cuenta de tipo «Efectivo» para el dinero en metálico del hogar. Funciona como una cuenta bancaria, y el efectivo entra por dos caminos: «Alimentar el efectivo» en una línea de retirada, y «Entrada de efectivo» en la pestaña Cuentas para lo que viene de otro sitio (un regalo, una venta, la parte de un amigo). Un gasto en efectivo se convierte en una operación de esa cuenta — un gasto que el control sabe conciliar, como los demás. Si solo ingresas una parte de una retirada en la caja, el Control te lo avisa: el resto no pertenecería a nada."
           },
           "openingBalance": {
             "title": "Indicar el saldo inicial",
@@ -3420,7 +3420,8 @@
       "noAccount": "Sin cuenta de efectivo",
       "noAccountHint": "Declare una cuenta «Efectivo» en la pestaña Cuentas: un gasto en metálico pasa entonces a ser una operación de cuenta, como las demás.",
       "createAccount": "Crear mi cuenta de efectivo",
-      "defaultAccountName": "Efectivo"
+      "defaultAccountName": "Efectivo",
+      "deposited": "Entrada de efectivo registrada."
     },
     "withdraw": {
       "title": "Pasar a efectivo",
@@ -3439,7 +3440,10 @@
       "linked": "Retirada reflejada en el efectivo.",
       "unlinked": "Contrapartida en efectivo eliminada.",
       "linkedBadge": "Efectivo",
-      "unlink": "Eliminar la contrapartida"
+      "unlink": "Eliminar la contrapartida",
+      "completeTitle": "Completar el ingreso en caja",
+      "completeHint": "Retirada de {{outflow}}, de la cual {{mirrored}} declarados como entrados en la caja. El resto no pertenece a nada: ni gasto, ni efectivo.",
+      "adjusted": "Parte ingresada en caja corregida."
     },
     "allocation": {
       "title": "Desglosar esta operación",
@@ -3581,6 +3585,14 @@
       "removeSplit": "Eliminar la asignación",
       "removeSplitHint": "Elimina este gasto; la operación bancaria no se toca y vuelve a la cola.",
       "splitRemoved": "Asignación eliminada"
+    },
+    "deposit": {
+      "title": "Entrada de efectivo",
+      "action": "Entrada de efectivo",
+      "labelPlaceholder": "Ej.: regalo, bici vendida, parte de Marie",
+      "amount": "Importe recibido",
+      "date": "Fecha",
+      "natureHint": "Una transferencia interna no se registra aquí: el efectivo procedente de una retirada se declara desde la línea de retirada, con «Alimentar el efectivo»."
     }
   },
   "pwa": {
@@ -3783,6 +3795,11 @@
           "title": "Reembolsos parcialmente asignados",
           "hint": "Una parte de lo devuelto no acredita ningún presupuesto: sus contadores siguen inflados en ese importe.",
           "resolution": "Completa el reparto desde la cola, o justifica el resto si no corresponde a ningún presupuesto."
+        },
+        "cash_mirror_partial": {
+          "title": "Retiradas solo parcialmente ingresadas en caja",
+          "hint": "Parte de la retirada no es ni un gasto ni efectivo declarado: ese dinero no pertenece a nada.",
+          "resolution": "Corrija la parte que entró en la caja, o arbitre si el resto fue a otro sitio (bolsillo propio, otro hogar)."
         }
       },
       "blocked": "Control no evaluable",
@@ -3795,7 +3812,9 @@
       "fix": "Corregir",
       "findBalance": "Encontrar el saldo",
       "anchorDrift": "Saldo leído: {{attested}} · calculado hoy: {{computed}}",
-      "allocate": "Ordenar"
+      "allocate": "Ordenar",
+      "pour": "Corregir el ingreso",
+      "cashMissing": "Retirada de {{outflow}}, {{mirrored}} ingresados en caja — {{missing}} no pertenecen a nada."
     },
     "pending": {
       "count": "{{count}} operación por ordenar",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1680,7 +1680,7 @@
           },
           "cash": {
             "title": "Suivre aussi les espèces",
-            "body": "Crée un compte de type « Espèces » pour l'argent liquide du foyer. Il fonctionne comme un compte bancaire : tes retraits l'alimentent, et une dépense en liquide devient une opération de ce compte — donc une dépense que le contrôle sait rattacher, comme les autres."
+            "body": "Crée un compte de type « Espèces » pour l'argent liquide du foyer. Il fonctionne comme un compte bancaire, et le liquide y entre par deux chemins : « Alimenter les espèces » sur une ligne de retrait, et « Rentrée d'espèces » dans l'onglet Comptes pour ce qui vient d'ailleurs (un cadeau, une vente, la part d'un ami). Une dépense en liquide devient une opération de ce compte — donc une dépense que le contrôle sait rattacher, comme les autres. Si tu ne verses qu'une partie d'un retrait dans la caisse, le Contrôle te le signale : le reste n'appartiendrait à rien."
           },
           "openingBalance": {
             "title": "Renseigner le solde de départ",
@@ -3420,7 +3420,8 @@
       "noAccount": "Aucun compte espèces",
       "noAccountHint": "Déclarez un compte « Espèces » dans l'onglet Comptes : une dépense en liquide devient alors une opération de compte, comme les autres.",
       "createAccount": "Créer mon compte espèces",
-      "defaultAccountName": "Espèces"
+      "defaultAccountName": "Espèces",
+      "deposited": "Rentrée d'espèces enregistrée."
     },
     "withdraw": {
       "title": "Retirer vers les espèces",
@@ -3439,7 +3440,10 @@
       "linked": "Retrait reflété sur les espèces.",
       "unlinked": "Contrepartie espèces supprimée.",
       "linkedBadge": "Espèces",
-      "unlink": "Supprimer la contrepartie"
+      "unlink": "Supprimer la contrepartie",
+      "completeTitle": "Compléter le versement en caisse",
+      "completeHint": "Retrait de {{outflow}}, dont {{mirrored}} déclarés entrés dans la caisse. Le reste n'appartient à rien : ni dépense, ni espèces.",
+      "adjusted": "Part versée en caisse corrigée."
     },
     "allocation": {
       "title": "Ventiler cette opération",
@@ -3581,6 +3585,14 @@
       "removeSplit": "Supprimer la ventilation",
       "removeSplitHint": "Supprime cette dépense ; l'opération bancaire n'est pas touchée et redevient à ranger.",
       "splitRemoved": "Ventilation supprimée"
+    },
+    "deposit": {
+      "title": "Rentrée d'espèces",
+      "action": "Rentrée d'espèces",
+      "labelPlaceholder": "Ex. : cadeau, vélo vendu, part de Marie",
+      "amount": "Montant reçu",
+      "date": "Date",
+      "natureHint": "Un transfert interne ne se saisit pas ici : des espèces venues d'un retrait se déclarent depuis la ligne de retrait, avec « Alimenter les espèces »."
     }
   },
   "pwa": {
@@ -3783,6 +3795,11 @@
           "title": "Remboursements partiellement attribués",
           "hint": "Une part de ce qui est revenu ne recrédite aucune enveloppe : les compteurs de ces budgets restent gonflés d'autant.",
           "resolution": "Complétez la répartition depuis « À ranger », ou arbitrez si le reste ne concerne aucune enveloppe."
+        },
+        "cash_mirror_partial": {
+          "title": "Retraits partiellement versés en caisse",
+          "hint": "Une partie du retrait n'est ni une dépense, ni des espèces déclarées : cet argent n'appartient à rien.",
+          "resolution": "Corrigez la part entrée dans la caisse, ou arbitrez si le reste est parti ailleurs (poche personnelle, autre foyer)."
         }
       },
       "blocked": "Contrôle non évaluable",
@@ -3795,7 +3812,9 @@
       "fix": "Corriger",
       "findBalance": "Retrouver le solde",
       "anchorDrift": "Solde constaté : {{attested}} · calculé aujourd'hui : {{computed}}",
-      "allocate": "Ranger"
+      "allocate": "Ranger",
+      "pour": "Corriger le versement",
+      "cashMissing": "Retrait de {{outflow}}, {{mirrored}} versés en caisse — {{missing}} n'appartiennent à rien."
     },
     "pending": {
       "count": "{{count}} opération à ranger",


### PR DESCRIPTION
Deux trous du liquide, symétriques. Le premier était le **dernier orphelin
silencieux** du modèle ; le second empêchait de déclarer de l'argent qui existe.

## 1. Le retrait partiellement versé (`cash_mirror_partial`)

100 € retirés, 60 € déclarés entrés en caisse. Rien n'est faux arithmétiquement — le
solde bancaire est juste, le solde espèces est juste — et **40 € n'appartiennent à
rien** : la ligne de retrait est `is_internal` *en entier*, donc son reste est exclu
des dépenses par la règle des mouvements internes, et aucune ligne espèces ne le
réclame.

**Pourquoi un détecteur de plus et pas l'extension d'un existant** — ses deux
voisins sont structurellement aveugles à ce cas, et un test le fige :

- `internal_without_counterpart` *voit* une contrepartie et se taît ;
- `account_cash_negative` ne peut rien dire non plus : sous-déclarer les espèces fait
  paraître la caisse **plus riche**, jamais négative.

Choix de conception :

- **Pur SQL** (`amount + transfer_counterpart__amount < 0`) : un `COUNT(*)` honnête
  pour le badge, rien de matérialisé en Python.
- **Arbitrable**, contrairement au solde espèces négatif : garder une partie d'un
  retrait hors du pot commun est un *choix* (« 40 € restés dans ma poche »), pas une
  impossibilité. Le `fingerprint` porte le **montant manquant**, donc en déclarer
  davantage périme l'arbitrage.
- **Hors de la file « À ranger »** : ce qui le résout n'est ni une ventilation ni une
  nature, mais la correction du montant versé — son geste vit dans le Contrôle.

**Le geste de résolution n'existait pas** : corriger un versement partiel demandait
de délier puis refaire, ce qui détruit et recrée la ligne espèces.
`adjust_cash_mirror` (`PATCH …/cash-mirror/`) n'ajuste que la jambe **qu'on a
générée**, reconnue exactement comme `unlink_counterpart` la reconnaît. ⚠️ Le
`dedup_hash` est **recalculé** — l'amount y entre, et une ligne qui revendique une
identité périmée peut se faire doubler au ré-import.

## 2. La rentrée d'espèces (`record_cash_deposit`)

Le liquide ne pouvait entrer qu'**en miroir d'un retrait**. Un billet donné à un
repas de famille, un vélo vendu, la part d'un ami payée en pièces n'avaient donc
aucune représentation : le seul conseil possible était de gonfler le solde
d'ouverture, c'est-à-dire réécrire l'histoire pour enregistrer un fait daté.

- `POST …/cash-deposit/`, compte **espèces** obligatoire : une rentrée sur un compte
  bancaire s'importe, elle ne se saisit pas.
- **Née classée** (`inflow_nature` requis), comme la dépense en espèces naît
  ventilée : sinon elle atterrirait dans « À ranger » et l'app fabriquerait son
  propre travail.
- **`transfer` est refusé** : il promettrait une contrepartie que rien ne fournira —
  `internal_without_counterpart` fabriqué par le geste censé combler un trou.
- Un remboursement en liquide passe ses `refund_lines` dans le **même** appel.
- UI dans l'onglet **Comptes**, pas Dépenses : ce n'est pas une dépense, c'est de
  l'argent qui arrive dans une caisse.

## Vérification

- `apps/banking/tests/test_cash_gap.py` — **18 tests**, dont l'aveuglement des deux
  détecteurs voisins, la péremption de l'arbitrage, le recalcul du hash, et le refus
  de réécrire une contrepartie importée.
- `pytest` complet sur base reconstruite : **3 546 passés, 2 skipped**.
- `tsc -b ui` propre, `vitest` 47/47, `npm run lint` 0 erreur (5 warnings
  préexistants), garde i18n verte ×4.
- Types API régénérés (`npm run gen:api:refresh`).
- Tutoriel « Comptes bancaires » → étape *espèces* réécrite (les deux chemins
  d'entrée + ce que le Contrôle signale). Docs `banking.md` et `money.md` à jour.