### PR TITLE
feat(money): un compte a sa propre fiche — imports, période contrôlée, reste à ranger

### DIFF
--- a/apps/banking/coverage.py
+++ b/apps/banking/coverage.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import date, timedelta
 
-from django.db.models import Max
+from django.db.models import Count, Max, Min
 
 from .models import BankAccount, BankTransaction, ImportStatus, StatementImport
 
@@ -106,6 +106,37 @@ def _latest_known_date(account) -> date | None:
 
     candidates = [d for d in (from_imports, from_lines) if d is not None]
     return max(candidates) if candidates else None
+
+
+def serialize_coverage(account) -> dict:
+    """What the control can assert about ``account`` — and otherwise why it cannot.
+
+    Exists for the account page, and it carries the ``status`` rather than just the
+    two bounds for the reason stated at the top of this module: a window of ``None``
+    has three completely different meanings (no starting point, a starting point
+    later than the data, nothing imported yet), and only the first two are problems.
+    A page that rendered them all as "not covered" would repeat the bug the
+    ``window_status`` split was introduced to kill.
+
+    ``first_line`` / ``last_line`` are what makes the second case *readable*: « ta
+    date de solde d'ouverture est postérieure à ta plus ancienne opération » cannot
+    be said without naming that operation's date.
+    """
+    status, window = window_status(account)
+    lines = BankTransaction.objects.filter(account=account).aggregate(
+        first=Min("booked_on"), last=Max("booked_on"), total=Count("pk")
+    )
+    return {
+        "status": status,
+        "start": window.start.isoformat() if window else None,
+        "end": window.end.isoformat() if window else None,
+        # Bornées à la fenêtre quand il y en a une : une période manquante hors
+        # fenêtre n'est pas un écart, et l'annoncer ferait une liste irrésoluble.
+        "gaps": period_gaps(account, between=window),
+        "first_line": lines["first"].isoformat() if lines["first"] else None,
+        "last_line": lines["last"].isoformat() if lines["last"] else None,
+        "transaction_count": lines["total"],
+    }
 
 
 def period_gaps(account, *, between: Window | None = None) -> list[dict]:

--- a/apps/banking/tests/test_api_account_coverage.py
+++ b/apps/banking/tests/test_api_account_coverage.py
@@ -1,0 +1,189 @@
+# banking/tests/test_api_account_coverage.py
+"""``GET /accounts/{id}/coverage/`` — ce que le contrôle peut affirmer d'un compte.
+
+Le point de cet endpoint n'est pas de renvoyer deux dates : c'est de renvoyer une
+**raison** quand il n'y en a pas. Un compte sans fenêtre a trois causes possibles,
+dont une seule est anodine (rien d'importé), et les confondre a déjà produit en
+prod une coche verte « tout est affecté » sur un compte dont *aucun* contrôle ne
+portait sur les lignes. La page d'un compte lit ce champ pour ne jamais refaire
+cette promesse.
+"""
+from __future__ import annotations
+
+import itertools
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from banking.dedup import compute_dedup_hash
+from banking.models import (
+    BankTransaction,
+    ImportStatus,
+    StatementImport,
+    TransactionDirection,
+)
+from households.models import HouseholdMember
+
+from .factories import BankAccountFactory, HouseholdFactory, HouseholdMemberFactory, UserFactory
+
+ACCOUNTS_URL = "/api/banking/accounts/"
+
+_counter = itertools.count()
+
+
+def make_txn(account, *, booked_on, amount="-10.00", label="CB LECLERC"):
+    value = Decimal(amount)
+    return BankTransaction.objects.create(
+        household=account.household,
+        account=account,
+        booked_on=booked_on,
+        label_raw=label,
+        label_norm=label.upper(),
+        amount=value,
+        direction=TransactionDirection.OUT if value < 0 else TransactionDirection.IN,
+        dedup_hash=compute_dedup_hash(
+            account_id=account.id,
+            booked_on=booked_on,
+            label_norm=label.upper(),
+            amount=value,
+            currency="EUR",
+            discriminant=f"#{next(_counter)}",
+        ),
+    )
+
+
+def make_import(account, *, start, end, status_=ImportStatus.COMPLETED):
+    return StatementImport.objects.create(
+        household=account.household,
+        account=account,
+        provider="generic_csv",
+        filename="releve.csv",
+        status=status_,
+        period_start=start,
+        period_end=end,
+    )
+
+
+@pytest.fixture
+def context(db):
+    household = HouseholdFactory()
+    user = UserFactory()
+    HouseholdMemberFactory(household=household, user=user, role=HouseholdMember.Role.MEMBER)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    client = APIClient()
+    client.force_authenticate(user=user)
+    account = BankAccountFactory(household=household, name="Compte joint")
+    return household, user, account, client
+
+
+@pytest.mark.django_db
+class TestTheWindowIsReportedWithItsReason:
+    def test_a_covered_account_returns_its_bounds(self, context):
+        _, _, account, client = context
+        account.opening_balance_date = date(2026, 1, 1)
+        account.save(update_fields=["opening_balance_date"])
+        make_txn(account, booked_on=date(2026, 3, 10))
+
+        body = client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()
+
+        assert body["status"] == ""
+        assert body["start"] == "2026-01-01"
+        assert body["end"] == "2026-03-10"
+        assert body["transaction_count"] == 1
+        assert body["first_line"] == "2026-03-10"
+        assert body["last_line"] == "2026-03-10"
+
+    def test_a_missing_opening_date_is_named_not_silent(self, context):
+        _, _, account, client = context
+        make_txn(account, booked_on=date(2026, 3, 10))
+
+        body = client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()
+
+        assert body["status"] == "no_opening_date"
+        assert body["start"] is None and body["end"] is None
+        # La ligne existe : c'est ce qui rend l'écart résoluble plutôt qu'abstrait.
+        assert body["transaction_count"] == 1
+
+    def test_an_opening_date_after_the_data_is_distinguished_from_an_empty_account(
+        self, context
+    ):
+        """Le cas silencieux : la date est remplie, et pourtant rien n'est contrôlé.
+
+        Il doit se lire autrement qu'un compte neuf — c'est exactement la confusion
+        qui a fait shipper une coche verte sur un compte non vérifié.
+        """
+        _, _, account, client = context
+        account.opening_balance_date = date(2026, 7, 1)
+        account.save(update_fields=["opening_balance_date"])
+        make_txn(account, booked_on=date(2026, 3, 10))
+
+        body = client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()
+
+        assert body["status"] == "opening_date_after_data"
+        assert body["start"] is None
+        # Le front dit « ta plus ancienne opération est du … » : sans cette date,
+        # le message ne peut pas nommer ce qu'il reproche.
+        assert body["first_line"] == "2026-03-10"
+
+    def test_an_account_with_nothing_imported_is_not_a_problem(self, context):
+        _, _, account, client = context
+        account.opening_balance_date = date(2026, 1, 1)
+        account.save(update_fields=["opening_balance_date"])
+
+        body = client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()
+
+        assert body["status"] == "no_data"
+        assert body["transaction_count"] == 0
+        assert body["first_line"] is None
+
+
+@pytest.mark.django_db
+class TestGapsFollowTheSameBound:
+    def test_a_hole_between_two_imported_periods_is_reported(self, context):
+        _, _, account, client = context
+        account.opening_balance_date = date(2026, 1, 1)
+        account.save(update_fields=["opening_balance_date"])
+        make_txn(account, booked_on=date(2026, 1, 15))
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 3, 1), end=date(2026, 3, 31))
+
+        body = client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()
+
+        assert body["end"] == "2026-03-31"
+        assert body["gaps"] == [
+            {"gap_start": "2026-02-01", "gap_end": "2026-02-28", "days": 28}
+        ]
+
+    def test_contiguous_periods_report_nothing(self, context):
+        _, _, account, client = context
+        account.opening_balance_date = date(2026, 1, 1)
+        account.save(update_fields=["opening_balance_date"])
+        make_import(account, start=date(2026, 1, 1), end=date(2026, 1, 31))
+        make_import(account, start=date(2026, 2, 1), end=date(2026, 2, 28))
+
+        assert client.get(f"{ACCOUNTS_URL}{account.id}/coverage/").json()["gaps"] == []
+
+
+@pytest.mark.django_db
+class TestScope:
+    def test_another_households_account_is_not_readable(self, context):
+        _, _, _, client = context
+        stranger = BankAccountFactory(household=HouseholdFactory(), name="Ailleurs")
+
+        response = client.get(f"{ACCOUNTS_URL}{stranger.id}/coverage/")
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_it_needs_authentication(self, context):
+        _, _, account, _ = context
+
+        response = APIClient().get(f"{ACCOUNTS_URL}{account.id}/coverage/")
+
+        assert response.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )

--- a/apps/banking/views.py
+++ b/apps/banking/views.py
@@ -24,6 +24,7 @@ from .anchoring import (
     serialize_anchor_context,
 )
 from .balances import compute_balance, serialize_balance
+from .coverage import serialize_coverage
 from .compliance import (
     get_detector,
     group_result,
@@ -160,6 +161,23 @@ class BankAccountViewSet(viewsets.ModelViewSet):
         account = self.get_object()
         as_of = _parse_date_param(request.query_params.get("as_of"), "as_of")
         return Response(serialize_balance(compute_balance(account=account, as_of=as_of)))
+
+    @action(detail=True, methods=["get"], url_path="coverage")
+    def coverage(self, request, pk=None):
+        """What the conformity control can — or cannot — assert about this account.
+
+        Its own endpoint rather than fields on the account: the window is derived
+        from the imports and the lines, so it changes without the account row ever
+        being written, and serializing it inline would make every list of accounts
+        pay two aggregates per row.
+
+        ⚠️ It answers with a **reason**, never a bare "no window". An account
+        nobody has imported anything into is normal; an account whose opening
+        balance date postdates its own statements is invisible to every control,
+        and must say so — that confusion once shipped a green checkmark over an
+        unchecked account (see ``banking.coverage``).
+        """
+        return Response(serialize_coverage(self.get_object()))
 
     @action(detail=True, methods=["get", "post"], url_path="balance-anchor")
     def balance_anchor(self, request, pk=None):

--- a/docs/MODULES/banking.md
+++ b/docs/MODULES/banking.md
@@ -130,6 +130,29 @@ pas la base.
 | GET | `/api/banking/accounts/{id}/` | Détail |
 | PATCH | `/api/banking/accounts/{id}/` | Mise à jour (allowlist) |
 | DELETE | `/api/banking/accounts/{id}/` | **Archive** (204), ne supprime pas |
+| GET | `/api/banking/accounts/{id}/coverage/` | Fenêtre de conformité du compte — **avec sa raison** quand il n'y en a pas |
+
+### `coverage/` répond par une raison, jamais par un `None`
+
+`banking.coverage.serialize_coverage` sert la fiche d'un compte
+(`/app/money/accounts/:id`) et renvoie `status` — `""`, `no_opening_date`,
+`opening_date_after_data`, `no_data` — plus les bornes, les périodes jamais
+importées et `first_line`/`last_line`.
+
+C'est son propre endpoint et non des champs du serializer, pour deux raisons : la
+fenêtre se **dérive** des imports et des lignes (elle bouge sans que la ligne du
+compte soit jamais réécrite), et l'inliner ferait payer deux agrégats par ligne à
+chaque liste de comptes.
+
+Et il porte le `status` plutôt que les deux bornes seules parce qu'un compte sans
+fenêtre a trois causes qui ne se valent pas : `no_data` est normal, les deux autres
+rendent le compte invisible à **tous** les détecteurs — dont une qui ressemble à un
+compte correctement réglé. Les fondre en « pas couvert » reproduirait le bug que le
+découpage de `window_status` a été introduit pour tuer. `first_line` existe pour que
+le cas vicieux soit *dicible* : « ta date de solde d'ouverture est postérieure à ta
+plus ancienne opération » a besoin de nommer cette opération.
+
+Régression : `apps/banking/tests/test_api_account_coverage.py`.
 
 ## Import de relevés (lot 2)
 

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -122,8 +122,9 @@ valeur initiale — l'initialiseur d'état du parent s'exécute avant le montage
 l'enfant, ce qui rend le mécanisme fiable plutôt que fragile.
 
 Sous-pages autonomes (avec `BackLink`) : `/app/money/transactions`,
-`/app/money/transactions/:id`, `/app/money/analysis`, `/app/money/budgets/:id`,
-`/app/money/expenses/:id`, `/app/money/recurring`, `/app/money/reports`.
+`/app/money/transactions/:id`, `/app/money/analysis`, `/app/money/accounts/:id`,
+`/app/money/budgets/:id`, `/app/money/expenses/:id`, `/app/money/recurring`,
+`/app/money/reports`.
 
 Les deux dernières ont rejoint la famille en juillet 2026 ; `/app/budget/recurring`
 et `/app/budget/reports` redirigent via `PreserveQueryRedirect`, qui conserve la
@@ -635,6 +636,52 @@ du liquide »).
 - La ligne d'écart affiche les trois chiffres (retiré / versé / manquant). « Le
   versement est partiel » n'apprend rien ; c'est le montant orphelin qui dit s'il
   faut corriger une faute de frappe ou arbitrer un choix.
+
+### Un compte a sa propre fiche
+
+`/app/money/accounts/:id` (`money/AccountDetailPage.tsx`), atteinte en touchant le
+nom d'un compte dans l'onglet Comptes. Même raison que pour la dépense : la carte
+d'un compte est le bon format pour **choisir**, et le mauvais pour **comprendre**.
+Les questions qui suivent se posent toutes *sur un compte*, et n'avaient nulle part
+où être répondues.
+
+- **Le solde, avec ce qu'il vaut** : le montant, sa provenance (`anchored` = lu sur
+  le relevé, `derived` = recalculé depuis le solde de départ) et `ChainGapAlert`
+  quand la chaîne est rompue. Rien de nouveau côté calcul — c'est le même
+  `GET /accounts/{id}/balance/` que la carte.
+- **La période contrôlée**, et ⚠️ **sa raison quand il n'y en a pas.** Nouveau
+  endpoint `GET /accounts/{id}/coverage/` → `banking.coverage.serialize_coverage`,
+  qui renvoie `status` (`""` / `no_opening_date` / `opening_date_after_data` /
+  `no_data`), les bornes, les périodes jamais importées et `first_line`/`last_line`.
+  Les trois `status` d'échec ne se rendent **pas** de la même façon : `no_data` est
+  normal (rien d'importé, rien à affirmer), les deux autres rendent le compte muet
+  pour *tous* les détecteurs et portent un bouton « Corriger ». C'est la règle
+  « un compteur à zéro a deux sens » appliquée à un compte : la fiche ne doit jamais
+  annoncer une période contrôlée qu'elle n'a pas. `first_line` est ce qui rend le
+  cas vicieux *lisible* — « ta date de solde de départ est postérieure à ta plus
+  ancienne opération » ne se dit pas sans nommer cette opération.
+- **Le reste à ranger sur ce compte** vient du serveur, par le filtre
+  `?account=…&allocation=todo` — donc de `detectors.pending_outflows`, le **même**
+  jugement que le badge Contrôle et que la file « À ranger ». Jamais un calcul local
+  sur les montants : deux voix sur le même chiffre, et plus personne n'en croit
+  aucune. Le compteur **mène** à la liste filtrée ; un compteur sans destination
+  n'est pas actionnable.
+- **L'historique complet des imports du compte** (`ImportHistoryCard`, `hideAccount`,
+  `limit=20`), enrichi de la **période couverte** — c'est elle qui borne la
+  conformité, pas la date du dépôt — et de `auto_matched_count`, le seul chiffre de
+  la trace qui parle de travail épargné plutôt que de volume.
+- Les cinq dernières opérations, la vue « banque » (sorties / entrées / taux de
+  couverture — **un ratio, jamais une somme**), et la fiche brute en dernier.
+- **Archiver ferme la fiche sans undo différé**, contrairement à la liste : archiver
+  n'est pas supprimer, la fiche reste accessible et son propre bouton « Rouvrir »
+  est le chemin de retour.
+- Le journal accepte désormais `?account=…&allocation=todo` : ses filtres vivent en
+  `sessionStorage`, donc le lien les **écrase** à l'arrivée puis **consomme** le
+  paramètre — sinon le bouton retour du navigateur réappliquerait un filtre que
+  l'utilisateur vient d'enlever.
+
+Régressions : `apps/banking/tests/test_api_account_coverage.py` et
+`ui/src/features/money/AccountDetailPage.test.tsx`.
 
 ### Reste ouvert
 

--- a/ui/src/features/banking/AccountCard.tsx
+++ b/ui/src/features/banking/AccountCard.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router-dom';
 import {
   ArchiveRestore,
   Banknote,
@@ -10,7 +11,8 @@ import {
 } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
 import CardActions, { type CardAction } from '@/components/CardActions';
-import { formatAmount } from '@/lib/format';
+import { pushBack } from '@/lib/backNavigation';
+import { formatAmount, formatDate } from '@/lib/format';
 import type { BankAccount } from '@/lib/api/banking';
 import { useAccountBalance } from './hooks';
 import BalanceBadge from './BalanceBadge';
@@ -35,6 +37,7 @@ export default function AccountCard({
   onFindBalance,
 }: AccountCardProps) {
   const { t } = useTranslation();
+  const location = useLocation();
   const isCash = account.kind === 'cash';
   const Icon = isCash ? Banknote : Landmark;
   // Un compte archivé n'a plus de solde à surveiller — on évite la requête.
@@ -69,7 +72,17 @@ export default function AccountCard({
 
           <div className="min-w-0 flex-1">
             <div className="flex items-baseline justify-between gap-2">
-              <CardTitle className="truncate">{account.name}</CardTitle>
+              {/* La carte choisit, la fiche explique : imports, période contrôlée,
+                  reste à ranger. Le nom est donc un lien, comme sur toute liste. */}
+              <Link
+                to={`/app/money/accounts/${account.id}`}
+                state={pushBack(location)}
+                className="group min-w-0 text-foreground hover:text-primary"
+              >
+                <CardTitle className="truncate text-inherit [&>span:last-child]:group-hover:underline">
+                  {account.name}
+                </CardTitle>
+              </Link>
               {!account.archived ? (
                 <BalanceBadge balance={balanceQuery.data} isLoading={balanceQuery.isLoading} />
               ) : null}
@@ -83,7 +96,7 @@ export default function AccountCard({
               <p className="mt-1 text-xs text-muted-foreground tabular-nums">
                 {t('banking.openingBalanceOn', {
                   amount: formatAmount(account.opening_balance),
-                  date: new Date(account.opening_balance_date).toLocaleDateString(),
+                  date: formatDate(account.opening_balance_date),
                 })}
               </p>
             ) : (
@@ -96,7 +109,7 @@ export default function AccountCard({
               <p className="mt-0.5 text-xs text-muted-foreground">
                 {t('banking.anchor.attestedOn', {
                   amount: formatAmount(account.attested_balance ?? '0'),
-                  date: new Date(account.attested_on).toLocaleDateString(),
+                  date: formatDate(account.attested_on),
                 })}
               </p>
             ) : null}

--- a/ui/src/features/banking/ImportHistoryCard.tsx
+++ b/ui/src/features/banking/ImportHistoryCard.tsx
@@ -1,10 +1,15 @@
 import { useTranslation } from 'react-i18next';
 import { AlertTriangle, CheckCircle2, FileSpreadsheet } from 'lucide-react';
 import { Card, CardTitle } from '@/design-system/card';
+import { formatDate } from '@/lib/format';
 import type { StatementImport } from '@/lib/api/banking';
 
 interface ImportHistoryCardProps {
   imports: StatementImport[];
+  /** Sur la fiche d'un compte, le nom du compte est déjà le titre de la page. */
+  hideAccount?: boolean;
+  /** Combien de dépôts afficher. 10 sur la liste des comptes, tout sur une fiche. */
+  limit?: number;
 }
 
 /**
@@ -12,8 +17,18 @@ interface ImportHistoryCardProps {
  *
  * Les imports échoués y figurent au même titre que les réussis : c'est la seule
  * trace qui explique pourquoi un relevé n'est pas dans les comptes.
+ *
+ * La **période** couverte s'affiche à côté du nombre de lignes, parce que c'est
+ * elle qui décide de la fenêtre de conformité du compte : « 116 opérations » ne
+ * dit pas jusqu'où le contrôle porte, « du 1er au 31 mars » le dit. Et le nombre
+ * de lignes rapprochées toutes seules est le seul chiffre de la trace qui parle de
+ * travail épargné plutôt que de volume.
  */
-export default function ImportHistoryCard({ imports }: ImportHistoryCardProps) {
+export default function ImportHistoryCard({
+  imports,
+  hideAccount = false,
+  limit = 10,
+}: ImportHistoryCardProps) {
   const { t } = useTranslation();
 
   if (imports.length === 0) return null;
@@ -23,7 +38,7 @@ export default function ImportHistoryCard({ imports }: ImportHistoryCardProps) {
       <CardTitle>{t('banking.import.history')}</CardTitle>
 
       <ul className="mt-3 space-y-2">
-        {imports.slice(0, 10).map((row) => (
+        {imports.slice(0, limit).map((row) => (
           <li key={row.id} className="flex items-start gap-2 text-sm">
             {row.status === 'failed' ? (
               <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" aria-hidden />
@@ -38,23 +53,49 @@ export default function ImportHistoryCard({ imports }: ImportHistoryCardProps) {
               </p>
 
               <p className="text-xs text-muted-foreground">
-                {row.account_name} · {new Date(row.created_at).toLocaleDateString()}
+                {[hideAccount ? '' : row.account_name, formatDate(row.created_at)]
+                  .filter(Boolean)
+                  .join(' · ')}
               </p>
 
               {row.status === 'failed' ? (
                 <p className="mt-0.5 text-xs text-destructive">{row.error}</p>
               ) : (
                 <p className="mt-0.5 text-xs text-muted-foreground">
-                  {t('banking.import.result.created', { count: row.created_count })}
-                  {row.skipped_count > 0
-                    ? ` · ${t('banking.import.result.skipped', { count: row.skipped_count })}`
-                    : ''}
+                  {[
+                    t('banking.import.result.created', { count: row.created_count }),
+                    row.skipped_count > 0
+                      ? t('banking.import.result.skipped', { count: row.skipped_count })
+                      : '',
+                    row.auto_matched_count > 0
+                      ? t('banking.import.result.autoMatched', { count: row.auto_matched_count })
+                      : '',
+                  ]
+                    .filter(Boolean)
+                    .join(' · ')}
                 </p>
               )}
+
+              {/* La période, quand la banque l'a donnée : c'est elle qui borne le
+                  contrôle, pas la date du dépôt. */}
+              {row.period_start && row.period_end ? (
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  {t('banking.import.result.period', {
+                    from: formatDate(row.period_start),
+                    to: formatDate(row.period_end),
+                  })}
+                </p>
+              ) : null}
             </div>
           </li>
         ))}
       </ul>
+
+      {imports.length > limit ? (
+        <p className="mt-2 text-center text-xs text-muted-foreground">
+          {t('banking.import.result.more', { count: imports.length - limit })}
+        </p>
+      ) : null}
     </Card>
   );
 }

--- a/ui/src/features/banking/TransactionsPage.tsx
+++ b/ui/src/features/banking/TransactionsPage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Sparkles } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import PageHeader from '@/components/PageHeader';
 import BackLink from '@/components/BackLink';
@@ -33,7 +34,26 @@ const NO_FILTERS: Filters = {};
 
 export default function TransactionsPage() {
   const { t } = useTranslation();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [filters, setFilters] = useSessionState<Filters>('banking.journal.filters', NO_FILTERS);
+
+  // Deep link `?account=…&allocation=todo` — ce qui permet à la fiche d'un compte
+  // d'écrire « voir les opérations de ce compte » et de tenir sa promesse. Les
+  // filtres vivent en `sessionStorage` (ils survivent au retour dans le journal),
+  // donc le lien ne peut pas être un simple état initial : il faut les écraser à
+  // l'arrivée, puis **consommer** le paramètre — sinon le bouton retour du
+  // navigateur réappliquerait un filtre que l'utilisateur vient d'enlever.
+  const requestedAccount = searchParams.get('account');
+  const requestedAllocation = searchParams.get('allocation');
+  React.useEffect(() => {
+    if (!requestedAccount && !requestedAllocation) return;
+    setFilters((previous) => ({
+      ...previous,
+      ...(requestedAccount ? { account: requestedAccount } : {}),
+      ...(requestedAllocation === 'todo' ? { allocation: 'todo' as const } : {}),
+    }));
+    setSearchParams(new URLSearchParams(), { replace: true });
+  }, [requestedAccount, requestedAllocation, setFilters, setSearchParams]);
 
   const accountsQuery = useBankAccounts();
   // Un registre se parcourt : 116 lignes par relevé mensuel, et un plafond muet

--- a/ui/src/features/banking/hooks.ts
+++ b/ui/src/features/banking/hooks.ts
@@ -4,6 +4,7 @@ import {
   archiveBankAccount,
   createBankAccount,
   fetchAccountBalance,
+  fetchAccountCoverage,
   fetchAllocations,
   fetchAccountFlow,
   fetchBalanceAnchor,
@@ -55,6 +56,7 @@ export const bankingKeys = {
   suggestions: (transactionId: string) =>
     [...bankingKeys.all, 'suggestions', transactionId] as const,
   anchor: (accountId: string) => [...bankingKeys.all, 'anchor', accountId] as const,
+  coverage: (accountId: string) => [...bankingKeys.all, 'coverage', accountId] as const,
 };
 
 export function useBankAccounts(includeArchived = false) {
@@ -110,6 +112,21 @@ export function useRestoreBankAccount() {
       toast({ description: t('banking.reopened'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/**
+ * Sur quoi le contrôle porte pour ce compte — et sinon pourquoi il ne porte pas.
+ *
+ * Sous la racine `banking` du cache, donc invalidée par `useInvalidateMoney` :
+ * la fenêtre bouge à chaque import et à chaque correction du solde d'ouverture,
+ * sans que la ligne du compte soit jamais réécrite.
+ */
+export function useAccountCoverage(accountId: string | undefined) {
+  return useQuery({
+    queryKey: bankingKeys.coverage(accountId ?? ''),
+    queryFn: () => fetchAccountCoverage(accountId as string),
+    enabled: Boolean(accountId),
   });
 }
 

--- a/ui/src/features/money/AccountDetailPage.test.tsx
+++ b/ui/src/features/money/AccountDetailPage.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { AccountCoverage, BankAccount } from '@/lib/api/banking';
+import AccountDetailPage from './AccountDetailPage';
+
+/**
+ * Ce que ces tests tiennent, et pourquoi :
+ *
+ * 1. **Un compte non évaluable ne se lit jamais comme un compte couvert.** C'est la
+ *    règle transverse du parcours 26, et le bug qui a shippé : une date de solde
+ *    d'ouverture postérieure aux relevés vidait la fenêtre de conformité, et l'app
+ *    annonçait « tout est affecté » sans avoir rien vérifié. La fiche doit nommer
+ *    la cause, et proposer de la corriger.
+ * 2. **Un compte neuf n'est pas un compte en faute.** `no_data` et
+ *    `opening_date_after_data` renvoient tous deux « pas de fenêtre » : les rendre
+ *    pareil reproduirait la confusion à l'identique, dans l'autre sens.
+ * 3. **Le reste à ranger vient du serveur**, du même filtre que le badge Contrôle,
+ *    et il mène à la liste filtrée — un compteur sans destination n'est pas
+ *    actionnable.
+ */
+
+const account: BankAccount = {
+  id: 'acc-1',
+  name: 'Compte joint',
+  bank_label: 'Crédit Agricole',
+  kind: 'bank',
+  currency: 'EUR',
+  iban_last4: '4242',
+  opening_balance: '1000.00',
+  opening_balance_date: '2026-01-01',
+  attested_balance: null,
+  attested_on: null,
+  default_provider: 'generic_csv',
+  import_options: {},
+  archived: false,
+  created_at: '2026-01-01T10:00:00Z',
+  updated_at: '2026-01-01T10:00:00Z',
+};
+
+const covered: AccountCoverage = {
+  status: '',
+  start: '2026-01-01',
+  end: '2026-07-20',
+  gaps: [],
+  first_line: '2026-01-03',
+  last_line: '2026-07-20',
+  transaction_count: 128,
+};
+
+let currentAccount: BankAccount = account;
+let currentCoverage: AccountCoverage = covered;
+let pendingCount = 0;
+
+vi.mock('@/features/banking/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/features/banking/hooks')>(
+    '@/features/banking/hooks',
+  );
+  return {
+    ...actual,
+    useBankAccounts: () => ({ data: [currentAccount], isLoading: false, error: null }),
+    useAccountCoverage: () => ({ data: currentCoverage, isLoading: false }),
+    useAccountBalance: () => ({
+      data: { amount: '1240.00', source: 'anchored', as_of: '2026-07-20', is_reliable: true, gaps: [] },
+      isLoading: false,
+    }),
+    useAccountFlow: () => ({
+      data: {
+        date_from: null,
+        date_to: null,
+        outflow: '900.00',
+        inflow: '2100.00',
+        net: '1200.00',
+        transaction_count: 128,
+        internal_count: 2,
+        unallocated_outflow: '90.00',
+        coverage_ratio: 0.9,
+      },
+    }),
+    useStatementImports: () => ({ data: [] }),
+    // La file « à ranger » du compte : c'est le `count` du serveur, filtre
+    // `allocation=todo` — jamais un calcul local sur les montants.
+    useTransactions: (filters: { allocation?: string }) => ({
+      data:
+        filters.allocation === 'todo'
+          ? { count: pendingCount, next: null, previous: null, results: [] }
+          : { count: 0, next: null, previous: null, results: [] },
+      isLoading: false,
+    }),
+    useArchiveBankAccount: () => ({ mutate: vi.fn(), isPending: false }),
+    useRestoreBankAccount: () => ({ mutate: vi.fn(), isPending: false }),
+  };
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, unknown>) =>
+      values && 'count' in values ? `${key}:${values.count}` : key,
+  }),
+}));
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/app/money/accounts/acc-1']}>
+        <Routes>
+          <Route path="/app/money/accounts/:id" element={<AccountDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('la fiche d’un compte', () => {
+  beforeAll(() => {
+    // jsdom n'implémente pas matchMedia, utilisé par useIsMobile (SheetDialog).
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  beforeEach(() => {
+    currentAccount = account;
+    currentCoverage = covered;
+    pendingCount = 0;
+  });
+
+  it('annonce la période contrôlée quand le compte en a une', () => {
+    renderPage();
+
+    expect(screen.getByText('banking.account.coverageWindow')).toBeTruthy();
+    expect(screen.queryByText(/banking\.account\.coverageNone/)).toBeNull();
+  });
+
+  it('nomme la cause quand le contrôle ne porte sur rien, et propose de la corriger', () => {
+    currentCoverage = { ...covered, status: 'opening_date_after_data', start: null, end: null };
+    renderPage();
+
+    // ⚠️ Jamais « couvert » : le compte est *non évaluable*, ce qui est un écart.
+    expect(screen.queryByText('banking.account.coverageWindow')).toBeNull();
+    expect(
+      screen.getByText('banking.account.coverageNone.opening_date_after_data'),
+    ).toBeTruthy();
+    expect(screen.getByText('money.compliance.fix')).toBeTruthy();
+  });
+
+  it('ne reproche rien à un compte dont rien n’a encore été importé', () => {
+    currentCoverage = { ...covered, status: 'no_data', start: null, end: null, transaction_count: 0 };
+    renderPage();
+
+    expect(screen.getByText('banking.account.coverageNone.no_data')).toBeTruthy();
+    // Rien à corriger : un compte neuf n'est pas en faute.
+    expect(screen.queryByText('money.compliance.fix')).toBeNull();
+  });
+
+  it('liste les périodes qu’aucun relevé n’a jamais couvertes', () => {
+    currentCoverage = {
+      ...covered,
+      gaps: [{ gap_start: '2026-02-01', gap_end: '2026-02-28', days: 28 }],
+    };
+    renderPage();
+
+    expect(screen.getByText('banking.account.gapsTitle')).toBeTruthy();
+    expect(screen.getByText('banking.account.coverageGap:28')).toBeTruthy();
+  });
+
+  it('mène de son compteur « à ranger » à la liste filtrée sur ce compte', () => {
+    pendingCount = 3;
+    renderPage();
+
+    expect(screen.getByText('banking.account.pendingCount:3')).toBeTruthy();
+    const link = screen.getByText('banking.account.pendingAction').closest('a');
+    expect(link?.getAttribute('href')).toBe(
+      '/app/money/transactions?account=acc-1&allocation=todo',
+    );
+  });
+
+  it('ne propose pas de ranger ce qui n’attend pas', () => {
+    renderPage();
+
+    expect(screen.getByText('banking.account.pendingNone')).toBeTruthy();
+    expect(screen.queryByText('banking.account.pendingAction')).toBeNull();
+  });
+
+  it('remplace les gestes d’un compte archivé par « rouvrir », sans rien détruire', () => {
+    currentAccount = { ...account, archived: true };
+    renderPage();
+
+    expect(screen.getByText('banking.account.archivedHint')).toBeTruthy();
+    expect(screen.getByText('banking.reopen')).toBeTruthy();
+    expect(screen.queryByText('banking.archive')).toBeNull();
+    expect(screen.queryByText('banking.import.action')).toBeNull();
+  });
+});

--- a/ui/src/features/money/AccountDetailPage.tsx
+++ b/ui/src/features/money/AccountDetailPage.tsx
@@ -1,0 +1,614 @@
+import * as React from 'react';
+import { Link, useLocation, useParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+  AlertTriangle,
+  ArchiveRestore,
+  Banknote,
+  CalendarRange,
+  CheckCircle2,
+  Landmark,
+  Pencil,
+  Receipt,
+  Scale,
+  Trash2,
+  Upload,
+} from 'lucide-react';
+import PageHeader from '@/components/PageHeader';
+import BackLink from '@/components/BackLink';
+import InfoField from '@/components/InfoField';
+import LoadError from '@/components/LoadError';
+import ListSkeleton from '@/components/ListSkeleton';
+import { Badge } from '@/design-system/badge';
+import { Button, buttonVariants } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import { pushBack, useNavigateBack } from '@/lib/backNavigation';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { formatAmount, formatDate } from '@/lib/format';
+import type { AccountCoverage, BankAccount, BankTransaction } from '@/lib/api/banking';
+import {
+  useAccountBalance,
+  useAccountCoverage,
+  useAccountFlow,
+  useArchiveBankAccount,
+  useBankAccounts,
+  useRestoreBankAccount,
+  useStatementImports,
+  useTransactions,
+} from '@/features/banking/hooks';
+import AccountDialog from '@/features/banking/AccountDialog';
+import BalanceAnchorDialog from '@/features/banking/BalanceAnchorDialog';
+import ChainGapAlert from '@/features/banking/ChainGapAlert';
+import ImportHistoryCard from '@/features/banking/ImportHistoryCard';
+import StatementImportDialog from '@/features/banking/StatementImportDialog';
+import CashExpenseDialog from './CashExpenseDialog';
+
+/** Combien d'opérations récentes montrer avant de renvoyer au journal. */
+const RECENT_LIMIT = 5;
+
+/**
+ * La fiche d'un compte (`/app/money/accounts/:id`).
+ *
+ * L'onglet Comptes tient dans une carte par compte : un nom, un solde, un menu.
+ * C'est le bon format pour choisir, et le mauvais pour comprendre — toutes les
+ * questions qu'on pose ensuite se posent *sur un compte* et n'avaient nulle part
+ * où être répondues :
+ *
+ * 1. **Combien, et est-ce fiable ?** Le solde, sa provenance (lu sur le relevé ou
+ *    recalculé), et les ruptures de chaîne qui le rendent incertain.
+ * 2. **Sur quoi le contrôle porte-t-il ?** La fenêtre de conformité du compte —
+ *    ⚠️ avec sa **raison** quand il n'y en a pas. Un compte sans fenêtre n'est
+ *    jamais « conforme », il est *non évaluable*, et les trois causes ne se valent
+ *    pas : rien d'importé est normal, une date de solde postérieure aux relevés
+ *    rend le compte invisible à tous les contrôles.
+ * 3. **Qu'ai-je importé, et qu'est-ce que ça a rangé ?** L'historique complet des
+ *    dépôts pour ce compte — période couverte, lignes créées, lignes ignorées,
+ *    lignes rapprochées d'elles-mêmes — plus les périodes qu'aucun relevé n'a
+ *    jamais couvertes.
+ * 4. **Que me reste-t-il à faire ici ?** Les opérations que le Contrôle réclame
+ *    sur ce compte, comptées par le **même** filtre serveur que la file « À
+ *    ranger » (`allocation=todo`) : deux voix sur le même chiffre, et plus
+ *    personne n'en croit aucune.
+ *
+ * Les totaux de flux sont la vue « banque », jamais additionnés aux budgets : le
+ * pont reste le taux de couverture (CLAUDE.md « Relevés bancaires »).
+ */
+export default function AccountDetailPage() {
+  const { id = '' } = useParams<{ id: string }>();
+  const { t } = useTranslation();
+  const location = useLocation();
+  const navigateBack = useNavigateBack('/app/money?tab=accounts');
+
+  const [editOpen, setEditOpen] = React.useState(false);
+  const [importOpen, setImportOpen] = React.useState(false);
+  const [anchorOpen, setAnchorOpen] = React.useState(false);
+  const [cashOpen, setCashOpen] = React.useState(false);
+
+  // Les archivés inclus : on doit pouvoir ouvrir la fiche d'un compte clos, ne
+  // serait-ce que pour le rouvrir.
+  const accountsQuery = useBankAccounts(true);
+  const account = (accountsQuery.data ?? []).find((row) => row.id === id);
+
+  const archiveMutation = useArchiveBankAccount();
+  const restoreMutation = useRestoreBankAccount();
+
+  // Un compte archivé n'a plus de solde à surveiller — même arbitrage que la carte.
+  const balanceQuery = useAccountBalance(account && !account.archived ? id : undefined);
+  const coverageQuery = useAccountCoverage(id);
+  const flowQuery = useAccountFlow(React.useMemo(() => ({ account: id }), [id]));
+  const importsQuery = useStatementImports(id);
+  // `limit: 1` : on ne veut que le `count`. Le filtre `allocation=todo` passe par
+  // `detectors.pending_outflows`, donc par le même jugement que le badge Contrôle.
+  const pendingQuery = useTransactions(
+    React.useMemo(() => ({ account: id, allocation: 'todo' as const }), [id]),
+    1,
+  );
+  const recentQuery = useTransactions(React.useMemo(() => ({ account: id }), [id]), RECENT_LIMIT);
+
+  const showSkeleton = useDelayedLoading(accountsQuery.isLoading);
+
+  if (!id) return null;
+  if (showSkeleton) return <ListSkeleton className="space-y-2 p-4" />;
+  if (accountsQuery.isLoading) return null;
+
+  if (accountsQuery.error || !account) {
+    return (
+      <LoadError
+        message={t('banking.account.notFound')}
+        link={{ to: '/app/money?tab=accounts', label: t('money.tabs.accounts') }}
+      />
+    );
+  }
+
+  const isCash = account.kind === 'cash';
+  const Icon = isCash ? Banknote : Landmark;
+  const balance = balanceQuery.data;
+  const flow = flowQuery.data;
+  const pendingCount = pendingQuery.data?.count ?? 0;
+  const recent = recentQuery.data?.results ?? [];
+  const details = [account.bank_label, account.iban_last4 ? `••••${account.iban_last4}` : '']
+    .filter(Boolean)
+    .join(' · ');
+
+  /**
+   * Archiver ferme la fiche. Pas d'undo différé ici, contrairement à la liste :
+   * archiver n'est pas une suppression — rien n'est détruit, la fiche reste
+   * accessible, et son propre bouton « Rouvrir » est le chemin de retour.
+   */
+  const archive = () => archiveMutation.mutate(id, { onSuccess: () => navigateBack() });
+
+  return (
+    <>
+      <PageHeader
+        backLink={
+          <BackLink fallback="/app/money?tab=accounts" fallbackLabel={t('money.tabs.accounts')} />
+        }
+        title={
+          <span className="flex items-center gap-2">
+            <span className="rounded-lg bg-primary/10 p-1.5 text-primary">
+              <Icon className="h-5 w-5" aria-hidden />
+            </span>
+            {account.name}
+          </span>
+        }
+        documentTitle={account.name}
+        titleSuffix={
+          account.archived ? (
+            <Badge variant="outline">{t('banking.archived')}</Badge>
+          ) : (
+            <Badge variant="secondary">{t(`banking.kinds.${account.kind}`)}</Badge>
+          )
+        }
+        description={details || t(`banking.kinds.${account.kind}`)}
+      >
+        {account.archived ? (
+          <Button
+            type="button"
+            variant="outline"
+            className="h-8 px-3 text-sm"
+            onClick={() => restoreMutation.mutate(account.id)}
+          >
+            <ArchiveRestore className="mr-1.5 h-3.5 w-3.5" />
+            {t('banking.reopen')}
+          </Button>
+        ) : (
+          <>
+            {isCash ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="h-8 px-3 text-sm"
+                onClick={() => setCashOpen(true)}
+              >
+                <Banknote className="mr-1.5 h-3.5 w-3.5" />
+                {t('banking.cash.title')}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="outline"
+                className="h-8 px-3 text-sm"
+                onClick={() => setImportOpen(true)}
+              >
+                <Upload className="mr-1.5 h-3.5 w-3.5" />
+                {t('banking.import.action')}
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 px-3 text-sm"
+              onClick={() => setAnchorOpen(true)}
+            >
+              <Scale className="mr-1.5 h-3.5 w-3.5" />
+              {t('banking.anchor.action')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 px-3 text-sm"
+              onClick={() => setEditOpen(true)}
+            >
+              <Pencil className="mr-1.5 h-3.5 w-3.5" />
+              {t('common.edit')}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="h-8 px-3 text-sm text-destructive hover:text-destructive"
+              onClick={archive}
+            >
+              <Trash2 className="mr-1.5 h-3.5 w-3.5" />
+              {t('banking.archive')}
+            </Button>
+          </>
+        )}
+      </PageHeader>
+
+      <div className="space-y-6">
+        {account.archived ? (
+          <Card className="p-3">
+            <p className="text-sm text-muted-foreground">{t('banking.account.archivedHint')}</p>
+          </Card>
+        ) : null}
+
+        {/* 1. Le solde — le chiffre qu'on vient lire, avec ce qu'il vaut. */}
+        <Card className="p-4">
+          <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            {t('banking.account.balanceTitle')}
+          </p>
+          {balanceQuery.isLoading ? (
+            <div className="mt-2 h-9 w-40 animate-pulse rounded bg-muted" />
+          ) : balance ? (
+            <>
+              <p
+                className={`mt-1 text-3xl font-semibold tabular-nums ${
+                  Number(balance.amount) < 0 ? 'text-destructive' : 'text-foreground'
+                }`}
+              >
+                {formatAmount(balance.amount)}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t(`banking.account.balanceSource.${balance.source}`)}
+                {balance.as_of
+                  ? ` · ${t('banking.account.balanceAsOf', { date: formatDate(balance.as_of) })}`
+                  : ''}
+              </p>
+            </>
+          ) : (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {t('banking.account.balanceUnavailable')}
+            </p>
+          )}
+
+          {balance ? (
+            <div className="mt-3">
+              <ChainGapAlert balance={balance} accountName={account.name} />
+            </div>
+          ) : null}
+        </Card>
+
+        {/* 2. Ce sur quoi le contrôle porte — jamais une coche verte muette. */}
+        <CoverageSection
+          account={account}
+          coverage={coverageQuery.data}
+          onFixOpeningDate={() => setEditOpen(true)}
+        />
+
+        {/* 3. Le pont banque ↔ dépenses : un ratio, jamais une somme. */}
+        {flow ? (
+          <section className="space-y-2">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('banking.account.flowTitle')}
+            </h2>
+            <div className="grid gap-2 sm:grid-cols-3">
+              <Card className="p-3">
+                <p className="text-xs text-muted-foreground">{t('banking.journal.outflow')}</p>
+                <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
+                  {formatAmount(flow.outflow)}
+                </p>
+              </Card>
+              <Card className="p-3">
+                <p className="text-xs text-muted-foreground">{t('banking.journal.inflow')}</p>
+                <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
+                  {formatAmount(flow.inflow)}
+                </p>
+              </Card>
+              <Card className="p-3">
+                <p className="text-xs text-muted-foreground">{t('expenses.summary.coverage')}</p>
+                <p className="mt-1 text-lg font-semibold tabular-nums text-foreground">
+                  {Math.round(flow.coverage_ratio * 100)}%
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {t('expenses.summary.coverageHint', {
+                    sorted: formatAmount(
+                      (Number(flow.outflow) - Number(flow.unallocated_outflow)).toFixed(2),
+                    ),
+                    outflow: formatAmount(flow.outflow),
+                  })}
+                </p>
+              </Card>
+            </div>
+            <p className="text-xs text-muted-foreground">{t('banking.account.flowHint')}</p>
+          </section>
+        ) : null}
+
+        {/* 4. Ce qu'il reste à faire ici, compté par le filtre du Contrôle. */}
+        <Card className="p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="flex items-center gap-2 text-sm text-foreground">
+              {pendingCount > 0 ? (
+                <AlertTriangle className="h-4 w-4 shrink-0 text-warning" aria-hidden />
+              ) : (
+                <CheckCircle2 className="h-4 w-4 shrink-0 text-primary" aria-hidden />
+              )}
+              {pendingCount > 0
+                ? t('banking.account.pendingCount', { count: pendingCount })
+                : t('banking.account.pendingNone')}
+            </p>
+            {pendingCount > 0 ? (
+              <Link
+                to={`/app/money/transactions?account=${account.id}&allocation=todo`}
+                state={pushBack(location)}
+                className={buttonVariants({ variant: 'outline', className: 'h-8 px-3 text-sm' })}
+              >
+                {t('banking.account.pendingAction')}
+              </Link>
+            ) : null}
+          </div>
+        </Card>
+
+        {/* 5. Les dernières opérations — un aperçu, pas un second journal. */}
+        <section className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('banking.account.recentTitle')}
+            </h2>
+            <Link
+              to={`/app/money/transactions?account=${account.id}`}
+              state={pushBack(location)}
+              className="text-sm text-primary hover:underline"
+            >
+              {t('banking.account.seeAll')}
+            </Link>
+          </div>
+
+          {recent.length === 0 ? (
+            <p className="text-sm italic text-muted-foreground">
+              {t('banking.account.noOperations')}
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {recent.map((line) => (
+                <RecentLine key={line.id} line={line} />
+              ))}
+            </ul>
+          )}
+        </section>
+
+        {/* 6. Les imports : la seule trace qui explique ce que le compte contient. */}
+        <section className="space-y-2">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+              <Receipt className="h-4 w-4 text-muted-foreground" aria-hidden />
+              {t('banking.import.history')}
+            </h2>
+            {!isCash && !account.archived ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="h-8 px-3 text-sm"
+                onClick={() => setImportOpen(true)}
+              >
+                <Upload className="mr-1.5 h-3.5 w-3.5" />
+                {t('banking.import.action')}
+              </Button>
+            ) : null}
+          </div>
+
+          {(importsQuery.data ?? []).length === 0 ? (
+            <p className="text-sm italic text-muted-foreground">
+              {t(isCash ? 'banking.account.noImportsCash' : 'banking.account.noImports')}
+            </p>
+          ) : (
+            <ImportHistoryCard imports={importsQuery.data ?? []} hideAccount limit={20} />
+          )}
+        </section>
+
+        {/* 7. La fiche brute en dernier : elle précise, elle ne se lit pas d'abord. */}
+        <section className="space-y-2">
+          <h2 className="text-base font-semibold text-foreground">
+            {t('banking.account.detailsTitle')}
+          </h2>
+          <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <InfoField label={t('banking.fields.openingBalance')}>
+              {account.opening_balance_date ? (
+                <span className="tabular-nums">
+                  {t('banking.openingBalanceOn', {
+                    amount: formatAmount(account.opening_balance),
+                    date: formatDate(account.opening_balance_date),
+                  })}
+                </span>
+              ) : (
+                <span className="text-warning">{t('banking.noOpeningBalance')}</span>
+              )}
+            </InfoField>
+
+            {/* La saisie dont le solde d'ouverture a été *dérivé* : gardée pour que
+                la soustraction reste re-vérifiable (parcours 26, lot 8). */}
+            {account.attested_on ? (
+              <InfoField label={t('banking.anchor.balanceLabel')}>
+                <span className="tabular-nums">
+                  {t('banking.anchor.attestedOn', {
+                    amount: formatAmount(account.attested_balance ?? '0'),
+                    date: formatDate(account.attested_on),
+                  })}
+                </span>
+              </InfoField>
+            ) : null}
+
+            <InfoField label={t('banking.account.transactionsLabel')}>
+              {t('banking.account.transactionCount', {
+                count: coverageQuery.data?.transaction_count ?? 0,
+              })}
+            </InfoField>
+
+            {account.bank_label ? (
+              <InfoField label={t('banking.fields.bankLabel')}>{account.bank_label}</InfoField>
+            ) : null}
+
+            {account.iban_last4 ? (
+              <InfoField label={t('banking.fields.ibanLast4')}>
+                <span className="font-mono">••••{account.iban_last4}</span>
+              </InfoField>
+            ) : null}
+
+            <InfoField label={t('banking.account.currencyLabel')}>{account.currency}</InfoField>
+          </dl>
+        </section>
+      </div>
+
+      <AccountDialog open={editOpen} onOpenChange={setEditOpen} existing={account} />
+
+      {importOpen ? (
+        <StatementImportDialog
+          open
+          onOpenChange={(next) => !next && setImportOpen(false)}
+          account={account}
+        />
+      ) : null}
+
+      {anchorOpen ? (
+        <BalanceAnchorDialog
+          open
+          onOpenChange={(next) => !next && setAnchorOpen(false)}
+          account={account}
+        />
+      ) : null}
+
+      <CashExpenseDialog open={cashOpen} onOpenChange={setCashOpen} />
+    </>
+  );
+}
+
+/**
+ * La période sur laquelle le contrôle porte — ou la raison pour laquelle il ne
+ * porte sur rien.
+ *
+ * ⚠️ Ne jamais rendre les trois `status` d'échec de la même façon. `no_data` est
+ * normal (rien d'importé), les deux autres rendent le compte muet pour **tous** les
+ * détecteurs, et l'un des deux ressemble à un compte correctement réglé : c'est
+ * exactement la confusion qui a fait afficher « tout est affecté » sur un compte
+ * dont pas une ligne n'était vérifiée.
+ */
+function CoverageSection({
+  account,
+  coverage,
+  onFixOpeningDate,
+}: {
+  account: BankAccount;
+  coverage: AccountCoverage | undefined;
+  onFixOpeningDate: () => void;
+}) {
+  const { t } = useTranslation();
+
+  if (!coverage) return null;
+
+  const covered = coverage.status === '';
+
+  return (
+    <section className="space-y-2">
+      <h2 className="flex items-center gap-1.5 text-base font-semibold text-foreground">
+        <CalendarRange className="h-4 w-4 text-muted-foreground" aria-hidden />
+        {t('banking.account.coverageTitle')}
+      </h2>
+
+      <Card
+        className={`p-3 ${
+          covered || coverage.status === 'no_data' ? '' : 'border-warning/40 bg-warning/10'
+        }`}
+      >
+        {covered ? (
+          <>
+            <p className="text-sm font-medium text-foreground">
+              {t('banking.account.coverageWindow', {
+                from: formatDate(coverage.start),
+                to: formatDate(coverage.end),
+              })}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t('banking.account.coverageHint')}
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="flex items-start gap-2 text-sm font-medium text-foreground">
+              <AlertTriangle
+                className={`mt-0.5 h-4 w-4 shrink-0 ${
+                  coverage.status === 'no_data' ? 'text-muted-foreground' : 'text-warning'
+                }`}
+                aria-hidden
+              />
+              {t(`banking.account.coverageNone.${coverage.status}`, {
+                openingDate: formatDate(account.opening_balance_date),
+                earliestLine: formatDate(coverage.first_line),
+              })}
+            </p>
+            {coverage.status !== 'no_data' ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="mt-2 h-7 px-2 text-xs"
+                onClick={onFixOpeningDate}
+              >
+                {t('money.compliance.fix')}
+              </Button>
+            ) : null}
+          </>
+        )}
+
+        {/* Les périodes qu'aucun relevé n'a jamais couvertes. Le contrôle de chaîne
+            ne peut pas les voir : rien n'a été importé, donc aucune arithmétique de
+            soldes n'en garde la trace. */}
+        {coverage.gaps.length > 0 ? (
+          <div className="mt-3 border-t border-border/60 pt-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t('banking.account.gapsTitle')}
+            </p>
+            <ul className="mt-1.5 space-y-1">
+              {coverage.gaps.map((gap) => (
+                <li key={gap.gap_start} className="text-xs text-warning">
+                  {t('banking.account.coverageGap', {
+                    from: formatDate(gap.gap_start),
+                    to: formatDate(gap.gap_end),
+                    count: gap.days,
+                  })}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </Card>
+    </section>
+  );
+}
+
+/** Une opération de l'aperçu — le montant signé, et le lien vers la ligne. */
+function RecentLine({ line }: { line: BankTransaction }) {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const isOut = line.direction === 'out';
+
+  return (
+    <li>
+      <Card className="p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <Link
+              to={`/app/money/transactions/${line.id}`}
+              state={pushBack(location)}
+              className="truncate text-sm font-medium text-foreground hover:text-primary hover:underline"
+            >
+              {line.label_raw}
+            </Link>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              {formatDate(line.booked_on)}
+              {line.is_internal ? ` · ${t('banking.journal.internal')}` : ''}
+            </p>
+          </div>
+          <p
+            className={`shrink-0 text-sm font-semibold tabular-nums ${
+              line.is_internal
+                ? 'text-muted-foreground'
+                : isOut
+                  ? 'text-destructive'
+                  : 'text-primary'
+            }`}
+          >
+            {formatAmount(line.amount)}
+          </p>
+        </div>
+      </Card>
+    </li>
+  );
+}

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -86,7 +86,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'money', moduleKey: 'money', Icon: ShieldCheck, to: '/app/money?tab=control', stepIds: ['source', 'allocation', 'axes', 'window', 'arbitrate', 'notEvaluable', 'cash'] },
   { key: 'expenses', moduleKey: 'money', Icon: Receipt, to: '/app/money?tab=pending', stepIds: ['record', 'sort', 'control', 'sources', 'sheet', 'trace', 'review'] },
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'analysis', 'recurring', 'report'] },
-  { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance'] },
+  { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance', 'sheet'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },
   { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add', 'file'] },
   { key: 'directory', moduleKey: 'directory', to: '/app/directory', stepIds: ['contacts', 'structures'] },

--- a/ui/src/lib/api/banking.ts
+++ b/ui/src/lib/api/banking.ts
@@ -132,6 +132,35 @@ export async function setBalanceAnchor(
   return data;
 }
 
+// --- Fenêtre de conformité d'un compte --------------------------------------
+
+/**
+ * Pourquoi ce compte a — ou n'a pas — une fenêtre de conformité.
+ *
+ * `''` = il en a une. Les trois autres ne se valent pas : `no_data` est normal
+ * (rien d'importé, rien à affirmer), les deux autres rendent le compte invisible
+ * à **tous** les contrôles. Ne jamais les fondre en « pas couvert » : c'est cette
+ * confusion qui a affiché une coche verte sur un compte non vérifié.
+ */
+export type CoverageStatus = '' | 'no_opening_date' | 'opening_date_after_data' | 'no_data';
+
+export interface AccountCoverage {
+  status: CoverageStatus;
+  /** Bornes de la fenêtre, `null` dès que `status` n'est pas vide. */
+  start: string | null;
+  end: string | null;
+  /** Périodes qu'aucun relevé n'a jamais couvertes, bornées à la fenêtre. */
+  gaps: { gap_start: string; gap_end: string; days: number }[];
+  first_line: string | null;
+  last_line: string | null;
+  transaction_count: number;
+}
+
+export async function fetchAccountCoverage(accountId: string): Promise<AccountCoverage> {
+  const { data } = await api.get<AccountCoverage>(`/banking/accounts/${accountId}/coverage/`);
+  return data;
+}
+
 // --- Import de relevés (parcours 25, lot 2) ---------------------------------
 
 export type ImportStatus = 'completed' | 'failed';
@@ -146,6 +175,12 @@ export interface StatementImport {
   status: ImportStatus;
   created_count: number;
   skipped_count: number;
+  /**
+   * Lignes que cet import a rapprochées tout seul de dépenses déjà saisies. Le
+   * chiffre qui intéresse vraiment : c'est ce que l'utilisateur n'a **pas** eu à
+   * ranger à la main.
+   */
+  auto_matched_count: number;
   error: string;
   period_start: string | null;
   period_end: string | null;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1709,6 +1709,10 @@
           "balance": {
             "title": "Saldo prüfen",
             "body": "Jedes Konto zeigt seinen Saldo, berechnet beim Lesen — nie in der Datenbank eingefroren. Exportiert deine Bank eine Saldo-Spalte, verankert House sich daran und prüft nebenbei die Auszugskette: Fehlen Buchungen, siehst du „Kette unterbrochen“ mit Zeitraum und fehlendem Betrag statt einer plausiblen, aber falschen Zahl. Das ist der beste Test deiner Importe: Stimmt der angezeigte Saldo mit deinem Papierauszug überein, passt alles. Für Bargeld öffne das Journal und nutze „Ins Bargeld buchen“ bei einer Abhebung — sie verlässt die Ausgabensummen und speist den Saldo deines Bargeldkontos."
+          },
+          "sheet": {
+            "title": "Die Kontoseite öffnen",
+            "body": "Tippe auf den Namen eines Kontos, um seine Seite zu öffnen. Dort ist alles versammelt, was House darüber weiß: der Saldo und woher er kommt, der **geprüfte Zeitraum** (außerhalb verlangt House nichts — davor ist Geschichte, danach fehlt der Auszug noch), die Zeiträume, die kein Auszug je abgedeckt hat, die vollständige Import-Historie mit dem, was jeder Import angelegt, übersprungen und selbst zugeordnet hat, sowie die Zahl der Umsätze, die auf diesem Konto noch auf Zuordnung warten. Wenn die Seite meldet, dass für dieses Konto keine Prüfung gilt, korrigiere es genau dort: Es ist die eine Einstellung, die alle anderen Prüfungen erst messbar macht."
           }
         }
       },
@@ -3445,7 +3449,12 @@
         "skipped_one": "{{count}} bereits vorhanden, übersprungen",
         "skipped_other": "{{count}} bereits vorhanden, übersprungen",
         "nothingNew": "Nichts Neues in dieser Datei",
-        "failed": "Datei nicht lesbar — es wurde nichts importiert"
+        "failed": "Datei nicht lesbar — es wurde nichts importiert",
+        "autoMatched_one": "{{count}} automatisch zugeordnet",
+        "autoMatched_other": "{{count}} automatisch zugeordnet",
+        "period": "Zeitraum vom {{from}} bis {{to}}",
+        "more_one": "und {{count}} älterer Upload",
+        "more_other": "und {{count}} ältere Uploads"
       },
       "errors": {
         "previewFailed": "Diese Datei konnte nicht gelesen werden. Prüfe, ob es eine CSV- oder Excel-Datei ist.",
@@ -3686,6 +3695,44 @@
       "amount": "Erhaltener Betrag",
       "date": "Datum",
       "natureHint": "Eine interne Umbuchung wird hier nicht erfasst: Bargeld aus einer Abhebung wird auf der Abhebungszeile mit „Kasse auffüllen“ erklärt."
+    },
+    "account": {
+      "notFound": "Konto nicht gefunden.",
+      "archivedHint": "Dieses Konto ist archiviert: Es erscheint nicht mehr in der Liste und sein Saldo wird nicht mehr verfolgt. Nichts wurde gelöscht — du kannst es wieder öffnen.",
+      "balanceTitle": "Saldo",
+      "balanceSource": {
+        "anchored": "Vom Auszug abgelesen",
+        "derived": "Aus dem Anfangssaldo berechnet"
+      },
+      "balanceAsOf": "zum {{date}}",
+      "balanceUnavailable": "Für dieses Konto wurde kein Saldo berechnet.",
+      "coverageTitle": "Geprüfter Zeitraum",
+      "coverageWindow": "Vom {{from}} bis {{to}}",
+      "coverageHint": "Außerhalb verlangt House nichts: davor ist Geschichte, danach fehlt der Auszug noch.",
+      "coverageNone": {
+        "no_opening_date": "Kein Datum für den Anfangssaldo: Für dieses Konto gilt keine Prüfung.",
+        "opening_date_after_data": "Das Datum deines Anfangssaldos ({{openingDate}}) liegt nach deinem ältesten Umsatz ({{earliestLine}}): Der geprüfte Zeitraum ist leer, also gilt für dieses Konto keine Prüfung.",
+        "no_data": "Noch kein Umsatz auf diesem Konto, es gibt also nichts zu prüfen. Importiere einen Auszug, um den Zeitraum zu öffnen."
+      },
+      "gapsTitle": "Nie importierte Zeiträume",
+      "coverageGap_one": "Kein Auszug vom {{from}} bis {{to}} ({{count}} Tag)",
+      "coverageGap_other": "Kein Auszug vom {{from}} bis {{to}} ({{count}} Tage)",
+      "flowTitle": "Was ein- und ausgegangen ist",
+      "flowHint": "Die Bank-Sicht über die gesamte Kontohistorie. Diese Summen werden nie zu Budget-Summen addiert: Die Brücke ist die Abdeckungsquote.",
+      "pendingCount_one": "{{count}} Umsatz wartet auf diesem Konto auf Zuordnung",
+      "pendingCount_other": "{{count}} Umsätze warten auf diesem Konto auf Zuordnung",
+      "pendingNone": "Auf diesem Konto wartet nichts auf Zuordnung.",
+      "pendingAction": "Diese Umsätze zuordnen",
+      "recentTitle": "Letzte Umsätze",
+      "seeAll": "Alle Umsätze ansehen",
+      "noOperations": "Kein Umsatz auf diesem Konto.",
+      "noImports": "Noch kein Auszug importiert.",
+      "noImportsCash": "Ein Bargeldkonto hat keinen Auszug: Seine Umsätze werden von Hand erfasst.",
+      "detailsTitle": "Kontodaten",
+      "transactionsLabel": "Vorhandene Umsätze",
+      "transactionCount_one": "{{count}} Umsatz",
+      "transactionCount_other": "{{count}} Umsätze",
+      "currencyLabel": "Währung"
     }
   },
   "pwa": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1709,6 +1709,10 @@
           "balance": {
             "title": "Check your balance",
             "body": "Each account shows its balance, computed at read time — never frozen in the database. If your bank exports a balance column, House anchors on it and checks the statement chain along the way: when operations are missing you get “chain broken” with the period and the missing amount, rather than a plausible but wrong figure. This is the best test of your imports: if the balance shown matches your paper statement, everything is right. For cash, open the journal and use “Move to cash” on a withdrawal — it leaves the spending totals and feeds your cash account balance."
+          },
+          "sheet": {
+            "title": "Open an account's sheet",
+            "body": "Tap an account's name to open its sheet. Everything House knows about it is gathered there: its balance and where that figure comes from, the **checked period** (outside it House requires nothing — before is history, after is a statement that has not arrived yet), the periods no statement ever covered, the full history of your imports with what each one created, skipped and reconciled by itself, and how many operations are still waiting to be sorted out on this account. If the sheet says no check applies to this account, fix it right there: it is the one setting that makes every other check meaningful."
           }
         }
       },
@@ -3445,7 +3449,12 @@
         "skipped_one": "{{count}} already there, skipped",
         "skipped_other": "{{count}} already there, skipped",
         "nothingNew": "Nothing new in this file",
-        "failed": "Unreadable file — nothing was imported"
+        "failed": "Unreadable file — nothing was imported",
+        "autoMatched_one": "{{count}} reconciled automatically",
+        "autoMatched_other": "{{count}} reconciled automatically",
+        "period": "Period from {{from}} to {{to}}",
+        "more_one": "and {{count}} older upload",
+        "more_other": "and {{count}} older uploads"
       },
       "errors": {
         "previewFailed": "Could not read this file. Check that it is a CSV or an Excel file.",
@@ -3686,6 +3695,44 @@
       "amount": "Amount received",
       "date": "Date",
       "natureHint": "An internal transfer is not recorded here: cash from a withdrawal is declared on the withdrawal line, with “Feed cash”."
+    },
+    "account": {
+      "notFound": "Account not found.",
+      "archivedHint": "This account is archived: it no longer shows in the list and its balance is no longer tracked. Nothing was deleted — you can reopen it.",
+      "balanceTitle": "Balance",
+      "balanceSource": {
+        "anchored": "Read from the statement",
+        "derived": "Computed from the opening balance"
+      },
+      "balanceAsOf": "as of {{date}}",
+      "balanceUnavailable": "No balance computed for this account.",
+      "coverageTitle": "Checked period",
+      "coverageWindow": "From {{from}} to {{to}}",
+      "coverageHint": "Outside it, House requires nothing: before is history, after is a statement that has not arrived yet.",
+      "coverageNone": {
+        "no_opening_date": "No opening balance date: no check applies to this account.",
+        "opening_date_after_data": "Your opening balance date ({{openingDate}}) is later than your oldest operation ({{earliestLine}}): the checked period is empty, so no check applies to this account.",
+        "no_data": "No operation on this account yet, so there is nothing to check. Import a statement to open the period."
+      },
+      "gapsTitle": "Periods never imported",
+      "coverageGap_one": "No statement from {{from}} to {{to}} ({{count}} day)",
+      "coverageGap_other": "No statement from {{from}} to {{to}} ({{count}} days)",
+      "flowTitle": "What came in and went out",
+      "flowHint": "The bank view, over the whole history of the account. These totals are never added to budget totals: the bridge is the coverage ratio.",
+      "pendingCount_one": "{{count}} operation still to sort out on this account",
+      "pendingCount_other": "{{count}} operations still to sort out on this account",
+      "pendingNone": "Nothing left to sort out on this account.",
+      "pendingAction": "Sort these out",
+      "recentTitle": "Latest operations",
+      "seeAll": "See every operation",
+      "noOperations": "No operation on this account.",
+      "noImports": "No statement imported yet.",
+      "noImportsCash": "A cash account has no statement: its operations are typed in by hand.",
+      "detailsTitle": "Account details",
+      "transactionsLabel": "Operations held",
+      "transactionCount_one": "{{count}} operation",
+      "transactionCount_other": "{{count}} operations",
+      "currencyLabel": "Currency"
     }
   },
   "pwa": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1709,6 +1709,10 @@
           "balance": {
             "title": "Comprobar tu saldo",
             "body": "Cada cuenta muestra su saldo, calculado al leer: nunca queda congelado en la base de datos. Si tu banco exporta la columna de saldo, House se ancla en ella y comprueba de paso que la cadena de extractos esté completa: si faltan operaciones verás «cadena rota» con el periodo y el importe que falta, en lugar de una cifra plausible pero falsa. Es la mejor prueba de tus importaciones: si el saldo mostrado coincide con tu extracto en papel, todo está bien. Para el efectivo, abre el diario y usa «Pasar al efectivo» en una retirada: sale de los totales de gasto y alimenta el saldo de tu cuenta de efectivo."
+          },
+          "sheet": {
+            "title": "Abrir la ficha de una cuenta",
+            "body": "Toca el nombre de una cuenta para abrir su ficha. Allí se reúne todo lo que House sabe de ella: su saldo y de dónde viene, el **periodo controlado** (fuera de él House no exige nada — antes es historia; después, el extracto aún no ha llegado), los periodos que ningún extracto ha cubierto nunca, el historial completo de tus importaciones con lo que cada una creó, omitió y concilió por sí sola, y cuántas operaciones siguen pendientes de clasificar en esta cuenta. Si la ficha indica que ningún control se aplica a esta cuenta, corrígelo ahí mismo: es el único ajuste que hace medibles todos los demás controles."
           }
         }
       },
@@ -3445,7 +3449,12 @@
         "skipped_one": "{{count}} ya presente, omitida",
         "skipped_other": "{{count}} ya presentes, omitidas",
         "nothingNew": "Nada nuevo en este archivo",
-        "failed": "Archivo ilegible: no se ha importado nada"
+        "failed": "Archivo ilegible: no se ha importado nada",
+        "autoMatched_one": "{{count}} conciliada automáticamente",
+        "autoMatched_other": "{{count}} conciliadas automáticamente",
+        "period": "Periodo del {{from}} al {{to}}",
+        "more_one": "y {{count}} carga más antigua",
+        "more_other": "y {{count}} cargas más antiguas"
       },
       "errors": {
         "previewFailed": "No se ha podido leer este archivo. Comprueba que sea un CSV o un Excel.",
@@ -3686,6 +3695,44 @@
       "amount": "Importe recibido",
       "date": "Fecha",
       "natureHint": "Una transferencia interna no se registra aquí: el efectivo procedente de una retirada se declara desde la línea de retirada, con «Alimentar el efectivo»."
+    },
+    "account": {
+      "notFound": "Cuenta no encontrada.",
+      "archivedHint": "Esta cuenta está archivada: ya no aparece en la lista y su saldo ya no se sigue. No se ha borrado nada — puedes reabrirla.",
+      "balanceTitle": "Saldo",
+      "balanceSource": {
+        "anchored": "Leído en el extracto",
+        "derived": "Calculado desde el saldo inicial"
+      },
+      "balanceAsOf": "a fecha del {{date}}",
+      "balanceUnavailable": "No se ha calculado ningún saldo para esta cuenta.",
+      "coverageTitle": "Periodo controlado",
+      "coverageWindow": "Del {{from}} al {{to}}",
+      "coverageHint": "Fuera de él, House no exige nada: antes es historia; después, el extracto aún no ha llegado.",
+      "coverageNone": {
+        "no_opening_date": "Sin fecha de saldo inicial: ningún control se aplica a esta cuenta.",
+        "opening_date_after_data": "La fecha de tu saldo inicial ({{openingDate}}) es posterior a tu operación más antigua ({{earliestLine}}): el periodo controlado está vacío, así que ningún control se aplica a esta cuenta.",
+        "no_data": "Todavía no hay ninguna operación en esta cuenta, así que no hay nada que controlar. Importa un extracto para abrir el periodo."
+      },
+      "gapsTitle": "Periodos nunca importados",
+      "coverageGap_one": "Ningún extracto del {{from}} al {{to}} ({{count}} día)",
+      "coverageGap_other": "Ningún extracto del {{from}} al {{to}} ({{count}} días)",
+      "flowTitle": "Lo que ha entrado y salido",
+      "flowHint": "Vista «banco», sobre todo el historial de la cuenta. Estos totales nunca se suman a los de los presupuestos: el puente es la tasa de cobertura.",
+      "pendingCount_one": "{{count}} operación pendiente de clasificar en esta cuenta",
+      "pendingCount_other": "{{count}} operaciones pendientes de clasificar en esta cuenta",
+      "pendingNone": "No queda nada por clasificar en esta cuenta.",
+      "pendingAction": "Clasificar estas operaciones",
+      "recentTitle": "Últimas operaciones",
+      "seeAll": "Ver todas las operaciones",
+      "noOperations": "Ninguna operación en esta cuenta.",
+      "noImports": "Ningún extracto importado todavía.",
+      "noImportsCash": "Una cuenta de efectivo no tiene extracto: sus operaciones se introducen a mano.",
+      "detailsTitle": "Ficha de la cuenta",
+      "transactionsLabel": "Operaciones registradas",
+      "transactionCount_one": "{{count}} operación",
+      "transactionCount_other": "{{count}} operaciones",
+      "currencyLabel": "Divisa"
     }
   },
   "pwa": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1709,6 +1709,10 @@
           "balance": {
             "title": "Vérifier ton solde",
             "body": "Chaque compte affiche son solde, calculé à la lecture — il n'est jamais figé en base. Si ta banque exporte la colonne solde, House s'y ancre et vérifie au passage que la chaîne des relevés est complète : s'il manque des opérations, tu vois « chaîne rompue » avec la période et le montant manquant, plutôt qu'un chiffre plausible mais faux. C'est le meilleur test de tes imports : si le solde affiché tombe sur celui de ton relevé papier, tout est bon. Pour le liquide, ouvre le journal et utilise « Verser aux espèces » sur un retrait : il sort des totaux de dépenses et alimente le solde de ton compte espèces."
+          },
+          "sheet": {
+            "title": "Ouvrir la fiche d'un compte",
+            "body": "Touche le nom d'un compte pour ouvrir sa fiche. Tout ce que House sait de lui y est réuni : son solde et d'où il vient, la **période contrôlée** (hors de cette période, House n'exige rien — avant c'est de l'histoire, après le relevé n'est pas encore arrivé), les périodes qu'aucun relevé n'a jamais couvertes, l'historique complet de tes imports avec ce que chacun a créé, ignoré et rapproché tout seul, et le nombre d'opérations qui attendent encore d'être rangées sur ce compte. Si la fiche annonce qu'aucun contrôle ne porte sur ce compte, corrige-le là : c'est le seul réglage qui rend tous les autres contrôles mesurables."
           }
         }
       },
@@ -3445,7 +3449,12 @@
         "skipped_one": "{{count}} déjà présente, ignorée",
         "skipped_other": "{{count}} déjà présentes, ignorées",
         "nothingNew": "Rien de nouveau dans ce fichier",
-        "failed": "Fichier illisible — rien n'a été importé"
+        "failed": "Fichier illisible — rien n'a été importé",
+        "autoMatched_one": "{{count}} rapprochée automatiquement",
+        "autoMatched_other": "{{count}} rapprochées automatiquement",
+        "period": "Période du {{from}} au {{to}}",
+        "more_one": "et {{count}} dépôt plus ancien",
+        "more_other": "et {{count}} dépôts plus anciens"
       },
       "errors": {
         "previewFailed": "Impossible de lire ce fichier. Vérifie qu'il s'agit bien d'un CSV ou d'un Excel.",
@@ -3686,6 +3695,44 @@
       "amount": "Montant reçu",
       "date": "Date",
       "natureHint": "Un transfert interne ne se saisit pas ici : des espèces venues d'un retrait se déclarent depuis la ligne de retrait, avec « Alimenter les espèces »."
+    },
+    "account": {
+      "notFound": "Compte introuvable.",
+      "archivedHint": "Ce compte est archivé : il n'apparaît plus dans la liste et son solde n'est plus suivi. Rien n'a été supprimé — tu peux le rouvrir.",
+      "balanceTitle": "Solde",
+      "balanceSource": {
+        "anchored": "Lu sur le relevé",
+        "derived": "Calculé depuis le solde de départ"
+      },
+      "balanceAsOf": "au {{date}}",
+      "balanceUnavailable": "Solde non calculé pour ce compte.",
+      "coverageTitle": "Période contrôlée",
+      "coverageWindow": "Du {{from}} au {{to}}",
+      "coverageHint": "En dehors, House n'exige rien : avant, c'est de l'histoire ; après, le relevé n'est pas encore arrivé.",
+      "coverageNone": {
+        "no_opening_date": "Aucune date de solde de départ : aucun contrôle ne porte sur ce compte.",
+        "opening_date_after_data": "Ta date de solde de départ ({{openingDate}}) est postérieure à ta plus ancienne opération ({{earliestLine}}) : la période contrôlée est vide, donc aucun contrôle ne porte sur ce compte.",
+        "no_data": "Aucune opération sur ce compte pour l'instant : il n'y a rien à contrôler. Importe un relevé pour ouvrir la période."
+      },
+      "gapsTitle": "Périodes jamais importées",
+      "coverageGap_one": "Aucun relevé du {{from}} au {{to}} ({{count}} jour)",
+      "coverageGap_other": "Aucun relevé du {{from}} au {{to}} ({{count}} jours)",
+      "flowTitle": "Ce qui est entré et sorti",
+      "flowHint": "Vue « banque », sur tout l'historique du compte. Ces totaux ne s'additionnent jamais à ceux des budgets : le pont est le taux de couverture.",
+      "pendingCount_one": "{{count}} opération attend d'être rangée sur ce compte",
+      "pendingCount_other": "{{count}} opérations attendent d'être rangées sur ce compte",
+      "pendingNone": "Rien n'attend d'être rangé sur ce compte.",
+      "pendingAction": "Ranger ces opérations",
+      "recentTitle": "Dernières opérations",
+      "seeAll": "Voir toutes les opérations",
+      "noOperations": "Aucune opération sur ce compte.",
+      "noImports": "Aucun relevé importé pour l'instant.",
+      "noImportsCash": "Un compte espèces n'a pas de relevé : ses opérations se saisissent à la main.",
+      "detailsTitle": "Fiche du compte",
+      "transactionsLabel": "Opérations détenues",
+      "transactionCount_one": "{{count}} opération",
+      "transactionCount_other": "{{count}} opérations",
+      "currencyLabel": "Devise"
     }
   },
   "pwa": {

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -54,6 +54,7 @@ const MoneyPage = lazyWithReload(() => import('./features/money/MoneyPage'));
 const RecurringPage = lazyWithReload(() => import('./features/budget/RecurringPage'));
 const ReportsPage = lazyWithReload(() => import('./features/budget/ReportsPage'));
 const MoneyAnalysisPage = lazyWithReload(() => import('./features/money/AnalysisPage'));
+const AccountDetailPage = lazyWithReload(() => import('./features/money/AccountDetailPage'));
 const BudgetDetailPage = lazyWithReload(() => import('./features/money/BudgetDetailPage'));
 const ExpenseDetailPage = lazyWithReload(() => import('./features/money/ExpenseDetailPage'));
 const BankingTransactionsPage = lazyWithReload(
@@ -103,6 +104,7 @@ export const router = createBrowserRouter([
       { path: 'money/transactions', element: <BankingTransactionsPage /> },
       { path: 'money/transactions/:id', element: <BankingTransactionDetailPage /> },
       { path: 'money/analysis', element: <MoneyAnalysisPage /> },
+      { path: 'money/accounts/:id', element: <AccountDetailPage /> },
       { path: 'money/budgets/:id', element: <BudgetDetailPage /> },
       // Une dépense est une `Interaction`, mais sa fiche appartient à la famille
       // argent : elle vit donc sous `/app/money`, comme toute URL de la famille.


### PR DESCRIPTION
## Pourquoi

La carte d'un compte est le bon format pour **choisir**, et le mauvais pour **comprendre**. Les questions qui suivent se posent toutes *sur un compte*, et n'avaient nulle part où être répondues : d'où vient ce solde, jusqu'où le contrôle porte, qu'ont fait mes imports, que me reste-t-il à ranger ici.

`/app/money/accounts/:id` y répond, dans cet ordre. On y arrive en touchant le nom d'un compte dans l'onglet Comptes.

## Ce que la fiche montre

1. **Le solde et ce qu'il vaut** — montant, provenance (`anchored` = lu sur le relevé / `derived` = recalculé depuis le solde de départ), `ChainGapAlert` si la chaîne est rompue. Même endpoint que la carte, aucun calcul nouveau.
2. **La période contrôlée — et sa raison quand il n'y en a pas.** Voir ci-dessous.
3. **Les périodes qu'aucun relevé n'a jamais couvertes.**
4. **La vue « banque »** — sorties / entrées / taux de couverture. Un ratio, jamais une somme.
5. **Le reste à ranger sur ce compte**, avec le lien vers la liste filtrée.
6. **L'historique complet des imports du compte** — période couverte, lignes créées, ignorées, rapprochées d'elles-mêmes.
7. Les dernières opérations, la fiche brute, et les gestes (importer, retrouver le solde, éditer, archiver / rouvrir, dépense espèces).

## Le point structurant : `coverage/` répond par une raison

Nouveau `GET /api/banking/accounts/{id}/coverage/` → `banking.coverage.serialize_coverage`, qui renvoie un **`status`** (`\"\"` / `no_opening_date` / `opening_date_after_data` / `no_data`), les bornes, les périodes manquantes et `first_line`/`last_line`.

⚠️ Les trois `status` d'échec ne se rendent **pas** de la même façon. `no_data` est normal — rien d'importé, rien à affirmer. Les deux autres rendent le compte muet pour **tous** les détecteurs, et l'un des deux ressemble à un compte correctement réglé : c'est exactement la confusion qui avait fait afficher « tout est affecté » sur un compte dont pas une ligne n'était vérifiée. C'est la règle « un compteur à zéro a deux sens » appliquée à un compte : **la fiche ne doit jamais annoncer une période contrôlée qu'elle n'a pas**, et les deux cas fautifs portent un bouton « Corriger ».

`first_line` existe pour que le cas vicieux soit *dicible* : « ta date de solde de départ est postérieure à ta plus ancienne opération » a besoin de nommer cette opération.

Son propre endpoint plutôt que des champs du serializer : la fenêtre se **dérive** des imports et des lignes (elle bouge sans que la ligne du compte soit jamais réécrite), et l'inliner ferait payer deux agrégats par ligne à chaque liste de comptes.

## Une seule voix par chiffre

Le reste à ranger vient du serveur, par `?account=…&allocation=todo`, donc de `detectors.pending_outflows` — le **même** jugement que le badge Contrôle et que la file « À ranger ». Jamais un calcul local sur les montants : deux voix sur le même chiffre, et plus personne n'en croit aucune. Et le compteur **mène** à la liste filtrée, d'où le deep link du journal : ses filtres vivant en `sessionStorage`, le lien les écrase à l'arrivée puis **consomme** le paramètre — sinon le bouton retour du navigateur réappliquerait un filtre que l'utilisateur vient d'enlever.

Autres décisions notables :

- **L'historique des imports** gagne la **période couverte** (c'est elle qui borne la conformité, pas la date du dépôt) et `auto_matched_count`, le seul chiffre de la trace qui parle de travail épargné plutôt que de volume.
- **Archiver ferme la fiche sans undo différé**, contrairement à la liste : archiver n'est pas supprimer, la fiche reste accessible et son bouton « Rouvrir » est le chemin de retour.

## Tests

- `apps/banking/tests/test_api_account_coverage.py` — 8 cas, dont les trois `status` distingués l'un de l'autre et le scope foyer.
- `ui/src/features/money/AccountDetailPage.test.tsx` — 7 cas, dont « un compte non évaluable ne se lit jamais comme un compte couvert » et « un compte neuf n'est pas un compte en faute ».
- Suite banking complète : 565 passed. `tsc -b` propre, ESLint 0 erreur.

Tutoriel « Comptes » : un pas de plus (`sheet`), dans les quatre langues. Docs : `docs/MODULES/money.md` et `docs/MODULES/banking.md`.

## ⚠️ Échec de CI préexistant, hors de cette PR

`ui/src/design-system/decimal-input.test.tsx` échoue **déjà sur `main`** : `features/banking/CashMirrorDialog.tsx` et `features/money/CashDepositDialog.tsx` (commit 9924ecaa, #446) portent un `type=\"number\"` à pas fractionnaire, ce que le garde-fou interdit. Aucun des deux fichiers n'est touché ici. À corriger dans sa propre PR.