### PR TITLE
feat(search): la palette cherche aussi par le sens, sans faire attendre le mot-clé

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1021,12 +1021,28 @@ globale ».
   pas lequel des deux se trompe, ça décrédibilise les deux. C'est la règle « un écart
   ne se dit jamais deux fois avec deux voix » appliquée à la connaissance du foyer.
   Régression : `agent/tests/test_global_search.py::TestTheTwoSearchBoxesAgree`.
-- **⚠️ La recherche-à-la-frappe passe `hybrid=False`** et n'hérite **pas** de
-  `AGENT_HYBRID_RETRIEVAL_ENABLED`. Le flag est le bon défaut pour une question posée
-  à l'agent (un embedding par tour) ; sur une boîte de recherche il vaut **un
-  embedding facturé par frappe débouncée**. La sortie est un choix explicite, jamais
-  un oubli à « corriger » — et ce n'est pas un kill switch : `search()` sans argument
-  continue de lire le flag.
+- **⚠️ La recherche répond en deux temps, et jamais en un seul appel hybride.**
+  `?q=` est l'étape lexicale (quelques requêtes SQL indexées, millisecondes) ;
+  `?q=&semantic=1` est l'étape sémantique, qui renvoie **ce que la première n'a pas
+  trouvé** (`retrieval.semantic_only`, différence des deux jambes). Raison mesurée sur
+  la prod : embedder une requête coûte **211 ms en moyenne, jusqu'à 1,6 s** — attendre
+  ça mettrait toute la boîte à cette vitesse et la placerait derrière la disponibilité
+  du fournisseur. Conséquences à préserver :
+  - l'étape lexicale passe `hybrid=False` **explicitement** et n'hérite pas de
+    `AGENT_HYBRID_RETRIEVAL_ENABLED` ; l'étape sémantique, elle, lit le flag et
+    renvoie `[]` sans appeler le fournisseur quand il est off ;
+  - le serveur renvoie la **différence**, pas la fusion, précisément pour que le front
+    **ajoute un groupe sans réordonner ce que l'utilisateur lit déjà** — une liste qui
+    se réorganise 200 ms après son apparition fait cliquer à côté ;
+  - l'exclusion se calcule **côté serveur** (la jambe lexicale est rejouée, c'est du
+    SQL) et jamais depuis une liste de clés envoyée par le client, qui dériverait au
+    premier changement de ranking ou de gating ;
+  - un échec de l'étape deux n'est **pas** une erreur affichée : les résultats
+    mot-clé sont déjà à l'écran et forment une réponse complète.
+  Régressions : `test_global_search.py::TestTheSemanticLegIsASecondStage` et
+  `::TestTheSecondStageAddsWhatTheFirstCannotFind` côté serveur ;
+  `e2e/global-search.spec.ts` pour le non-blocage, qui ne se prouve que dans un vrai
+  navigateur.
 - **Le surlignage se parse, il ne s'injecte pas.** `ts_headline` renvoie des `<<…>>` ;
   `features/search/highlight.ts` les transforme en segments rendus en `<mark>`. Le
   texte vient du foyer (OCR d'un PDF, note) : un `dangerouslySetInnerHTML` ferait de

--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -266,6 +266,48 @@ def _hybrid_enabled() -> bool:
     return bool(getattr(settings, "AGENT_HYBRID_RETRIEVAL_ENABLED", False))
 
 
+def semantic_only(
+    household_id: UUID,
+    query: str,
+    limit: int = 20,
+    disabled: frozenset[str] | None = None,
+) -> list[Hit]:
+    """The semantic leg alone, minus everything the lexical leg already finds.
+
+    This is the *second* half of a two-stage search box: the palette shows the
+    lexical hits the instant they come back (a few indexed SQL queries), then folds
+    in what only the meaning could surface — « chauffage » → « pompe à chaleur ».
+    Returning the difference rather than the fused set is what lets the client append
+    a group **without re-ordering what the user is already reading**: a list that
+    reshuffles 200 ms after appearing makes people click the wrong row.
+
+    Unlike ``search(hybrid=…)``, this reads ``AGENT_HYBRID_RETRIEVAL_ENABLED`` and
+    returns ``[]`` when it is off — no embedding call, no cost, and a deployment
+    without a semantic index simply has no second stage.
+
+    The lexical leg is re-run here (cheap, no provider call) rather than trusted from
+    the client: the exclusion must match exactly what the first stage returned, and a
+    client-supplied list of keys would drift the moment ranking or gating changes.
+    """
+    if not _hybrid_enabled():
+        return []
+    if not query or not query.strip():
+        return []
+
+    if disabled is None:
+        disabled = disabled_modules_for(household_id)
+
+    vector_hits = _vector_search(household_id, query, limit, disabled=disabled)
+    if not vector_hits:
+        return []
+
+    already_shown = {
+        (hit.entity_type, hit.id)
+        for hit in search(household_id, query, limit=limit, disabled=disabled, hybrid=False)
+    }
+    return [hit for hit in vector_hits if (hit.entity_type, hit.id) not in already_shown]
+
+
 def _vector_search(
     household_id: UUID,
     query: str,

--- a/apps/agent/search_api.py
+++ b/apps/agent/search_api.py
@@ -8,14 +8,24 @@ one query, one ranking, one set of module-disabled exclusions. Nothing here know
 about any particular entity — adding a ``SearchableSpec`` makes the new entity
 searchable from the palette with zero change to this file.
 
-Two deliberate choices, both about search-as-you-type rather than about search:
+**The search box answers in two stages, and the query string says which one.**
+``?q=…`` is the lexical stage: a few indexed SQL queries, back in milliseconds, shown
+the instant they land. ``?q=…&semantic=1`` is the second stage — what only the meaning
+finds (« chauffage » → « pompe à chaleur »), *minus* what the first stage already
+returned, so the client appends a group instead of re-ordering the list under the
+user's cursor.
 
-- **``hybrid=False``.** The semantic leg costs one embedding call per query. Fine for
-  a question asked to the agent, absurd for a debounced keystroke — see
-  ``retrieval.search``.
-- **Its own throttle scope.** Full-text is cheap, so the agent's 10/min burst cap
-  would be absurdly tight here; but a type-ahead endpoint is the easiest loop to
-  leave running, hence a bound of its own rather than none at all.
+Why two calls rather than one hybrid call: measured on production usage, embedding a
+query takes **211 ms on average and up to 1.6 s**. Waiting for it would make every
+keystroke feel that slow, and would put the search box behind the embedding
+provider's availability. Two stages keep the box instant, degrade to lexical-only on
+their own (an empty second response is a normal answer, not an error), and cost
+nothing extra when a deployment has no semantic index — ``retrieval.semantic_only``
+returns ``[]`` when the hybrid flag is off, without calling the provider.
+
+Its own throttle scope: full-text is cheap, so the agent's 10/min burst cap would be
+absurdly tight here; but a type-ahead endpoint is the easiest loop to leave running,
+hence a bound of its own rather than none at all.
 """
 from __future__ import annotations
 
@@ -71,7 +81,7 @@ def _clamp_limit(raw: str | None) -> int:
 
 
 def search_household_entities(household_id, query: str, limit: int) -> list[dict]:
-    """Run the palette's search and serialize it. One entry point, two URLs.
+    """Stage one — the lexical search, serialized. One entry point, two URLs.
 
     Strips and gates the query here rather than trusting callers to: this is the
     shared door, and a caller that forgot would send whitespace to the retrieval.
@@ -83,8 +93,27 @@ def search_household_entities(household_id, query: str, limit: int) -> list[dict
     return serialize_hits(hits)
 
 
+def semantic_household_entities(household_id, query: str, limit: int) -> list[dict]:
+    """Stage two — what only the meaning finds, minus stage one's results."""
+    query = (query or "").strip()
+    if len(query) < MIN_QUERY_LENGTH:
+        return []
+    return serialize_hits(retrieval.semantic_only(household_id, query, limit=limit))
+
+
+def _wants_semantic(request) -> bool:
+    """``?semantic=1`` (or ``true``/``yes``) asks for the second stage."""
+    raw = (request.query_params.get("semantic") or "").strip().lower()
+    return raw in {"1", "true", "yes"}
+
+
 class GlobalSearchView(APIView):
-    """``GET /api/search/?q=&limit=`` — search everything the household owns."""
+    """``GET /api/search/?q=&limit=&semantic=`` — search everything the household owns.
+
+    Same URL for both stages so the client has one contract and one payload shape;
+    ``semantic=1`` is what changes which leg runs. Both answer ``{"results": [...]}``,
+    and an empty list is always a valid answer — never an error.
+    """
 
     permission_classes = [IsAuthenticated, IsHouseholdMember]
     throttle_classes = [SearchRateThrottle]
@@ -99,7 +128,8 @@ class GlobalSearchView(APIView):
 
         query = (request.query_params.get("q") or "").strip()
         limit = _clamp_limit(request.query_params.get("limit"))
+        run = semantic_household_entities if _wants_semantic(request) else search_household_entities
         return Response(
-            {"results": search_household_entities(household.id, query, limit)},
+            {"results": run(household.id, query, limit)},
             status=status.HTTP_200_OK,
         )

--- a/apps/agent/tests/test_global_search.py
+++ b/apps/agent/tests/test_global_search.py
@@ -176,27 +176,47 @@ class TestBounds:
 
 
 @pytest.mark.django_db
-class TestTheSemanticLegStaysOut:
-    """A debounced keystroke must never cost an embedding call.
+class TestTheSemanticLegIsASecondStage:
+    """Stage one never embeds; stage two is where the meaning comes from.
 
-    The hybrid flag is the right default for a question asked to the agent (one
-    embedding per turn). On a search box it would be one per keystroke — so the
-    palette opts out explicitly instead of inheriting the setting.
+    Embedding a query costs 211 ms on average in production (up to 1.6 s). Waiting for
+    it would make every keystroke feel that slow and put the search box behind the
+    provider's availability — so the two legs answer separately and the client appends
+    the second when it lands.
     """
 
-    def test_hybrid_is_off_even_when_the_setting_is_on(
+    def test_the_first_stage_never_embeds_even_when_hybrid_is_on(
         self, owner_client, project, settings, monkeypatch
     ):
         settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
 
         def _boom(*args, **kwargs):  # pragma: no cover - must never run
-            raise AssertionError("the global search must not embed the query")
+            raise AssertionError("the first stage must not embed the query")
 
         monkeypatch.setattr("agent.embeddings.get_embedding_client", _boom)
 
         resp = owner_client.get(URL, {"q": "pompe"})
         assert resp.status_code == status.HTTP_200_OK
         assert "Pompe à chaleur" in _labels(resp)
+
+    def test_the_second_stage_is_empty_when_hybrid_is_off(
+        self, owner_client, project, settings, monkeypatch
+    ):
+        """No semantic index, no second stage — and above all no provider call.
+
+        A deployment that never turned the flag on must not pay a request per
+        keystroke to be told there is nothing to add.
+        """
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = False
+
+        def _boom(*args, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("no embedding call when hybrid is disabled")
+
+        monkeypatch.setattr("agent.embeddings.get_embedding_client", _boom)
+
+        resp = owner_client.get(URL, {"q": "pompe", "semantic": "1"})
+        assert resp.status_code == status.HTTP_200_OK
+        assert _results(resp) == []
 
     def test_the_agent_still_honours_the_setting(
         self, household, project, settings, monkeypatch
@@ -213,6 +233,115 @@ class TestTheSemanticLegStaysOut:
         monkeypatch.setattr("agent.retrieval._vector_search", _spy)
         retrieval.search(household.id, "pompe")
         assert calls == [1]
+
+
+_HEAT_WORDS = ("chauffage", "pompe", "chaleur", "pac", "daikin")
+
+
+class _FakeEmbeddingClient:
+    """Deterministic one-hot embeddings — same trick as `test_retrieval_hybrid.py`.
+
+    A query and a document land at cosine distance 0 iff they share a "bucket", which
+    drives the k-NN with no provider and no network.
+    """
+
+    model = "fake-embed"
+
+    def _vec(self, text: str):
+        vector = [0.0] * 1024
+        vector[0 if any(word in text.lower() for word in _HEAT_WORDS) else 1] = 1.0
+        return vector
+
+    def embed(self, texts, *, household_id, feature="embed", user_id=None, metadata=None):
+        from agent.embeddings import EmbeddingResponse
+
+        return EmbeddingResponse(
+            vectors=[self._vec(t) for t in texts],
+            model=self.model,
+            dimensions=1024,
+            duration_ms=1,
+        )
+
+    def embed_query(self, text, *, household_id, feature="embed", user_id=None, metadata=None):
+        return self._vec(text)
+
+
+@pytest.mark.django_db
+class TestTheSecondStageAddsWhatTheFirstCannotFind:
+    """The whole point of stage two: recall the keyword search cannot reach.
+
+    « chauffage » shares no word with a document titled « Pompe à chaleur Daikin » —
+    lexical search returns nothing, the semantic leg returns it. And what stage one
+    already showed must NOT come back, or the palette would list it twice.
+    """
+
+    @pytest.fixture
+    def heat_pump(self, household, settings, monkeypatch):
+        """An indexed equipment named « Pompe à chaleur Daikin »."""
+        from agent import embeddings as embeddings_module
+        from agent import indexing
+        from equipment.models import Equipment
+
+        settings.AGENT_HYBRID_RETRIEVAL_ENABLED = True
+        client = _FakeEmbeddingClient()
+        # The *query* side resolves the client at call time, so patching the module
+        # attribute covers it. `indexing` imported the name at import time — hence the
+        # explicit `client=`, same as `test_retrieval_hybrid.py`.
+        monkeypatch.setattr(embeddings_module, "get_embedding_client", lambda *a, **k: client)
+
+        equipment = Equipment.objects.create(
+            household=household,
+            name="Pompe à chaleur Daikin",
+            notes="Installation air/eau",
+        )
+        indexing.reindex_instance(equipment, client=client)
+        return equipment
+
+    def test_a_synonym_is_found_only_by_the_second_stage(self, owner_client, heat_pump):
+        lexical = _results(owner_client.get(URL, {"q": "chauffage"}))
+        assert lexical == [], "« chauffage » ne partage aucun mot avec l'équipement"
+
+        semantic = _results(owner_client.get(URL, {"q": "chauffage", "semantic": "1"}))
+        assert [row["label"] for row in semantic] == ["Pompe à chaleur Daikin"]
+
+    def test_the_second_stage_never_repeats_the_first(self, owner_client, heat_pump):
+        """« pompe » matches both legs — the extras must exclude what stage one showed,
+        otherwise the palette lists the same entity twice."""
+        lexical = _results(owner_client.get(URL, {"q": "pompe"}))
+        assert "Pompe à chaleur Daikin" in [row["label"] for row in lexical]
+
+        semantic = _results(owner_client.get(URL, {"q": "pompe", "semantic": "1"}))
+        assert "Pompe à chaleur Daikin" not in [row["label"] for row in semantic]
+
+    def test_the_second_stage_stays_in_the_household(self, stranger, heat_pump):
+        resp = _client_for(stranger).get(URL, {"q": "chauffage", "semantic": "1"})
+        assert _results(resp) == []
+
+    def test_a_disabled_module_is_invisible_to_the_second_stage_too(
+        self, owner_client, household, heat_pump
+    ):
+        """The semantic leg does its own gating — an entity of a module the household
+        turned off must not slip in through the second stage. Insurance because it is
+        an optional module (`equipment` is core, so it is never gated)."""
+        from agent import indexing
+        from insurance.models import InsuranceContract
+
+        contract = InsuranceContract.objects.create(
+            household=household,
+            name="Entretien pompe à chaleur",
+            # Surtout pas le mot « chauffage » : il rendrait le contrat trouvable dès
+            # l'étape lexicale, donc légitimement absent de l'étape deux.
+            coverage_summary="Contrat PAC air/eau",
+        )
+        indexing.reindex_instance(contract, client=_FakeEmbeddingClient())
+
+        found = _results(owner_client.get(URL, {"q": "chauffage", "semantic": "1"}))
+        assert "Entretien pompe à chaleur" in [row["label"] for row in found]
+
+        household.disabled_modules = ["insurance"]
+        household.save(update_fields=["disabled_modules"])
+        found = _results(owner_client.get(URL, {"q": "chauffage", "semantic": "1"}))
+        assert "Entretien pompe à chaleur" not in [row["label"] for row in found]
 
 
 class TestThePaletteCoversTheRegistry:

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -244,13 +244,20 @@ Sous `/api/agent/` :
 
 Hors de `/api/agent/`, parce que ce n'est pas une conversation :
 
-- `GET /api/search/?q=&limit=` — **recherche globale de l'app** (palette de la barre
-  du haut), `apps/agent/search_api.py`. Même retrieval, même ranking, même gating par
-  modules que le tool `search_household` ; renvoie `{results: [{entity_type,
-  object_id, label, url, snippet}]}`. Throttle propre (`search`, 120/min) : le
-  plein-texte ne coûte aucun appel provider, mais un endpoint de type-ahead reste
-  ce qu'on laisse tourner en boucle le plus facilement. Doc :
-  `docs/MODULES/shell-and-design-system.md` § « Recherche globale ».
+- `GET /api/search/?q=&limit=&semantic=` — **recherche globale de l'app** (palette de
+  la barre du haut), `apps/agent/search_api.py`. Même retrieval, même ranking, même
+  gating par modules que le tool `search_household` ; renvoie `{results:
+  [{entity_type, object_id, label, url, snippet}]}` dans les deux cas.
+  - sans `semantic` : **étape lexicale** (`hybrid=False`), quelques requêtes SQL
+    indexées — c'est ce qui part à chaque frappe débouncée ;
+  - `semantic=1` : **étape sémantique** (`retrieval.semantic_only`), qui renvoie ce
+    que la jambe vectorielle trouve **moins** ce que l'étape lexicale a déjà renvoyé,
+    et `[]` quand `AGENT_HYBRID_RETRIEVAL_ENABLED` est off (sans appeler le
+    fournisseur).
+  - Throttle propre (`search`, 120/min) : le plein-texte ne coûte aucun appel
+    provider, mais un endpoint de type-ahead reste ce qu'on laisse tourner en boucle
+    le plus facilement. Doc :
+    `docs/MODULES/shell-and-design-system.md` § « Recherche globale ».
 - `memories/` (CRUD, privé par user × foyer) + `DELETE memories/clear/` (efface
   tout, renvoie `{deleted: n}`) — mémoire utilisateur.
 - Permissions : `IsAuthenticated, IsHouseholdMember` ; `ask`, `messages` et
@@ -295,14 +302,18 @@ et les fonctions `_vector_search` / `_fuse_rrf` de `retrieval.py`.
   full-text à l'octet près). À activer une fois `VOYAGE_API_KEY` posé et le corpus
   indexé (`manage.py backfill_embeddings`).
 
-**⚠️ La recherche-à-la-frappe sort explicitement de l'hybride** (`hybrid=False`, param
-de `search()`). Le flag global est le bon défaut pour une *question* posée à l'agent —
-un embedding par tour. Ce serait le mauvais défaut pour la palette de recherche
-globale et le picker de contexte : **un embedding par frappe débouncée**, facturé, sur
-un geste qui doit rester instantané. Ne pas remplacer par un héritage du flag ; la
-sortie est un choix, pas un oubli. Régression :
-`agent/tests/test_global_search.py::TestTheSemanticLegStaysOut` (qui vérifie aussi que
-l'agent, lui, continue d'honorer le flag — ce n'est pas un kill switch).
+**⚠️ La recherche-à-la-frappe ne fusionne pas, elle sert en deux temps.** Une
+*question* posée à l'agent paie un embedding par tour : négligeable, donc `search()`
+lit le flag. Une boîte de recherche envoie une requête tous les 250 ms de frappe, et
+l'embedding coûte **211 ms en moyenne, 1,6 s au pire** (mesuré sur 808 appels de prod).
+D'où le découpage : l'étape lexicale passe `hybrid=False`, l'étape sémantique
+(`retrieval.semantic_only`) lit le flag et renvoie la **différence** des deux jambes.
+Ne pas remplacer par un héritage du flag dans `search()` — ce serait remettre les deux
+legs en série derrière le fournisseur. Régressions :
+`agent/tests/test_global_search.py::TestTheSemanticLegIsASecondStage` (dont : l'agent
+continue d'honorer le flag, ce n'est pas un kill switch) et
+`::TestTheSecondStageAddsWhatTheFirstCannotFind` (le gain de rappel, et l'absence de
+doublon avec l'étape une).
 
 Fiche concept (le cours) : [docs/fiches/EMBEDDINGS.md](../fiches/EMBEDDINGS.md).
 Backlog : [PARCOURS_21_BACKLOG_TECHNIQUE.md](../parcours/PARCOURS_21_BACKLOG_TECHNIQUE.md).

--- a/docs/MODULES/shell-and-design-system.md
+++ b/docs/MODULES/shell-and-design-system.md
@@ -29,6 +29,13 @@ lien retour de la page de détail ramène là où la recherche a été lancée).
   `GET /api/search/?q=`, qui exécute la retrieval de l'agent
   (`agent.retrieval.search`). Une entité devient donc trouvable en s'enregistrant
   dans `agent.searchables`, sans une ligne de front.
+- **Deux temps, une liste.** Le mot-clé s'affiche en quelques millisecondes ; ce que
+  seul le **sens** trouve (« chauffage » → « pompe à chaleur ») arrive ~200 ms plus
+  tard via `?semantic=1` et s'**ajoute** dans un groupe « Par le sens », sans jamais
+  réordonner la liste du dessus. Les deux appels partent en parallèle : `hooks.ts`
+  expose deux `useQuery` distincts, pas un `Promise.all` qui retiendrait la moitié
+  rapide. Un échec du second n'affiche aucune erreur — le premier est déjà une réponse
+  complète.
 - **La palette, le picker de contexte de l'agent et le tool `search_household`
   passent par le même point d'entrée** (`agent.search_api.search_household_entities`).
   Un utilisateur qui trouve un document dans la barre du haut et s'entend répondre

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -105,4 +105,55 @@ test.describe('Recherche globale', () => {
     await page.getByTestId('global-search-input').fill('zzzzintrouvable');
     await expect(page.getByText('Aucun résultat.')).toBeVisible();
   });
+
+  /**
+   * La recherche répond en deux temps : le mot-clé tout de suite, le sens ensuite.
+   * C'est la seule garantie qui ne se teste qu'ici — en jsdom rien ne dit qu'un
+   * `await` de trop n'a pas remis les deux appels en série. On retarde donc l'étape
+   * sémantique de 1,5 s et on exige que le résultat lexical soit déjà à l'écran.
+   */
+  test("l'étape par le sens n'attend jamais l'étape mot-clé", async ({ page }) => {
+    const fabricated = {
+      entity_type: 'document',
+      object_id: '00000000-0000-0000-0000-000000000001',
+      label: 'Devis trouvé par le sens',
+      url: '/app/documents/00000000-0000-0000-0000-000000000001',
+      snippet: 'Chaudière à remplacer',
+    };
+
+    await page.route(/\/api\/search\/\?.*semantic=1/, async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ results: [fabricated] }),
+      });
+    });
+
+    await page.getByTestId('global-search-trigger').click();
+    await page.getByTestId('global-search-input').fill(needle);
+
+    // Le résultat lexical est là bien avant que le sens ait répondu.
+    await expect(page.getByTestId('global-search-result').filter({ hasText: needle })).toBeVisible({
+      timeout: 1000,
+    });
+    await expect(page.getByTestId('global-search-sense-group')).toBeHidden();
+
+    // Puis le groupe « Par le sens » s'ajoute, sans déplacer ce qui précède.
+    await expect(page.getByTestId('global-search-sense-group')).toBeVisible({ timeout: 4000 });
+    await expect(page.getByText('Devis trouvé par le sens')).toBeVisible();
+  });
+
+  test('un échec de l’étape par le sens ne casse pas la recherche', async ({ page }) => {
+    await page.route(/\/api\/search\/\?.*semantic=1/, (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: '{"detail":"nope"}' }),
+    );
+
+    await page.getByTestId('global-search-trigger').click();
+    await page.getByTestId('global-search-input').fill(needle);
+
+    // Les résultats mot-clé restent une réponse complète : aucune erreur affichée.
+    await expect(page.getByTestId('global-search-result').filter({ hasText: needle })).toBeVisible();
+    await expect(page.getByTestId('global-search-sense-group')).toBeHidden();
+  });
 });

--- a/ui/src/features/search/SearchPalette.tsx
+++ b/ui/src/features/search/SearchPalette.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
-import { Search } from 'lucide-react';
+import { Search, Sparkles } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
 import { pushBack } from '@/lib/backNavigation';
@@ -36,6 +36,10 @@ function groupByType(results: SearchResult[]): Group[] {
   return groups;
 }
 
+function resultKey(result: SearchResult): string {
+  return `${result.entity_type}:${result.object_id}`;
+}
+
 /** Excerpt with the matched terms marked. Rendered as text — never as HTML. */
 function Snippet({ snippet }: { snippet: string }) {
   const segments = React.useMemo(() => parseSnippet(snippet), [snippet]);
@@ -55,6 +59,40 @@ function Snippet({ snippet }: { snippet: string }) {
   );
 }
 
+interface RowProps {
+  result: SearchResult;
+  isActive: boolean;
+  onSelect: () => void;
+  onHover: () => void;
+  activeRef: (node: HTMLButtonElement | null) => void;
+}
+
+/** One result row — shared by the keyword groups and the "by meaning" group. */
+function ResultRow({ result, isActive, onSelect, onHover, activeRef }: RowProps) {
+  const Icon = ENTITY_ICONS[result.entity_type] ?? ENTITY_ICON_FALLBACK;
+  return (
+    <li>
+      <button
+        type="button"
+        ref={isActive ? activeRef : undefined}
+        onClick={onSelect}
+        onMouseEnter={onHover}
+        data-testid="global-search-result"
+        aria-current={isActive || undefined}
+        className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+          isActive ? 'border-primary/40 bg-primary/10' : 'border-border bg-card hover:bg-primary/10'
+        }`}
+      >
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-foreground">{result.label}</span>
+          <Snippet snippet={result.snippet} />
+        </span>
+      </button>
+    </li>
+  );
+}
+
 /**
  * App-wide search — every entity the household owns, from one box.
  *
@@ -62,6 +100,12 @@ function Snippet({ snippet }: { snippet: string }) {
  * finds and what the assistant can cite are the same index: a user who finds a
  * document here and hears "I don't know about it" in the chat would have no way to
  * tell which of the two is wrong.
+ *
+ * **Two stages, one list.** Keyword hits appear in milliseconds, grouped by type.
+ * What only the *meaning* finds arrives ~200 ms later and is **appended** in its own
+ * group — never merged into the list above. That is the whole reason the server
+ * returns the difference rather than a fused ranking: a list that reshuffles just
+ * after appearing makes people click the row they did not aim at.
  */
 export default function SearchPalette({ open, onOpenChange }: Props) {
   const { t } = useTranslation();
@@ -70,9 +114,14 @@ export default function SearchPalette({ open, onOpenChange }: Props) {
   const [query, setQuery] = React.useState('');
   const [activeIndex, setActiveIndex] = React.useState(0);
 
-  const { data, isLoading, isTyping, hasQuery } = useHouseholdSearch(open ? query : '');
-  const results = React.useMemo(() => data ?? [], [data]);
+  const { results, senseResults, isLoading, isTyping, isSearchingBySense, hasQuery } =
+    useHouseholdSearch(open ? query : '');
   const groups = React.useMemo(() => groupByType(results), [results]);
+
+  // Keyboard order = what is on screen, top to bottom: keyword hits then the
+  // by-meaning extras. Appending keeps every already-assigned position valid, so the
+  // selection does not move when the second stage lands.
+  const navigable = React.useMemo(() => [...results, ...senseResults], [results, senseResults]);
 
   // Reset on each open — a palette reopening on the previous search would answer a
   // question the user is no longer asking.
@@ -83,8 +132,9 @@ export default function SearchPalette({ open, onOpenChange }: Props) {
     }
   }, [open]);
 
-  // New results, new selection: keeping the old index would highlight (and, on
-  // Enter, open) whatever now happens to sit at that position.
+  // New keyword results, new selection: keeping the old index would highlight (and,
+  // on Enter, open) whatever now happens to sit at that position. Deliberately keyed
+  // on `results` alone — the by-meaning group only ever appends below.
   React.useEffect(() => setActiveIndex(0), [results]);
 
   const go = React.useCallback(
@@ -102,19 +152,29 @@ export default function SearchPalette({ open, onOpenChange }: Props) {
   }, []);
 
   const onKeyDown = (event: React.KeyboardEvent) => {
-    if (results.length === 0) return;
+    if (navigable.length === 0) return;
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      setActiveIndex((index) => (index + 1) % results.length);
+      setActiveIndex((index) => (index + 1) % navigable.length);
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
-      setActiveIndex((index) => (index - 1 + results.length) % results.length);
+      setActiveIndex((index) => (index - 1 + navigable.length) % navigable.length);
     } else if (event.key === 'Enter') {
       event.preventDefault();
-      const target = results[activeIndex];
+      const target = navigable[activeIndex];
       if (target) go(target);
     }
   };
+
+  const rowProps = (result: SearchResult, position: number) => ({
+    result,
+    isActive: position === activeIndex,
+    onSelect: () => go(result),
+    onHover: () => setActiveIndex(position),
+    activeRef: scrollActiveIntoView,
+  });
+
+  const nothingFound = results.length === 0 && senseResults.length === 0;
 
   return (
     <SheetDialog
@@ -150,55 +210,50 @@ export default function SearchPalette({ open, onOpenChange }: Props) {
                 <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
               ))}
             </div>
-          ) : results.length === 0 ? (
+          ) : nothingFound && !isSearchingBySense ? (
             <p className="px-1 py-6 text-center text-sm text-muted-foreground">
               {t('search.noResults')}
             </p>
           ) : (
             <div className="space-y-3">
-              {groups.map((group) => {
-                const Icon = ENTITY_ICONS[group.entityType] ?? ENTITY_ICON_FALLBACK;
-                return (
-                  <div key={group.entityType}>
-                    <p className="px-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                      {t(`search.entity.${group.entityType}`)}
-                    </p>
-                    <ul className="space-y-1">
-                      {group.results.map((result) => {
-                        // Position in the flat, rank-ordered list — ↑↓ walks the
-                        // whole list, group headings included.
-                        const position = results.indexOf(result);
-                        const isActive = position === activeIndex;
-                        return (
-                          <li key={`${result.entity_type}:${result.object_id}`}>
-                            <button
-                              type="button"
-                              ref={isActive ? scrollActiveIntoView : undefined}
-                              onClick={() => go(result)}
-                              onMouseEnter={() => setActiveIndex(position)}
-                              data-testid="global-search-result"
-                              aria-current={isActive || undefined}
-                              className={`flex w-full items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
-                                isActive
-                                  ? 'border-primary/40 bg-primary/10'
-                                  : 'border-border bg-card hover:bg-primary/10'
-                              }`}
-                            >
-                              <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
-                              <span className="min-w-0 flex-1">
-                                <span className="block truncate text-foreground">
-                                  {result.label}
-                                </span>
-                                <Snippet snippet={result.snippet} />
-                              </span>
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  </div>
-                );
-              })}
+              {groups.map((group) => (
+                <div key={group.entityType}>
+                  <p className="px-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    {t(`search.entity.${group.entityType}`)}
+                  </p>
+                  <ul className="space-y-1">
+                    {group.results.map((result) => (
+                      <ResultRow
+                        key={resultKey(result)}
+                        {...rowProps(result, results.indexOf(result))}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              ))}
+
+              {/* Second stage. Announced as such: these rows may share no word with
+                  what was typed, and an unexplained result reads as a bug. */}
+              {senseResults.length > 0 ? (
+                <div data-testid="global-search-sense-group">
+                  <p className="flex items-center gap-1.5 px-1 pb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                    <Sparkles className="h-3 w-3 shrink-0" />
+                    {t('search.senseGroup')}
+                  </p>
+                  <ul className="space-y-1">
+                    {senseResults.map((result) => (
+                      <ResultRow
+                        key={resultKey(result)}
+                        {...rowProps(result, results.length + senseResults.indexOf(result))}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              ) : isSearchingBySense ? (
+                <p className="px-1 pt-1 text-xs text-muted-foreground">
+                  {t('search.senseSearching')}
+                </p>
+              ) : null}
             </div>
           )}
         </div>

--- a/ui/src/features/search/hooks.ts
+++ b/ui/src/features/search/hooks.ts
@@ -1,37 +1,69 @@
 import * as React from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { MIN_QUERY_LENGTH, searchHousehold, type SearchResult } from '@/lib/api/search';
+import {
+  MIN_QUERY_LENGTH,
+  searchHousehold,
+  searchHouseholdBySense,
+  type SearchResult,
+} from '@/lib/api/search';
 import { useDebouncedValue } from '@/lib/useDebouncedValue';
 
 export const searchKeys = {
   all: ['search'] as const,
-  query: (q: string) => [...searchKeys.all, q] as const,
+  query: (q: string) => [...searchKeys.all, 'keyword', q] as const,
+  sense: (q: string) => [...searchKeys.all, 'sense', q] as const,
 };
 
 /** Debounce before hitting the network: a keystroke is not a request. */
 const DEBOUNCE_MS = 250;
 
+// Results are re-fetched on the next open rather than kept warm: the palette is a
+// navigation tool, and stale rows would point at entities that may be gone.
+const STALE_MS = 30_000;
+
 /**
- * Search-as-you-type over the household. Returns the *debounced* query alongside
- * the results so the caller can tell "still typing" from "nothing found" — the two
- * look identical from `data === []` alone, and showing "no results" while the user
- * is mid-word reads as a wrong answer.
+ * Search-as-you-type over the household, **in two stages**.
+ *
+ * The keyword leg answers in milliseconds and is what the user sees while typing.
+ * The semantic leg needs to embed the query (~200 ms, up to 1.6 s observed in
+ * production) and returns only what the keywords could not reach, so it is fetched
+ * *in parallel* and rendered as an extra group when it lands — never awaited, never
+ * merged into the first list. Two separate queries rather than one: a single
+ * `Promise.all` would hold the fast half hostage to the slow one.
+ *
+ * Also returns the *debounced* query so the caller can tell "still typing" from
+ * "nothing found" — the two look identical from `data === []` alone, and showing
+ * "no results" mid-word reads as a wrong answer.
  */
 export function useHouseholdSearch(query: string) {
   const debounced = useDebouncedValue(query.trim(), DEBOUNCE_MS);
   const enabled = debounced.length >= MIN_QUERY_LENGTH;
 
-  const search = useQuery<SearchResult[]>({
+  const keyword = useQuery<SearchResult[]>({
     queryKey: searchKeys.query(debounced),
     queryFn: () => searchHousehold(debounced),
     enabled,
-    // Results are re-fetched on the next open rather than kept warm: the palette is
-    // a navigation tool, and stale rows would point at entities that may be gone.
-    staleTime: 30_000,
+    staleTime: STALE_MS,
+  });
+
+  const sense = useQuery<SearchResult[]>({
+    queryKey: searchKeys.sense(debounced),
+    queryFn: () => searchHouseholdBySense(debounced),
+    enabled,
+    staleTime: STALE_MS,
+    // A semantic index that is unavailable is not an error the user should read: the
+    // keyword results are already on screen and remain a complete answer.
+    retry: false,
   });
 
   return {
-    ...search,
+    ...keyword,
+    /** Keyword hits — the list shown while typing. */
+    results: keyword.data ?? [],
+    /** Semantic-only extras, already deduped server-side against `results`. */
+    senseResults: sense.data ?? [],
+    /** True while the semantic leg is still in flight for the current query. */
+    isSearchingBySense: enabled && sense.isFetching,
     /** The query the results correspond to (not what is currently typed). */
     debouncedQuery: debounced,
     /** True while the typed query has not reached the network yet. */

--- a/ui/src/lib/api/search.ts
+++ b/ui/src/lib/api/search.ts
@@ -19,12 +19,31 @@ export interface SearchResult {
 /** Below this the server returns nothing: one letter ranks nothing. */
 export const MIN_QUERY_LENGTH = 2;
 
-/** Search everything the household owns. Empty/short queries resolve to `[]`. */
-export async function searchHousehold(query: string): Promise<SearchResult[]> {
+async function get(query: string, semantic: boolean): Promise<SearchResult[]> {
   const trimmed = query.trim();
   if (trimmed.length < MIN_QUERY_LENGTH) return [];
   const { data } = await api.get<{ results: SearchResult[] }>('/search/', {
-    params: { q: trimmed },
+    params: semantic ? { q: trimmed, semantic: 1 } : { q: trimmed },
   });
   return data?.results ?? [];
+}
+
+/**
+ * Stage one — keyword search over everything the household owns. A few indexed SQL
+ * queries, back in milliseconds, so it can run on every debounced keystroke.
+ */
+export function searchHousehold(query: string): Promise<SearchResult[]> {
+  return get(query, false);
+}
+
+/**
+ * Stage two — what only the *meaning* finds (« chauffage » → « pompe à chaleur »),
+ * minus everything stage one already returned.
+ *
+ * Separate call because embedding the query costs ~200 ms (up to 1.6 s observed in
+ * production): waiting for it would make the whole box feel that slow. Resolves to
+ * `[]` when the deployment has no semantic index — a normal answer, not an error.
+ */
+export function searchHouseholdBySense(query: string): Promise<SearchResult[]> {
+  return get(query, true);
 }

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -2984,6 +2984,8 @@
     "placeholder": "Suchen…",
     "hint": "Gib mindestens zwei Zeichen ein, um zu suchen.",
     "noResults": "Nichts gefunden.",
+    "senseGroup": "Nach Bedeutung",
+    "senseSearching": "Suche auch nach Bedeutung…",
     "entity": {
       "document": "Dokumente",
       "interaction": "Aktivität",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -2984,6 +2984,8 @@
     "placeholder": "Search…",
     "hint": "Type at least two characters to search.",
     "noResults": "Nothing found.",
+    "senseGroup": "By meaning",
+    "senseSearching": "Also searching by meaning…",
     "entity": {
       "document": "Documents",
       "interaction": "Activity",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -2984,6 +2984,8 @@
     "placeholder": "Buscar…",
     "hint": "Escribe al menos dos caracteres para buscar.",
     "noResults": "Sin resultados.",
+    "senseGroup": "Por significado",
+    "senseSearching": "Buscando también por significado…",
     "entity": {
       "document": "Documentos",
       "interaction": "Actividad",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -2984,6 +2984,8 @@
     "placeholder": "Rechercher…",
     "hint": "Saisis au moins deux caractères pour lancer la recherche.",
     "noResults": "Aucun résultat.",
+    "senseGroup": "Par le sens",
+    "senseSearching": "Recherche aussi par le sens…",
     "entity": {
       "document": "Documents",
       "interaction": "Activité",


### PR DESCRIPTION
Suite de #466, qui a été mergée pendant que ce travail était en cours (le commit n'a donc jamais eu de CI sur cette PR-là — il est ici, rebasé sur `main`).

## Pourquoi

#466 a livré une palette **mot-clé uniquement**, sur une justification que j'ai fondée sur une lecture fausse : je pensais la jambe sémantique dormante. Vérification faite sur le VPS, la prod tourne en hybride depuis un moment :

| | Prod |
|---|---|
| `EMBEDDING_PROVIDER` | `openai` — `text-embedding-3-small`, 1024 dims |
| `AGENT_HYBRID_RETRIEVAL_ENABLED` | **True** |
| `EMBEDDING_INDEXING_ENABLED` | **True** |
| Index | **1532 chunks** (941 documents, 359 interactions, 79 tâches…) |

La palette livrée prive donc l'utilisateur de la moitié de ce que l'agent sait faire : « chauffage » ne trouve pas « pompe à chaleur ». Et l'argument coût ne tient pas à ce tarif — 0,02 $/M tokens, soit **~1,6 centime pour 100 000 recherches**.

Ce qui reste vrai, mesuré sur les 808 appels `embed_query` de la prod : **211 ms de moyenne, 137 ms au mieux, 1,6 s au pire**. Le problème n'est pas de payer l'embedding, c'est de l'**attendre**.

## Quoi

Deux étapes sur la même URL, jamais un appel hybride bloquant :

- `?q=` — étape lexicale, quelques requêtes SQL indexées, part à chaque frappe débouncée.
- `?q=&semantic=1` — étape sémantique (`retrieval.semantic_only`), qui renvoie ce que la jambe vectorielle trouve **moins** ce que l'étape une a déjà renvoyé.

Le front tire les deux en parallèle (deux `useQuery`, pas un `Promise.all` qui retiendrait la moitié rapide) et **ajoute** un groupe « Par le sens » sous la liste, sans rien réordonner au-dessus.

### Les choix qui méritent un regard

- **Le serveur renvoie la différence, pas la fusion.** C'est ce qui rend l'ajout possible sans réorganiser : une liste qui se réordonne 200 ms après son apparition fait cliquer à côté. Une fusion RRF renvoyée telle quelle imposerait de remplacer la liste.
- **L'exclusion se calcule côté serveur** (la jambe lexicale est rejouée — c'est du SQL, aucun appel fournisseur) et non depuis une liste de clés envoyée par le client, qui dériverait au premier changement de ranking ou de gating.
- **`[]` sans appel fournisseur quand le flag est off.** Un déploiement sans index sémantique ne paie pas une requête par frappe pour se faire répondre qu'il n'y a rien à ajouter.
- **Un échec de l'étape deux n'affiche aucune erreur** (`retry: false`, pas de toast) : les résultats mot-clé sont déjà à l'écran et forment une réponse complète.
- **Le groupe est annoncé comme tel** (« Par le sens », icône `Sparkles`) : ces lignes peuvent ne partager aucun mot avec ce qui a été tapé, et un résultat inexpliqué se lit comme un bug.

## Tests

| Où | Quoi |
|---|---|
| `test_global_search.py::TestTheSecondStageAddsWhatTheFirstCannotFind` | Le gain de rappel via un faux client d'embeddings déterministe (« chauffage » ne trouve rien en lexical, trouve la PAC en sémantique), l'absence de doublon avec l'étape une, le scope foyer, le gating par module sur la jambe vectorielle |
| `::TestTheSemanticLegIsASecondStage` | L'étape une n'embedde jamais, même flag on ; l'étape deux se tait sans appeler le fournisseur quand le flag est off ; l'agent continue d'honorer le flag |
| `e2e/global-search.spec.ts` | **Le non-blocage, qui ne se prouve que dans un vrai navigateur** : l'étape sémantique est retardée de 1,5 s et on exige le résultat lexical à l'écran avant. Plus un 503 sur l'étape deux qui ne casse rien. |

Vert en local : `pytest` 3803 passed · `vitest` 172 passed · `npm run lint` 0 erreur · `tsc -b ui/tsconfig.json` OK · `playwright e2e/global-search.spec.ts` 9 passed.

## Doc

`CLAUDE.md`, `docs/MODULES/agent.md` et `docs/MODULES/shell-and-design-system.md` décrivaient « la palette sort de l'hybride » — elles décrivent maintenant les deux étapes, avec les chiffres de prod qui motivent le découpage et la raison pour laquelle le serveur renvoie une différence.

## Hors scope

- Le stemming reste absent (`simple_unaccent`) : « facture » ne trouve toujours pas « factures » côté lexical. Le sémantique en rattrape une partie, mais ce n'est pas le même correctif — `docs/fiches/RAG.md` §4.2 garde le plan.
- Pas de cache serveur sur l'embedding de requête : deux utilisateurs cherchant le même mot paient deux appels. À regarder si le volume monte.
