### PR TITLE
fix(general): un montant se saisit à la virgule, dans tous les champs décimaux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -675,6 +675,42 @@ formatAmount('12.50')                      // « 12,50 € » (fr)
 formatAmount(420, { fractionDigits: 0 })   // « 420 € »
 ```
 
+### Saisie d'un décimal — jamais `<input type="number">`
+
+Le pendant en écriture de `formatAmount` : tout champ portant un décimal (montant,
+prix, index de compteur, tarif, quantité, surface) est un **`DecimalInput` de
+`@/design-system/decimal-input`**. Les `type="number"` restants sont les
+**compteurs entiers**, qui gardent leurs flèches.
+
+```tsx
+import { DecimalInput } from '@/design-system/decimal-input';
+
+<DecimalInput value={amount} onChange={setAmount} />              // 2 décimales
+<DecimalInput value={index} onChange={setIndex} decimals={3} />   // index compteur
+<DecimalInput value={balance} onChange={setBalance} allowNegative />  // découvert
+```
+
+- L'état du parent est **canonique** (séparateur point, tel qu'il part vers
+  l'API) ; le champ affiche celui de la locale. Donc **plus aucun
+  `.replace(',', '.')` au moment du submit** — il y en avait seize, tous morts.
+- `onChange` reçoit **la valeur**, pas l'événement.
+- Le pas fractionnaire est remplacé par `decimals`, et il **borne la frappe** au
+  lieu de la signaler invalide après coup ; `min="0"` est remplacé par le refus du
+  moins (`allowNegative` pour un solde, qui peut être à découvert).
+
+**Pourquoi c'est du métier et pas de la plomberie :** le HTML impose au `value`
+d'un champ `number` d'être un *valid floating-point number* — le séparateur y est
+**toujours** le point. Une virgule rend la valeur invalide, `e.target.value`
+renvoie du tronqué, React réécrit ce tronqué dans le DOM et détruit le tampon de
+saisie. Taper « 12,5 » sur un clavier français donnait **512 €** sur Chromium et
+**5 €** sur Safari et Firefox : pas un champ qui refuse une touche, **un montant
+faux enregistré sans un mot**. C'est la règle « un compteur ne peut pas avoir deux
+définitions » à l'entrée : ce que l'utilisateur tape et ce que le foyer enregistre
+doivent être le même nombre. Régressions : `ui/src/design-system/decimal-input.test.tsx`
+(dont le garde-fou « aucun pas fractionnaire dans le front ») et
+`e2e/decimal-input.spec.ts` — **le bug n'existait que dans un vrai moteur, jamais
+en jsdom : il fallait un test navigateur pour l'attester.**
+
 ### Dates de calendrier — jamais `toISOString()`
 
 Même règle, pour la même raison. Une date `YYYY-MM-DD` passe par

--- a/e2e/decimal-input.spec.ts
+++ b/e2e/decimal-input.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Régression #448 — un montant se saisit à la virgule.
+ *
+ * **Ce test est ici et pas en vitest parce que le bug n'existait que dans un vrai
+ * moteur.** `<input type="number">` refuse le séparateur de la locale : la valeur
+ * lue devenait tronquée, React la réécrivait dans le champ et détruisait le
+ * tampon de saisie. Taper `1` `2` `,` `5` donnait **512** sur Chromium, `5` sur
+ * Safari et Firefox — un montant faux, sans le moindre message. jsdom ne
+ * reproduit pas cette sanitisation : seul le navigateur pouvait attester le fix.
+ *
+ * D'où la frappe **touche à touche** (`pressSequentially`) : un `fill()` écrit la
+ * valeur d'un coup et passe à côté du bug, comme les tests existants.
+ */
+
+async function getAccessToken(page: import('@playwright/test').Page): Promise<string> {
+  return page.evaluate(() => localStorage.getItem('access_token') ?? '');
+}
+
+/** Part d'un onglet Budgets vide — la card créée doit être identifiable. */
+async function deleteAllBudgets(page: import('@playwright/test').Page): Promise<void> {
+  const token = await getAccessToken(page);
+  const resp = await page.request.get('/api/budget/budgets/', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok()) return;
+  const body = (await resp.json()) as unknown;
+  const items: Array<{ id: string }> = Array.isArray(body)
+    ? (body as Array<{ id: string }>)
+    : ((body as { results?: Array<{ id: string }> }).results ?? []);
+  for (const item of items) {
+    await page.request.delete(`/api/budget/budgets/${item.id}/`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  }
+}
+
+test.describe('Champs décimaux — la virgule du clavier français', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/app/money?tab=budgets');
+    await expect(page).toHaveURL(/\/app\/money/);
+    await deleteAllBudgets(page);
+    await page.reload();
+  });
+
+  test('un plafond tapé « 12,5 » vaut 12,50 € — et non 512 €', async ({ page }) => {
+    await page.getByRole('button', { name: 'Nouveau budget' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await dialog.locator('#budget-name').fill('Virgule');
+
+    const amount = dialog.locator('#budget-amount');
+    await amount.click();
+    // Touche à touche, et la virgule en **événement clavier** : c'est ce chemin-là
+    // qui produisait 512, là où un `pressSequentially` passe par l'insertion de
+    // texte et ne voyait qu'un séparateur mal affiché.
+    for (const key of ['1', '2', 'Comma', '5']) {
+      await page.keyboard.press(key);
+    }
+
+    // Ce que l'utilisateur voit : sa frappe, dans le séparateur de sa locale.
+    await expect(amount).toHaveValue('12,5');
+
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(dialog).toBeHidden();
+
+    // Ce que le foyer a enregistré : douze euros cinquante.
+    await expect(page.getByText('Virgule', { exact: true })).toBeVisible();
+    await expect(page.getByText(/12,50/).first()).toBeVisible();
+    await expect(page.getByText(/512/)).toHaveCount(0);
+  });
+
+  test('le point reste accepté sur le même champ — pavé numérique, copier-coller', async ({
+    page,
+  }) => {
+    await page.getByRole('button', { name: 'Nouveau budget' }).first().click();
+
+    const dialog = page.getByRole('dialog');
+    await dialog.locator('#budget-name').fill('Point');
+
+    const amount = dialog.locator('#budget-amount');
+    await amount.click();
+    await amount.pressSequentially('12.5');
+
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText(/12,50/).first()).toBeVisible();
+  });
+
+  test('rouvrir le budget réaffiche le plafond dans la locale', async ({ page }) => {
+    await page.getByRole('button', { name: 'Nouveau budget' }).first().click();
+    let dialog = page.getByRole('dialog');
+    await dialog.locator('#budget-name').fill('Relecture');
+    await dialog.locator('#budget-amount').click();
+    await dialog.locator('#budget-amount').pressSequentially('12,5');
+    await dialog.getByRole('button', { name: 'Enregistrer' }).click();
+    await expect(dialog).toBeHidden();
+
+    const card = page.getByText('Relecture', { exact: true }).locator('xpath=ancestor::*[3]');
+    await card.locator('button').last().click();
+    await page.getByRole('menuitem', { name: 'Modifier' }).click();
+
+    dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    await expect(dialog.locator('#budget-amount')).toHaveValue('12,50');
+  });
+});

--- a/ui/src/design-system/decimal-input.test.tsx
+++ b/ui/src/design-system/decimal-input.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DecimalInput } from './decimal-input';
+import { decimalSeparator } from '@/lib/format';
+
+const SEP = decimalSeparator();
+
+/** Champ contrôlé, exactement comme les dialogues de l'app. */
+function Harness({
+  onValue,
+  ...props
+}: { onValue?: (v: string) => void } & Partial<React.ComponentProps<typeof DecimalInput>>) {
+  const [value, setValue] = React.useState('');
+  return (
+    <DecimalInput
+      aria-label="montant"
+      value={value}
+      onChange={(v) => {
+        setValue(v);
+        onValue?.(v);
+      }}
+      {...props}
+    />
+  );
+}
+
+/**
+ * Le garde-fou : plus aucun champ décimal en `type="number"` dans le front.
+ *
+ * Un pas fractionnaire est la signature d'un champ décimal, et un champ décimal
+ * ne peut pas être un `<input type="number">` — voir le bug #448 juste en
+ * dessous. Le contrôle porte sur le pas et non sur `type="number"` : les
+ * compteurs entiers (nombre de circuits, de lignes à importer) restent des
+ * champs `number` légitimes, avec leurs flèches.
+ *
+ * Sans ce test, la substitution des trente-cinq champs se referait à la main à
+ * chaque branche en cours : les deux dialogues « espèces » d'une PR ouverte au
+ * moment du fix réintroduisaient déjà le motif.
+ */
+const sources = import.meta.glob<string>('../{features,components,design-system,lib}/**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
+describe('aucun champ décimal ne revient en type="number"', () => {
+  it('aucun pas fractionnaire dans le front — un décimal passe par DecimalInput', () => {
+    const offenders = Object.entries(sources)
+      .filter(([path]) => !path.includes('.test.'))
+      .filter(([, source]) => /step=["{]0\./.test(source))
+      .map(([path]) => path);
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('DecimalInput — régression #448', () => {
+  it('accepte la virgule : la frappe reste lisible, la valeur part à point', async () => {
+    const onValue = vi.fn();
+    render(<Harness onValue={onValue} />);
+    const field = screen.getByLabelText('montant');
+
+    await userEvent.type(field, '12,5');
+
+    // Ce que l'utilisateur voit : sa frappe, intacte.
+    expect(field).toHaveValue('12,5');
+    // Ce que le parent stocke et enverra à l'API : un décimal canonique.
+    expect(onValue).toHaveBeenLastCalledWith('12.5');
+  });
+
+  it('accepte le point sur la même frappe — pavé numérique', async () => {
+    const onValue = vi.fn();
+    render(<Harness onValue={onValue} />);
+    await userEvent.type(screen.getByLabelText('montant'), '12.5');
+    expect(onValue).toHaveBeenLastCalledWith('12.5');
+  });
+
+  it('n\'est pas un input number — sinon le navigateur reprend la main sur le séparateur', () => {
+    render(<Harness />);
+    const field = screen.getByLabelText('montant');
+    expect(field).toHaveAttribute('type', 'text');
+    expect(field).toHaveAttribute('inputmode', 'decimal');
+  });
+
+  it('ignore la frappe qui n\'est pas décimale, sans vider ce qui est déjà saisi', async () => {
+    render(<Harness />);
+    const field = screen.getByLabelText('montant');
+    await userEvent.type(field, '12,5abc€');
+    expect(field).toHaveValue('12,5');
+  });
+
+  it('borne les décimales — un montant s\'arrête à deux', async () => {
+    render(<Harness />);
+    const field = screen.getByLabelText('montant');
+    await userEvent.type(field, '12,555');
+    expect(field).toHaveValue('12,55');
+  });
+
+  it('accepte trois décimales là où la feature en demande trois', async () => {
+    render(<Harness decimals={3} />);
+    const field = screen.getByLabelText('montant');
+    await userEvent.type(field, '12,555');
+    expect(field).toHaveValue('12,555');
+  });
+
+  it('refuse le moins par défaut, l\'accepte pour un solde', async () => {
+    const { unmount } = render(<Harness />);
+    await userEvent.type(screen.getByLabelText('montant'), '-12');
+    expect(screen.getByLabelText('montant')).toHaveValue('12');
+    unmount();
+
+    render(<Harness allowNegative />);
+    await userEvent.type(screen.getByLabelText('montant'), '-12');
+    expect(screen.getByLabelText('montant')).toHaveValue('-12');
+  });
+
+  it('relit la valeur du parent dans la locale — un dialogue rouvert affiche « 12,50 »', () => {
+    render(<DecimalInput aria-label="montant" value="12.50" onChange={() => {}} />);
+    expect(screen.getByLabelText('montant')).toHaveValue(`12${SEP}50`);
+  });
+
+  it('lâche la frappe en cours dès que le parent réécrit la valeur (reset de dialogue)', async () => {
+    function Resettable() {
+      const [value, setValue] = React.useState('');
+      return (
+        <>
+          <DecimalInput aria-label="montant" value={value} onChange={setValue} />
+          <button onClick={() => setValue('')}>reset</button>
+        </>
+      );
+    }
+    render(<Resettable />);
+    const field = screen.getByLabelText('montant');
+    await userEvent.type(field, '12,5');
+    expect(field).toHaveValue('12,5');
+    await userEvent.click(screen.getByRole('button', { name: 'reset' }));
+    expect(field).toHaveValue('');
+  });
+});

--- a/ui/src/design-system/decimal-input.tsx
+++ b/ui/src/design-system/decimal-input.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+
+import { parseDecimalInput, toDecimalDisplay } from '@/lib/format';
+import { Input, type InputProps } from './input';
+
+export interface DecimalInputProps
+  extends Omit<InputProps, 'value' | 'onChange' | 'type' | 'inputMode' | 'step'> {
+  /** Valeur **canonique** : séparateur point, telle qu'elle part vers l'API. */
+  value: string;
+  /** Reçoit la valeur canonique, jamais la frappe brute. */
+  onChange: (value: string) => void;
+  /** Décimales maximum — 2 pour un montant, 3 pour un index, 5 pour un tarif. */
+  decimals?: number;
+  /** Autorise le signe moins : un solde, un ajustement. Refusé par défaut. */
+  allowNegative?: boolean;
+}
+
+/**
+ * Le champ décimal de l'app — **jamais un `<input type="number">`**.
+ *
+ * Le HTML impose au `value` d'un champ `number` d'être un *valid floating-point
+ * number* : le séparateur y est toujours le point, jamais celui de la locale. Une
+ * virgule rend la valeur invalide, `e.target.value` renvoie du tronqué, React
+ * réécrit ce tronqué dans le DOM et détruit le tampon de saisie — taper « 12,5 »
+ * donnait `512` sur Chromium, `5` sur Safari et Firefox. Un montant faux, sans
+ * message. Voir #448.
+ *
+ * Ici la frappe est lue par `parseDecimalInput` (les deux séparateurs, toujours),
+ * le parent reçoit du canonique, et le champ réaffiche le séparateur de la
+ * locale. Ce qui n'est pas décimal est ignoré : c'est le filtrage que `number`
+ * assurait, rendu explicite.
+ */
+const DecimalInput = React.forwardRef<HTMLInputElement, DecimalInputProps>(
+  ({ value, onChange, decimals = 2, allowNegative = false, placeholder, ...props }, ref) => {
+    const [draft, setDraft] = React.useState<string | null>(null);
+    const parseOptions = { decimals, allowNegative };
+
+    // La frappe brute ne s'affiche que tant qu'elle dit la valeur du parent : dès
+    // que celui-ci réécrit (ouverture de dialogue, reset après envoi), c'est la
+    // sienne qu'on relit — sans quoi le champ garderait un fantôme de la saisie
+    // précédente.
+    const display =
+      draft !== null && parseDecimalInput(draft, parseOptions) === value
+        ? draft
+        : toDecimalDisplay(value);
+
+    return (
+      <Input
+        {...props}
+        ref={ref}
+        type="text"
+        inputMode="decimal"
+        // Un gabarit chiffré (« 0.00 ») se lit dans la locale comme la valeur ;
+        // un gabarit en prose traverse inchangé.
+        placeholder={placeholder ? toDecimalDisplay(String(placeholder)) : placeholder}
+        value={display}
+        onChange={(event) => {
+          const raw = event.target.value;
+          const parsed = parseDecimalInput(raw, parseOptions);
+          if (parsed === null) return; // frappe refusée : lettre, 3e décimale, moins…
+          setDraft(raw);
+          onChange(parsed);
+        }}
+      />
+    );
+  },
+);
+DecimalInput.displayName = 'DecimalInput';
+
+export { DecimalInput };

--- a/ui/src/features/banking/AccountDialog.tsx
+++ b/ui/src/features/banking/AccountDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import type { BankAccount, BankAccountKind } from '@/lib/api/banking';
@@ -69,7 +70,7 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
 
     // Le solde d'ouverture peut être négatif (découvert) : on ne valide que la
     // forme numérique, jamais le signe.
-    const rawBalance = openingBalance.trim().replace(',', '.');
+    const rawBalance = openingBalance.trim();
     if (rawBalance && !Number.isFinite(Number(rawBalance))) {
       setError(t('banking.errors.openingBalanceInvalid'));
       return;
@@ -160,12 +161,11 @@ export default function AccountDialog({ open, onOpenChange, existing }: AccountD
         ) : null}
 
         <FormField label={t('banking.fields.openingBalance')} htmlFor="account-opening-balance">
-          <Input
+          <DecimalInput
             id="account-opening-balance"
-            type="number"
-            step="0.01"
+            allowNegative
             value={openingBalance}
-            onChange={(e) => setOpeningBalance(e.target.value)}
+            onChange={setOpeningBalance}
             placeholder="0.00"
           />
           <p className="text-xs text-muted-foreground">

--- a/ui/src/features/banking/AllocationDialog.tsx
+++ b/ui/src/features/banking/AllocationDialog.tsx
@@ -5,6 +5,7 @@ import UnreconciledPicker from './UnreconciledPicker';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
@@ -114,7 +115,7 @@ export default function AllocationDialog({
   }, [open, allocationsQuery.data, label, total]);
 
   const allocated = lines.reduce((sum, line) => {
-    const value = Number(line.amount.replace(',', '.'));
+    const value = Number(line.amount);
     return sum + (Number.isFinite(value) ? value : 0);
   }, 0);
   const remaining = editable - allocated;
@@ -133,7 +134,7 @@ export default function AllocationDialog({
 
     const payload: AllocationLine[] = [];
     for (const line of lines) {
-      const value = Number(line.amount.replace(',', '.'));
+      const value = Number(line.amount);
       if (!Number.isFinite(value) || value <= 0) {
         setError(t('banking.allocation.errors.amountInvalid'));
         return;
@@ -282,13 +283,10 @@ export default function AllocationDialog({
                     label={t('banking.allocation.fields.amount')}
                     htmlFor={`a-${line.key}`}
                   >
-                    <Input
+                    <DecimalInput
                       id={`a-${line.key}`}
-                      type="number"
-                      step="0.01"
-                      min="0"
                       value={line.amount}
-                      onChange={(e) => update(line.key, { amount: e.target.value })}
+                      onChange={(value) => update(line.key, { amount: value })}
                     />
                   </FormField>
 

--- a/ui/src/features/banking/BalanceAnchorDialog.tsx
+++ b/ui/src/features/banking/BalanceAnchorDialog.tsx
@@ -4,6 +4,7 @@ import { AlertTriangle, Check } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { Card } from '@/design-system/card';
 import { formatAmount, todayISO } from '@/lib/format';
@@ -66,7 +67,7 @@ export default function BalanceAnchorDialog({
   // Le solde du jour moins tout ce qui a bougé depuis la première ligne. Calculé
   // ici uniquement pour l'aperçu — le serveur refait la soustraction, parce qu'un
   // montant calculé par le client n'a rien à faire en base.
-  const parsed = Number(balance.trim().replace(',', '.'));
+  const parsed = Number(balance.trim());
   const preview =
     context && balance.trim() && Number.isFinite(parsed)
       ? parsed - Number(context.movements)
@@ -134,12 +135,11 @@ export default function BalanceAnchorDialog({
           ) : null}
 
           <FormField label={t('banking.anchor.balanceLabel')} htmlFor="anchor-balance">
-            <Input
+            <DecimalInput
               id="anchor-balance"
-              type="number"
-              step="0.01"
+              allowNegative
               value={balance}
-              onChange={(e) => setBalance(e.target.value)}
+              onChange={setBalance}
               placeholder="0.00"
               disabled={blocked}
               autoFocus
@@ -204,7 +204,7 @@ export default function BalanceAnchorDialog({
 
           <Footer
             onCancel={() => onOpenChange(false)}
-            onSubmit={() => void apply({ balance: balance.trim().replace(',', '.'), as_of: asOf })}
+            onSubmit={() => void apply({ balance: balance.trim(), as_of: asOf })}
             disabled={
               anchor.isPending ||
               blocked ||

--- a/ui/src/features/banking/ClassifyInflowDialog.tsx
+++ b/ui/src/features/banking/ClassifyInflowDialog.tsx
@@ -4,7 +4,7 @@ import { Plus, Trash2 } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Select } from '@/design-system/select';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
 import type { BankTransaction, InflowNature } from '@/lib/api/banking';
@@ -86,7 +86,7 @@ export default function ClassifyInflowDialog({
 
   const isRefund = nature === 'refund';
   const credited = lines.reduce((sum, line) => {
-    const value = Number(line.amount.replace(',', '.'));
+    const value = Number(line.amount);
     return sum + (Number.isFinite(value) ? value : 0);
   }, 0);
   const remaining = total - credited;
@@ -117,7 +117,7 @@ export default function ClassifyInflowDialog({
 
     const payload: { budget_id: string; amount: string }[] = [];
     for (const line of lines) {
-      const value = Number(line.amount.replace(',', '.'));
+      const value = Number(line.amount);
       if (!line.budgetId && !line.amount.trim()) continue; // ligne laissée vide
       if (!line.budgetId) {
         setError(t('banking.inflow.errors.budgetRequired'));
@@ -205,14 +205,11 @@ export default function ClassifyInflowDialog({
                     ]}
                   />
                 </div>
-                <Input
+                <DecimalInput
                   className="w-28"
-                  type="number"
-                  step="0.01"
-                  min="0"
                   aria-label={t('banking.inflow.refundAmount')}
                   value={line.amount}
-                  onChange={(e) => update(line.key, { amount: e.target.value })}
+                  onChange={(value) => update(line.key, { amount: value })}
                 />
                 {lines.length > 1 ? (
                   <button

--- a/ui/src/features/banking/WithdrawToCashDialog.tsx
+++ b/ui/src/features/banking/WithdrawToCashDialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
@@ -52,7 +52,7 @@ export default function WithdrawToCashDialog({
       setError(t('banking.withdraw.errors.accountRequired'));
       return;
     }
-    const parsed = Number(amount.trim().replace(',', '.'));
+    const parsed = Number(amount.trim());
     if (!Number.isFinite(parsed) || parsed <= 0 || parsed > Number(fullAmount)) {
       setError(t('banking.withdraw.errors.amountInvalid', { max: formatAmount(fullAmount) }));
       return;
@@ -98,14 +98,10 @@ export default function WithdrawToCashDialog({
             </FormField>
 
             <FormField label={t('banking.withdraw.fields.amount')} htmlFor="cash-amount">
-              <Input
+              <DecimalInput
                 id="cash-amount"
-                type="number"
-                step="0.01"
-                min="0"
-                max={fullAmount}
                 value={amount}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={setAmount}
               />
               <p className="text-xs text-muted-foreground">{t('banking.withdraw.fields.amountHint')}</p>
             </FormField>

--- a/ui/src/features/budget/BudgetDialog.tsx
+++ b/ui/src/features/budget/BudgetDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { CheckboxField } from '@/design-system/checkbox-field';
 import { Select } from '@/design-system/select';
@@ -70,7 +71,7 @@ export default function BudgetDialog({ open, onOpenChange, existing, allowGlobal
     e.preventDefault();
     setError(null);
 
-    const raw = amount.trim().replace(',', '.');
+    const raw = amount.trim();
     const parsed = Number(raw);
     const hasAmount = raw !== '';
 
@@ -153,13 +154,10 @@ export default function BudgetDialog({ open, onOpenChange, existing, allowGlobal
             : t('budget.fields.monthlyAmountOptional')}
           htmlFor="budget-amount"
         >
-          <Input
+          <DecimalInput
             id="budget-amount"
-            type="number"
-            step="0.01"
-            min="0"
             value={amount}
-            onChange={(e) => setAmount(e.target.value)}
+            onChange={setAmount}
             placeholder="0.00"
             autoFocus={isGlobal}
           />

--- a/ui/src/features/budget/ConfirmOccurrenceDialog.tsx
+++ b/ui/src/features/budget/ConfirmOccurrenceDialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import type { RecurringExpense } from '@/lib/api/budget';
 
@@ -36,7 +36,7 @@ export default function ConfirmOccurrenceDialog({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    const parsed = Number(amount.trim().replace(',', '.'));
+    const parsed = Number(amount.trim());
     if (!Number.isFinite(parsed) || parsed <= 0) {
       setError(t('recurring.errors.amountInvalid'));
       return;
@@ -54,13 +54,10 @@ export default function ConfirmOccurrenceDialog({
       <form onSubmit={handleSubmit} className="mt-4 space-y-4">
         <p className="text-sm text-muted-foreground">{t('recurring.confirm.hint')}</p>
         <FormField label={`${t('recurring.confirm.amount')} *`} htmlFor="confirm-amount">
-          <Input
+          <DecimalInput
             id="confirm-amount"
-            type="number"
-            step="0.01"
-            min="0"
             value={amount}
-            onChange={(e) => setAmount(e.target.value)}
+            onChange={setAmount}
             autoFocus
           />
         </FormField>

--- a/ui/src/features/budget/RecurringExpenseDialog.tsx
+++ b/ui/src/features/budget/RecurringExpenseDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Textarea } from '@/design-system/textarea';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
@@ -70,7 +71,7 @@ export default function RecurringExpenseDialog({ open, onOpenChange, existing }:
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    const parsed = Number(amount.trim().replace(',', '.'));
+    const parsed = Number(amount.trim());
     if (!label.trim()) {
       setError(t('recurring.errors.labelRequired'));
       return;
@@ -123,13 +124,10 @@ export default function RecurringExpenseDialog({ open, onOpenChange, existing }:
 
         <div className="grid gap-4 sm:grid-cols-2">
           <FormField label={`${t('recurring.fields.amount')} *`} htmlFor="rec-amount">
-            <Input
+            <DecimalInput
               id="rec-amount"
-              type="number"
-              step="0.01"
-              min="0"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={setAmount}
               placeholder="0.00"
             />
           </FormField>

--- a/ui/src/features/electricity/ReadingDialog.tsx
+++ b/ui/src/features/electricity/ReadingDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
@@ -109,14 +110,11 @@ export default function ReadingDialog({ open, onOpenChange, meter, existing }: R
           </FormField>
         </div>
         <FormField label={t('electricity.reading.indexKwh')} htmlFor="reading-index">
-          <Input
+          <DecimalInput
             id="reading-index"
-            type="number"
-            step="0.001"
-            min="0"
-            inputMode="decimal"
+            decimals={3}
             value={indexKwh}
-            onChange={(e) => setIndexKwh(e.target.value)}
+            onChange={setIndexKwh}
             placeholder="45230.5"
             required
           />

--- a/ui/src/features/electricity/TariffsDialog.tsx
+++ b/ui/src/features/electricity/TariffsDialog.tsx
@@ -5,6 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Card } from '@/design-system/card';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import CardActions, { type CardAction } from '@/components/CardActions';
@@ -138,27 +139,21 @@ export default function TariffsDialog({ open, onOpenChange, meter }: TariffsDial
           {isHpHc ? (
             <div className="grid grid-cols-2 gap-3">
               <FormField label={t('electricity.tariff.priceHp')} htmlFor="tariff-price-hp">
-                <Input
+                <DecimalInput
                   id="tariff-price-hp"
-                  type="number"
-                  step="0.00001"
-                  min="0"
-                  inputMode="decimal"
+                  decimals={5}
                   value={priceHp}
-                  onChange={(e) => setPriceHp(e.target.value)}
+                  onChange={setPriceHp}
                   placeholder="0.27"
                   required
                 />
               </FormField>
               <FormField label={t('electricity.tariff.priceHc')} htmlFor="tariff-price-hc">
-                <Input
+                <DecimalInput
                   id="tariff-price-hc"
-                  type="number"
-                  step="0.00001"
-                  min="0"
-                  inputMode="decimal"
+                  decimals={5}
                   value={priceHc}
-                  onChange={(e) => setPriceHc(e.target.value)}
+                  onChange={setPriceHc}
                   placeholder="0.2068"
                   required
                 />
@@ -166,28 +161,21 @@ export default function TariffsDialog({ open, onOpenChange, meter }: TariffsDial
             </div>
           ) : (
             <FormField label={t('electricity.tariff.priceBase')} htmlFor="tariff-price-base">
-              <Input
+              <DecimalInput
                 id="tariff-price-base"
-                type="number"
-                step="0.00001"
-                min="0"
-                inputMode="decimal"
+                decimals={5}
                 value={priceBase}
-                onChange={(e) => setPriceBase(e.target.value)}
+                onChange={setPriceBase}
                 placeholder="0.2516"
                 required
               />
             </FormField>
           )}
           <FormField label={t('electricity.tariff.subscription')} htmlFor="tariff-subscription">
-            <Input
+            <DecimalInput
               id="tariff-subscription"
-              type="number"
-              step="0.01"
-              min="0"
-              inputMode="decimal"
               value={subscription}
-              onChange={(e) => setSubscription(e.target.value)}
+              onChange={setSubscription}
               placeholder="12.44"
             />
           </FormField>

--- a/ui/src/features/equipment/EquipmentDialog.tsx
+++ b/ui/src/features/equipment/EquipmentDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
@@ -273,12 +274,10 @@ export default function EquipmentDialog({
               />
             </FormField>
             <FormField label={t('equipment.form.fields.purchase_price')} htmlFor="eq-purchase-price">
-              <Input
+              <DecimalInput
                 id="eq-purchase-price"
-                type="number"
-                step="0.01"
                 value={form.purchase_price}
-                onChange={(e) => updateField('purchase_price', e.target.value)}
+                onChange={(value) => updateField('purchase_price', value)}
               />
             </FormField>
             <FormField label={t('equipment.form.fields.purchase_vendor')} htmlFor="eq-purchase-vendor">

--- a/ui/src/features/insurance/InsuranceDialog.tsx
+++ b/ui/src/features/insurance/InsuranceDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
@@ -255,24 +256,18 @@ export default function InsuranceDialog({ open, onOpenChange, onSaved, existing 
               />
             </FormField>
             <FormField label={t('insurance.field.monthly_cost')} htmlFor="insurance-monthly-cost">
-              <Input
+              <DecimalInput
                 id="insurance-monthly-cost"
-                type="number"
-                step="0.01"
-                min="0"
                 value={form.monthly_cost}
-                onChange={(e) => update('monthly_cost', e.target.value)}
+                onChange={(value) => update('monthly_cost', value)}
                 placeholder="0.00"
               />
             </FormField>
             <FormField label={t('insurance.field.yearly_cost')} htmlFor="insurance-yearly-cost">
-              <Input
+              <DecimalInput
                 id="insurance-yearly-cost"
-                type="number"
-                step="0.01"
-                min="0"
                 value={form.yearly_cost}
-                onChange={(e) => update('yearly_cost', e.target.value)}
+                onChange={(value) => update('yearly_cost', value)}
                 placeholder="0.00"
               />
             </FormField>

--- a/ui/src/features/interactions/ExpenseFields.tsx
+++ b/ui/src/features/interactions/ExpenseFields.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Badge } from '@/design-system/badge';
 import { Select } from '@/design-system/select';
 import { FormField } from '@/design-system/form-field';
@@ -127,13 +128,10 @@ export default function ExpenseFields({
           <label htmlFor="expense-amount" className="text-sm font-medium">
             {t('interactions.expense.amount_label')}
           </label>
-          <Input
+          <DecimalInput
             id="expense-amount"
-            type="number"
-            step="0.01"
-            min="0"
             value={amount}
-            onChange={(e) => onAmountChange(e.target.value)}
+            onChange={onAmountChange}
             placeholder="0.00"
           />
         </div>

--- a/ui/src/features/interactions/PurchaseForm.tsx
+++ b/ui/src/features/interactions/PurchaseForm.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
@@ -72,7 +73,7 @@ function emptyState(currentQuantity?: number, budgetId = ''): FormState {
 }
 
 function parseDecimal(value: string): number | null {
-  const trimmed = value.trim().replace(',', '.');
+  const trimmed = value.trim();
   if (!trimmed) return null;
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
@@ -172,13 +173,11 @@ export default function PurchaseForm({
           label={`${t('purchase.fields.delta', { unit: deltaUnit ?? '' })} *`}
           htmlFor="purchase-delta"
         >
-          <Input
+          <DecimalInput
             id="purchase-delta"
-            type="number"
-            step="0.001"
-            min="0"
+            decimals={3}
             value={form.delta}
-            onChange={(e) => updateField('delta', e.target.value)}
+            onChange={(value) => updateField('delta', value)}
             required
             autoFocus
           />
@@ -190,13 +189,11 @@ export default function PurchaseForm({
           label={t('purchase.fields.remaining_before', { unit: deltaUnit ?? '' })}
           htmlFor="purchase-remaining"
         >
-          <Input
+          <DecimalInput
             id="purchase-remaining"
-            type="number"
-            step="0.001"
-            min="0"
+            decimals={3}
             value={form.remaining}
-            onChange={(e) => updateField('remaining', e.target.value)}
+            onChange={(value) => updateField('remaining', value)}
           />
           <p className="mt-1 text-xs text-muted-foreground">
             {isRecalibrating
@@ -234,13 +231,10 @@ export default function PurchaseForm({
             </div>
           ) : null}
         </div>
-        <Input
+        <DecimalInput
           id="purchase-price"
-          type="number"
-          step="0.01"
-          min="0"
           value={form.price}
-          onChange={(e) => updateField('price', e.target.value)}
+          onChange={(value) => updateField('price', value)}
           placeholder={t('purchase.fields.price_placeholder')}
           autoFocus={!withDelta}
         />

--- a/ui/src/features/projects/ProjectDialog.tsx
+++ b/ui/src/features/projects/ProjectDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { Select } from '@/design-system/select';
@@ -217,13 +218,10 @@ export default function ProjectDialog({
 
           {/* Budget */}
           <FormField label={t('projects.form.fields.planned_budget')} htmlFor="proj-budget">
-            <Input
+            <DecimalInput
               id="proj-budget"
-              type="number"
-              step="0.01"
-              min="0"
               value={plannedBudget}
-              onChange={(e) => setPlannedBudget(e.target.value)}
+              onChange={setPlannedBudget}
             />
           </FormField>
 

--- a/ui/src/features/shopping/ShoppingItemDialog.tsx
+++ b/ui/src/features/shopping/ShoppingItemDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
@@ -68,12 +69,11 @@ export default function ShoppingItemDialog({ open, onOpenChange, existing }: Pro
 
         <div className="grid gap-4 sm:grid-cols-2">
           <FormField label={t('shoppingList.fields.quantity')} htmlFor="shopping-qty">
-            <Input
+            <DecimalInput
               id="shopping-qty"
-              type="number"
-              step="0.001"
+              decimals={3}
               value={quantity}
-              onChange={(e) => setQuantity(e.target.value)}
+              onChange={setQuantity}
             />
           </FormField>
           <FormField label={t('shoppingList.fields.unit')} htmlFor="shopping-unit">

--- a/ui/src/features/stock/StockInventoryDialog.tsx
+++ b/ui/src/features/stock/StockInventoryDialog.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import type { StockItem } from '@/lib/api/stock';
@@ -14,7 +14,7 @@ interface StockInventoryDialogProps {
 }
 
 function parseDecimal(value: string): number | null {
-  const trimmed = value.trim().replace(',', '.');
+  const trimmed = value.trim();
   if (!trimmed) return null;
   const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? parsed : null;
@@ -70,13 +70,11 @@ export default function StockInventoryDialog({ open, onOpenChange, item }: Stock
           label={`${t('stock.inventory.fields.quantity', { unit: item.unit })} *`}
           htmlFor="inventory-quantity"
         >
-          <Input
+          <DecimalInput
             id="inventory-quantity"
-            type="number"
-            step="0.001"
-            min="0"
+            decimals={3}
             value={quantity}
-            onChange={(e) => setQuantity(e.target.value)}
+            onChange={setQuantity}
             required
             autoFocus
           />

--- a/ui/src/features/stock/StockItemDialog.tsx
+++ b/ui/src/features/stock/StockItemDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
@@ -195,12 +196,11 @@ export default function StockItemDialog({
           {/* Quantity + Unit + Min + Max */}
           <div className="grid gap-4 md:grid-cols-4">
             <FormField label={t('stock.fields.quantity')} htmlFor="stock-item-qty">
-              <Input
+              <DecimalInput
                 id="stock-item-qty"
-                type="number"
-                step="0.001"
+                decimals={3}
                 value={form.quantity}
-                onChange={(e) => updateField('quantity', e.target.value)}
+                onChange={(value) => updateField('quantity', value)}
               />
             </FormField>
             <FormField label={t('stock.fields.unit')} htmlFor="stock-item-unit">
@@ -211,21 +211,19 @@ export default function StockItemDialog({
               />
             </FormField>
             <FormField label={t('stock.fields.min_quantity')} htmlFor="stock-item-min">
-              <Input
+              <DecimalInput
                 id="stock-item-min"
-                type="number"
-                step="0.001"
+                decimals={3}
                 value={form.min_quantity}
-                onChange={(e) => updateField('min_quantity', e.target.value)}
+                onChange={(value) => updateField('min_quantity', value)}
               />
             </FormField>
             <FormField label={t('stock.fields.max_quantity')} htmlFor="stock-item-max">
-              <Input
+              <DecimalInput
                 id="stock-item-max"
-                type="number"
-                step="0.001"
+                decimals={3}
                 value={form.max_quantity}
-                onChange={(e) => updateField('max_quantity', e.target.value)}
+                onChange={(value) => updateField('max_quantity', value)}
               />
             </FormField>
           </div>

--- a/ui/src/features/trackers/EntryDialog.tsx
+++ b/ui/src/features/trackers/EntryDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { formatTrackerValue, type Tracker, type TrackerEntry } from '@/lib/api/trackers';
 import { useCreateEntry, useUpdateEntry } from './hooks';
@@ -51,7 +52,7 @@ export default function EntryDialog({ open, onOpenChange, tracker, existing }: E
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError(null);
-    const normalized = value.trim().replace(',', '.');
+    const normalized = value.trim();
     if (!normalized || Number.isNaN(Number(normalized)) || !occurredAt) {
       setError(t('trackers.valueRequired'));
       return;
@@ -94,12 +95,12 @@ export default function EntryDialog({ open, onOpenChange, tracker, existing }: E
             }
             htmlFor="entry-value"
           >
-            <Input
+            <DecimalInput
               id="entry-value"
-              type="text"
-              inputMode="decimal"
+              decimals={3}
+              allowNegative
               value={value}
-              onChange={(e) => setValue(e.target.value)}
+              onChange={setValue}
               required
               autoFocus
             />

--- a/ui/src/features/trackers/TrackerCard.tsx
+++ b/ui/src/features/trackers/TrackerCard.tsx
@@ -6,7 +6,7 @@ import { Check, FolderKanban, Pencil, Plus, Trash2 } from 'lucide-react';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import Sparkline from '@/components/Sparkline';
 import { Card, CardTitle } from '@/design-system/card';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { formatTrackerValue, type Tracker } from '@/lib/api/trackers';
 import { pushBack } from '@/lib/backNavigation';
 
@@ -65,7 +65,7 @@ export default function TrackerCard({
   };
 
   const submitQuickAdd = async () => {
-    const value = quickValue.trim().replace(',', '.');
+    const value = quickValue.trim();
     if (!value || Number.isNaN(Number(value))) return;
     setSaving(true);
     try {
@@ -144,12 +144,12 @@ export default function TrackerCard({
               void submitQuickAdd();
             }}
           >
-            <Input
+            <DecimalInput
               ref={inputRef}
-              type="text"
-              inputMode="decimal"
+              decimals={3}
+              allowNegative
               value={quickValue}
-              onChange={(e) => setQuickValue(e.target.value)}
+              onChange={setQuickValue}
               onKeyDown={(e) => {
                 if (e.key === 'Escape') setQuickAddOpen(false);
               }}

--- a/ui/src/features/water/WaterReadingDialog.tsx
+++ b/ui/src/features/water/WaterReadingDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import { isoDate } from '@/lib/period';
@@ -83,14 +84,11 @@ export default function WaterReadingDialog({ open, onOpenChange, existing }: Wat
             />
           </FormField>
           <FormField label={t('water.reading.indexM3')} htmlFor="water-reading-index">
-            <Input
+            <DecimalInput
               id="water-reading-index"
-              type="number"
-              step="0.001"
-              min="0"
-              inputMode="decimal"
+              decimals={3}
               value={indexM3}
-              onChange={(e) => setIndexM3(e.target.value)}
+              onChange={setIndexM3}
               placeholder="1250.5"
               required
             />

--- a/ui/src/features/zones/ZoneDialog.tsx
+++ b/ui/src/features/zones/ZoneDialog.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
@@ -83,7 +84,7 @@ export default function ZoneDialog({ open, onOpenChange, existing }: ZoneDialogP
     const trimmedSurface = surface.trim();
     let parsedSurface: number | null = null;
     if (trimmedSurface !== '') {
-      parsedSurface = Number(trimmedSurface.replace(',', '.'));
+      parsedSurface = Number(trimmedSurface);
       if (!Number.isFinite(parsedSurface) || parsedSurface < 0) {
         setError(t('zones.invalidSurface'));
         return;
@@ -178,14 +179,10 @@ export default function ZoneDialog({ open, onOpenChange, existing }: ZoneDialogP
           {/* Surface — affichée dans la liste des zones et sommée en tête de
               page : sans ce champ, la colonne resterait vide pour tout le monde. */}
           <FormField label={t('zones.surfaceLabel')} htmlFor="zone-surface">
-            <Input
+            <DecimalInput
               id="zone-surface"
-              type="number"
-              inputMode="decimal"
-              min="0"
-              step="0.01"
               value={surface}
-              onChange={(e) => setSurface(e.target.value)}
+              onChange={setSurface}
               placeholder={t('zones.surfacePlaceholder')}
             />
           </FormField>

--- a/ui/src/lib/decimalInput.test.ts
+++ b/ui/src/lib/decimalInput.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { decimalSeparator, parseDecimalInput, toDecimalDisplay } from './format';
+
+/**
+ * Régression #448 — la virgule du clavier français dans un champ décimal.
+ *
+ * `<input type="number">` n'accepte que le point : le HTML impose au `value`
+ * d'être un *valid floating-point number*, jamais un décimal localisé. Taper
+ * `12,5` produisait `512` sur Chromium et `5` sur Safari/Firefox — une valeur
+ * fausse, sans message.
+ *
+ * La lecture d'une frappe est donc **indépendante de la locale** : les deux
+ * séparateurs sont toujours acceptés (un français sur un navigateur anglais tape
+ * une virgule ; un pavé numérique et un copier-coller donnent un point).
+ */
+describe('parseDecimalInput — la frappe devient une valeur canonique', () => {
+  it('accepte la virgule et rend un décimal à point, prêt pour l\'API', () => {
+    expect(parseDecimalInput('12,5')).toBe('12.5');
+  });
+
+  it('accepte aussi le point — pavé numérique, copier-coller', () => {
+    expect(parseDecimalInput('12.5')).toBe('12.5');
+  });
+
+  it('laisse passer la frappe intermédiaire sans jamais produire un décimal invalide', () => {
+    // « 12, » est une frappe légitime en cours ; « 12. » ne doit pas partir tel
+    // quel vers l'API, donc le séparateur en attente est retiré de la valeur.
+    expect(parseDecimalInput('12,')).toBe('12');
+    expect(parseDecimalInput('12.')).toBe('12');
+    expect(parseDecimalInput(',')).toBe('');
+    expect(parseDecimalInput('-', { allowNegative: true })).toBe('');
+    expect(parseDecimalInput('')).toBe('');
+  });
+
+  it('complète le séparateur de tête — « ,5 » vaut cinquante centimes', () => {
+    expect(parseDecimalInput(',5')).toBe('0.5');
+    expect(parseDecimalInput('.5')).toBe('0.5');
+  });
+
+  it('ignore les espaces de groupement d\'un montant collé', () => {
+    expect(parseDecimalInput('1 234,56')).toBe('1234.56');
+    expect(parseDecimalInput('1 234,56')).toBe('1234.56');
+    expect(parseDecimalInput('1 234,56')).toBe('1234.56');
+  });
+
+  it('refuse ce qui n\'est pas un décimal — la frappe est alors ignorée', () => {
+    expect(parseDecimalInput('12€')).toBeNull();
+    expect(parseDecimalInput('abc')).toBeNull();
+    expect(parseDecimalInput('12,5,5')).toBeNull();
+    expect(parseDecimalInput('1.234,56')).toBeNull();
+  });
+
+  it('borne les décimales — deux pour un montant, cinq pour un tarif', () => {
+    expect(parseDecimalInput('12,555')).toBeNull();
+    expect(parseDecimalInput('12,555', { decimals: 3 })).toBe('12.555');
+    expect(parseDecimalInput('0,12345', { decimals: 5 })).toBe('0.12345');
+  });
+
+  it('refuse le signe moins sauf là où un solde peut être négatif', () => {
+    expect(parseDecimalInput('-12,5')).toBeNull();
+    expect(parseDecimalInput('-12,5', { allowNegative: true })).toBe('-12.5');
+  });
+});
+
+describe('toDecimalDisplay — la valeur canonique se relit dans la locale', () => {
+  it('affiche la virgule en français, le point en anglais', () => {
+    expect(toDecimalDisplay('12.50', 'fr-FR')).toBe('12,50');
+    expect(toDecimalDisplay('12.50', 'en-US')).toBe('12.50');
+  });
+
+  it('ne groupe jamais les milliers — un séparateur de groupe casse l\'édition', () => {
+    expect(toDecimalDisplay('1234.56', 'fr-FR')).toBe('1234,56');
+  });
+
+  it('rend le vide et le non-numérique tels quels', () => {
+    expect(toDecimalDisplay('', 'fr-FR')).toBe('');
+    expect(toDecimalDisplay('abc', 'fr-FR')).toBe('abc');
+  });
+
+  it('fait l\'aller-retour avec parseDecimalInput dans la locale de lecture', () => {
+    const typed = `12${decimalSeparator()}5`;
+    expect(toDecimalDisplay(parseDecimalInput(typed) ?? '')).toBe(typed);
+  });
+});
+
+describe('decimalSeparator', () => {
+  it('lit le séparateur de la locale, comme formatAmount lit la devise', () => {
+    expect(decimalSeparator('fr-FR')).toBe(',');
+    expect(decimalSeparator('en-US')).toBe('.');
+    expect(decimalSeparator('de-DE')).toBe(',');
+  });
+});

--- a/ui/src/lib/format.ts
+++ b/ui/src/lib/format.ts
@@ -43,6 +43,65 @@ export function formatAmount(
 }
 
 /**
+ * Le séparateur décimal de la locale de lecture — « , » en français, « . » en
+ * anglais. Même source que `formatAmount` (la locale du navigateur), pour qu'un
+ * montant saisi et le même montant réaffiché ne se lisent pas de deux façons.
+ */
+export function decimalSeparator(locale?: string): string {
+  const parts = new Intl.NumberFormat(locale).formatToParts(1.1);
+  return parts.find((part) => part.type === 'decimal')?.value ?? '.';
+}
+
+/**
+ * Les séparateurs de groupe d'un montant collé. `\s` couvre l'espace insécable
+ * (U+00A0) et l'espace fine insécable (U+202F) — celle que produit `Intl` en
+ * français, donc celle qu'on récupère en copiant un montant affiché par l'app.
+ */
+const GROUP_SPACES = /\s/g;
+
+/**
+ * Frappe utilisateur → décimal canonique (séparateur point), ou `null` si la
+ * frappe n'est pas un décimal acceptable — auquel cas `DecimalInput` l'ignore.
+ *
+ * **Les deux séparateurs sont toujours acceptés, quelle que soit la locale** : un
+ * pavé numérique et un copier-coller donnent un point, un clavier français une
+ * virgule, et l'utilisateur ne choisit pas la locale de son navigateur.
+ *
+ * Ne jamais rendre un décimal invalide même en cours de frappe : « 12, » vaut
+ * « 12 » (le séparateur en attente ne part pas vers l'API), « ,5 » vaut « 0.5 ».
+ */
+export function parseDecimalInput(
+  raw: string,
+  options?: { decimals?: number; allowNegative?: boolean },
+): string | null {
+  const decimals = options?.decimals ?? 2;
+  const compact = raw.replace(GROUP_SPACES, '').replace(',', '.');
+  if (compact === '') return '';
+
+  const match = /^(-?)(\d*)(?:\.(\d*))?$/.exec(compact);
+  if (!match) return null;
+
+  const [, sign, whole, fraction] = match;
+  if (sign && !options?.allowNegative) return null;
+  if (fraction != null && fraction.length > decimals) return null;
+
+  if (whole === '' && !fraction) return '';          // « - », « , », « -, »
+  if (!fraction) return `${sign}${whole}`;           // « 12 », « 12, »
+  return `${sign}${whole || '0'}.${fraction}`;       // « 12,5 », « ,5 »
+}
+
+/**
+ * Décimal canonique → ce que l'utilisateur relit dans son champ : le séparateur
+ * de sa locale, et **jamais** de séparateur de groupe (« 1 234,56 » dans un champ
+ * rend l'édition au caret illisible).
+ */
+export function toDecimalDisplay(value: string, locale?: string): string {
+  if (!value) return '';
+  if (!/^-?\d*\.?\d*$/.test(value)) return value;
+  return value.replace('.', decimalSeparator(locale));
+}
+
+/**
  * `Date` → `YYYY-MM-DD` **dans le fuseau du navigateur**.
  *
  * `toISOString().slice(0, 10)` convertit d'abord en UTC : à Paris, tout ce qui


### PR DESCRIPTION
Closes #448.

## Ce que voyait l'utilisateur

Taper `12,5` dans un champ montant ne donnait **jamais** 12,5 :

| moteur | frappe `1` `2` `,` `5` |
|---|---|
| Chromium (fr-FR **et** en-US) | `512` |
| WebKit / Safari (fr-FR) | `5` |
| Firefox | `5` |

Pas un champ qui refuse une touche : **un montant faux enregistré sans un mot.**

## Cause

Les ~35 champs décimaux étaient des `<input type="number">`. Le HTML impose au
`value` d'un champ `number` d'être un *valid floating-point number* : le séparateur
y est **toujours** le point, jamais celui de la locale. Une virgule rend la valeur
invalide, `e.target.value` renvoie du tronqué, React réécrit aussitôt ce tronqué
dans le DOM et détruit le tampon de saisie **et le caret** — d'où le `512` de
Chromium, où le chiffre suivant atterrit en tête.

Ce n'est pas une divergence de navigateurs à contourner : `type="number"` ne sait
pas exprimer une saisie décimale localisée. Les **seize** `.replace(',', '.')`
présents au moment du submit le disent — l'intention était là, à la mauvaise
couche : le navigateur avait mangé la virgule bien avant.

## Fix

Un `DecimalInput` partagé (`ui/src/design-system/decimal-input.tsx`) :
`type="text"` + `inputMode="decimal"` (clavier numérique sur mobile), les deux
séparateurs acceptés **quelle que soit la locale** (l'utilisateur ne choisit pas
celle de son navigateur), état parent **canonique** (point, tel qu'il part vers
l'API), réaffichage dans le séparateur de la locale. La lecture et le rendu vivent
dans `@/lib/format`, à côté de `formatAmount` — un seul formatteur, dans les deux
sens.

- `decimals` remplace `step` et **borne la frappe** au lieu de la signaler
  invalide après coup (2 pour un montant, 3 pour un index, 5 pour un tarif).
- `allowNegative` remplace `min="0"` — accordé au solde d'ouverture et au solde
  attesté, qui peuvent être à découvert, refusé partout ailleurs.
- Les **compteurs entiers** (circuits, lignes à importer) restent des
  `type="number"` avec leurs flèches.
- Les seize `.replace(',', '.')` du submit disparaissent, ainsi que le
  `type="text" inputMode="decimal"` que les trackers avaient inventé pour eux
  seuls — c'était le bon geste, il devient partagé.

## Garde-fous

- `ui/src/design-system/decimal-input.test.tsx` — le comportement du composant,
  **et** un scan qui interdit tout pas fractionnaire dans le front : la
  substitution ne se refera pas à la main branche par branche.
- `e2e/decimal-input.spec.ts` — **le seul test qui aurait vu le bug.** jsdom ne
  reproduit pas la sanitisation d'un champ `number` : il fallait un vrai moteur, et
  une frappe **touche à touche** avec la virgule en événement clavier (un
  `fill()` ou un `pressSequentially` passe à côté). Vérifié rouge sur le code
  d'avant, vert après.
- `CLAUDE.md` — la règle « saisie d'un décimal », pendant en écriture de
  « Montants — un seul formatter ».

## Vérifications

`pytest` 3634 ✅ · `npm run lint` 0 erreur · `tsc -b` ✅ · `vitest` 74 ✅ ·
suite Playwright complète rejouée dans un worktree isolé.

## Deux points pour la revue

1. **PR #446** (`feat/money-cash-gaps`) porte deux dialogues espèces avec le même
   motif (`CashDepositDialog`, `CashMirrorDialog`) : après rebase, le garde-fou les
   signalera — c'est voulu, ils sont à convertir là-bas.
2. La section `CLAUDE.md` de cette PR a **aussi** été emportée par mégarde dans le
   commit `b63ec9c7` de `fix/deploy-502-redeploy` (deux sessions dans le même
   working tree). À retirer de cette branche-là, ou conflit trivial à l'arrivée.
