### PR TITLE
feat(money): corriger un lot de dépenses depuis la fiche d'un budget

### DIFF
--- a/ui/src/features/money/BudgetDetailPage.test.tsx
+++ b/ui/src/features/money/BudgetDetailPage.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { BudgetInsights } from '@/lib/api/budget';
+import type { FetchInteractionsResult, InteractionListItem } from '@/lib/api/interactions';
+import BudgetDetailPage from './BudgetDetailPage';
+
+/**
+ * Ce que ces tests tiennent, et pourquoi :
+ *
+ * 1. **La liste se parcourt, elle ne se tronque pas.** Elle s'arrêtait à 100
+ *    lignes avec une note. Sous une sélection multiple, ce plafond devient un
+ *    mensonge : « tout sélectionner » ne porterait que sur les cent premières
+ *    pendant que le compteur du haut en annonce trois cents.
+ * 2. **Cocher n'ouvre pas.** En mode sélection, le clic sur une ligne coche —
+ *    viser une case de 16 px pour en cocher douze est un supplice, et partir sur
+ *    la fiche au douzième clic perd le lot en cours.
+ * 3. **⚠️ Changer d'enveloppe vide la sélection, y compris au retour.** La route
+ *    est la même d'une enveloppe à l'autre : le composant n'est pas démonté.
+ *    Arriver sur « Courses » remet bien le compteur à zéro sans rien de spécial
+ *    (la sélection est dérivée des ids affichés), mais sans l'id dans la portée
+ *    les lignes cochées sur « Bricolage » dorment dans le `Set` et se rallument
+ *    au retour — un lot qu'on ne se sait plus tenir.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key}:${Object.values(vars).join(',')}` : key,
+    i18n: { language: 'fr' },
+  }),
+}));
+
+// Graphiques et comparaisons : ils ne disent rien de la sélection, et recharts ne
+// se mesure pas en jsdom.
+vi.mock('@/components/charts/ConsumptionBarChart', () => ({ default: () => null }));
+vi.mock('./ShareChart', () => ({ default: () => null }));
+vi.mock('./InsightComparison', () => ({ default: () => null }));
+vi.mock('@/features/expenses/PeriodPicker', () => ({ default: () => null }));
+vi.mock('@/features/banking/AttachToTransactionDialog', () => ({ default: () => null }));
+vi.mock('@/features/banking/LinkedLineActions', () => ({ default: () => null }));
+vi.mock('./ReconciliationBadge', () => ({ default: () => null }));
+
+/** Le dialogue de lot, réduit à ce qu'on veut vérifier : les ids qu'il reçoit. */
+vi.mock('@/features/expenses/BulkEditDialog', () => ({
+  default: ({ open, ids }: { open: boolean; ids: string[] }) =>
+    open ? <div data-testid="bulk-ids">{ids.join(',')}</div> : null,
+}));
+
+const insights: BudgetInsights = {
+  period: { from: '2026-07-01', to: '2026-07-31' },
+  previous_period: { from: '2026-06-01', to: '2026-06-30' },
+  current: { total: '900.00', refunded: '0.00', net_total: '900.00', count: 120 },
+  previous: { total: '800.00', refunded: '0.00', net_total: '800.00', count: 110 },
+  delta: { amount: '100.00', ratio: 0.125 },
+  granularity: 'day',
+  buckets: [],
+  suppliers: [],
+  budgets: [],
+  budgets_returned: [],
+  budgets_net_total: '900.00',
+};
+
+vi.mock('@/features/budget/hooks', () => ({
+  useBudgetOverview: () => ({
+    data: {
+      categories: [],
+      budgets: [
+        { id: 'b-1', name: 'Bricolage', amount: '400.00', category_id: null },
+        { id: 'b-2', name: 'Courses', amount: '600.00', category_id: null },
+      ],
+      global: null,
+    },
+    isLoading: false,
+  }),
+  useBudgetInsights: () => ({ data: insights, isLoading: false }),
+  useBudgets: () => ({ data: [] }),
+}));
+
+vi.mock('@/features/banking/hooks', () => ({
+  useTransactions: () => ({ data: { results: [] } }),
+}));
+
+function expense(id: string, subject: string): InteractionListItem {
+  return {
+    id,
+    subject,
+    content: '',
+    type: 'expense',
+    occurred_at: '2026-07-10T12:00:00Z',
+    tags: [],
+    zone_names: [],
+    document_count: 0,
+    amount: '42.00',
+    supplier: 'Leroy Merlin',
+  } as InteractionListItem;
+}
+
+/** 120 dépenses sur l'enveloppe : deux pages et demie, l'ancien plafond dépassé. */
+const TOTAL = 120;
+
+const fetchInteractions = vi.fn(
+  async (options: { budget?: string; offset?: number }): Promise<FetchInteractionsResult> => {
+    const offset = options.offset ?? 0;
+    const prefix = options.budget === 'b-2' ? 'c' : 'e';
+    const items = Array.from({ length: Math.min(50, TOTAL - offset) }, (_, i) =>
+      expense(`${prefix}${offset + i}`, `Dépense ${prefix}${offset + i}`),
+    );
+    return { items, count: TOTAL, next: null, previous: null };
+  },
+);
+
+vi.mock('@/lib/api/interactions', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/api/interactions')>(
+    '@/lib/api/interactions',
+  );
+  return { ...actual, fetchInteractions: (o: never) => fetchInteractions(o) };
+});
+
+function renderPage(at = '/app/money/budgets/b-1') {
+  const router = createMemoryRouter(
+    [{ path: '/app/money/budgets/:id', element: <BudgetDetailPage /> }, { path: '*', element: null }],
+    { initialEntries: [at] },
+  );
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  render(
+    <QueryClientProvider client={client}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>,
+  );
+  return router;
+}
+
+beforeEach(() => {
+  fetchInteractions.mockClear();
+});
+
+describe('BudgetDetailPage — la liste des dépenses', () => {
+  it('se parcourt par pages au lieu de se tronquer', async () => {
+    renderPage();
+
+    await screen.findByText('Dépense e0');
+    expect(fetchInteractions).toHaveBeenCalledWith(
+      expect.objectContaining({ budget: 'b-1', limit: 50, offset: 0 }),
+    );
+    // « 1–50 sur 120 » plutôt que « 100 dépenses affichées sur 120 ».
+    expect(screen.getByText('common.rangeOfTotal:1,50,120')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /common.next/ }));
+
+    await screen.findByText('Dépense e50');
+    expect(fetchInteractions).toHaveBeenCalledWith(expect.objectContaining({ offset: 50 }));
+  });
+
+  it('coche la ligne au lieu d’ouvrir sa fiche, en mode sélection', async () => {
+    const router = renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByRole('button', { name: /common.select/ }));
+    await userEvent.click(screen.getByText('Dépense e0'));
+
+    expect(screen.getByText('expenses.bulk.selected:1')).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/app/money/budgets/b-1');
+  });
+
+  it('passe au lot exactement les lignes cochées', async () => {
+    renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByRole('button', { name: /common.select/ }));
+    await userEvent.click(screen.getByText('Dépense e0'));
+    await userEvent.click(screen.getByText('Dépense e2'));
+    await userEvent.click(screen.getByRole('button', { name: /expenses.bulk.action/ }));
+
+    expect(screen.getByTestId('bulk-ids').textContent).toBe('e0,e2');
+  });
+
+  it('⚠️ vide la sélection quand on change d’enveloppe, retour compris', async () => {
+    const router = renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByRole('button', { name: /common.select/ }));
+    await userEvent.click(screen.getByText('Dépense e0'));
+    expect(screen.getByText('expenses.bulk.selected:1')).toBeInTheDocument();
+
+    // Même route, autre `:id` : le composant n'est pas démonté. Le compteur tombe
+    // à zéro tout seul, la sélection étant dérivée des ids affichés.
+    // ⚠️ Les libellés sont **distincts par enveloppe** (`e0` / `c0`), sans quoi
+    // l'attente ci-dessous se satisfait des lignes de l'autre budget et le test
+    // passe quoi qu'on fasse — c'est ce qui l'a rendu muet une première fois.
+    await router.navigate('/app/money/budgets/b-2');
+    await screen.findByText('Dépense c0');
+    await waitFor(() =>
+      expect(screen.getByText('expenses.bulk.selected:0')).toBeInTheDocument(),
+    );
+
+    // C'est **ici** que l'id de la portée se prouve : sans lui, `e0` a dormi dans
+    // le `Set` pendant le détour et se rallume, sur un lot que l'utilisateur a
+    // composé deux écrans plus tôt.
+    await router.navigate('/app/money/budgets/b-1');
+    await screen.findByText('Dépense e0');
+    await waitFor(() =>
+      expect(screen.getByText('expenses.bulk.selected:0')).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/src/features/money/BudgetDetailPage.test.tsx
+++ b/ui/src/features/money/BudgetDetailPage.test.tsx
@@ -102,7 +102,7 @@ function expense(id: string, subject: string): InteractionListItem {
 const TOTAL = 120;
 
 const fetchInteractions = vi.fn(
-  async (options: { budget?: string; offset?: number }): Promise<FetchInteractionsResult> => {
+  async (options: { budget?: string; offset?: number } = {}): Promise<FetchInteractionsResult> => {
     const offset = options.offset ?? 0;
     const prefix = options.budget === 'b-2' ? 'c' : 'e';
     const items = Array.from({ length: Math.min(50, TOTAL - offset) }, (_, i) =>
@@ -116,12 +116,21 @@ vi.mock('@/lib/api/interactions', async () => {
   const actual = await vi.importActual<typeof import('@/lib/api/interactions')>(
     '@/lib/api/interactions',
   );
-  return { ...actual, fetchInteractions: (o: never) => fetchInteractions(o) };
+  return {
+    ...actual,
+    fetchInteractions: ((options) =>
+      fetchInteractions(options)) as typeof actual.fetchInteractions,
+  };
 });
 
 function renderPage(at = '/app/money/budgets/b-1') {
   const router = createMemoryRouter(
-    [{ path: '/app/money/budgets/:id', element: <BudgetDetailPage /> }, { path: '*', element: null }],
+    [
+      { path: '/app/money/budgets/:id', element: <BudgetDetailPage /> },
+      // La fiche d'une dépense, en cul-de-sac : le test « cocher n'ouvre pas »
+      // doit échouer sur son assertion de chemin, pas sur une erreur de routeur.
+      { path: '*', element: null },
+    ],
     { initialEntries: [at] },
   );
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -135,6 +144,9 @@ function renderPage(at = '/app/money/budgets/b-1') {
 
 beforeEach(() => {
   fetchInteractions.mockClear();
+  // La période vit dans `sessionStorage` (`useSessionState`) et survit au démontage :
+  // un test qui en changerait la fixerait pour tous les suivants.
+  sessionStorage.clear();
 });
 
 describe('BudgetDetailPage — la liste des dépenses', () => {

--- a/ui/src/features/money/BudgetDetailPage.tsx
+++ b/ui/src/features/money/BudgetDetailPage.tsx
@@ -2,17 +2,22 @@ import * as React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { Receipt } from 'lucide-react';
+import { CheckSquare, Pencil, Receipt } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import BackLink from '@/components/BackLink';
 import EmptyState from '@/components/EmptyState';
+import Pager from '@/components/Pager';
+import SelectionBar from '@/components/SelectionBar';
 import ConsumptionBarChart, {
   type ConsumptionChartBucket,
 } from '@/components/charts/ConsumptionBarChart';
+import { Button } from '@/design-system/button';
 import { Card, CardTitle } from '@/design-system/card';
 import { formatAmount, formatDate } from '@/lib/format';
 import { chartColor } from '@/lib/chartColors';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { useMultiSelect } from '@/lib/useMultiSelect';
+import { usePager } from '@/lib/usePager';
 import { useSessionState } from '@/lib/useSessionState';
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
 import { interactionKeys } from '@/features/interactions/hooks';
@@ -21,6 +26,7 @@ import { useTransactions } from '@/features/banking/hooks';
 import { resolvePeriod, type PeriodRange } from '@/features/expenses/period';
 import PeriodPicker from '@/features/expenses/PeriodPicker';
 import ExpenseList from '@/features/expenses/ExpenseList';
+import BulkEditDialog from '@/features/expenses/BulkEditDialog';
 import ShareChart, { type ShareRow } from './ShareChart';
 import InsightComparison from './InsightComparison';
 
@@ -46,6 +52,12 @@ export const UNBUDGETED = 'none';
  * par fournisseur). Tout arrive du serveur en un appel : refaire ces agrégats
  * ici imposerait de charger toutes les dépenses de la fenêtre, et donnerait au
  * compteur affiché juste au-dessus une seconde définition.
+ *
+ * Et une fois qu'on voit *lesquelles*, le geste suivant est de **corriger** —
+ * typiquement déplacer trois lignes mal rangées dans une autre enveloppe. D'où
+ * la même sélection multiple que l'onglet Dépenses, sur les mêmes composants
+ * génériques : cette page n'a pas de règle propre à la sélection, seulement une
+ * portée à elle (voir `selection` plus bas).
  */
 export default function BudgetDetailPage() {
   const { t, i18n } = useTranslation();
@@ -69,15 +81,29 @@ export default function BudgetDetailPage() {
   const insightsQuery = useBudgetInsights(id, range.from, range.to);
   const insights = insightsQuery.data;
 
+  /**
+   * La liste se **parcourt**, elle ne se plafonne pas.
+   *
+   * Elle s'arrêtait à 100 lignes avec une note de troncature. Sur une enveloppe
+   * chargée c'était déjà gênant à lire ; avec la sélection multiple ça devenait
+   * faux : « tout sélectionner » n'aurait porté que sur les cent premières
+   * pendant que le compteur du haut en annonce trois cents, et un lot qui
+   * prétend traiter *tout* en laissant deux cents lignes derrière est exactement
+   * le dégât qu'aucun écran ne rattrape. Le serveur plafonne d'ailleurs à 100
+   * par requête — une fenêtre qu'on agrandit s'y serait arrêtée sans le dire.
+   */
+  const pager = usePager(50, `${id}|${range.from}|${range.to}`);
+
   const listFilters = React.useMemo(
     () => ({
       type: 'expense' as const,
       budget: id,
       ...(range.from ? { start_date: range.from } : {}),
       ...(range.to ? { end_date: range.to } : {}),
-      limit: 100,
+      limit: pager.limit,
+      offset: pager.offset,
     }),
-    [id, range.from, range.to],
+    [id, range.from, range.to, pager.limit, pager.offset],
   );
 
   const listQuery = useQuery({
@@ -98,7 +124,41 @@ export default function BudgetDetailPage() {
   const refundsQuery = useTransactions(refundFilters, 50, { enabled: !isUnbudgeted });
   const refunds = refundsQuery.data?.results ?? [];
 
-  const items: InteractionListItem[] = listQuery.data?.items ?? [];
+  // Mémoïsé : le `?? []` fabriquait un tableau neuf à chaque rendu, donc la liste
+  // d'ids que lit `useMultiSelect` changeait d'identité en permanence et
+  // recalculait la sélection pour rien. Inoffensif tant que rien ne la lisait.
+  const items: InteractionListItem[] = React.useMemo(
+    () => listQuery.data?.items ?? [],
+    [listQuery.data],
+  );
+
+  /**
+   * La portée de la sélection porte **l'enveloppe** en plus de la période et de
+   * la page, parce que la route est la même d'une enveloppe à l'autre : `:id`
+   * change, le composant reste monté.
+   *
+   * La dérivation par les ids affichés fait déjà tomber le compteur à zéro en
+   * arrivant sur « Courses » — ce n'est pas ce que l'id protège. Ce qu'il protège
+   * est le **retour** : sans lui, les trois lignes cochées sur « Bricolage »
+   * dorment dans le `Set` et se rallument au premier détour ramenant à elles,
+   * alors que l'utilisateur a composé son lot deux écrans plus tôt et ne le sait
+   * plus. Un lot qu'on n'a pas conscience de tenir est exactement celui qu'on
+   * envoie de travers.
+   */
+  const selection = useMultiSelect(
+    React.useMemo(() => items.map((item) => item.id), [items]),
+    { scopeKey: `${id}|${range.from}|${range.to}|${pager.offset}` },
+  );
+
+  // Une page qui s'est vidée sous les doigts ramène à la première. Le cas est ici
+  // la règle plutôt que l'exception : déplacer tout un lot vers une autre
+  // enveloppe le fait **sortir** de cette liste, qui est filtrée par budget.
+  // Rester sur une page vide afficherait « aucune dépense » sur une enveloppe qui
+  // en compte deux cents.
+  React.useEffect(() => {
+    if (!listQuery.isFetching && items.length === 0 && pager.offset > 0) pager.reset();
+  }, [listQuery.isFetching, items.length, pager]);
+
   const isLoading = insightsQuery.isLoading || listQuery.isLoading;
   const showSkeleton = useDelayedLoading(isLoading);
 
@@ -135,6 +195,7 @@ export default function BudgetDetailPage() {
   );
 
   const hasSpending = Boolean(insights && Number(insights.current.total) > 0);
+  const [bulkOpen, setBulkOpen] = React.useState(false);
 
   return (
     <>
@@ -267,21 +328,70 @@ export default function BudgetDetailPage() {
             />
           ) : (
             <>
-              <ExpenseList items={items} />
-              {/* La liste est plafonnée : le dire plutôt que laisser croire que
-                  le total ne correspond pas aux lignes affichées. */}
-              {(listQuery.data?.count ?? 0) > items.length ? (
-                <p className="text-center text-xs text-muted-foreground">
-                  {t('budgetDetail.truncated', {
-                    shown: items.length,
-                    total: listQuery.data?.count ?? 0,
-                  })}
-                </p>
+              {/* Le bouton vit ici, contre la liste, et non en tête de page avec
+                  la période : entrer en sélection est un geste qui porte sur les
+                  lignes, et deux graphiques le séparent de son objet s'il monte. */}
+              <div className="flex justify-end">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => (selection.active ? selection.exit() : selection.enter())}
+                  className="gap-1.5"
+                >
+                  <CheckSquare className="h-4 w-4" />
+                  {selection.active ? t('common.cancel') : t('common.select')}
+                </Button>
+              </div>
+              <ExpenseList
+                items={items}
+                onToggleSelected={
+                  selection.active ? (item) => selection.toggle(item.id) : undefined
+                }
+                isSelected={(item) => selection.isSelected(item.id)}
+              />
+              {selection.active ? (
+                <SelectionBar
+                  label={t('expenses.bulk.selected', { count: selection.count })}
+                  allSelected={selection.allSelected}
+                  onToggleAll={selection.allSelected ? selection.clear : selection.selectAll}
+                  onExit={selection.exit}
+                >
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={selection.count === 0}
+                    onClick={() => setBulkOpen(true)}
+                    className="gap-1.5"
+                  >
+                    <Pencil className="h-4 w-4" />
+                    {t('expenses.bulk.action')}
+                  </Button>
+                </SelectionBar>
               ) : null}
+              <Pager
+                offset={pager.offset}
+                limit={pager.limit}
+                shown={items.length}
+                total={listQuery.data?.count ?? items.length}
+                onPrevious={pager.previous}
+                onNext={pager.next}
+                isFetching={listQuery.isFetching}
+              />
             </>
           )}
         </div>
       ) : null}
+
+      {/* Le même dialogue que l'onglet Dépenses, sans une ligne de plus : il ne
+          prend qu'une liste d'ids. Son champ budget est justement le geste qu'on
+          vient chercher ici — ranger ailleurs ce qui est mal rangé. */}
+      <BulkEditDialog
+        open={bulkOpen}
+        onOpenChange={setBulkOpen}
+        ids={selection.selectedIds}
+        onDone={selection.exit}
+      />
     </>
   );
 }

--- a/ui/src/features/money/ExpensesPanel.tsx
+++ b/ui/src/features/money/ExpensesPanel.tsx
@@ -146,14 +146,23 @@ export default function ExpensesPanel() {
   const [bulkOpen, setBulkOpen] = React.useState(false);
 
   /**
-   * La `scopeKey` porte les filtres **et** la pagination : cocher douze dépenses
-   * de juillet puis basculer sur juin ou tourner la page laisserait sinon une
-   * sélection invisible, et le lot suivant porterait sur autre chose que ce que
-   * l'écran montre.
+   * La `scopeKey` porte **tous** les filtres et la pagination : cocher douze
+   * dépenses de juillet puis basculer sur juin ou tourner la page laisserait
+   * sinon une sélection invisible, et le lot suivant porterait sur autre chose
+   * que ce que l'écran montre.
+   *
+   * `withoutSupplier` en fait partie au même titre que les autres — il y
+   * manquait. Éteindre puis rallumer la pastille ramenait les lignes cochées
+   * avant le détour : elles quittent bien la sélection le temps qu'elles sont
+   * hors filtre (elle est dérivée des ids affichés), mais elles y dorment et se
+   * rallument au retour. Or c'est **le** filtre qu'on manipule en composant un
+   * lot, puisque corriger un fournisseur manquant est ce qui l'éteint.
    */
   const selection = useMultiSelect(
     React.useMemo(() => items.map((item) => item.id), [items]),
-    { scopeKey: `${kind}|${supplier}|${range.from}|${range.to}|${pager.offset}` },
+    {
+      scopeKey: `${kind}|${supplier}|${withoutSupplier}|${range.from}|${range.to}|${pager.offset}`,
+    },
   );
 
   return (

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Das Blatt eines Budgets öffnen",
-            "body": "Tippe auf ein Budget, um sein Blatt zu öffnen. Wähle den Zeitraum — die vier Kürzel oder zwei freie Daten — und alles wird neu berechnet. Unter dem Betrag steht der Vergleich mit dem entsprechenden Vorzeitraum: ein Monat mit dem Vormonat, ein Jahr mit dem Vorjahr, ein freies Fenster mit derselben Dauer unmittelbar davor. Darunter der Ausgabenrhythmus Tag für Tag (bei langen Fenstern Monat für Monat) und der Anteil jedes Lieferanten in Prozent. Wurde zuvor nichts ausgegeben, schreibt House, dass es keinen Vergleich gibt, statt einen Prozentsatz zu erfinden. « Ohne Budget » öffnet sich genauso."
+            "body": "Tippe auf ein Budget, um sein Blatt zu öffnen. Wähle den Zeitraum — die vier Kürzel oder zwei freie Daten — und alles wird neu berechnet. Unter dem Betrag steht der Vergleich mit dem entsprechenden Vorzeitraum: ein Monat mit dem Vormonat, ein Jahr mit dem Vorjahr, ein freies Fenster mit derselben Dauer unmittelbar davor. Darunter der Ausgabenrhythmus Tag für Tag (bei langen Fenstern Monat für Monat) und der Anteil jedes Lieferanten in Prozent. Wurde zuvor nichts ausgegeben, schreibt House, dass es keinen Vergleich gibt, statt einen Prozentsatz zu erfinden. « Ohne Budget » öffnet sich genauso.\n\nUnten wird die Ausgabenliste des Zeitraums Seite für Seite durchblättert. Mit « Auswählen » hakst du mehrere Zeilen ab, dann ändert « Korrigieren… » Lieferant oder Budget auf einmal — so verschiebst du, was im falschen Budget liegt. Verschobene Zeilen verlassen das Blatt sofort: sie zählen jetzt anderswo."
           },
           "analysis": {
             "title": "Sehen, wohin es wirklich geht",
@@ -3431,7 +3431,6 @@
     "count_other": "{{count}} Ausgaben",
     "empty": "Keine Ausgabe in diesem Zeitraum",
     "emptyDescription": "Ändere den Zeitraum oder ordne Ausgaben diesem Budget zu.",
-    "truncated": "{{shown}} von {{total}} Ausgaben angezeigt.",
     "refundsTitle": "Erstattungen im Zeitraum",
     "trend": {
       "title": "Ausgabenrhythmus",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Open a budget's sheet",
-            "body": "Tap a budget to open its sheet. Pick the period — the four shortcuts, or two free dates — and everything recomputes. Under the amount sits the comparison with the equivalent previous period: a month compares with the month before, a year with the year before, a free window with the same duration just before it. Below that, the spending rhythm day by day (month by month over a long window) and each supplier's share as a percentage. With nothing spent before, House says there is no comparison rather than inventing a percentage. « Unbudgeted » opens exactly the same way."
+            "body": "Tap a budget to open its sheet. Pick the period — the four shortcuts, or two free dates — and everything recomputes. Under the amount sits the comparison with the equivalent previous period: a month compares with the month before, a year with the year before, a free window with the same duration just before it. Below that, the spending rhythm day by day (month by month over a long window) and each supplier's share as a percentage. With nothing spent before, House says there is no comparison rather than inventing a percentage. « Unbudgeted » opens exactly the same way.\n\nAt the bottom, the period's expenses are browsed page by page. « Select » ticks several lines, then « Fix… » changes their supplier or their budget in one go — that is how you move what sits in the wrong envelope. Moved lines leave the sheet right away: they now count elsewhere."
           },
           "analysis": {
             "title": "See where it actually goes",
@@ -3431,7 +3431,6 @@
     "count_other": "{{count}} expenses",
     "empty": "No expense in this period",
     "emptyDescription": "Change the period, or sort some expenses into this budget.",
-    "truncated": "Showing {{shown}} of {{total}} expenses.",
     "refundsTitle": "Refunds over the period",
     "trend": {
       "title": "Spending rhythm",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Abrir la ficha de un presupuesto",
-            "body": "Toca un presupuesto para abrir su ficha. Elige el periodo — los cuatro accesos rápidos o dos fechas libres — y todo se recalcula. Bajo el importe está la comparación con el periodo anterior equivalente: un mes se compara con el mes anterior, un año con el año anterior, una ventana libre con la misma duración justo antes. Debajo, el ritmo de gastos día a día (mes a mes en una ventana larga) y la parte de cada proveedor en porcentaje. Si antes no se gastó nada, House dice que no hay comparación en lugar de inventar un porcentaje. « Sin presupuesto » se abre exactamente igual."
+            "body": "Toca un presupuesto para abrir su ficha. Elige el periodo — los cuatro accesos rápidos o dos fechas libres — y todo se recalcula. Bajo el importe está la comparación con el periodo anterior equivalente: un mes se compara con el mes anterior, un año con el año anterior, una ventana libre con la misma duración justo antes. Debajo, el ritmo de gastos día a día (mes a mes en una ventana larga) y la parte de cada proveedor en porcentaje. Si antes no se gastó nada, House dice que no hay comparación en lugar de inventar un porcentaje. « Sin presupuesto » se abre exactamente igual.\n\nAbajo, la lista de gastos del periodo se recorre página a página. « Seleccionar » marca varias líneas y « Corregir… » cambia su proveedor o su presupuesto de una vez — es el gesto para mover lo que está en el sobre equivocado. Las líneas movidas salen de la ficha al instante: ahora cuentan en otro sitio."
           },
           "analysis": {
             "title": "Ver adónde va de verdad",
@@ -3431,7 +3431,6 @@
     "count_other": "{{count}} gastos",
     "empty": "Ningún gasto en este periodo",
     "emptyDescription": "Cambia de periodo o clasifica gastos en este presupuesto.",
-    "truncated": "Mostrando {{shown}} de {{total}} gastos.",
     "refundsTitle": "Reembolsos del periodo",
     "trend": {
       "title": "Ritmo de gastos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Ouvrir la fiche d'un budget",
-            "body": "Touche un budget pour ouvrir sa fiche. Choisis la période — les quatre raccourcis, ou deux dates libres — et tout se recalcule. Sous le montant, la comparaison avec la période précédente équivalente : un mois se compare au mois d'avant, une année à l'année d'avant, une fenêtre libre à la même durée juste avant. En dessous, le rythme des dépenses jour par jour (mois par mois sur une longue fenêtre) et la part de chaque fournisseur en pourcentage. Sans dépense avant, House écrit qu'il n'y a pas de comparaison plutôt que d'inventer un pourcentage. « Hors budget » s'ouvre exactement pareil."
+            "body": "Touche un budget pour ouvrir sa fiche. Choisis la période — les quatre raccourcis, ou deux dates libres — et tout se recalcule. Sous le montant, la comparaison avec la période précédente équivalente : un mois se compare au mois d'avant, une année à l'année d'avant, une fenêtre libre à la même durée juste avant. En dessous, le rythme des dépenses jour par jour (mois par mois sur une longue fenêtre) et la part de chaque fournisseur en pourcentage. Sans dépense avant, House écrit qu'il n'y a pas de comparaison plutôt que d'inventer un pourcentage. « Hors budget » s'ouvre exactement pareil.\n\nEn bas, la liste des dépenses de la période se parcourt page par page. « Sélectionner » y coche plusieurs lignes, puis « Corriger… » change leur fournisseur ou leur budget d'un coup — c'est le geste pour déplacer ce qui est rangé dans la mauvaise enveloppe. Les lignes déplacées quittent la fiche aussitôt : elles comptent désormais ailleurs."
           },
           "analysis": {
             "title": "Comprendre où ça part",
@@ -3431,7 +3431,6 @@
     "count_other": "{{count}} dépenses",
     "empty": "Aucune dépense sur cette période",
     "emptyDescription": "Change de période, ou range des dépenses dans ce budget.",
-    "truncated": "{{shown}} dépenses affichées sur {{total}}.",
     "refundsTitle": "Remboursements de la période",
     "trend": {
       "title": "Rythme des dépenses",


### PR DESCRIPTION
Closes #479

## Quoi

La fiche d'une enveloppe (`/app/money/budgets/:id`) répondait à « lesquelles ? » et
s'arrêtait là. Le geste qui suit — déplacer trois lignes rangées dans la mauvaise
enveloppe — imposait de partir dans l'onglet Dépenses et de refaire le filtre à la
main. C'est pourtant **la même liste** : même endpoint, même `ExpenseList`, même tri.
Seule la coque autour différait, d'où une PR qui n'ajoute aucune brique et n'en
modifie aucune.

- **Sélection multiple** sur les composants génériques existants (`useMultiSelect`,
  `SelectionBar`, `BulkEditDialog`). Le bouton « Sélectionner » vit **contre la
  liste** et non en tête de page : deux graphiques l'y sépareraient de son objet.
- **La portée de la sélection porte l'enveloppe** en plus de la période et de la
  page. La route est la même d'une enveloppe à l'autre, donc le composant n'est pas
  démonté. Arriver sur « Courses » remet bien le compteur à zéro tout seul (la
  sélection est dérivée des ids affichés) — ce n'est pas ce que l'id protège. Il
  protège le **retour** : sans lui les lignes cochées dorment dans le `Set` et se
  rallument, sur un lot composé deux écrans plus tôt. Un lot qu'on ne se sait plus
  tenir est celui qu'on envoie de travers.
- **La liste se parcourt** (pager 50) au lieu de s'arrêter à 100 avec une note de
  troncature. Sous une sélection ce plafond devenait faux : « tout sélectionner »
  n'aurait porté que sur les cent premières pendant que le compteur du haut en
  annonce trois cents.
- **Une page vidée ramène à la première** — ici la règle plutôt que l'exception,
  une dépense rangée ailleurs quittant aussitôt cette liste filtrée par budget.
- **`items` mémoïsé** : le `?? []` fabriquait un tableau neuf à chaque rendu, donc
  la liste d'ids que lit `useMultiSelect` changeait d'identité en permanence.

Rien côté serveur : `bulk-update/` ne connaît pas la provenance du lot (il filtre
`household` + `type='expense'`), ses règles et ses tests valent tels quels.

## Critères de l'issue

- ✅ sélection sur les composants génériques, aucune règle propre à cette page
- ✅ portée = enveloppe | période | page
- ✅ liste paginée, note de troncature supprimée (clé `budgetDetail.truncated` retirée des 4 locales)
- ✅ page vidée → retour à la première
- ✅ tutoriel du guide budget étendu dans les 4 locales

## Sur le test de régression

Le test de la portée **passait d'abord sans le correctif** : mes deux enveloppes
portaient les mêmes libellés, donc l'attente se satisfaisait des lignes de l'autre
budget et l'assertion tournait avant le retour des bonnes données. Libellés
distincts par enveloppe (`e0` / `c0`), et il échoue bien quand on retire l'id de la
`scopeKey` — vérifié dans les deux sens. Le commentaire du test garde la trace du
piège.

## Hors scope

La file « À ranger » (`PendingQueue.tsx:105`) garde sa sélection maison
(`Set<string>` + toggle), sans les deux garde-fous de `useMultiSelect` — c'est la
duplication que le docstring du hook cite comme motif de son existence. Troisième
écran à sélection du module, à traiter à part.
