### PR TITLE
feat(documents): la liste des documents se parcourt, au lieu de se dérouler

### DIFF
--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -62,6 +62,7 @@ class DocumentSerializer(serializers.ModelSerializer):
     legacy_interaction_subject = serializers.SerializerMethodField()
     phase = serializers.SerializerMethodField()
     zone_links = serializers.SerializerMethodField()
+    entity_links = serializers.SerializerMethodField()
 
     class Meta:
         model = Document
@@ -72,7 +73,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             'file_url', 'thumbnail_url', 'medium_url',
             'qualification', 'linked_interactions',
             'legacy_interaction', 'legacy_interaction_subject',
-            'phase', 'taken_at', 'zone_links',
+            'phase', 'taken_at', 'zone_links', 'entity_links',
         ]
         # `taken_at` est lu dans l'EXIF, jamais saisi : l'exposer en écriture
         # permettrait de le contredire par un PATCH, et le tri de la galerie
@@ -183,6 +184,23 @@ class DocumentSerializer(serializers.ModelSerializer):
             payload.append({'zone_id': str(zone.id), 'zone_name': zone.name})
         return ZoneLinkSummarySerializer(payload, many=True).data
 
+    def get_entity_links(self, obj):
+        """Tout ce à quoi le document est rattaché — **dans la liste**, pas seulement
+        dans le détail.
+
+        Même raison que `zone_links` juste au-dessus : c'est ce champ qui permet à la
+        liste de dire *où vit* un document, et une liste de deux cents fichiers qui
+        n'affiche que des noms de fichiers ne se lit pas. Un tableau vide est une
+        information (rattaché à rien), jamais l'absence de la clé.
+
+        Le coût ne suit pas le nombre de documents : la vue précharge les liens **et**
+        leur `GenericForeignKey` (`prefetched_links` + `entity`), que
+        `entity_links_for_document` réutilise. Régression :
+        `test_document_links.py::test_entity_links_cost_a_bounded_number_of_queries`.
+        """
+        from .services import entity_links_for_document
+        return EntityLinkSummarySerializer(entity_links_for_document(obj), many=True).data
+
     def get_phase(self, obj):
         """Photo phase relative to the entity currently being filtered on.
 
@@ -204,15 +222,14 @@ class DocumentDetailSerializer(DocumentSerializer):
 
     interaction_subject = serializers.SerializerMethodField()
     project_links = serializers.SerializerMethodField()
-    entity_links = serializers.SerializerMethodField()
     recent_interaction_candidates = serializers.SerializerMethodField()
 
     class Meta(DocumentSerializer.Meta):
-        # `zone_links` est hérité : la galerie en a besoin dès la liste.
+        # `zone_links` et `entity_links` sont hérités : la galerie et la liste des
+        # documents en ont besoin dès la liste.
         fields = DocumentSerializer.Meta.fields + [
             'interaction_subject',
             'project_links',
-            'entity_links',
             'recent_interaction_candidates',
         ]
 

--- a/apps/documents/tests/test_document_links.py
+++ b/apps/documents/tests/test_document_links.py
@@ -99,3 +99,46 @@ def test_document_detail_api_exposes_entity_links(client, household, user, doc, 
     entity_links = response.json()["entity_links"]
     assert {"entity_type": "equipment", "id": str(equipment.id),
             "label": "Ballon d'eau", "url_path": f"/app/equipment/{equipment.id}"} in entity_links
+
+
+@pytest.mark.django_db
+def test_document_list_api_exposes_entity_links(client, household, user, doc, membership):
+    """La liste dit *où vit* un document, pas seulement son nom de fichier.
+
+    Sans ce champ dès la liste, la page Documents ne peut afficher que des noms de
+    fichiers ; il faut ouvrir chaque document pour savoir à quoi il se rattache.
+    """
+    equipment = Equipment.objects.create(household=household, name="Chaudière", created_by=user)
+    services.link_document(entity=equipment, document=doc, user=user)
+    client.force_login(user)
+
+    response = client.get("/api/documents/documents/")
+    assert response.status_code == 200, response.content
+    payload = response.json()
+    items = payload if isinstance(payload, list) else payload["results"]
+    assert {"entity_type": "equipment", "id": str(equipment.id),
+            "label": "Chaudière", "url_path": f"/app/equipment/{equipment.id}"} in items[0]["entity_links"]
+
+
+@pytest.mark.django_db
+def test_entity_links_cost_a_bounded_number_of_queries(
+    client, household, user, membership, django_assert_max_num_queries
+):
+    """La liste n'est pas paginée : le coût ne peut pas suivre le nombre de documents.
+
+    `entity_links_for_document` résout une `GenericForeignKey` par lien. Sans le
+    prefetch de la vue (`prefetched_links` + `entity`), vingt documents rattachés
+    coûteraient vingt requêtes de plus — et deux cents pour un vrai foyer.
+    """
+    equipment = Equipment.objects.create(household=household, name="Chaudière", created_by=user)
+    for index in range(20):
+        document = Document.objects.create(
+            household=household, created_by=user, file_path=f"documents/f{index}.pdf",
+            name=f"Facture {index}", mime_type="application/pdf", type="invoice",
+        )
+        services.link_document(entity=equipment, document=document, user=user)
+    client.force_login(user)
+
+    with django_assert_max_num_queries(15):
+        response = client.get("/api/documents/documents/")
+        assert response.status_code == 200

--- a/ui/src/features/documents/DocumentCard.tsx
+++ b/ui/src/features/documents/DocumentCard.tsx
@@ -1,20 +1,71 @@
+import * as React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { FileText, FileX, Pencil, Trash2, ExternalLink, ScanText } from 'lucide-react';
+import {
+  CheckSquare,
+  Egg,
+  ExternalLink,
+  FileText,
+  FileX,
+  FolderKanban,
+  Link2,
+  MapPin,
+  Pencil,
+  ScanText,
+  Trash2,
+  Wrench,
+  type LucideIcon,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Badge } from '@/design-system/badge';
 import { CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
 import { pushBack } from '@/lib/backNavigation';
 import { formatFileSize, type DocumentItem } from '@/lib/api/documents';
+import { isWithoutContext } from './grouping';
+
+/**
+ * Icône par type d'entité rattachée. Volontairement **sans libellé de type** : la
+ * ligne se lit « 🔧 Chaudière · 📍 Cave », et l'entité peut être de n'importe quel
+ * type enregistré dans `agent.searchables` — une clé i18n construite
+ * (`documents.linked_to.types.<type>`) afficherait la clé brute le jour où un
+ * nouveau type devient rattachable. Le mot du type reste sur la page détail, où le
+ * catalogue est complet.
+ */
+const ENTITY_ICONS: Record<string, LucideIcon> = {
+  zone: MapPin,
+  project: FolderKanban,
+  equipment: Wrench,
+  task: CheckSquare,
+  chicken: Egg,
+};
 
 interface DocumentCardProps {
   doc: DocumentItem;
   onEdit: (doc: DocumentItem) => void;
   onDelete: (id: string) => void;
   deleteLabel?: string;
+  /**
+   * Affiche à quoi le document est rattaché. Faux par défaut : dans l'onglet
+   * Documents d'une entité, rappeler l'entité qu'on est en train de regarder est du
+   * bruit.
+   */
+  showEntityLinks?: boolean;
+  /**
+   * Masque la pastille de type. À poser quand le contexte le dit déjà — sous un
+   * en-tête de section « Factures », ou quand le filtre de type est actif : répété
+   * sur chaque ligne, le mot cesse d'informer et vole la place du nom du fichier.
+   */
+  hideType?: boolean;
 }
 
-export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: DocumentCardProps) {
+export default function DocumentCard({
+  doc,
+  onEdit,
+  onDelete,
+  deleteLabel,
+  showEntityLinks = false,
+  hideType = false,
+}: DocumentCardProps) {
   const { t } = useTranslation();
   const location = useLocation();
 
@@ -23,6 +74,13 @@ export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: Doc
     typeof doc.metadata?.size === 'number' ? formatFileSize(doc.metadata.size) : null;
   const createdDate = new Date(doc.created_at).toLocaleDateString();
   const hasOcrText = Boolean(doc.ocr_text && doc.ocr_text.trim());
+
+  // Les activités liées ont déjà leur ligne juste en dessous : les répéter ici
+  // ferait dire deux fois la même chose à la même carte.
+  const backlinks = React.useMemo(
+    () => (doc.entity_links ?? []).filter((link) => link.entity_type !== 'interaction'),
+    [doc.entity_links],
+  );
 
   const actions: CardAction[] = [
     { label: t('common.edit'), icon: Pencil, onClick: () => onEdit(doc) },
@@ -51,7 +109,7 @@ export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: Doc
             <CardTitle className="text-inherit [&>span:last-child]:group-hover:underline">{fileName}</CardTitle>
           </Link>
 
-          {doc.type && doc.type !== 'photo' && (
+          {!hideType && doc.type && doc.type !== 'photo' && (
             <Badge variant="secondary" className="text-xs">
               {t(`documents.type.${doc.type}`)}
             </Badge>
@@ -76,6 +134,25 @@ export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: Doc
           <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{doc.notes}</p>
         )}
 
+        {showEntityLinks && backlinks.length > 0 && (
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs">
+            {backlinks.map((link) => {
+              const Icon = ENTITY_ICONS[link.entity_type] ?? Link2;
+              return (
+                <Link
+                  key={`${link.entity_type}:${link.id}`}
+                  to={link.url_path}
+                  state={pushBack(location)}
+                  className="inline-flex max-w-full items-center gap-1 text-muted-foreground hover:text-primary hover:underline"
+                >
+                  <Icon className="h-3 w-3 flex-shrink-0" aria-hidden="true" />
+                  <span className="truncate">{link.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+        )}
+
         <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
           <span>{createdDate}</span>
 
@@ -86,7 +163,11 @@ export default function DocumentCard({ doc, onEdit, onDelete, deleteLabel }: Doc
             </span>
           )}
 
-          {doc.qualification.qualification_state === 'without_activity' && !doc.qualification.has_secondary_context && (
+          {/* Même prédicat que la pastille « Sans contexte » de la liste — voir
+              `grouping.isWithoutContext` : deux expressions du même état finissent
+              par se contredire, et un badge qui démentait le compteur ferait perdre
+              son crédit aux deux. */}
+          {isWithoutContext(doc) && (
             <span className="inline-flex rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-300">
               {t('documents.qualification.withoutActivity')}
             </span>

--- a/ui/src/features/documents/DocumentsPage.tsx
+++ b/ui/src/features/documents/DocumentsPage.tsx
@@ -1,39 +1,81 @@
 import * as React from 'react';
-import { FileText } from 'lucide-react';
+import { FileText, FileWarning, SearchX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import ListPage from '@/components/ListPage';
-import { FilterBar } from '@/design-system/filter-bar';
+import EmptyState from '@/components/EmptyState';
+import LoadError from '@/components/LoadError';
+import { Button } from '@/design-system/button';
+import { FilterPill } from '@/design-system/filter-pill';
+import { Input } from '@/design-system/input';
+import { Label } from '@/design-system/label';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useDebouncedValue } from '@/lib/useDebouncedValue';
+import { useSessionState } from '@/lib/useSessionState';
+import { formatMonthYear } from '@/lib/format';
 import { DOCUMENT_TYPES, type DocumentItem } from '@/lib/api/documents';
 import { useDocuments, useDeleteDocument, documentKeys } from './hooks';
+import { countByType, groupDocuments, isWithoutContext, type GroupMode } from './grouping';
 import DocumentCard from './DocumentCard';
 import DocumentUploadDialog from './DocumentUploadDialog';
 import DocumentEditDialog from './DocumentEditDialog';
+
+const GROUP_MODES: GroupMode[] = ['type', 'date'];
 
 export default function DocumentsPage() {
   const { t } = useTranslation();
   const qc = useQueryClient();
 
   const [search, setSearch] = React.useState('');
-  const [type, setType] = React.useState('');
+  const [type, setType] = useSessionState<string>('documents.type', '');
+  const [withoutContext, setWithoutContext] = useSessionState<boolean>(
+    'documents.withoutContext',
+    false,
+  );
+  const [groupMode, setGroupMode] = useSessionState<GroupMode>('documents.groupBy', 'type');
   const [uploadOpen, setUploadOpen] = React.useState(false);
   const [editingDoc, setEditingDoc] = React.useState<DocumentItem | null>(null);
 
+  // Une frappe ne vaut pas une requête : la recherche partait à chaque caractère.
+  const debouncedSearch = useDebouncedValue(search.trim(), 300);
+
+  /**
+   * Seule la recherche est un filtre serveur — elle doit l'être, car elle porte sur
+   * le texte OCR que le client n'a pas. Type et « sans contexte » se filtrent ici :
+   * c'est ce qui permet aux pastilles de porter des **compteurs**, et un compteur
+   * calculé sur une liste que le serveur a déjà réduite dirait le contraire de ce
+   * que le clic produit. La liste n'est pas paginée (comme la galerie), donc le
+   * client a bien tout sous la main.
+   */
   const filters = React.useMemo(
-    () => ({
-      ...(search ? { search } : {}),
-      ...(type ? { type } : {}),
-    }),
-    [search, type],
+    () => (debouncedSearch ? { search: debouncedSearch } : {}),
+    [debouncedSearch],
   );
 
   const { data: documents = [], isLoading, error } = useDocuments(filters);
   const deleteDocumentMutation = useDeleteDocument();
 
+  const counts = React.useMemo(() => countByType(documents), [documents]);
+  const withoutContextCount = React.useMemo(
+    () => documents.filter(isWithoutContext).length,
+    [documents],
+  );
+
+  const visible = React.useMemo(
+    () =>
+      documents.filter(
+        (doc) =>
+          (!type || (doc.type || 'document') === type) &&
+          (!withoutContext || isWithoutContext(doc)),
+      ),
+    [documents, type, withoutContext],
+  );
+
+  const groups = React.useMemo(() => groupDocuments(visible, groupMode), [visible, groupMode]);
+
   const handleSaved = React.useCallback(() => {
-    qc.invalidateQueries({ queryKey: documentKeys.all });
+    void qc.invalidateQueries({ queryKey: documentKeys.all });
   }, [qc]);
 
   const { deleteWithUndo } = useDeleteWithUndo({
@@ -47,41 +89,56 @@ export default function DocumentsPage() {
       if (!doc) return;
       deleteWithUndo(docId, {
         onRemove: () =>
-          qc.setQueryData<DocumentItem[]>(
-            documentKeys.list(filters),
-            (old) => old?.filter((d) => d.id !== docId),
+          qc.setQueryData<DocumentItem[]>(documentKeys.list(filters), (old) =>
+            old?.filter((d) => d.id !== docId),
           ),
         onRestore: () =>
-          qc.setQueryData<DocumentItem[]>(
-            documentKeys.list(filters),
-            (old) => (old ? [...old, doc] : [doc]),
+          qc.setQueryData<DocumentItem[]>(documentKeys.list(filters), (old) =>
+            old ? [...old, doc] : [doc],
           ),
       });
     },
     [documents, deleteWithUndo, qc, filters],
   );
 
-  function resetFilters() {
+  const hasFilters = debouncedSearch !== '' || type !== '' || withoutContext;
+
+  const resetFilters = React.useCallback(() => {
     setSearch('');
     setType('');
-  }
+    setWithoutContext(false);
+  }, [setType, setWithoutContext]);
 
-  const typeOptions = [
-    { value: '', label: t('documents.filter.allTypes') },
-    ...DOCUMENT_TYPES.map((v) => ({
-      value: v,
-      label: t(`documents.type.${v}`),
-    })),
-  ];
+  /**
+   * « Les factures » et « celles sans contexte » se cumulent volontiers, mais choisir
+   * un type quand on cherchait à qualifier fait sortir de la file de travail sans le
+   * dire. On garde donc les deux indépendants — c'est un cumul, pas une exclusion —
+   * et le compteur de chaque pastille reste lu sur la liste complète, pour que
+   * revenir en arrière soit toujours possible.
+   */
+  const toggleType = React.useCallback(
+    (next: string) => setType((current) => (current === next ? '' : next)),
+    [setType],
+  );
 
-  const isEmpty = !isLoading && !error && documents.length === 0;
+  // `ListPage` masque ses enfants quand la liste est vide — donc la barre de filtres
+  // avec. On ne lui déclare « vide » que la liste réellement vide : sinon une
+  // recherche sans résultat effaçait le champ qui l'a produite, et il devenait
+  // impossible de revenir en arrière.
+  const isTrulyEmpty = !isLoading && !error && documents.length === 0 && !hasFilters;
+  const isNoResults = !isLoading && !error && visible.length === 0 && hasFilters;
   const showSkeleton = useDelayedLoading(isLoading);
 
   return (
     <>
       <ListPage
         title={t('documents.title')}
-        isEmpty={isEmpty}
+        description={
+          !isLoading && !error && documents.length > 0
+            ? t('documents.count.all', { count: documents.length })
+            : undefined
+        }
+        isEmpty={isTrulyEmpty}
         emptyState={{
           icon: FileText,
           title: t('documents.empty'),
@@ -89,74 +146,128 @@ export default function DocumentsPage() {
           action: { label: t('documents.upload.title'), onClick: () => setUploadOpen(true) },
         }}
         actions={
-          <button
-            type="button"
-            onClick={() => setUploadOpen(true)}
-            className="inline-flex h-9 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground"
-          >
+          <Button type="button" onClick={() => setUploadOpen(true)}>
             {t('documents.upload.title')}
-          </button>
+          </Button>
         }
       >
         <div className="space-y-4">
-          <FilterBar
-            fields={[
-              {
-                type: 'search',
-                id: 'documents-search',
-                label: t('documents.search'),
-                value: search,
-                onChange: setSearch,
-                placeholder: t('documents.search_placeholder'),
-              },
-              {
-                type: 'select',
-                id: 'documents-type',
-                label: t('documents.fieldType'),
-                value: type,
-                onChange: setType,
-                options: typeOptions,
-              },
-            ]}
-            onReset={resetFilters}
-            hasActiveFilters={!!(search || type)}
-            resetLabel={t('equipment.reset')}
-            applyLabel={t('equipment.apply')}
-          />
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div className="flex-1 space-y-1 sm:max-w-xs">
+              <Label htmlFor="documents-search">{t('documents.search')}</Label>
+              <Input
+                id="documents-search"
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder={t('documents.search_placeholder')}
+              />
+            </div>
+            {hasFilters ? (
+              <Button type="button" variant="outline" onClick={resetFilters}>
+                {t('documents.filter.reset')}
+              </Button>
+            ) : null}
+          </div>
+
+          {/* Le paysage d'un coup d'œil : ce qui existe, et en quelle quantité. Les
+              compteurs suivent la recherche courante — et quand elle ne ramène rien,
+              une rangée réduite à « Tous les types 0 » ne pilote plus rien. */}
+          {documents.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              <FilterPill active={type === ''} onClick={() => setType('')}>
+                {t('documents.filter.allTypes')}
+                <span className="tabular-nums opacity-70">{counts[''] ?? 0}</span>
+              </FilterPill>
+              {DOCUMENT_TYPES.filter((v) => (counts[v] ?? 0) > 0).map((v) => (
+                <FilterPill key={v} active={type === v} onClick={() => toggleType(v)}>
+                  {t(`documents.type.${v}`)}
+                  <span className="tabular-nums opacity-70">{counts[v]}</span>
+                </FilterPill>
+              ))}
+              {withoutContextCount > 0 ? (
+                <FilterPill
+                  active={withoutContext}
+                  onClick={() => setWithoutContext((current) => !current)}
+                >
+                  <FileWarning className="h-3 w-3" aria-hidden="true" />
+                  {t('documents.qualification.withoutActivity')}
+                  <span className="tabular-nums opacity-70">{withoutContextCount}</span>
+                </FilterPill>
+              ) : null}
+            </div>
+          ) : null}
 
           {error ? (
-            <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-              {t('documents.loadFailed')}
-              <button
-                type="button"
-                onClick={() => qc.invalidateQueries({ queryKey: documentKeys.all })}
-                className="ml-2 underline hover:no-underline"
-              >
-                {t('common.retry')}
-              </button>
-            </div>
-          ) : null}
-
-          {showSkeleton ? (
+            <LoadError
+              message={t('documents.loadFailed')}
+              onRetry={() => void qc.invalidateQueries({ queryKey: documentKeys.all })}
+              retryLabel={t('common.retry')}
+            />
+          ) : showSkeleton ? (
             <div className="space-y-2">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-14 animate-pulse rounded-lg bg-slate-100" />
+                <div key={i} className="h-14 animate-pulse rounded-lg bg-muted" />
               ))}
             </div>
-          ) : null}
+          ) : isNoResults ? (
+            <EmptyState
+              icon={SearchX}
+              title={t('common.noResults')}
+              description={t('documents.noResults_description')}
+              action={{ label: t('documents.filter.reset'), onClick: resetFilters }}
+            />
+          ) : (
+            <>
+              {/* Un seul groupe ne se « groupe » pas : la bascule n'aurait rien à
+                  changer, et un en-tête au-dessus de l'unique section serait du bruit. */}
+              {groups.length > 1 ? (
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-xs text-muted-foreground">
+                    {t('documents.filter.groupBy')}
+                  </span>
+                  {GROUP_MODES.map((mode) => (
+                    <FilterPill
+                      key={mode}
+                      active={groupMode === mode}
+                      onClick={() => setGroupMode(mode)}
+                    >
+                      {t(`documents.filter.groupBy_${mode}`)}
+                    </FilterPill>
+                  ))}
+                </div>
+              ) : null}
 
-          {!isLoading && !error ? (
-            <ul className="space-y-2">
-              {documents.map((doc) => (
-                <DocumentCard
-                  key={doc.id}
-                  doc={doc}
-                  onEdit={setEditingDoc}
-                  onDelete={handleDelete}
-                />
-              ))}
-            </ul>
-          ) : null}
+              <div className="space-y-6">
+                {groups.map((group) => (
+                  <section key={group.key} className="space-y-2">
+                    {groups.length > 1 ? (
+                      <h2 className="text-sm font-medium capitalize text-muted-foreground">
+                        {group.type
+                          ? t(`documents.type.${group.type}`)
+                          : formatMonthYear(group.anchor)}{' '}
+                        <span className="tabular-nums">({group.documents.length})</span>
+                      </h2>
+                    ) : null}
+                    <ul className="space-y-2">
+                      {group.documents.map((doc) => (
+                        <DocumentCard
+                          key={doc.id}
+                          doc={doc}
+                          onEdit={setEditingDoc}
+                          onDelete={handleDelete}
+                          showEntityLinks
+                          // L'en-tête de section ou la pastille active dit déjà le
+                          // type ; le répéter sur chaque ligne vole la place du nom.
+                          hideType={groupMode === 'type' || type !== ''}
+                        />
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+              </div>
+            </>
+          )}
         </div>
       </ListPage>
 

--- a/ui/src/features/documents/grouping.test.ts
+++ b/ui/src/features/documents/grouping.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import { groupDocuments, countByType, isWithoutContext } from './grouping';
+import type { DocumentItem } from '@/lib/api/documents';
+
+function doc(
+  id: string,
+  type: string,
+  createdAt = '2026-07-10T10:00:00Z',
+  qualification?: Partial<DocumentItem['qualification']>,
+): DocumentItem {
+  return {
+    id,
+    name: id,
+    type,
+    created_at: createdAt,
+    qualification: {
+      has_activity_context: false,
+      qualification_state: 'without_activity',
+      linked_interactions_count: 0,
+      has_secondary_context: false,
+      ...qualification,
+    },
+  } as DocumentItem;
+}
+
+/**
+ * Ce que ces tests tiennent :
+ *
+ * L'ordre des sections en mode « type » vient du **catalogue**, pas du volume. Un
+ * ordre qui suit les compteurs se réorganise à chaque import : la section qu'on
+ * vise n'est jamais deux fois à la même place, et c'est justement la mémoire de la
+ * position qui rend une longue liste navigable.
+ */
+describe('groupDocuments — mode type', () => {
+  it('ordonne les sections selon le catalogue, pas selon le volume', () => {
+    // « other » est dernier au catalogue mais majoritaire ici ; « invoice » vient
+    // avant « manual », qui vient avant « other ».
+    const groups = groupDocuments(
+      [
+        doc('a', 'other'),
+        doc('b', 'other'),
+        doc('c', 'other'),
+        doc('d', 'manual'),
+        doc('e', 'invoice'),
+      ],
+      'type',
+    );
+
+    expect(groups.map((g) => g.key)).toEqual(['invoice', 'manual', 'other']);
+  });
+
+  it('préserve l’ordre reçu du serveur à l’intérieur d’une section', () => {
+    const groups = groupDocuments(
+      [
+        doc('recent', 'invoice', '2026-07-20T10:00:00Z'),
+        doc('ancien', 'invoice', '2026-01-05T10:00:00Z'),
+      ],
+      'type',
+    );
+
+    expect(groups[0].documents.map((d) => d.id)).toEqual(['recent', 'ancien']);
+  });
+
+  it('ne perd pas un type hors catalogue — il ferme la marche', () => {
+    const groups = groupDocuments([doc('legacy', 'contrat'), doc('f', 'invoice')], 'type');
+
+    expect(groups.map((g) => g.key)).toEqual(['invoice', 'contrat']);
+    expect(groups[1].documents).toHaveLength(1);
+  });
+
+  it('expose le type à traduire et jamais d’ancre de date', () => {
+    const [group] = groupDocuments([doc('a', 'invoice')], 'type');
+
+    expect(group.type).toBe('invoice');
+    expect(group.anchor).toBeNull();
+  });
+
+  it('range un type vide sous « document », le défaut du backend', () => {
+    const groups = groupDocuments([doc('a', '')], 'type');
+
+    expect(groups.map((g) => g.key)).toEqual(['document']);
+  });
+});
+
+/**
+ * Ce que ces tests tiennent :
+ *
+ * Le regroupement par mois se fait **dans le fuseau de l'utilisateur**. La suite
+ * tourne en `TZ=Europe/Paris`, donc un document ajouté le 1er juillet à 00 h 30
+ * locale est daté du 30 juin en UTC. Grouper sur `toISOString().slice(0, 7)` le
+ * rangerait sous « juin » — même faute que celle que `toLocalISODate` corrige pour
+ * les bornes de période.
+ */
+describe('groupDocuments — mode date', () => {
+  it('range un document du tout début de mois dans SON mois local', () => {
+    // 00 h 30 à Paris le 1er juillet = 22 h 30 UTC le 30 juin.
+    const groups = groupDocuments([doc('a', 'invoice', '2026-06-30T22:30:00Z')], 'date');
+
+    expect(groups.map((g) => g.key)).toEqual(['2026-07']);
+  });
+
+  it('sépare les mois en préservant l’ordre reçu, tous types mêlés', () => {
+    const groups = groupDocuments(
+      [
+        doc('juillet-facture', 'invoice', '2026-07-20T10:00:00Z'),
+        doc('juillet-manuel', 'manual', '2026-07-02T10:00:00Z'),
+        doc('juin', 'plan', '2026-06-15T10:00:00Z'),
+      ],
+      'date',
+    );
+
+    expect(groups.map((g) => g.key)).toEqual(['2026-07', '2026-06']);
+    expect(groups[0].documents.map((d) => d.id)).toEqual(['juillet-facture', 'juillet-manuel']);
+  });
+
+  it('regroupe le même mois de deux années différentes séparément', () => {
+    const groups = groupDocuments(
+      [doc('2026', 'invoice', '2026-07-10T10:00:00Z'), doc('2025', 'invoice', '2025-07-10T10:00:00Z')],
+      'date',
+    );
+
+    expect(groups.map((g) => g.key)).toEqual(['2026-07', '2025-07']);
+  });
+
+  it('expose l’ancre à formater et jamais de type', () => {
+    const [group] = groupDocuments([doc('a', 'invoice', '2026-07-10T10:00:00Z')], 'date');
+
+    expect(group.anchor).toBe('2026-07-10T10:00:00Z');
+    expect(group.type).toBeNull();
+  });
+
+  it('ne perd pas un document à date invalide', () => {
+    const groups = groupDocuments([doc('cassé', 'invoice', 'pas-une-date')], 'date');
+
+    expect(groups.map((g) => g.key)).toEqual(['unknown']);
+    expect(groups[0].documents).toHaveLength(1);
+  });
+
+  it('renvoie une liste vide sans document', () => {
+    expect(groupDocuments([], 'date')).toEqual([]);
+    expect(groupDocuments([], 'type')).toEqual([]);
+  });
+});
+
+/**
+ * Ce que ces tests tiennent :
+ *
+ * Les compteurs des pastilles se lisent sur la liste **déjà filtrée par la
+ * recherche**. Un compteur qui annoncerait 18 factures alors que la recherche
+ * courante n'en montre que deux dirait le contraire de ce que le clic produit.
+ */
+describe('countByType', () => {
+  it('compte par type et expose le total sous la clé vide', () => {
+    const counts = countByType([doc('a', 'invoice'), doc('b', 'invoice'), doc('c', 'manual')]);
+
+    expect(counts).toEqual({ '': 3, invoice: 2, manual: 1 });
+  });
+
+  it('n’invente pas de zéro pour un type absent', () => {
+    const counts = countByType([doc('a', 'invoice')]);
+
+    expect(counts.manual).toBeUndefined();
+  });
+
+  it('donne un total nul sur une liste vide', () => {
+    expect(countByType([])).toEqual({ '': 0 });
+  });
+});
+
+/**
+ * Ce que ce test tient :
+ *
+ * Une seule définition de « sans contexte », partagée par la pastille de filtre et
+ * le badge de la carte. « 12 sans contexte » face à onze badges à l'écran fait
+ * perdre son crédit aux deux compteurs.
+ */
+describe('isWithoutContext', () => {
+  it('est vrai sans activité ni contexte secondaire', () => {
+    expect(isWithoutContext(doc('a', 'invoice'))).toBe(true);
+  });
+
+  it('est faux dès qu’une activité est liée', () => {
+    const linked = doc('a', 'invoice', '2026-07-10T10:00:00Z', {
+      qualification_state: 'activity_linked',
+      has_activity_context: true,
+      linked_interactions_count: 1,
+    });
+    expect(isWithoutContext(linked)).toBe(false);
+  });
+
+  it('est faux si une zone ou un projet donne déjà un contexte', () => {
+    const zoned = doc('a', 'invoice', '2026-07-10T10:00:00Z', { has_secondary_context: true });
+    expect(isWithoutContext(zoned)).toBe(false);
+  });
+});

--- a/ui/src/features/documents/grouping.ts
+++ b/ui/src/features/documents/grouping.ts
@@ -1,0 +1,111 @@
+import { DOCUMENT_TYPES, type DocumentItem } from '@/lib/api/documents';
+
+/** Axe de regroupement de la liste des documents. */
+export type GroupMode = 'type' | 'date';
+
+export interface DocumentGroup {
+  /** Clé stable — un type de document, ou `YYYY-MM` en mode date. */
+  key: string;
+  /**
+   * De quoi étiqueter l'en-tête : un type à traduire (`documents.type.<key>`), ou
+   * une date du mois à passer au formateur. L'un des deux est toujours nul — c'est
+   * le mode qui décide, et l'appelant n'a pas à le redeviner.
+   */
+  type: string | null;
+  anchor: string | null;
+  documents: DocumentItem[];
+}
+
+/**
+ * `true` si le document n'est rattaché à aucune activité **ni** à un contexte
+ * secondaire (zone, projet).
+ *
+ * Une seule définition, partagée par la pastille de filtre de la liste et le badge
+ * de la carte (`DocumentCard`). Les deux disaient la même chose avec deux
+ * expressions différentes, et « 12 sans contexte » face à onze badges sur l'écran
+ * fait perdre son crédit aux deux compteurs.
+ */
+export function isWithoutContext(doc: DocumentItem): boolean {
+  return (
+    doc.qualification.qualification_state === 'without_activity' &&
+    !doc.qualification.has_secondary_context
+  );
+}
+
+/**
+ * Nombre de documents par type, plus `''` pour le total.
+ *
+ * Compté sur la liste **déjà filtrée par la recherche** : un compteur qui
+ * annoncerait 18 factures alors que la recherche courante n'en montre que 2 dirait
+ * juste le contraire de ce que le clic va produire.
+ */
+export function countByType(documents: DocumentItem[]): Record<string, number> {
+  const counts: Record<string, number> = { '': documents.length };
+  for (const doc of documents) {
+    const key = doc.type || 'document';
+    counts[key] = (counts[key] ?? 0) + 1;
+  }
+  return counts;
+}
+
+/**
+ * Ordre des sections en mode « type » : celui du catalogue `DOCUMENT_TYPES`, et non
+ * le volume décroissant.
+ *
+ * Un ordre qui suit les compteurs se réorganise sous les yeux à chaque import : la
+ * section qu'on vise n'est jamais deux fois à la même place, et la mémoire de la
+ * position — la seule chose qui rend une longue liste navigable — ne se construit
+ * pas. Les types hors catalogue (donnée ancienne, valeur retirée depuis) ferment la
+ * marche plutôt que de disparaître.
+ */
+function typeRank(type: string): number {
+  const index = (DOCUMENT_TYPES as readonly string[]).indexOf(type);
+  return index === -1 ? DOCUMENT_TYPES.length : index;
+}
+
+/**
+ * Regroupe les documents selon `mode`, en préservant l'ordre reçu à l'intérieur de
+ * chaque groupe (l'API renvoie `-created_at`, donc du plus récent au plus ancien).
+ *
+ * En mode date, la clé est bâtie sur `getFullYear()` / `getMonth()` et **jamais** sur
+ * `toISOString().slice(0, 7)` : à Paris, un document ajouté le 1er juillet à 00 h 30
+ * est en juin en UTC — il atterrirait sous le mauvais en-tête, et la coupure entre
+ * deux mois se ferait au mauvais endroit (même raison que `toLocalISODate`).
+ */
+export function groupDocuments(documents: DocumentItem[], mode: GroupMode): DocumentGroup[] {
+  const groups: DocumentGroup[] = [];
+  const index = new Map<string, DocumentGroup>();
+
+  for (const doc of documents) {
+    let key: string;
+    if (mode === 'type') {
+      key = doc.type || 'document';
+    } else {
+      const date = new Date(doc.created_at);
+      key = Number.isNaN(date.getTime())
+        ? 'unknown'
+        : `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+    }
+
+    let group = index.get(key);
+    if (!group) {
+      group = {
+        key,
+        type: mode === 'type' ? key : null,
+        anchor: mode === 'date' ? doc.created_at : null,
+        documents: [],
+      };
+      index.set(key, group);
+      groups.push(group);
+    }
+    group.documents.push(doc);
+  }
+
+  // En mode date l'ordre reçu est déjà le bon (l'API trie par `-created_at`) ; en
+  // mode type il n'a aucune raison de l'être, c'est le catalogue qui l'ordonne.
+  if (mode === 'type') {
+    groups.sort((a, b) => typeRank(a.key) - typeRank(b.key));
+  }
+
+  return groups;
+}

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -71,11 +71,17 @@ export interface DocumentItem {
    * information (aucune zone), et le backend l'envoie toujours.
    */
   zone_links: ZoneLinkSummary[];
+  /**
+   * Tout ce à quoi le document est rattaché (projet, équipement, zone, tâche…) —
+   * servi **dès la liste**, comme `zone_links`. C'est ce qui permet à la page
+   * Documents de dire *où vit* un fichier : une liste de deux cents noms de
+   * fichiers ne se lit pas. Tableau vide = rattaché à rien, une information.
+   */
+  entity_links: EntityLinkSummary[];
 }
 
 export interface DocumentDetail extends DocumentItem {
   project_links: ProjectLinkSummary[];
-  entity_links: EntityLinkSummary[];
   recent_interaction_candidates: LinkedInteractionSummary[];
 }
 

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1545,7 +1545,7 @@
           },
           "find": {
             "title": "Ein Dokument wiederfinden",
-            "body": "Suche und Filter nach Typ; auch der KI-Assistent findet sie."
+            "body": "Mit einem Klick nach Typ filtern, nach Typ oder Datum gruppieren, im Dateitext suchen — der KI-Assistent findet sie ebenfalls."
           }
         }
       },
@@ -1918,7 +1918,11 @@
     "filter": {
       "unlinked": "Nur ohne Aktivität anzeigen",
       "unlinkedActive": "Zeige ohne Aktivität",
-      "allTypes": "Alle Typen"
+      "allTypes": "Alle Typen",
+      "reset": "Zurücksetzen",
+      "groupBy": "Gruppieren nach:",
+      "groupBy_type": "Typ",
+      "groupBy_date": "Datum"
     },
     "upload": {
       "title": "Dokument hochladen",
@@ -2026,7 +2030,8 @@
         "task": "Aufgabe",
         "interaction": "Aktivität"
       }
-    }
+    },
+    "noResults_description": "Kein Dokument entspricht Ihrer Suche."
   },
   "equipment": {
     "app_title": "Geräte-Mini-App",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1545,7 +1545,7 @@
           },
           "find": {
             "title": "Find a document again",
-            "body": "Search and filter by type; the AI assistant can find them too."
+            "body": "Filter by type in one click, group by type or date, search inside file text — the AI assistant can find them too."
           }
         }
       },
@@ -1918,7 +1918,11 @@
     "filter": {
       "unlinked": "Show without activity only",
       "unlinkedActive": "Showing without activity",
-      "allTypes": "All types"
+      "allTypes": "All types",
+      "reset": "Reset",
+      "groupBy": "Group by:",
+      "groupBy_type": "Type",
+      "groupBy_date": "Date"
     },
     "upload": {
       "title": "Upload document",
@@ -2026,7 +2030,8 @@
         "task": "Task",
         "interaction": "Activity"
       }
-    }
+    },
+    "noResults_description": "No document matches your search."
   },
   "equipment": {
     "app_title": "Equipment mini-app",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1545,7 +1545,7 @@
           },
           "find": {
             "title": "Reencontrar un documento",
-            "body": "Búsqueda y filtros por tipo; el asistente de IA también sabe encontrarlos."
+            "body": "Filtra por tipo con un clic, agrupa por tipo o fecha, busca en el texto de los archivos — el asistente de IA también sabe encontrarlos."
           }
         }
       },
@@ -1918,7 +1918,11 @@
     "filter": {
       "unlinked": "Mostrar solo sin actividad",
       "unlinkedActive": "Mostrando sin actividad",
-      "allTypes": "Todos los tipos"
+      "allTypes": "Todos los tipos",
+      "reset": "Restablecer",
+      "groupBy": "Agrupar por:",
+      "groupBy_type": "Tipo",
+      "groupBy_date": "Fecha"
     },
     "upload": {
       "title": "Subir documento",
@@ -2026,7 +2030,8 @@
         "task": "Tarea",
         "interaction": "Actividad"
       }
-    }
+    },
+    "noResults_description": "Ningún documento coincide con tu búsqueda."
   },
   "equipment": {
     "app_title": "Mini-app Equipos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1545,7 +1545,7 @@
           },
           "find": {
             "title": "Retrouver un document",
-            "body": "Recherche et filtres par type ; l'assistant IA sait aussi les retrouver."
+            "body": "Filtrez par type d'un clic, groupez par type ou par date, cherchez dans le texte des fichiers — l'assistant IA sait aussi les retrouver."
           }
         }
       },
@@ -1918,7 +1918,11 @@
     "filter": {
       "unlinked": "Afficher seulement sans activité",
       "unlinkedActive": "Affichage sans activité",
-      "allTypes": "Tous les types"
+      "allTypes": "Tous les types",
+      "reset": "Réinitialiser",
+      "groupBy": "Grouper par :",
+      "groupBy_type": "Type",
+      "groupBy_date": "Date"
     },
     "upload": {
       "title": "Téléverser un document",
@@ -2026,7 +2030,8 @@
         "task": "Tâche",
         "interaction": "Activité"
       }
-    }
+    },
+    "noResults_description": "Aucun document ne correspond à votre recherche."
   },
   "equipment": {
     "app_title": "Mini-app Équipements",


### PR DESCRIPTION
## Le problème

> « j'ai une immense liste je ne sais pas m'y retrouver »

La page `/app/documents` ne proposait qu'une **liste plate** de tous les documents
du foyer, du plus récent au plus ancien, avec le type caché dans un `<select>`.
Passé quelques dizaines de fichiers, elle ne se lisait plus : rien ne disait ce
qu'on avait, ni où vivait un fichier. L'affichage dans les autres modules
(`EntityDocumentsTab`) restait bon, et n'est pas touché.

## Ce que ça change

Trois ajouts, tous alignés sur la galerie photos — même modèle `Document`,
mêmes repères :

- **Pastilles de type avec compteurs** — le paysage d'un coup d'œil, plus une
  pastille « Sans contexte » pour la file de qualification.
- **Regroupement en sections**, par type (défaut) ou par date, mémorisé en
  session. La bascule disparaît quand il n'y a qu'un groupe.
- **`entity_links` dès la liste** — chaque carte dit à quoi le document est
  rattaché : « 🔧 Chaudière · 📍 Cave » plutôt qu'un nom de fichier seul.

## Points structurants

- **Seule la recherche est un filtre serveur** : elle porte sur le texte OCR, que
  le client n'a pas. Type et « sans contexte » se filtrent côté client, et c'est
  ce qui permet aux pastilles de porter des compteurs — un compteur lu sur une
  liste que le serveur a déjà réduite dirait le contraire de ce que le clic
  produit. La liste n'est pas paginée, le client a bien tout sous la main.
- **L'ordre des sections vient du catalogue, jamais du volume.** Un ordre qui
  suit les compteurs se réorganise à chaque import : la section qu'on vise n'est
  jamais deux fois à la même place, et c'est cette mémoire de la position qui
  rend une longue liste navigable.
- **« Sans contexte » a une seule définition** (`grouping.isWithoutContext`),
  partagée par la pastille et le badge de la carte, qui l'exprimaient chacun à sa
  façon. Un badge qui démentirait le compteur ferait perdre son crédit aux deux.
- **Le coût de `entity_links` ne suit pas le nombre de documents.** Le champ monte
  du serializer de détail vers celui de liste ; la vue préchargeait déjà les liens
  **et** leur `GenericForeignKey`, donc rien de neuf en requêtes.

## Au passage

La page rejoint les règles du projet : tokens de couleur au lieu de
`bg-slate-100` / `red-*`, `LoadError` et `Button` partagés, recherche débouncée,
et un état « aucun résultat » **distinct** de « aucun document » — qui garde le
champ de recherche l'ayant produit, au lieu de l'effacer avec le reste.

Le pas de tutoriel `documents.find` est mis à jour dans les 4 locales (règle
CLAUDE.md).

## Tests

| Suite | Résultat |
|---|---|
| `pytest` (complet) | 3701 passed, 2 skipped |
| `vitest` (complet) | 125 passed (dont 17 nouveaux sur `grouping.ts`) |
| `npm run lint` | 0 erreur |
| `tsc -b` | aucune erreur nouvelle (5 pré-existantes sur `main`, identiques) |

Nouvelles régressions :
- `test_document_links.py::test_document_list_api_exposes_entity_links`
- `test_document_links.py::test_entity_links_cost_a_bounded_number_of_queries`
- `grouping.test.ts` — ordre par catalogue, coupure de mois en fuseau local,
  compteurs lus après recherche, définition unique de « sans contexte »

Vérifié dans un vrai navigateur (Playwright + 26 documents de démo rattachés à
des projets / équipements / zones) sur les quatre états : groupé par type, groupé
par date, pastille de type active, et recherche sans résultat.