### PR TITLE
feat(search): chercher dans tout le foyer depuis la barre du haut

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1005,6 +1005,40 @@ Doc complète : `docs/MODULES/agent.md` + `docs/parcours/PARCOURS_07_LOT8_ACTION
 
 ---
 
+## Recherche globale — la barre du haut cherche dans le RAG
+
+La boîte de recherche de la `TopBar` (⌘K, `ui/src/features/search/`) n'a **pas** de
+moteur : elle appelle `GET /api/search/?q=`, qui exécute `agent.retrieval.search`.
+Enregistrer un `SearchableSpec` rend donc une entité trouvable dans toute l'app sans
+une ligne de front. Doc : `docs/MODULES/shell-and-design-system.md` § « Recherche
+globale ».
+
+- **Une seule recherche, trois portes.** La palette, le picker « Ajouter du contexte »
+  de l'agent et le tool `search_household` passent par
+  `agent.search_api.search_household_entities` — même ranking, même payload, même
+  gating par modules. Ne jamais rouvrir un second chemin : trouver un document dans la
+  barre du haut et s'entendre répondre « je ne le connais pas » dans le chat ne dit
+  pas lequel des deux se trompe, ça décrédibilise les deux. C'est la règle « un écart
+  ne se dit jamais deux fois avec deux voix » appliquée à la connaissance du foyer.
+  Régression : `agent/tests/test_global_search.py::TestTheTwoSearchBoxesAgree`.
+- **⚠️ La recherche-à-la-frappe passe `hybrid=False`** et n'hérite **pas** de
+  `AGENT_HYBRID_RETRIEVAL_ENABLED`. Le flag est le bon défaut pour une question posée
+  à l'agent (un embedding par tour) ; sur une boîte de recherche il vaut **un
+  embedding facturé par frappe débouncée**. La sortie est un choix explicite, jamais
+  un oubli à « corriger » — et ce n'est pas un kill switch : `search()` sans argument
+  continue de lire le flag.
+- **Le surlignage se parse, il ne s'injecte pas.** `ts_headline` renvoie des `<<…>>` ;
+  `features/search/highlight.ts` les transforme en segments rendus en `<mark>`. Le
+  texte vient du foyer (OCR d'un PDF, note) : un `dangerouslySetInnerHTML` ferait de
+  chaque `<` saisi un point d'injection.
+- **Ajouter une entité searchable = ajouter son icône et son libellé de groupe**
+  (`features/agent/entityIcons.ts`, `search.entity.*` dans les 4 locales). Sans ça le
+  nouveau type arrive dans la palette avec un glyphe générique et une clé i18n brute.
+  Vérifié depuis Python, seul côté qui connaît la liste des `entity_type` :
+  `test_global_search.py::TestThePaletteCoversTheRegistry`.
+
+---
+
 ## Page Tutoriel (`ui/src/features/tutorials/`)
 
 Page `/app/tutorial` (sidebar, section Compte) : checklist « Bien démarrer » +

--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -220,11 +220,20 @@ def search(
     query: str,
     limit: int = 20,
     disabled: frozenset[str] | None = None,
+    *,
+    hybrid: bool | None = None,
 ) -> list[Hit]:
     """Return up to `limit` hits across all registered entities, ranked desc.
 
     Specs of household-disabled modules are skipped. ``disabled`` lets callers
     that loop over several queries (``search_multi``) fetch the set once.
+
+    ``hybrid`` overrides ``AGENT_HYBRID_RETRIEVAL_ENABLED`` for this call. The
+    global flag is the right default for a *question* asked to the agent, where one
+    embedding call per turn is negligible. It is the wrong default for
+    search-as-you-type: the global search box would pay an embedding call per
+    debounced keystroke, and the palette must stay instant and free. Hence
+    ``hybrid=False`` there — an explicit choice, not an inherited one.
     """
     if not query or not query.strip():
         return []
@@ -241,7 +250,7 @@ def search(
     all_hits.sort(key=lambda h: h.rank, reverse=True)
     fulltext_hits = all_hits[:limit]
 
-    if not _hybrid_enabled():
+    if not (_hybrid_enabled() if hybrid is None else hybrid):
         return fulltext_hits
 
     vector_hits = _vector_search(household_id, query, limit, disabled=disabled)

--- a/apps/agent/search_api.py
+++ b/apps/agent/search_api.py
@@ -1,0 +1,100 @@
+"""
+Global household search — the app-wide search box, served by the agent's retrieval.
+
+``GET /api/search/?q=…`` is the *only* endpoint of the app-wide search. It runs the
+exact same ``retrieval.search`` the ``search_household`` tool runs, so what the user
+finds in the top-bar palette and what the agent can cite are one and the same index:
+one query, one ranking, one set of module-disabled exclusions. Nothing here knows
+about any particular entity — adding a ``SearchableSpec`` makes the new entity
+searchable from the palette with zero change to this file.
+
+Two deliberate choices, both about search-as-you-type rather than about search:
+
+- **``hybrid=False``.** The semantic leg costs one embedding call per query. Fine for
+  a question asked to the agent, absurd for a debounced keystroke — see
+  ``retrieval.search``.
+- **Its own throttle scope.** Full-text is cheap, so the agent's 10/min burst cap
+  would be absurdly tight here; but a type-ahead endpoint is the easiest loop to
+  leave running, hence a bound of its own rather than none at all.
+"""
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from core.permissions import IsHouseholdMember, resolve_request_household
+
+from . import retrieval
+from .throttles import SearchRateThrottle
+
+# Cap on `limit`. The palette shows a couple of results per entity type; a client
+# asking for hundreds would turn a type-ahead into a full table scan per keystroke.
+MAX_LIMIT = 50
+DEFAULT_LIMIT = 20
+
+# Below this, a query matches nearly everything and ranks nothing. The client
+# debounces and waits for the same threshold; the server enforces it so a direct
+# caller cannot trigger the expensive-and-useless case.
+MIN_QUERY_LENGTH = 2
+
+
+def serialize_hits(hits: list[retrieval.Hit]) -> list[dict]:
+    """Render retrieval hits as the search payload.
+
+    Shared with the agent's context picker (``conversations/search_context``) so the
+    two consumers of household search cannot drift into two shapes.
+
+    ``snippet`` keeps the ``<<…>>`` markers emitted by ``SearchHeadline``: they carry
+    *where* the match landed, which is the whole point of showing a snippet. The
+    client turns them into ``<mark>`` — see ``ui/src/features/search/highlight.ts``.
+    """
+    return [
+        {
+            "entity_type": hit.entity_type,
+            "object_id": str(hit.id),
+            "label": hit.label,
+            "url": hit.url_path,
+            "snippet": hit.snippet,
+        }
+        for hit in hits
+    ]
+
+
+def _clamp_limit(raw: str | None) -> int:
+    try:
+        limit = int(raw) if raw else DEFAULT_LIMIT
+    except (TypeError, ValueError):
+        return DEFAULT_LIMIT
+    return max(1, min(limit, MAX_LIMIT))
+
+
+def search_household_entities(household_id, query: str, limit: int) -> list[dict]:
+    """Run the palette's search and serialize it. One entry point, two URLs."""
+    if len(query) < MIN_QUERY_LENGTH:
+        return []
+    hits = retrieval.search(household_id, query, limit=limit, hybrid=False)
+    return serialize_hits(hits)
+
+
+class GlobalSearchView(APIView):
+    """``GET /api/search/?q=&limit=`` — search everything the household owns."""
+
+    permission_classes = [IsAuthenticated, IsHouseholdMember]
+    throttle_classes = [SearchRateThrottle]
+
+    def get(self, request):
+        household = getattr(request, "household", None) or resolve_request_household(request)
+        if household is None:
+            return Response(
+                {"detail": "No active household for this user."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        query = (request.query_params.get("q") or "").strip()
+        limit = _clamp_limit(request.query_params.get("limit"))
+        return Response(
+            {"results": search_household_entities(household.id, query, limit)},
+            status=status.HTTP_200_OK,
+        )

--- a/apps/agent/search_api.py
+++ b/apps/agent/search_api.py
@@ -71,7 +71,12 @@ def _clamp_limit(raw: str | None) -> int:
 
 
 def search_household_entities(household_id, query: str, limit: int) -> list[dict]:
-    """Run the palette's search and serialize it. One entry point, two URLs."""
+    """Run the palette's search and serialize it. One entry point, two URLs.
+
+    Strips and gates the query here rather than trusting callers to: this is the
+    shared door, and a caller that forgot would send whitespace to the retrieval.
+    """
+    query = (query or "").strip()
     if len(query) < MIN_QUERY_LENGTH:
         return []
     hits = retrieval.search(household_id, query, limit=limit, hybrid=False)

--- a/apps/agent/search_urls.py
+++ b/apps/agent/search_urls.py
@@ -1,0 +1,13 @@
+"""Global search URL — mounted at `/api/search/` (see config/urls.py).
+
+It lives in the agent app because the retrieval layer does, but it is *not* under
+`/api/agent/`: the app-wide search box is a navigation affordance, not a
+conversation with the assistant. The URL says so.
+"""
+from django.urls import path
+
+from .search_api import GlobalSearchView
+
+urlpatterns = [
+    path("", GlobalSearchView.as_view(), name="global-search"),
+]

--- a/apps/agent/tests/test_global_search.py
+++ b/apps/agent/tests/test_global_search.py
@@ -198,23 +198,20 @@ class TestTheSemanticLegStaysOut:
         assert resp.status_code == status.HTTP_200_OK
         assert "Pompe à chaleur" in _labels(resp)
 
-    def test_the_agent_still_honours_the_setting(self, household, project, settings):
+    def test_the_agent_still_honours_the_setting(
+        self, household, project, settings, monkeypatch
+    ):
         """The opt-out is the palette's, not a global kill switch: `search()` with no
         `hybrid` argument keeps reading the flag."""
         settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
         calls = []
 
-        original = retrieval._vector_search
-
         def _spy(*args, **kwargs):
             calls.append(1)
             return []
 
-        retrieval._vector_search = _spy
-        try:
-            retrieval.search(household.id, "pompe")
-        finally:
-            retrieval._vector_search = original
+        monkeypatch.setattr("agent.retrieval._vector_search", _spy)
+        retrieval.search(household.id, "pompe")
         assert calls == [1]
 
 

--- a/apps/agent/tests/test_global_search.py
+++ b/apps/agent/tests/test_global_search.py
@@ -1,0 +1,286 @@
+"""Tests for `GET /api/search/` — the app-wide search box.
+
+The endpoint adds no retrieval logic of its own: it exists to expose the agent's
+index to the UI. So what is worth locking is exactly that — that it stays the *same*
+search (same ranking, same household scope, same module gating as the
+`search_household` tool), that a type-ahead cannot become expensive, and that the
+snippet reaches the client with the markers it needs to highlight.
+"""
+from __future__ import annotations
+
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from agent import retrieval
+from households.models import Household, HouseholdMember
+
+URL = "/api/search/"
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="search-owner@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    h = Household.objects.create(name="Search House")
+    HouseholdMember.objects.create(user=owner, household=h, role=HouseholdMember.Role.OWNER)
+    owner.active_household = h
+    owner.save(update_fields=["active_household"])
+    return h
+
+
+@pytest.fixture
+def stranger(db):
+    """A user of another household, with a project of the same name."""
+    user = UserFactory(email="search-stranger@example.com")
+    other = Household.objects.create(name="Other House")
+    HouseholdMember.objects.create(user=user, household=other, role=HouseholdMember.Role.OWNER)
+    user.active_household = other
+    user.save(update_fields=["active_household"])
+    return user
+
+
+@pytest.fixture
+def owner_client(owner, household):
+    return _client_for(owner)
+
+
+@pytest.fixture
+def project(household):
+    from projects.models import Project
+
+    return Project.objects.create(
+        household=household,
+        title="Pompe à chaleur",
+        description="Remplacement de la chaudière au fioul",
+    )
+
+
+def _results(resp) -> list[dict]:
+    return resp.json()["results"]
+
+
+def _labels(resp) -> list[str]:
+    return [row["label"] for row in _results(resp)]
+
+
+@pytest.mark.django_db
+class TestSearching:
+    def test_finds_an_entity_by_its_name(self, owner_client, project):
+        resp = owner_client.get(URL, {"q": "pompe"})
+        assert resp.status_code == status.HTTP_200_OK
+        assert "Pompe à chaleur" in _labels(resp)
+
+    def test_finds_an_entity_by_its_body(self, owner_client, project):
+        resp = owner_client.get(URL, {"q": "chaudière"})
+        assert "Pompe à chaleur" in _labels(resp)
+
+    def test_accents_are_ignored(self, owner_client, project):
+        """`simple_unaccent`: typing without accents must still match."""
+        resp = owner_client.get(URL, {"q": "chaudiere"})
+        assert "Pompe à chaleur" in _labels(resp)
+
+    def test_a_result_carries_what_the_palette_needs(self, owner_client, project):
+        resp = owner_client.get(URL, {"q": "pompe"})
+        row = next(r for r in _results(resp) if r["label"] == "Pompe à chaleur")
+        assert row["entity_type"] == "project"
+        assert row["object_id"] == str(project.id)
+        assert row["url"] == f"/app/projects/{project.id}"
+
+    def test_the_snippet_keeps_its_highlight_markers(self, owner_client, project):
+        """The client renders `<<…>>` as `<mark>`; stripping them here would make
+        the snippet a blob of text with no visible reason for being shown."""
+        resp = owner_client.get(URL, {"q": "chaudière"})
+        row = next(r for r in _results(resp) if r["label"] == "Pompe à chaleur")
+        assert "<<" in row["snippet"] and ">>" in row["snippet"]
+
+    def test_no_match_is_an_empty_list_not_an_error(self, owner_client, project):
+        resp = owner_client.get(URL, {"q": "zzzznothing"})
+        assert resp.status_code == status.HTTP_200_OK
+        assert _results(resp) == []
+
+
+@pytest.mark.django_db
+class TestScope:
+    def test_another_household_never_surfaces(self, stranger, project):
+        """`project` belongs to the owner's household — the stranger must see nothing."""
+        resp = _client_for(stranger).get(URL, {"q": "pompe"})
+        assert resp.status_code == status.HTTP_200_OK
+        assert _results(resp) == []
+
+    def test_anonymous_is_rejected(self, project):
+        resp = APIClient().get(URL, {"q": "pompe"})
+        assert resp.status_code in (
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        )
+
+    def test_a_disabled_module_is_invisible(self, owner_client, household):
+        """Same gating as the agent: an entity of a module the household turned off
+        does not exist as far as search is concerned."""
+        from chickens.models import Chicken
+
+        Chicken.objects.create(household=household, name="Roussette la poule")
+        assert "Roussette la poule" in _labels(owner_client.get(URL, {"q": "roussette"}))
+
+        household.disabled_modules = ["chickens"]
+        household.save(update_fields=["disabled_modules"])
+        assert _results(owner_client.get(URL, {"q": "roussette"})) == []
+
+
+def _spy_on_retrieval(monkeypatch) -> list[dict]:
+    """Replace `retrieval.search` with a recorder. Returns the list of calls."""
+    calls: list[dict] = []
+
+    def _record(household_id, query, limit=20, disabled=None, **kwargs):
+        calls.append({"query": query, "limit": limit, **kwargs})
+        return []
+
+    monkeypatch.setattr("agent.search_api.retrieval.search", _record)
+    return calls
+
+
+@pytest.mark.django_db
+class TestBounds:
+    def test_a_blank_query_searches_nothing(self, owner_client, project, monkeypatch):
+        """No query, no work — an empty box must not scan every table."""
+        calls = _spy_on_retrieval(monkeypatch)
+        assert _results(owner_client.get(URL, {"q": "   "})) == []
+        assert _results(owner_client.get(URL)) == []
+        assert calls == []
+
+    def test_a_single_character_searches_nothing(self, owner_client, project):
+        """One letter matches nearly everything and ranks nothing. The client gates
+        at two characters; the server enforces it so a direct caller cannot."""
+        assert _results(owner_client.get(URL, {"q": "p"})) == []
+
+    def test_limit_is_clamped(self, owner_client, monkeypatch):
+        calls = _spy_on_retrieval(monkeypatch)
+        owner_client.get(URL, {"q": "pompe", "limit": "5000"})
+        assert calls[0]["limit"] == 50
+
+    def test_a_garbage_limit_falls_back_to_the_default(self, owner_client, monkeypatch):
+        calls = _spy_on_retrieval(monkeypatch)
+        owner_client.get(URL, {"q": "pompe", "limit": "beaucoup"})
+        assert calls[0]["limit"] == 20
+
+
+@pytest.mark.django_db
+class TestTheSemanticLegStaysOut:
+    """A debounced keystroke must never cost an embedding call.
+
+    The hybrid flag is the right default for a question asked to the agent (one
+    embedding per turn). On a search box it would be one per keystroke — so the
+    palette opts out explicitly instead of inheriting the setting.
+    """
+
+    def test_hybrid_is_off_even_when_the_setting_is_on(
+        self, owner_client, project, settings, monkeypatch
+    ):
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("the global search must not embed the query")
+
+        monkeypatch.setattr("agent.embeddings.get_embedding_client", _boom)
+
+        resp = owner_client.get(URL, {"q": "pompe"})
+        assert resp.status_code == status.HTTP_200_OK
+        assert "Pompe à chaleur" in _labels(resp)
+
+    def test_the_agent_still_honours_the_setting(self, household, project, settings):
+        """The opt-out is the palette's, not a global kill switch: `search()` with no
+        `hybrid` argument keeps reading the flag."""
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        calls = []
+
+        original = retrieval._vector_search
+
+        def _spy(*args, **kwargs):
+            calls.append(1)
+            return []
+
+        retrieval._vector_search = _spy
+        try:
+            retrieval.search(household.id, "pompe")
+        finally:
+            retrieval._vector_search = original
+        assert calls == [1]
+
+
+class TestThePaletteCoversTheRegistry:
+    """The registry is the source of truth; the palette must not lag behind it.
+
+    Registering a `SearchableSpec` is all it takes to make an entity findable — which
+    means a new entity type reaches the search box with no front-end change at all,
+    and would show up there under a generic glyph and a raw i18n key. Both files
+    below are checked from Python, on the registry itself, because that is the only
+    side that knows the full list.
+    """
+
+    @staticmethod
+    def _entity_types() -> set[str]:
+        from agent.searchables import REGISTRY
+
+        return {spec.entity_type for spec in REGISTRY}
+
+    def test_every_searchable_type_has_an_icon(self):
+        from pathlib import Path
+
+        source = (
+            Path(__file__).resolve().parents[3]
+            / "ui/src/features/agent/entityIcons.ts"
+        ).read_text(encoding="utf-8")
+        missing = {t for t in self._entity_types() if f"  {t}:" not in source}
+        assert not missing, (
+            f"entity types without an icon in entityIcons.ts: {sorted(missing)} — "
+            "they would all render as the same fallback glyph in the search palette"
+        )
+
+    def test_every_searchable_type_has_a_group_label_in_the_four_catalogues(self):
+        import json
+        from pathlib import Path
+
+        ui = Path(__file__).resolve().parents[3] / "ui/src/locales"
+        for lang in ("en", "fr", "de", "es"):
+            catalogue = json.loads(
+                (ui / lang / "translation.json").read_text(encoding="utf-8")
+            )
+            labels = catalogue.get("search", {}).get("entity", {})
+            missing = self._entity_types() - set(labels)
+            assert not missing, (
+                f"{lang}: search.entity.* is missing {sorted(missing)} — the palette "
+                "would show a raw i18n key as a group heading"
+            )
+
+
+@pytest.mark.django_db
+class TestTheTwoSearchBoxesAgree:
+    """The palette and the agent's context picker are one search, not two.
+
+    They had to be: a user who finds a document in the top bar and cannot find it in
+    the picker (or the reverse) has no way to tell which of the two is lying about
+    what the household contains.
+    """
+
+    def test_same_results_as_the_context_picker(self, owner_client, project):
+        palette = _results(owner_client.get(URL, {"q": "pompe"}))
+        picker = owner_client.get(
+            "/api/agent/conversations/search_context/", {"q": "pompe"}
+        ).json()
+        assert palette == picker
+
+    def test_same_results_as_the_agent_tool(self, owner_client, household, project):
+        palette = _results(owner_client.get(URL, {"q": "pompe"}))
+        hits = retrieval.search(household.id, "pompe", limit=20, hybrid=False)
+        assert [row["object_id"] for row in palette] == [str(hit.id) for hit in hits]

--- a/apps/agent/throttles.py
+++ b/apps/agent/throttles.py
@@ -22,6 +22,17 @@ class AgentBurstRateThrottle(UserRateThrottle):
     scope = "agent_burst"
 
 
+class SearchRateThrottle(UserRateThrottle):
+    """Global search (`/api/search/`) — 120 requests per minute per user.
+
+    Full-text search costs no provider call, so the agent's caps do not apply: at
+    10/min a user typing in the top-bar palette would be blocked mid-word. The bound
+    exists because a type-ahead endpoint is the easiest thing to leave looping, and
+    it is set well above human typing behind a 250 ms debounce.
+    """
+    scope = "search"
+
+
 class AgentSustainedRateThrottle(UserRateThrottle):
     """100 agent questions per hour per user."""
     scope = "agent_sustained"

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -377,6 +377,10 @@ class ConversationViewSet(viewsets.ModelViewSet):
         and the agent's ``search_household`` tool can never drift into three
         rankings or three payload shapes. Kept as a bare list (not
         ``{"results": …}``) because that is the shape its client already reads.
+
+        Conséquence du partage : le plancher de deux caractères s'applique ici aussi
+        (avant, une requête d'un caractère cherchait). Le picker le respectait déjà
+        côté client.
         """
         query = (request.query_params.get("q") or "").strip()
         household = self._resolve_household()

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -17,7 +17,7 @@ from rest_framework.views import APIView
 from core.permissions import IsHouseholdMember, resolve_request_household
 
 from . import memory as memory_service
-from . import retrieval, searchables, service, tools
+from . import search_api, searchables, service, tools
 from .conversations import (
     ask_inputs as _ask_inputs,
     persist_turns as _persist_turns,
@@ -372,26 +372,18 @@ class ConversationViewSet(viewsets.ModelViewSet):
     def search_context(self, request):
         """Full-text search over the household's entities, for the context picker.
 
-        Query param ``q``. Reuses the exact retrieval the ``search_household`` tool
-        uses (same ranking, same disabled-module filtering), so the picker surfaces
-        precisely what the agent could find. Returns a light list of candidates.
+        Query param ``q``. Delegates to ``search_api.search_household_entities`` —
+        the same entry point the global search box uses — so the picker, the palette
+        and the agent's ``search_household`` tool can never drift into three
+        rankings or three payload shapes. Kept as a bare list (not
+        ``{"results": …}``) because that is the shape its client already reads.
         """
         query = (request.query_params.get("q") or "").strip()
         household = self._resolve_household()
-        if not query:
-            return Response([], status=status.HTTP_200_OK)
-        hits = retrieval.search(household.id, query, limit=20)
         return Response(
-            [
-                {
-                    "entity_type": hit.entity_type,
-                    "object_id": str(hit.id),
-                    "label": hit.label,
-                    "url": hit.url_path,
-                    "snippet": hit.snippet,
-                }
-                for hit in hits
-            ],
+            search_api.search_household_entities(
+                household.id, query, search_api.DEFAULT_LIMIT
+            ),
             status=status.HTTP_200_OK,
         )
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -173,6 +173,7 @@ REST_FRAMEWORK = {
         "password_reset": "3/hour",
         "agent_burst": "10/min",
         "agent_sustained": "100/hour",
+        "search": "120/min",
     },
 }
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -41,6 +41,7 @@ urlpatterns = [
     path("api/notifications/", include("notifications.urls")),
     path("api/alerts/", include("alerts.urls")),
     path("api/agent/", include("agent.urls")),
+    path("api/search/", include("agent.search_urls")),
     path("api/ai-usage/", include("ai_usage.urls")),
     path("api/telegram/", include("telegram.urls")),
     path("api/releases/", include("releases.urls")),

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -238,8 +238,19 @@ Sous `/api/agent/` :
 - `POST {id}/pin_context/` / `POST {id}/unpin_context/` (body `{entity_type,
   object_id}`) — épingle/retire une entité du contexte de la conversation ; renvoie
   la conversation avec son `injected_context` rafraîchi.
-- `GET conversations/search_context/?q=` — recherche full-text foyer (réutilise
-  `retrieval.search`) pour le picker « Ajouter du contexte » ; `q` vide → `[]`.
+- `GET conversations/search_context/?q=` — recherche full-text foyer pour le picker
+  « Ajouter du contexte » ; délègue à `search_api.search_household_entities` (voir
+  juste en dessous) ; `q` vide → `[]`.
+
+Hors de `/api/agent/`, parce que ce n'est pas une conversation :
+
+- `GET /api/search/?q=&limit=` — **recherche globale de l'app** (palette de la barre
+  du haut), `apps/agent/search_api.py`. Même retrieval, même ranking, même gating par
+  modules que le tool `search_household` ; renvoie `{results: [{entity_type,
+  object_id, label, url, snippet}]}`. Throttle propre (`search`, 120/min) : le
+  plein-texte ne coûte aucun appel provider, mais un endpoint de type-ahead reste
+  ce qu'on laisse tourner en boucle le plus facilement. Doc :
+  `docs/MODULES/shell-and-design-system.md` § « Recherche globale ».
 - `memories/` (CRUD, privé par user × foyer) + `DELETE memories/clear/` (efface
   tout, renvoie `{deleted: n}`) — mémoire utilisateur.
 - Permissions : `IsAuthenticated, IsHouseholdMember` ; `ask`, `messages` et
@@ -283,6 +294,15 @@ et les fonctions `_vector_search` / `_fuse_rrf` de `retrieval.py`.
 - `AGENT_HYBRID_RETRIEVAL_ENABLED` — jambe sémantique dans `search()` (off =
   full-text à l'octet près). À activer une fois `VOYAGE_API_KEY` posé et le corpus
   indexé (`manage.py backfill_embeddings`).
+
+**⚠️ La recherche-à-la-frappe sort explicitement de l'hybride** (`hybrid=False`, param
+de `search()`). Le flag global est le bon défaut pour une *question* posée à l'agent —
+un embedding par tour. Ce serait le mauvais défaut pour la palette de recherche
+globale et le picker de contexte : **un embedding par frappe débouncée**, facturé, sur
+un geste qui doit rester instantané. Ne pas remplacer par un héritage du flag ; la
+sortie est un choix, pas un oubli. Régression :
+`agent/tests/test_global_search.py::TestTheSemanticLegStaysOut` (qui vérifie aussi que
+l'agent, lui, continue d'honorer le flag — ce n'est pas un kill switch).
 
 Fiche concept (le cours) : [docs/fiches/EMBEDDINGS.md](../fiches/EMBEDDINGS.md).
 Backlog : [PARCOURS_21_BACKLOG_TECHNIQUE.md](../parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md).

--- a/docs/MODULES/shell-and-design-system.md
+++ b/docs/MODULES/shell-and-design-system.md
@@ -11,10 +11,38 @@
 
 - Shell : `ui/src/components/AppShell.tsx`, `Sidebar.tsx`, `SidebarToggleContext.tsx`, `TopBar.tsx`, `HouseholdSwitcher.tsx`, `ImpersonationBanner.tsx`
 - Helpers de page : `PageHeader.tsx`, `ListPage.tsx`, `ListSkeleton.tsx`, `EmptyState.tsx`, `TabShell.tsx`, `CardActions.tsx`, `ConfirmDialog.tsx`
+- Recherche globale : `ui/src/features/search/` (`GlobalSearch.tsx` posé dans la `TopBar`, `SearchPalette.tsx`, `highlight.ts`, `hooks.ts`) — voir « Recherche globale » plus bas
 - Design system : `ui/src/design-system/` (button, input, card, dialog, sheet-dialog, dropdown-menu, dropdown-select, select, checkbox-field, form-field, filter-bar, filter-pill, alert, badge, skeleton, separator, label, textarea, toast)
 - i18n : `ui/src/lib/i18n.ts` (init i18next, détection lang) + `ui/src/locales/{en,fr,de,es}/translation.json`
 - Thèmes : `ui/src/lib/theme.ts` (`applyDarkMode`, `applyColorTheme`), appliqués dans `ProtectedLayout` au chargement du profil
 - Tokens CSS : `ui/src/styles.css` (référencé via Tailwind 4)
+
+## Recherche globale (2026-07)
+
+Une seule boîte pour tout ce que contient le foyer, dans la barre du haut : champ sur
+desktop (avec ⌘K/Ctrl-K), loupe sur mobile où la barre est déjà pleine. Les deux
+ouvrent la même palette (`SheetDialog`), résultats groupés par type d'entité,
+navigation ↑↓/Entrée, et un clic **mène à la page** de l'entité (`pushBack`, donc le
+lien retour de la page de détail ramène là où la recherche a été lancée).
+
+- **Aucun moteur de recherche n'a été écrit** : la palette appelle
+  `GET /api/search/?q=`, qui exécute la retrieval de l'agent
+  (`agent.retrieval.search`). Une entité devient donc trouvable en s'enregistrant
+  dans `agent.searchables`, sans une ligne de front.
+- **La palette, le picker de contexte de l'agent et le tool `search_household`
+  passent par le même point d'entrée** (`agent.search_api.search_household_entities`).
+  Un utilisateur qui trouve un document dans la barre du haut et s'entend répondre
+  « je ne le connais pas » dans le chat n'a aucun moyen de savoir lequel des deux
+  ment. Régression : `agent/tests/test_global_search.py::TestTheTwoSearchBoxesAgree`.
+- **Le surlignage n'est pas du HTML.** `ts_headline` encadre les termes trouvés de
+  `<<…>>` ; `features/search/highlight.ts` les parse en segments rendus en `<mark>`.
+  Le contenu vient du foyer (OCR d'un PDF, note) : un `dangerouslySetInnerHTML`
+  ferait de chaque `<` saisi un point d'injection.
+- **Le catalogue front doit couvrir le registre backend** — icône
+  (`features/agent/entityIcons.ts`) et libellé de groupe (`search.entity.*` dans les
+  4 locales) pour chaque `entity_type`. Sans ça un nouveau type arrive dans la
+  palette avec un glyphe générique et une clé i18n brute. Tenu depuis Python, seul
+  côté qui connaît la liste : `test_global_search.py::TestThePaletteCoversTheRegistry`.
 
 ## Notes
 

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Tests E2E — Recherche globale (palette de la top bar).
+ *
+ * Aucun appel LLM : `/api/search/` est du plein texte Postgres. Ce qui se vérifie
+ * ici et nulle part ailleurs, c'est la chaîne complète — la palette s'ouvre depuis
+ * la barre du haut *et* au clavier, la frappe atteint le réseau (debounce), et un
+ * résultat **mène à sa page**. Un test unitaire sur le groupement ne dit rien de ces
+ * quatre maillons.
+ *
+ * Seed : un projet créé par l'API avec un titre unique par test, supprimé ensuite.
+ * Le titre porte un mot rare (`Kryptonite`) pour ne dépendre d'aucune donnée de
+ * démo et ne jamais se noyer dans les résultats.
+ */
+
+interface Project {
+  id: string;
+  title: string;
+}
+
+async function getAccessToken(page: Page): Promise<string> {
+  return page.evaluate(() => localStorage.getItem('access_token') ?? '');
+}
+
+async function createProject(page: Page, title: string): Promise<Project> {
+  const token = await getAccessToken(page);
+  const resp = await page.request.post('/api/projects/projects/', {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    data: { title, status: 'active', type: 'other', priority: 3 },
+  });
+  if (!resp.ok()) {
+    throw new Error(`Impossible de créer le projet "${title}" : ${resp.status()}`);
+  }
+  return (await resp.json()) as Project;
+}
+
+async function deleteProject(page: Page, projectId: string): Promise<void> {
+  const token = await getAccessToken(page);
+  await page.request.delete(`/api/projects/projects/${projectId}/`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+test.describe('Recherche globale', () => {
+  let project: Project;
+  let needle: string;
+
+  test.beforeEach(async ({ page }) => {
+    // Hydrater le JWT avant d'appeler l'API.
+    await page.goto('/app/dashboard');
+    await expect(page).toHaveURL(/\/app\/dashboard/);
+
+    needle = `Kryptonite${Date.now()}`;
+    project = await createProject(page, `Chantier ${needle}`);
+    // Recharger : la palette est montée dans la coque, la donnée doit exister
+    // avant la première requête de recherche.
+    await page.reload();
+  });
+
+  test.afterEach(async ({ page }) => {
+    if (project?.id) await deleteProject(page, project.id);
+  });
+
+  test('trouve un projet depuis la barre du haut et mène à sa page', async ({ page }) => {
+    await page.getByTestId('global-search-trigger').click();
+
+    const input = page.getByTestId('global-search-input');
+    await expect(input).toBeFocused();
+    await input.fill(needle);
+
+    const result = page.getByTestId('global-search-result').filter({ hasText: needle });
+    await expect(result.first()).toBeVisible();
+
+    await result.first().click();
+    await expect(page).toHaveURL(new RegExp(`/app/projects/${project.id}`));
+  });
+
+  test('le raccourci clavier ouvre la palette depuis n’importe quelle page', async ({ page }) => {
+    await page.goto('/app/tasks');
+    await page.keyboard.press('ControlOrMeta+k');
+    await expect(page.getByTestId('global-search-input')).toBeVisible();
+  });
+
+  test('les flèches et Entrée suffisent — sans toucher la souris', async ({ page }) => {
+    await page.keyboard.press('ControlOrMeta+k');
+    await page.getByTestId('global-search-input').fill(needle);
+    await expect(page.getByTestId('global-search-result').first()).toBeVisible();
+
+    await page.keyboard.press('ArrowDown');
+    await page.keyboard.press('Enter');
+    await expect(page).toHaveURL(/\/app\//);
+    // La palette se ferme en naviguant : elle ne doit pas rester par-dessus la page.
+    await expect(page.getByTestId('global-search-input')).toBeHidden();
+  });
+
+  test('une frappe trop courte ne cherche rien', async ({ page }) => {
+    await page.getByTestId('global-search-trigger').click();
+    await page.getByTestId('global-search-input').fill('K');
+    await expect(page.getByTestId('global-search-result')).toHaveCount(0);
+  });
+
+  test('un terme absent affiche une absence de résultat, pas une erreur', async ({ page }) => {
+    await page.getByTestId('global-search-trigger').click();
+    await page.getByTestId('global-search-input').fill('zzzzintrouvable');
+    await expect(page.getByText('Aucun résultat.')).toBeVisible();
+  });
+});

--- a/ui/src/components/TopBar.tsx
+++ b/ui/src/components/TopBar.tsx
@@ -4,6 +4,7 @@ import { useAuth } from '@/lib/auth/useAuth';
 import { useSidebarToggle } from './SidebarToggleContext';
 import HouseholdSwitcher from './HouseholdSwitcher';
 import NotificationsBell from '@/features/notifications/NotificationsBell';
+import GlobalSearch from '@/features/search/GlobalSearch';
 
 export default function TopBar() {
   const { t } = useTranslation();
@@ -38,6 +39,9 @@ export default function TopBar() {
       </div>
 
       <div className="flex-1" />
+
+      {/* App-wide search — box on desktop, magnifier on mobile */}
+      <GlobalSearch />
 
       {/* Notifications */}
       <NotificationsBell />

--- a/ui/src/features/agent/entityIcons.ts
+++ b/ui/src/features/agent/entityIcons.ts
@@ -1,13 +1,19 @@
 import {
   FileText, Notebook, Wrench, ListTodo, FolderKanban, MapPin,
   Box, ShieldCheck, User, Building2, ExternalLink,
+  Bird, Egg, Gauge, PiggyBank, Repeat, LineChart, ShoppingCart,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 /**
  * Maps an agent `entity_type` to its lucide icon. Shared by every place that
- * renders an entity chip (citations, the "what I know" context panel, the
- * context picker) so a new entity type gets a consistent icon in one edit.
+ * renders an entity chip (citations, the "what I know" context panel, the context
+ * picker, the global search palette) so a new entity type gets a consistent icon in
+ * one edit.
+ *
+ * It must cover every `entity_type` registered in `agent.searchables` — a type
+ * missing here falls back to a generic glyph, and in the search palette that means
+ * several groups of results looking alike. Tenu par `entityIcons.test.ts`.
  */
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
   document: FileText,
@@ -20,6 +26,13 @@ export const ENTITY_ICONS: Record<string, LucideIcon> = {
   insurance_contract: ShieldCheck,
   contact: User,
   structure: Building2,
+  budget: PiggyBank,
+  recurring_expense: Repeat,
+  chicken: Bird,
+  chicken_event: Egg,
+  meter: Gauge,
+  tracker: LineChart,
+  shopping_item: ShoppingCart,
 };
 
 /** Generic fallback glyph for an unmapped entity type. */

--- a/ui/src/features/agent/entityIcons.ts
+++ b/ui/src/features/agent/entityIcons.ts
@@ -13,7 +13,8 @@ import type { LucideIcon } from 'lucide-react';
  *
  * It must cover every `entity_type` registered in `agent.searchables` — a type
  * missing here falls back to a generic glyph, and in the search palette that means
- * several groups of results looking alike. Tenu par `entityIcons.test.ts`.
+ * several groups of results looking alike. Tenu depuis Python, seul côté qui connaît
+ * la liste : `agent/tests/test_global_search.py::TestThePaletteCoversTheRegistry`.
  */
 export const ENTITY_ICONS: Record<string, LucideIcon> = {
   document: FileText,

--- a/ui/src/features/search/GlobalSearch.tsx
+++ b/ui/src/features/search/GlobalSearch.tsx
@@ -1,0 +1,60 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Search } from 'lucide-react';
+import SearchPalette from './SearchPalette';
+import { useSearchShortcut } from './hooks';
+
+/**
+ * The top bar's entry point into app-wide search.
+ *
+ * Desktop shows a fake input — it looks like the box it opens, so the affordance is
+ * readable without a tooltip, and it advertises ⌘K. Mobile gets the magnifier only:
+ * the bar there already carries the burger, the logo, the bell and the avatar, and
+ * a real input would squeeze all of them. Both open the same palette.
+ */
+export default function GlobalSearch() {
+  const { t } = useTranslation();
+  const [open, setOpen] = React.useState(false);
+
+  const openPalette = React.useCallback(() => setOpen(true), []);
+  useSearchShortcut(openPalette);
+
+  // ⌘ on Apple platforms, Ctrl elsewhere — showing the wrong one teaches a shortcut
+  // that does not work.
+  const shortcutLabel = React.useMemo(() => {
+    const isApple =
+      typeof navigator !== 'undefined' &&
+      /Mac|iPhone|iPad|iPod/.test(navigator.platform || navigator.userAgent || '');
+    return isApple ? '⌘K' : 'Ctrl K';
+  }, []);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={openPalette}
+        aria-label={t('search.title')}
+        data-testid="global-search-trigger"
+        className="hidden md:flex items-center gap-2 rounded-md border border-border bg-background/50 px-2.5 py-1.5 text-sm text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground"
+      >
+        <Search className="h-4 w-4 shrink-0" />
+        <span className="hidden lg:block">{t('search.placeholder')}</span>
+        <kbd className="ml-2 hidden rounded border border-border px-1.5 py-0.5 text-[10px] font-medium lg:block">
+          {shortcutLabel}
+        </kbd>
+      </button>
+
+      <button
+        type="button"
+        onClick={openPalette}
+        aria-label={t('search.title')}
+        data-testid="global-search-trigger-mobile"
+        className="md:hidden p-1.5 rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <Search className="h-5 w-5" />
+      </button>
+
+      <SearchPalette open={open} onOpenChange={setOpen} />
+    </>
+  );
+}

--- a/ui/src/features/search/SearchPalette.tsx
+++ b/ui/src/features/search/SearchPalette.tsx
@@ -1,0 +1,208 @@
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Search } from 'lucide-react';
+import { SheetDialog } from '@/design-system/sheet-dialog';
+import { Input } from '@/design-system/input';
+import { pushBack } from '@/lib/backNavigation';
+import { ENTITY_ICONS, ENTITY_ICON_FALLBACK } from '@/features/agent/entityIcons';
+import type { SearchResult } from '@/lib/api/search';
+import { useHouseholdSearch } from './hooks';
+import { parseSnippet, stripMarkers } from './highlight';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface Group {
+  entityType: string;
+  results: SearchResult[];
+}
+
+/**
+ * Group results by entity type while preserving the server's ranking: the groups
+ * come out in the order their best hit did, and each group keeps its own order. A
+ * grouping that re-sorted (alphabetically, by a hardcoded type order) would put a
+ * weak match above a strong one and quietly contradict the ranking.
+ */
+function groupByType(results: SearchResult[]): Group[] {
+  const groups: Group[] = [];
+  for (const result of results) {
+    const existing = groups.find((group) => group.entityType === result.entity_type);
+    if (existing) existing.results.push(result);
+    else groups.push({ entityType: result.entity_type, results: [result] });
+  }
+  return groups;
+}
+
+/** Excerpt with the matched terms marked. Rendered as text — never as HTML. */
+function Snippet({ snippet }: { snippet: string }) {
+  const segments = React.useMemo(() => parseSnippet(snippet), [snippet]);
+  if (segments.length === 0) return null;
+  return (
+    <span className="block truncate text-xs text-muted-foreground" title={stripMarkers(snippet)}>
+      {segments.map((segment, index) =>
+        segment.match ? (
+          <mark key={index} className="bg-primary/20 text-foreground">
+            {segment.text}
+          </mark>
+        ) : (
+          <React.Fragment key={index}>{segment.text}</React.Fragment>
+        ),
+      )}
+    </span>
+  );
+}
+
+/**
+ * App-wide search — every entity the household owns, from one box.
+ *
+ * It queries the agent's own retrieval (`GET /api/search/`), so what the palette
+ * finds and what the assistant can cite are the same index: a user who finds a
+ * document here and hears "I don't know about it" in the chat would have no way to
+ * tell which of the two is wrong.
+ */
+export default function SearchPalette({ open, onOpenChange }: Props) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [query, setQuery] = React.useState('');
+  const [activeIndex, setActiveIndex] = React.useState(0);
+
+  const { data, isLoading, isTyping, hasQuery } = useHouseholdSearch(open ? query : '');
+  const results = React.useMemo(() => data ?? [], [data]);
+  const groups = React.useMemo(() => groupByType(results), [results]);
+
+  // Reset on each open — a palette reopening on the previous search would answer a
+  // question the user is no longer asking.
+  React.useEffect(() => {
+    if (open) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+  }, [open]);
+
+  // New results, new selection: keeping the old index would highlight (and, on
+  // Enter, open) whatever now happens to sit at that position.
+  React.useEffect(() => setActiveIndex(0), [results]);
+
+  const go = React.useCallback(
+    (result: SearchResult) => {
+      onOpenChange(false);
+      navigate(result.url, { state: pushBack(location) });
+    },
+    [location, navigate, onOpenChange],
+  );
+
+  /** Keeps the arrow-selected row visible: below the fold, ↑↓ would move a
+   *  selection the user cannot see. `nearest` so it never jumps on mouse hover. */
+  const scrollActiveIntoView = React.useCallback((node: HTMLButtonElement | null) => {
+    node?.scrollIntoView({ block: 'nearest' });
+  }, []);
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (results.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((index) => (index + 1) % results.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((index) => (index - 1 + results.length) % results.length);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const target = results[activeIndex];
+      if (target) go(target);
+    }
+  };
+
+  return (
+    <SheetDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('search.title')}
+      description={t('search.description')}
+      size="l"
+    >
+      <div className="flex min-h-0 flex-col gap-3">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder={t('search.placeholder')}
+            aria-label={t('search.title')}
+            className="pl-9"
+            data-testid="global-search-input"
+          />
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {!hasQuery ? (
+            <p className="px-1 py-6 text-center text-sm text-muted-foreground">
+              {t('search.hint')}
+            </p>
+          ) : isLoading || isTyping ? (
+            <div className="space-y-2">
+              {[1, 2, 3].map((i) => (
+                <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
+              ))}
+            </div>
+          ) : results.length === 0 ? (
+            <p className="px-1 py-6 text-center text-sm text-muted-foreground">
+              {t('search.noResults')}
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {groups.map((group) => {
+                const Icon = ENTITY_ICONS[group.entityType] ?? ENTITY_ICON_FALLBACK;
+                return (
+                  <div key={group.entityType}>
+                    <p className="px-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      {t(`search.entity.${group.entityType}`)}
+                    </p>
+                    <ul className="space-y-1">
+                      {group.results.map((result) => {
+                        // Position in the flat, rank-ordered list — ↑↓ walks the
+                        // whole list, group headings included.
+                        const position = results.indexOf(result);
+                        const isActive = position === activeIndex;
+                        return (
+                          <li key={`${result.entity_type}:${result.object_id}`}>
+                            <button
+                              type="button"
+                              ref={isActive ? scrollActiveIntoView : undefined}
+                              onClick={() => go(result)}
+                              onMouseEnter={() => setActiveIndex(position)}
+                              data-testid="global-search-result"
+                              aria-current={isActive || undefined}
+                              className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+                                isActive
+                                  ? 'border-primary/40 bg-primary/10'
+                                  : 'border-border bg-card hover:bg-primary/10'
+                              }`}
+                            >
+                              <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+                              <span className="min-w-0 flex-1">
+                                <span className="block truncate text-foreground">
+                                  {result.label}
+                                </span>
+                                <Snippet snippet={result.snippet} />
+                              </span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </SheetDialog>
+  );
+}

--- a/ui/src/features/search/highlight.test.ts
+++ b/ui/src/features/search/highlight.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { parseSnippet, stripMarkers } from './highlight';
+
+describe('parseSnippet', () => {
+  it('renvoie un seul segment neutre sans marqueur', () => {
+    expect(parseSnippet('rien à surligner')).toEqual([
+      { text: 'rien à surligner', match: false },
+    ]);
+  });
+
+  it('isole le terme trouvé entre les marqueurs', () => {
+    expect(parseSnippet('remplacement de la <<chaudière>> au fioul')).toEqual([
+      { text: 'remplacement de la ', match: false },
+      { text: 'chaudière', match: true },
+      { text: ' au fioul', match: false },
+    ]);
+  });
+
+  it('gère plusieurs occurrences', () => {
+    const segments = parseSnippet('<<pompe>> à chaleur et <<pompe>> de puits');
+    expect(segments.filter((s) => s.match).map((s) => s.text)).toEqual(['pompe', 'pompe']);
+    expect(stripMarkers('<<pompe>> à chaleur et <<pompe>> de puits')).toBe(
+      'pompe à chaleur et pompe de puits',
+    );
+  });
+
+  it('garde un marqueur tronqué en texte littéral plutôt que de le manger', () => {
+    // ts_headline peut couper au milieu d'un marqueur en fin de fenêtre.
+    expect(stripMarkers('facture <<Engie')).toBe('facture <<Engie');
+  });
+
+  it('traverse les retours à la ligne — les champs sont concaténés par \\n', () => {
+    expect(parseSnippet('titre\n<<corps>>')).toEqual([
+      { text: 'titre\n', match: false },
+      { text: 'corps', match: true },
+    ]);
+  });
+
+  it('ne renvoie rien pour un extrait vide', () => {
+    expect(parseSnippet('')).toEqual([]);
+  });
+
+  it("laisse le HTML de l'utilisateur intact — il sera rendu comme du texte", () => {
+    // Le contenu vient du foyer (OCR, note) : aucun échappement ici, donc aucun
+    // rendu HTML côté composant.
+    expect(parseSnippet('<script>alert(1)</script> <<devis>>')).toEqual([
+      { text: '<script>alert(1)</script> ', match: false },
+      { text: 'devis', match: true },
+    ]);
+  });
+});

--- a/ui/src/features/search/highlight.ts
+++ b/ui/src/features/search/highlight.ts
@@ -1,0 +1,53 @@
+/**
+ * Parsing of the `<<…>>` markers Postgres' `ts_headline` puts around matched
+ * terms (`start_sel`/`stop_sel` in `apps/agent/retrieval.py`).
+ *
+ * The markers are the only thing that says *why* a result is a result — a snippet
+ * shown without them is a blob of text the user has to re-read to find their own
+ * query in. They are parsed here rather than injected as HTML: the snippet is
+ * household content (a document's OCR, a note), and `dangerouslySetInnerHTML` on
+ * it would make any `<` the user ever typed an injection point.
+ */
+
+export interface SnippetSegment {
+  text: string;
+  match: boolean;
+}
+
+const MARKER = /<<(.*?)>>/gs;
+
+/**
+ * Split a snippet into plain and matched segments, in order.
+ *
+ * Unpaired markers are left as literal text rather than swallowed: a `<<` with no
+ * `>>` means the headline was truncated mid-marker, and showing it beats showing
+ * nothing.
+ */
+export function parseSnippet(snippet: string): SnippetSegment[] {
+  if (!snippet) return [];
+
+  const segments: SnippetSegment[] = [];
+  let cursor = 0;
+
+  for (const found of snippet.matchAll(MARKER)) {
+    const start = found.index ?? 0;
+    if (start > cursor) {
+      segments.push({ text: snippet.slice(cursor, start), match: false });
+    }
+    if (found[1]) segments.push({ text: found[1], match: true });
+    cursor = start + found[0].length;
+  }
+
+  if (cursor < snippet.length) {
+    segments.push({ text: snippet.slice(cursor), match: false });
+  }
+
+  return segments;
+}
+
+/** The snippet with every marker removed — for `title` attributes and tests. */
+export function stripMarkers(snippet: string): string {
+  return parseSnippet(snippet)
+    .map((segment) => segment.text)
+    .join('');
+}

--- a/ui/src/features/search/hooks.ts
+++ b/ui/src/features/search/hooks.ts
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { MIN_QUERY_LENGTH, searchHousehold, type SearchResult } from '@/lib/api/search';
+import { useDebouncedValue } from '@/lib/useDebouncedValue';
+
+export const searchKeys = {
+  all: ['search'] as const,
+  query: (q: string) => [...searchKeys.all, q] as const,
+};
+
+/** Debounce before hitting the network: a keystroke is not a request. */
+const DEBOUNCE_MS = 250;
+
+/**
+ * Search-as-you-type over the household. Returns the *debounced* query alongside
+ * the results so the caller can tell "still typing" from "nothing found" — the two
+ * look identical from `data === []` alone, and showing "no results" while the user
+ * is mid-word reads as a wrong answer.
+ */
+export function useHouseholdSearch(query: string) {
+  const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
+  const enabled = debounced.length >= MIN_QUERY_LENGTH;
+
+  const search = useQuery<SearchResult[]>({
+    queryKey: searchKeys.query(debounced),
+    queryFn: () => searchHousehold(debounced),
+    enabled,
+    // Results are re-fetched on the next open rather than kept warm: the palette is
+    // a navigation tool, and stale rows would point at entities that may be gone.
+    staleTime: 30_000,
+  });
+
+  return {
+    ...search,
+    /** The query the results correspond to (not what is currently typed). */
+    debouncedQuery: debounced,
+    /** True while the typed query has not reached the network yet. */
+    isTyping: query.trim() !== debounced,
+    hasQuery: enabled,
+  };
+}
+
+/**
+ * ⌘K / Ctrl-K opens the palette, from anywhere in the app.
+ *
+ * `/` is deliberately *not* bound: the app is full of text inputs, and a bare
+ * letter shortcut would steal a character from whoever is typing in one.
+ */
+export function useSearchShortcut(onOpen: () => void) {
+  React.useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.key !== 'k' || !(event.metaKey || event.ctrlKey)) return;
+      event.preventDefault();
+      onOpen();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onOpen]);
+}

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -60,7 +60,10 @@ export const GETTING_STARTED: GettingStartedItem[] = [
 
 /** Guides — pages transverses d'abord, puis un guide par module (ordre MODULES). */
 export const TUTORIAL_GUIDES: TutorialGuide[] = [
-  { key: 'dashboard', Icon: LayoutDashboard, to: '/app/dashboard', stepIds: ['overview', 'activity', 'alerts'] },
+  // `search` vit ici et pas dans un guide à lui : la palette n'a pas de page, elle
+  // est dans la barre du haut de *toutes* les pages — le guide transverse du
+  // tableau de bord est le seul endroit où elle se raconte sans deep-link menteur.
+  { key: 'dashboard', Icon: LayoutDashboard, to: '/app/dashboard', stepIds: ['overview', 'activity', 'alerts', 'search'] },
   { key: 'agent', Icon: Sparkles, to: '/app/agent', stepIds: ['ask', 'citations', 'web', 'context', 'create', 'memory'] },
   { key: 'digest', Icon: Newspaper, to: '/app/digest', stepIds: ['preview', 'enable', 'sections'] },
   { key: 'recap', Icon: PartyPopper, to: '/app/recap', stepIds: ['what', 'story', 'chapters', 'appointment', 'frozen'] },

--- a/ui/src/lib/api/search.ts
+++ b/ui/src/lib/api/search.ts
@@ -1,0 +1,30 @@
+import { api } from '@/lib/axios';
+
+/**
+ * One search result. Same shape as the agent's context picker
+ * (`AgentSearchResult`) because it is the same endpoint family — see
+ * `apps/agent/search_api.py`.
+ */
+export interface SearchResult {
+  /** Agent `entity_type` — drives the icon and the group heading. */
+  entity_type: string;
+  object_id: string;
+  label: string;
+  /** In-app path to the entity, built server-side from its `SearchableSpec`. */
+  url: string;
+  /** Excerpt with `<<…>>` around the matched terms — see `highlight.ts`. */
+  snippet: string;
+}
+
+/** Below this the server returns nothing: one letter ranks nothing. */
+export const MIN_QUERY_LENGTH = 2;
+
+/** Search everything the household owns. Empty/short queries resolve to `[]`. */
+export async function searchHousehold(query: string): Promise<SearchResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length < MIN_QUERY_LENGTH) return [];
+  const { data } = await api.get<{ results: SearchResult[] }>('/search/', {
+    params: { q: trimmed },
+  });
+  return data?.results ?? [];
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1194,6 +1194,10 @@
           "alerts": {
             "title": "Warnungen im Blick behalten",
             "body": "Das Badge in der Seitenleiste zeigt, was Ihre Aufmerksamkeit braucht; Details auf der Warnungen-Seite."
+          },
+          "search": {
+            "title": "Alles auf einmal durchsuchen",
+            "body": "Das Feld in der oberen Leiste (⌘K) durchsucht alle Dokumente, Aufgaben, Projekte und Ausgaben des Haushalts."
           }
         }
       },
@@ -2931,6 +2935,32 @@
         "weather": "Kürzlich extremes Wetter · {{recent}} statt {{baseline}} Eier/Tag",
         "unknown": "Unklare Ursache, beobachten · {{recent}} statt {{baseline}} Eier/Tag"
       }
+    }
+  },
+  "search": {
+    "title": "Suche",
+    "description": "Durchsuche alles, was zu deinem Haushalt gehört — Dokumente, Aufgaben, Projekte, Ausgaben…",
+    "placeholder": "Suchen…",
+    "hint": "Gib mindestens zwei Zeichen ein, um zu suchen.",
+    "noResults": "Nichts gefunden.",
+    "entity": {
+      "document": "Dokumente",
+      "interaction": "Aktivität",
+      "equipment": "Geräte",
+      "task": "Aufgaben",
+      "project": "Projekte",
+      "zone": "Zonen",
+      "stock_item": "Bestand",
+      "insurance_contract": "Versicherungen",
+      "contact": "Kontakte",
+      "structure": "Strukturen",
+      "budget": "Budgets",
+      "recurring_expense": "Wiederkehrende Ausgaben",
+      "chicken": "Hühner",
+      "chicken_event": "Hühnerstall-Journal",
+      "meter": "Zähler",
+      "tracker": "Tracker",
+      "shopping_item": "Einkaufsliste"
     }
   },
   "agent": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1194,6 +1194,10 @@
           "alerts": {
             "title": "Keep an eye on alerts",
             "body": "The sidebar badge shows what needs your attention; the Alerts page has the details."
+          },
+          "search": {
+            "title": "Search everything at once",
+            "body": "The box in the top bar (⌘K) searches every document, task, project or expense your household holds."
           }
         }
       },
@@ -2931,6 +2935,32 @@
         "weather": "Recent extreme weather · {{recent}} vs {{baseline}} eggs/day",
         "unknown": "Unknown cause, keep an eye · {{recent}} vs {{baseline}} eggs/day"
       }
+    }
+  },
+  "search": {
+    "title": "Search",
+    "description": "Search everything your household owns — documents, tasks, projects, expenses…",
+    "placeholder": "Search…",
+    "hint": "Type at least two characters to search.",
+    "noResults": "Nothing found.",
+    "entity": {
+      "document": "Documents",
+      "interaction": "Activity",
+      "equipment": "Equipment",
+      "task": "Tasks",
+      "project": "Projects",
+      "zone": "Zones",
+      "stock_item": "Stock",
+      "insurance_contract": "Insurance",
+      "contact": "Contacts",
+      "structure": "Structures",
+      "budget": "Budgets",
+      "recurring_expense": "Recurring expenses",
+      "chicken": "Chickens",
+      "chicken_event": "Chicken coop log",
+      "meter": "Meters",
+      "tracker": "Trackers",
+      "shopping_item": "Shopping list"
     }
   },
   "agent": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1194,6 +1194,10 @@
           "alerts": {
             "title": "Vigilar las alertas",
             "body": "La insignia de la barra lateral indica lo que requiere tu atención; la página de Alertas da el detalle."
+          },
+          "search": {
+            "title": "Buscar en todo a la vez",
+            "body": "La caja de la barra superior (⌘K) busca en todos los documentos, tareas, proyectos y gastos del hogar."
           }
         }
       },
@@ -2931,6 +2935,32 @@
         "weather": "Clima extremo reciente · {{recent}} vs {{baseline}} huevos/día",
         "unknown": "Causa desconocida, vigilar · {{recent}} vs {{baseline}} huevos/día"
       }
+    }
+  },
+  "search": {
+    "title": "Búsqueda",
+    "description": "Busca en todo lo que tiene tu hogar: documentos, tareas, proyectos, gastos…",
+    "placeholder": "Buscar…",
+    "hint": "Escribe al menos dos caracteres para buscar.",
+    "noResults": "Sin resultados.",
+    "entity": {
+      "document": "Documentos",
+      "interaction": "Actividad",
+      "equipment": "Equipos",
+      "task": "Tareas",
+      "project": "Proyectos",
+      "zone": "Zonas",
+      "stock_item": "Inventario",
+      "insurance_contract": "Seguros",
+      "contact": "Contactos",
+      "structure": "Estructuras",
+      "budget": "Presupuestos",
+      "recurring_expense": "Gastos recurrentes",
+      "chicken": "Gallinas",
+      "chicken_event": "Diario del gallinero",
+      "meter": "Contadores",
+      "tracker": "Trackers",
+      "shopping_item": "Lista de la compra"
     }
   },
   "agent": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1194,6 +1194,10 @@
           "alerts": {
             "title": "Garder un œil sur les alertes",
             "body": "Le badge de la sidebar indique ce qui demande votre attention ; la page Alertes les détaille."
+          },
+          "search": {
+            "title": "Tout chercher d'un coup",
+            "body": "La boîte de la barre du haut (⌘K) cherche dans tous les documents, tâches, projets ou dépenses du foyer."
           }
         }
       },
@@ -2931,6 +2935,32 @@
         "weather": "Météo extrême récente · {{recent}} vs {{baseline}} œufs/jour",
         "unknown": "Cause inconnue, à surveiller · {{recent}} vs {{baseline}} œufs/jour"
       }
+    }
+  },
+  "search": {
+    "title": "Recherche",
+    "description": "Cherche dans tout ce que contient ton foyer — documents, tâches, projets, dépenses…",
+    "placeholder": "Rechercher…",
+    "hint": "Saisis au moins deux caractères pour lancer la recherche.",
+    "noResults": "Aucun résultat.",
+    "entity": {
+      "document": "Documents",
+      "interaction": "Activité",
+      "equipment": "Équipements",
+      "task": "Tâches",
+      "project": "Projets",
+      "zone": "Zones",
+      "stock_item": "Stock",
+      "insurance_contract": "Assurances",
+      "contact": "Contacts",
+      "structure": "Structures",
+      "budget": "Budgets",
+      "recurring_expense": "Dépenses récurrentes",
+      "chicken": "Poules",
+      "chicken_event": "Journal du poulailler",
+      "meter": "Compteurs",
+      "tracker": "Trackers",
+      "shopping_item": "Liste de courses"
     }
   },
   "agent": {


### PR DESCRIPTION
## Quoi

Une boîte de recherche dans la barre du haut — champ + ⌘K sur desktop, loupe sur mobile — ouvre une palette qui cherche dans **tout** ce que contient le foyer : documents, tâches, projets, dépenses, budgets, compteurs, poules… Résultats groupés par type, navigation ↑↓/Entrée, et un résultat **mène à sa page**.

**Aucun moteur de recherche n'a été écrit.** La palette appelle `GET /api/search/?q=`, qui exécute la retrieval de l'agent (`agent.retrieval.search`) : même index, même ranking, même gating par modules désactivés. Une entité devient donc trouvable dans toute l'app en s'enregistrant dans `agent.searchables`, sans une ligne de front.

### Décisions qui méritent un regard

- **Une seule recherche, trois portes.** La palette, le picker « Ajouter du contexte » de l'agent et le tool `search_household` passent par `agent.search_api.search_household_entities`. Trouver un document dans la barre du haut et s'entendre répondre « je ne le connais pas » dans le chat ne dirait pas lequel des deux se trompe — ça décrédibiliserait les deux. Le `search_context` existant a donc été rebranché sur ce point d'entrée au lieu de garder sa propre sérialisation.
- **La recherche-à-la-frappe sort explicitement de l'hybride** (`hybrid=False`, nouveau param de `search()`). Hériter de `AGENT_HYBRID_RETRIEVAL_ENABLED` coûterait **un appel d'embedding facturé par frappe débouncée** ; le flag reste le bon défaut pour une question posée à l'agent (un embedding par tour). Ce n'est pas un kill switch : `search()` sans argument continue de lire le flag, et un test le vérifie.
- **Le surlignage se parse, il ne s'injecte pas.** `ts_headline` renvoie des `<<…>>` ; `highlight.ts` les transforme en segments rendus en `<mark>`. Le texte vient du foyer (OCR d'un PDF, note) : un `dangerouslySetInnerHTML` ferait de chaque `<` saisi un point d'injection.
- **Le groupement par type ne re-trie pas.** Les groupes sortent dans l'ordre de leur meilleur résultat — un tri alphabétique ou un ordre de types codé en dur mettrait un match faible au-dessus d'un match fort et contredirait silencieusement le ranking.
- **Throttle propre** (`search`, 120/min) plutôt que celui de l'agent : à 10/min l'utilisateur serait bloqué en plein mot. Le plein-texte ne coûte aucun appel provider, mais un endpoint de type-ahead reste ce qu'on laisse tourner en boucle le plus facilement.
- **Le catalogue front doit couvrir le registre backend** : icônes et libellés de groupe complétés pour les 17 `entity_type` (7 manquaient, dont budget, compteurs, poules et liste de courses). Le garde-fou est en **Python**, seul côté qui connaît la liste.

## Tests

| Où | Quoi |
|---|---|
| `apps/agent/tests/test_global_search.py` | 19 tests — scope foyer, module désactivé invisible, bornes (q vide / 1 caractère / `limit` clampé), sortie de l'hybride dans les deux sens, accord palette ↔ picker ↔ tool, couverture icônes + i18n depuis le registre |
| `ui/src/features/search/highlight.test.ts` | 7 tests — marqueurs multiples, marqueur tronqué gardé littéral, HTML du foyer non rendu |
| `e2e/global-search.spec.ts` | 5 tests — ouverture depuis la barre, raccourci clavier depuis une autre page, clavier seul jusqu'à la navigation, frappe trop courte, absence de résultat |

Vert en local : `pytest` 3718 passed · `npm run lint` 0 erreur · `npx tsc -b ui/tsconfig.json` OK · `npx playwright test e2e/global-search.spec.ts` 7 passed.

## Doc

`docs/MODULES/shell-and-design-system.md` (§ Recherche globale), `docs/MODULES/agent.md` (endpoint + la note sur l'hybride), `CLAUDE.md` (les invariants), et une étape `search` dans le guide « tableau de bord » des tutoriels (4 locales).

## Hors scope

- Le stemming reste absent (`simple_unaccent`) : « facture » ne trouve pas « factures ». Limite héritée du retrieval, documentée dans `retrieval.py`, non touchée ici.
- Pas d'index GIN matérialisé : les `SearchVector` sont calculés à la volée. Invisible au volume d'un foyer, mais la palette sollicitera la retrieval bien plus que l'agent — à surveiller.
- Pas de recherche dans les entités non enregistrées comme searchable (relevés bancaires, photos, zones d'un module désactivé).
