### PR TITLE
fix(money): les trois champs de saisie des espèces repassent par DecimalInput

### DIFF
--- a/ui/src/features/banking/CashMirrorDialog.tsx
+++ b/ui/src/features/banking/CashMirrorDialog.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
-import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Button } from '@/design-system/button';
 import { formatAmount } from '@/lib/format';
 import { useAdjustCashMirror } from './hooks';
@@ -51,7 +51,7 @@ export default function CashMirrorDialog({
     event.preventDefault();
     setError(null);
 
-    const parsed = Number(amount.trim().replace(',', '.'));
+    const parsed = Number(amount.trim());
     if (!Number.isFinite(parsed) || parsed <= 0 || parsed > Number(outflow)) {
       setError(t('banking.withdraw.errors.amountInvalid', { max: formatAmount(outflow) }));
       return;
@@ -76,14 +76,10 @@ export default function CashMirrorDialog({
         </p>
 
         <FormField label={t('banking.withdraw.fields.amount')} htmlFor="cash-mirror-amount">
-          <Input
+          <DecimalInput
             id="cash-mirror-amount"
-            type="number"
-            step="0.01"
-            min="0"
-            max={outflow}
             value={amount}
-            onChange={(e) => setAmount(e.target.value)}
+            onChange={setAmount}
             autoFocus
           />
         </FormField>

--- a/ui/src/features/money/CashDepositDialog.tsx
+++ b/ui/src/features/money/CashDepositDialog.tsx
@@ -4,6 +4,7 @@ import { Landmark, Plus, Trash2 } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { FormField } from '@/design-system/form-field';
 import { Input } from '@/design-system/input';
+import { DecimalInput } from '@/design-system/decimal-input';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { formatAmount, todayISO } from '@/lib/format';
@@ -94,9 +95,9 @@ export default function CashDepositDialog({ open, onOpenChange }: CashDepositDia
     setAccountId((prev) => prev || cashAccounts[0]?.id || '');
   }, [open, cashAccounts]);
 
-  const total = Number(amount.replace(',', '.')) || 0;
+  const total = Number(amount) || 0;
   const credited = lines.reduce((sum, line) => {
-    const value = Number(line.amount.replace(',', '.'));
+    const value = Number(line.amount);
     return sum + (Number.isFinite(value) ? value : 0);
   }, 0);
   const remaining = total - credited;
@@ -129,7 +130,7 @@ export default function CashDepositDialog({ open, onOpenChange }: CashDepositDia
     const refundLines: { budget_id: string; amount: string }[] = [];
     if (isRefund) {
       for (const line of lines) {
-        const value = Number(line.amount.replace(',', '.'));
+        const value = Number(line.amount);
         if (!line.budgetId && !line.amount.trim()) continue;
         if (!line.budgetId) {
           setError(t('banking.inflow.errors.budgetRequired'));
@@ -224,13 +225,10 @@ export default function CashDepositDialog({ open, onOpenChange }: CashDepositDia
 
           <div className="grid gap-3 sm:grid-cols-2">
             <FormField label={`${t('banking.deposit.amount')} *`} htmlFor="deposit-amount">
-              <Input
+              <DecimalInput
                 id="deposit-amount"
-                type="number"
-                step="0.01"
-                min="0"
                 value={amount}
-                onChange={(e) => setAmount(e.target.value)}
+                onChange={setAmount}
                 placeholder="0.00"
                 required
               />
@@ -298,14 +296,11 @@ export default function CashDepositDialog({ open, onOpenChange }: CashDepositDia
                       ]}
                     />
                   </div>
-                  <Input
+                  <DecimalInput
                     className="w-28"
-                    type="number"
-                    step="0.01"
-                    min="0"
                     aria-label={t('banking.inflow.refundAmount')}
                     value={line.amount}
-                    onChange={(e) => update(line.key, { amount: e.target.value })}
+                    onChange={(value) => update(line.key, { amount: value })}
                   />
                   {lines.length > 1 ? (
                     <button


### PR DESCRIPTION
## Quoi

Le garde-fou de `ui/src/design-system/decimal-input.test.tsx` échoue sur `main` depuis #446 (commit `9924ecaa`). Conséquence : `Deploy to Production` reste en **`skipped`** — **plus rien ne part en prod**, y compris #462 qui vient d'être mergée.

Les trois champs fautifs sont des `<input type="number" step="0.01">` :

| Fichier | Champ |
|---|---|
| `money/CashDepositDialog.tsx` | montant du dépôt |
| `money/CashDepositDialog.tsx` | montant d'une ligne de remboursement |
| `banking/CashMirrorDialog.tsx` | montant du miroir de retrait |

C'est exactement la saisie que `DecimalInput` existe pour empêcher : sur un clavier français, « 12,5 » y donnait **512 €** sur Chromium et **5 €** sur Safari et Firefox — un montant faux enregistré sans un message (#448).

## Deux attributs disparaissent avec les champs

- **`max={outflow}`** (miroir de retrait) : `handleSubmit` refuse déjà `parsed > Number(outflow)` avec un message localisé (`banking.withdraw.errors.amountInvalid`). L'attribut HTML ne portait aucune validation réelle.
- **`min="0"`** : `DecimalInput` refuse le signe moins par défaut (`allowNegative` non passé), donc la borne est conservée — et elle **borne la frappe** au lieu de signaler l'invalidité après coup.

## Vérifications

- `npm run test -- --run` : **19 fichiers / 158 tests** verts — le compte exact de la CI, garde-fou compris. Mon premier passage local n'en voyait que 15 parce que je lançais `vitest` depuis `ui/` au lieu de la commande du job.
- `npx tsc -b ui/tsconfig.json` propre, `npm run lint` 0 erreur, `npm run build` ok.

## Hors scope

Ce n'est pas une revue de #446 : je ne touche qu'à ce qui bloque le déploiement.