### PR TITLE
fix(general): les changements apparaissent sans recharger la page (#481)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -790,6 +790,43 @@ deux voix » appliquée à un montant : **un compteur ne peut pas avoir deux
 définitions.** Régression :
 `apps/interactions/tests/test_period_bounds.py::TestTheTwoScreensAgree`.
 
+### Fraîcheur des données — une écriture déclare ce qu'elle écrit, jamais ce qu'elle rafraîchit
+
+Le pendant de la règle du dessus dans le temps : un chiffre juste affiché après
+coup est un chiffre faux. Toute la fraîcheur du front tient dans **deux règles,
+tenues par `ui/src/lib/invalidate.test.ts`** :
+
+1. **Une mutation vit dans le `hooks.ts` de sa feature.** Une fonction
+   d'écriture de `lib/api/` ne s'importe **que** là — un composant qui appelle
+   `updateInteraction()` en direct doit redéclarer l'invalidation, et ce doublon
+   a dérivé dix fois. Le test refuse l'import.
+2. **Le `onSuccess` déclare la racine écrite, pas la liste des caches** :
+   `invalidate('tasks')`, via `useInvalidate` de `ui/src/lib/invalidate.ts`. Ce
+   qui **dérive** de cette racine est déclaré une fois dans le graphe
+   `DERIVED_FROM` du même fichier, et la fermeture est **transitive** — ventiler
+   une ligne bancaire crée des dépenses, qui changent le coût d'un projet, qui
+   s'affiche sur le dashboard.
+
+**Ajouter un écran qui lit les données d'une autre feature = ajouter sa ligne
+dans `DERIVED_FROM`.** Sans elle, l'écran s'affiche juste à sa première écriture
+puis mentira jusqu'à la fin du `staleTime`.
+
+**Pourquoi un test et pas une relecture :** le défaut est invisible deux fois. En
+revue, le diff d'un `onSuccess` qui oublie une racine ressemble exactement à
+celui qui la liste. En développement, Vite recharge le cache à chaque
+sauvegarde : l'écran qu'on vient d'écrire est toujours frais chez celui qui
+l'écrit. Il ne se voit qu'en prod, et il se dit toujours pareil : « je dois
+recharger la page ». Constaté sur l'édition d'une dépense (fournisseur corrigé,
+liste inchangée au retour), puis retrouvé sur neuf autres composants, et sur
+trois racines que **personne** n'invalidait : `dashboard`, `alerts`, et
+`projects` vu depuis l'argent — alors que le coût réel d'un chantier est une
+somme de dépenses.
+
+Le `staleTime` de 5 min du `QueryClient` (avec `refetchOnWindowFocus: false`) est
+l'**amplificateur**, pas la cause : rien ne rattrape l'oubli avant l'expiration.
+Ne pas le baisser pour masquer un cache mal invalidé — ce serait une requête à
+chaque montage pour cacher le défaut au lieu de le corriger.
+
 ---
 
 ## Pattern standard — Feature page

--- a/ui/src/features/budget/RecurringPage.tsx
+++ b/ui/src/features/budget/RecurringPage.tsx
@@ -9,14 +9,15 @@ import { Card } from '@/design-system/card';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useToast } from '@/lib/toast';
-import { deleteInteraction } from '@/lib/api/interactions';
-import { updateRecurringExpense, type RecurringExpense } from '@/lib/api/budget';
+import { useDeleteInteraction } from '@/features/interactions/hooks';
+import { type RecurringExpense } from '@/lib/api/budget';
 import {
   useCashflowProjection,
   useConfirmRecurringOccurrence,
   useDeleteRecurringExpense,
   useRecurringDue,
   useRecurringExpenses,
+  useRestoreRecurringSchedule,
 } from './hooks';
 import RecurringCard from './RecurringCard';
 import RecurringExpenseDialog from './RecurringExpenseDialog';
@@ -32,6 +33,12 @@ export default function RecurringPage() {
   const projectionQuery = useCashflowProjection();
   const deleteMutation = useDeleteRecurringExpense();
   const confirmMutation = useConfirmRecurringOccurrence();
+  // L'annulation d'une confirmation touche l'argent (elle supprime une dépense)
+  // *et* l'échéancier : par les hooks, pour que les compteurs de budget et la
+  // conformité se rafraîchissent avec la liste — un `refetch()` des trois
+  // requêtes de cette page ne voyait qu'elle-même.
+  const deleteExpenseMutation = useDeleteInteraction();
+  const restoreScheduleMutation = useRestoreRecurringSchedule();
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<RecurringExpense | undefined>(undefined);
@@ -85,13 +92,12 @@ export default function RecurringPage() {
           label: t('common.undo'),
           onClick: () => {
             void Promise.all([
-              deleteInteraction(result.interaction_id),
-              updateRecurringExpense(rec.id, { next_due_date: previousDueDate }),
-            ]).finally(() => {
-              void listQuery.refetch();
-              void dueQuery.refetch();
-              void projectionQuery.refetch();
-            });
+              deleteExpenseMutation.mutateAsync(result.interaction_id),
+              restoreScheduleMutation.mutateAsync({
+                id: rec.id,
+                nextDueDate: previousDueDate,
+              }),
+            ]);
           },
         },
       });

--- a/ui/src/features/budget/hooks.ts
+++ b/ui/src/features/budget/hooks.ts
@@ -176,6 +176,23 @@ export function useUpdateRecurringExpense() {
   });
 }
 
+/**
+ * Variante muette de la mutation ci-dessus, pour l'annulation d'une
+ * confirmation d'échéance.
+ *
+ * Elle existe pour le **toast**, pas pour le cache : annoncer « échéance mise à
+ * jour » par-dessus l'undo que l'utilisateur vient de cliquer dit le contraire
+ * de ce qu'il a fait. L'invalidation, elle, reste celle de l'argent.
+ */
+export function useRestoreRecurringSchedule() {
+  const invalidate = useInvalidateMoney();
+  return useMutation({
+    mutationFn: ({ id, nextDueDate }: { id: string; nextDueDate: string | null | undefined }) =>
+      updateRecurringExpense(id, { next_due_date: nextDueDate ?? undefined }),
+    onSuccess: invalidate,
+  });
+}
+
 /** Bare delete mutation — the page wraps it in useDeleteWithUndo. */
 export function useDeleteRecurringExpense() {
   const invalidate = useInvalidateMoney();

--- a/ui/src/features/dashboard/QuickActions.tsx
+++ b/ui/src/features/dashboard/QuickActions.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useLocation } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
 import { Droplets, ListPlus, MessageCircle, Receipt, StickyNote, Zap } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import { useToast } from '@/lib/toast';
@@ -12,7 +11,6 @@ import WaterReadingDialog from '@/features/water/WaterReadingDialog';
 import ReadingDialog from '@/features/electricity/ReadingDialog';
 import { useMeters } from '@/features/electricity/hooks';
 import { useWaterReadings } from '@/features/water/hooks';
-import { dashboardKeys } from './hooks';
 
 /** One-tap entry points for the most frequent captures. Module-specific
  * actions (readings) only show up once the module holds data. */
@@ -21,7 +19,6 @@ export default function QuickActions() {
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
-  const qc = useQueryClient();
   const [expenseOpen, setExpenseOpen] = React.useState(false);
   const [taskOpen, setTaskOpen] = React.useState(false);
   const [waterOpen, setWaterOpen] = React.useState(false);
@@ -73,8 +70,10 @@ export default function QuickActions() {
       <NewTaskDialog
         open={taskOpen}
         onOpenChange={setTaskOpen}
+        // Pas d'invalidation ici : c'est `useCreateTask` qui périme ce qui
+        // dérive d'une tâche, dashboard compris. Ce point d'appel n'invalidait
+        // que « Ma semaine » — la page Tâches restait sur sa liste d'avant.
         onCreated={() => {
-          void qc.invalidateQueries({ queryKey: dashboardKeys.myWeek() });
           toast({ description: t('dashboard.quickActions.taskCreated'), variant: 'success' });
         }}
       />

--- a/ui/src/features/dashboard/hooks.ts
+++ b/ui/src/features/dashboard/hooks.ts
@@ -1,5 +1,6 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { api } from '@/lib/axios';
+import { useInvalidate } from '@/lib/invalidate';
 import type { Task, TaskStatus } from '@/lib/api/tasks';
 import { updateTaskStatus } from '@/lib/api/tasks';
 
@@ -91,14 +92,13 @@ export function useActiveProjects() {
 
 /** Status toggle for "My week" checkboxes — invalidates both dashboard and tasks caches. */
 export function useSetTaskStatus() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, status }: { id: string; status: TaskStatus }) =>
       updateTaskStatus(id, status),
-    onSettled: () => {
-      void qc.invalidateQueries({ queryKey: dashboardKeys.myWeek() });
-      void qc.invalidateQueries({ queryKey: ['tasks'] });
-      void qc.invalidateQueries({ queryKey: ['alerts'] });
-    },
+    // Ce qu'on écrit, c'est une tâche : le dashboard et les alertes en dérivent
+    // (`lib/invalidate`). Cette liste-ci était la seule de l'app à connaître le
+    // lien tâche → alertes, et elle ne servait qu'à cet écran.
+    onSettled: () => invalidate('tasks'),
   });
 }

--- a/ui/src/features/directory/ContactDialog.tsx
+++ b/ui/src/features/directory/ContactDialog.tsx
@@ -6,8 +6,8 @@ import { Textarea } from '@/design-system/textarea';
 import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
-import { createContact, updateContact, type Contact } from '@/lib/api/contacts';
-import { useStructures } from './hooks';
+import { type Contact } from '@/lib/api/contacts';
+import { useCreateContact, useStructures, useUpdateContact } from './hooks';
 
 interface ContactDialogProps {
   open: boolean;
@@ -35,6 +35,8 @@ export default function ContactDialog({
   const [error, setError] = React.useState<string | null>(null);
 
   const { data: structures = [] } = useStructures();
+  const createMutation = useCreateContact();
+  const updateMutation = useUpdateContact();
 
   React.useEffect(() => {
     if (!open) return;
@@ -73,12 +75,12 @@ export default function ContactDialog({
     };
 
     const action = isEditing && existingContact
-      ? updateContact(existingContact.id, input)
-      : createContact(
+      ? updateMutation.mutateAsync({ id: existingContact.id, input })
+      : createMutation.mutateAsync({
           input,
-          email.trim() ? { email: email.trim(), label: 'main' } : null,
-          phone.trim() ? { phone: phone.trim(), label: 'mobile' } : null,
-        );
+          email: email.trim() ? { email: email.trim(), label: 'main' } : null,
+          phone: phone.trim() ? { phone: phone.trim(), label: 'mobile' } : null,
+        });
 
     action
       .then(() => {

--- a/ui/src/features/directory/StructureDialog.tsx
+++ b/ui/src/features/directory/StructureDialog.tsx
@@ -7,7 +7,8 @@ import { Select } from '@/design-system/select';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
 import { Label } from '@/design-system/label';
-import { createStructure, updateStructure, type Structure } from '@/lib/api/structures';
+import { type Structure } from '@/lib/api/structures';
+import { useCreateStructure, useUpdateStructure } from './hooks';
 
 const STRUCTURE_TYPES = ['company', 'association', 'administration', 'artisan', 'other'];
 
@@ -33,6 +34,9 @@ export default function StructureDialog({
   const [notes, setNotes] = React.useState('');
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
+
+  const createMutation = useCreateStructure();
+  const updateMutation = useUpdateStructure();
 
   React.useEffect(() => {
     if (!open) return;
@@ -67,8 +71,12 @@ export default function StructureDialog({
     };
 
     const action = isEditing && existingStructure
-      ? updateStructure(existingStructure.id, values, existingStructure)
-      : createStructure(values);
+      ? updateMutation.mutateAsync({
+          id: existingStructure.id,
+          values,
+          existing: existingStructure,
+        })
+      : createMutation.mutateAsync(values);
 
     action
       .then(() => {

--- a/ui/src/features/documents/EntityAttachDocumentDialog.tsx
+++ b/ui/src/features/documents/EntityAttachDocumentDialog.tsx
@@ -1,15 +1,13 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { SheetDialog } from '@/design-system/sheet-dialog';
 import { Input } from '@/design-system/input';
 import { Button } from '@/design-system/button';
-import { documentKeys } from './hooks';
+import { documentKeys, useAttachEntityDocument } from './hooks';
 import {
   fetchDocuments,
   fetchPhotoDocuments,
-  attachEntityDocument,
-  entityDetailQueryKey,
   type DocumentItem,
   type PhotoPhase,
 } from '@/lib/api/documents';
@@ -42,7 +40,7 @@ export default function EntityAttachDocumentDialog({
   title,
 }: Props) {
   const { t } = useTranslation();
-  const qc = useQueryClient();
+  const attachMutation = useAttachEntityDocument(entityType, objectId);
   const [search, setSearch] = React.useState('');
   const [selected, setSelected] = React.useState<Set<string>>(new Set());
   const [error, setError] = React.useState<string | null>(null);
@@ -86,13 +84,8 @@ export default function EntityAttachDocumentDialog({
     setIsAttaching(true);
     try {
       await Promise.all(
-        Array.from(selected).map((id) =>
-          attachEntityDocument(entityType, objectId, id, phase),
-        ),
+        Array.from(selected).map((id) => attachMutation.mutateAsync({ documentId: id, phase })),
       );
-      void qc.invalidateQueries({ queryKey: documentKeys.all });
-      const detailKey = entityDetailQueryKey(entityType);
-      if (detailKey) void qc.invalidateQueries({ queryKey: detailKey });
       onAttached?.();
       onOpenChange(false);
     } catch {

--- a/ui/src/features/documents/EntityDocumentsTab.tsx
+++ b/ui/src/features/documents/EntityDocumentsTab.tsx
@@ -66,7 +66,7 @@ export default function EntityDocumentsTab({ entityType, objectId }: Props) {
   const handleUploaded = React.useCallback(
     async (created?: DocumentDetail) => {
       if (created) {
-        await attachMutation.mutateAsync(created.id);
+        await attachMutation.mutateAsync({ documentId: created.id });
       }
       void qc.invalidateQueries({ queryKey: documentKeys.all });
     },

--- a/ui/src/features/documents/hooks.ts
+++ b/ui/src/features/documents/hooks.ts
@@ -10,6 +10,7 @@ import {
   detachEntityDocument,
   entityDetailQueryKey,
   type DocumentFilters,
+  type PhotoPhase,
   type UploadDocumentInput,
 } from '@/lib/api/documents';
 import type { QueryClient } from '@tanstack/react-query';
@@ -28,11 +29,18 @@ function invalidateEntityDocuments(qc: QueryClient, entityType: string) {
   if (detailKey) void qc.invalidateQueries({ queryKey: detailKey });
 }
 
-/** Attach an existing document to any linkable entity (project, equipment, …). */
+/**
+ * Attach an existing document to any linkable entity (project, equipment, …).
+ *
+ * `phase` ne concerne que les photos (avant/après) : le dialogue de rattachement
+ * en lot le passe, l'onglet Documents l'omet. C'est le seul paramètre qui
+ * justifiait un appel direct à l'API depuis un composant — il vit donc ici.
+ */
 export function useAttachEntityDocument(entityType: string, objectId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (documentId: string) => attachEntityDocument(entityType, objectId, documentId),
+    mutationFn: ({ documentId, phase }: { documentId: string; phase?: PhotoPhase | '' }) =>
+      attachEntityDocument(entityType, objectId, documentId, phase),
     onSuccess: () => invalidateEntityDocuments(qc, entityType),
   });
 }

--- a/ui/src/features/equipment/hooks.ts
+++ b/ui/src/features/equipment/hooks.ts
@@ -1,4 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useInvalidate } from '@/lib/invalidate';
 import { useTranslation } from 'react-i18next';
 import {
   fetchEquipmentList,
@@ -58,40 +59,39 @@ export function useEquipmentHistory(id: string) {
 export { useZones } from '@/features/zones/hooks';
 
 export function useCreateEquipment() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (payload: EquipmentPayload) => createEquipment(payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: equipmentKeys.all }),
+    onSuccess: () => invalidate('equipment'),
   });
 }
 
 export function useUpdateEquipment() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: EquipmentPayload }) =>
       updateEquipment(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: equipmentKeys.all }),
+    onSuccess: () => invalidate('equipment'),
   });
 }
 
 export function useDeleteEquipment() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (id: string) => deleteEquipment(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: equipmentKeys.all }),
+    onSuccess: () => invalidate('equipment'),
   });
 }
 
 export function useRegisterEquipmentPurchase() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: EquipmentPurchasePayload }) =>
       registerEquipmentPurchase(id, payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: equipmentKeys.all });
-      qc.invalidateQueries({ queryKey: ['interactions'] });
-      toast({ description: t('equipment.purchase.created'), variant: 'success' });
+      invalidate('equipment', 'interactions');
+            toast({ description: t('equipment.purchase.created'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });

--- a/ui/src/features/interactions/InteractionEditPage.tsx
+++ b/ui/src/features/interactions/InteractionEditPage.tsx
@@ -10,12 +10,11 @@ import { Textarea } from '@/design-system/textarea';
 import { fetchContacts, type Contact } from '@/lib/api/contacts';
 import { fetchStructures, type Structure } from '@/lib/api/structures';
 import { fetchEquipmentList, type EquipmentListItem } from '@/lib/api/equipment';
-import { updateInteraction } from '@/lib/api/interactions';
 import { fetchHouseholdMembers, type HouseholdMember } from '@/lib/api/tasks';
 import NewTaskDialog from '@/features/tasks/NewTaskDialog';
 import { isOwnedByAllocationEditor } from '@/features/banking/ownership';
 import InteractionDeleteAction from './InteractionDeleteAction';
-import { useInteraction } from './hooks';
+import { useInteraction, useUpdateInteraction } from './hooks';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useNavigateBack } from '@/lib/backNavigation';
 import ExpenseFields from './ExpenseFields';
@@ -46,6 +45,10 @@ export default function InteractionEditPage() {
   const navigateBackAfterDelete = useNavigateBack('/app/money?tab=expenses');
 
   const { data: interaction, isLoading, error } = useInteraction(id ?? '');
+  // Le hook, jamais `updateInteraction` en direct : c'est lui qui périme les
+  // caches de l'argent. Sans lui, corriger un fournisseur puis revenir en
+  // arrière affichait la liste d'avant jusqu'à un rechargement de la page.
+  const updateMutation = useUpdateInteraction();
 
   const [subject, setSubject] = React.useState('');
   const [occurredOn, setOccurredOn] = React.useState('');
@@ -150,16 +153,19 @@ export default function InteractionEditPage() {
 
     try {
       setSubmitting(true);
-      await updateInteraction(id ?? '', {
-        subject: subject.trim(),
-        content: description,
-        occurred_at: occurredAt.toISOString(),
-        zone_ids: zoneId ? [zoneId] : [],
-        tags_input: tags,
-        contact_ids: contactId ? [contactId] : [],
-        structure_ids: structureId ? [structureId] : [],
-        equipment_ids: equipmentId ? [equipmentId] : [],
-        ...expenseFields,
+      await updateMutation.mutateAsync({
+        id: id ?? '',
+        payload: {
+          subject: subject.trim(),
+          content: description,
+          occurred_at: occurredAt.toISOString(),
+          zone_ids: zoneId ? [zoneId] : [],
+          tags_input: tags,
+          contact_ids: contactId ? [contactId] : [],
+          structure_ids: structureId ? [structureId] : [],
+          equipment_ids: equipmentId ? [equipmentId] : [],
+          ...expenseFields,
+        },
       });
       navigate(-1);
     } catch {

--- a/ui/src/features/money/invalidate.ts
+++ b/ui/src/features/money/invalidate.ts
@@ -1,11 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query';
-import {
-  BANKING_ROOT,
-  BUDGET_ROOT,
-  COMPLIANCE_ROOT,
-  EXPENSES_ROOT,
-  INTERACTIONS_ROOT,
-} from './keys';
+import { useInvalidate } from '@/lib/invalidate';
 
 /**
  * Ce qu'une écriture sur l'argent rend périmé — **déclaré une fois**.
@@ -31,18 +24,15 @@ import {
  * touche à l'argent invalide tout l'argent.** Invalider trop large coûte
  * quelques requêtes sur des vues déjà montées ; invalider trop étroit coûte la
  * confiance dans les chiffres, et le bug est invisible en revue.
+ *
+ * ⚠️ Les cinq racines ne sont plus énumérées ici : elles sont **déclarées dans
+ * le graphe** de `lib/invalidate`, généralisation de cette règle au reste de
+ * l'app (le même oubli existait sur le dashboard, les alertes et le coût d'un
+ * projet). Passer par le graphe apporte en prime ce que l'argent périmait sans
+ * le dire : **le coût réel d'un projet** est une somme de dépenses, et
+ * l'activité du dashboard en est le fil.
  */
 export function useInvalidateMoney() {
-  const queryClient = useQueryClient();
-  return () => {
-    for (const root of [
-      BANKING_ROOT,
-      INTERACTIONS_ROOT,
-      EXPENSES_ROOT,
-      BUDGET_ROOT,
-      COMPLIANCE_ROOT,
-    ]) {
-      void queryClient.invalidateQueries({ queryKey: root });
-    }
-  };
+  const invalidate = useInvalidate();
+  return () => invalidate('interactions');
 }

--- a/ui/src/features/projects/GroupDialog.tsx
+++ b/ui/src/features/projects/GroupDialog.tsx
@@ -5,7 +5,8 @@ import { Input } from '@/design-system/input';
 import { Textarea } from '@/design-system/textarea';
 import { Button } from '@/design-system/button';
 import { FormField } from '@/design-system/form-field';
-import { createProjectGroup, updateProjectGroup, type ProjectGroupItem } from '@/lib/api/projects';
+import { type ProjectGroupItem } from '@/lib/api/projects';
+import { useCreateGroup, useUpdateGroup } from './hooks';
 
 interface GroupDialogProps {
   open: boolean;
@@ -28,6 +29,9 @@ export default function GroupDialog({
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
+  const createMutation = useCreateGroup();
+  const updateMutation = useUpdateGroup();
+
   React.useEffect(() => {
     if (!open) return;
     setName(existingGroup?.name ?? '');
@@ -46,8 +50,11 @@ export default function GroupDialog({
 
     const action =
       isEditing && existingGroup
-        ? updateProjectGroup(existingGroup.id, { name: name.trim(), description })
-        : createProjectGroup({ name: name.trim(), description });
+        ? updateMutation.mutateAsync({
+            id: existingGroup.id,
+            payload: { name: name.trim(), description },
+          })
+        : createMutation.mutateAsync({ name: name.trim(), description });
 
     action
       .then(() => {

--- a/ui/src/features/projects/ProjectDialog.tsx
+++ b/ui/src/features/projects/ProjectDialog.tsx
@@ -9,13 +9,11 @@ import { Select } from '@/design-system/select';
 import { FormField } from '@/design-system/form-field';
 import ZonePicker from '@/features/zones/ZonePicker';
 import {
-  createProject,
-  updateProject,
   type ProjectListItem,
   type ProjectStatus,
   type ProjectType,
 } from '@/lib/api/projects';
-import { useProjectGroups } from './hooks';
+import { useCreateProject, useProjectGroups, useUpdateProject } from './hooks';
 
 const STATUS_OPTIONS: ProjectStatus[] = ['draft', 'active', 'on_hold', 'completed', 'cancelled'];
 const TYPE_OPTIONS: ProjectType[] = [
@@ -40,6 +38,8 @@ export default function ProjectDialog({
   const isEditing = Boolean(existingProject);
 
   const { data: groups = [] } = useProjectGroups();
+  const createMutation = useCreateProject();
+  const updateMutation = useUpdateProject();
 
   const [title, setTitle] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -92,8 +92,8 @@ export default function ProjectDialog({
 
     const action =
       isEditing && existingProject
-        ? updateProject(existingProject.id, payload)
-        : createProject(payload);
+        ? updateMutation.mutateAsync({ id: existingProject.id, payload })
+        : createMutation.mutateAsync(payload);
 
     action
       .then(() => {

--- a/ui/src/features/projects/hooks.ts
+++ b/ui/src/features/projects/hooks.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
+import { useInvalidate } from '@/lib/invalidate';
 import {
   fetchProjects,
   fetchProject,
@@ -73,65 +74,63 @@ export function useProjectGroups() {
 }
 
 export function useCreateProject() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (payload: ProjectPayload) => createProject(payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.all }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useUpdateProject() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<ProjectPayload> }) =>
       updateProject(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.all }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useDeleteProject() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (id: string) => deleteProject(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.all }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useCreateGroup() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (payload: ProjectGroupPayload) => createProjectGroup(payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.groups() }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useUpdateGroup() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Partial<ProjectGroupPayload> }) =>
       updateProjectGroup(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.groups() }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useDeleteGroup() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (id: string) => deleteProjectGroup(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: projectKeys.groups() }),
+    onSuccess: () => invalidate('projects'),
   });
 }
 
 export function useRegisterProjectPurchase() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: ProjectPurchasePayload }) =>
       registerProjectPurchase(id, payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: projectKeys.all });
-      qc.invalidateQueries({ queryKey: ['interactions'] });
-      qc.invalidateQueries({ queryKey: ['expenses'] });
+      invalidate('projects', 'interactions');
       toast({ description: t('projects.purchase.created'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
@@ -140,6 +139,7 @@ export function useRegisterProjectPurchase() {
 
 export function usePinProject() {
   const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, pinned }: { id: string; pinned: boolean }) =>
       pinned ? unpinProject(id) : pinProject(id),
@@ -151,6 +151,6 @@ export function usePinProject() {
         return old.map((p) => (p.id === id ? { ...p, is_pinned: !pinned } : p));
       });
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: projectKeys.all }),
+    onSettled: () => invalidate('projects'),
   });
 }

--- a/ui/src/features/renovation/RenovationTab.tsx
+++ b/ui/src/features/renovation/RenovationTab.tsx
@@ -1,21 +1,20 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useQueryClient } from '@tanstack/react-query';
 import { Paintbrush, Plus } from 'lucide-react';
 import { Button } from '@/design-system/button';
 import EmptyState from '@/components/EmptyState';
 import { useDelayedLoading } from '@/lib/useDelayedLoading';
 import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
-import { deleteInteraction, type InteractionListItem } from '@/lib/api/interactions';
-import { useRenovationEntries, renovationKeys } from './hooks';
+import { type InteractionListItem } from '@/lib/api/interactions';
+import { useDeleteRenovation, useRenovationEntries } from './hooks';
 import RenovationCard from './RenovationCard';
 import RenovationDialog from './RenovationDialog';
 
 export default function RenovationTab({ zoneId }: { zoneId: string }) {
   const { t } = useTranslation();
-  const qc = useQueryClient();
   const { data, isLoading } = useRenovationEntries(zoneId);
   const entries = data?.items ?? [];
+  const deleteMutation = useDeleteRenovation();
 
   const [dialogOpen, setDialogOpen] = React.useState(false);
   const [editing, setEditing] = React.useState<InteractionListItem | undefined>(undefined);
@@ -23,12 +22,7 @@ export default function RenovationTab({ zoneId }: { zoneId: string }) {
 
   const { deleteWithUndo } = useDeleteWithUndo({
     label: t('renovation.deleted'),
-    onDelete: (id) =>
-      deleteInteraction(id).then(() => {
-        void qc.invalidateQueries({ queryKey: renovationKeys.all });
-        void qc.invalidateQueries({ queryKey: ['zones'] });
-        void qc.invalidateQueries({ queryKey: ['interactions'] });
-      }),
+    onDelete: (id) => deleteMutation.mutateAsync(id),
   });
 
   function openCreate() {

--- a/ui/src/features/renovation/hooks.ts
+++ b/ui/src/features/renovation/hooks.ts
@@ -1,7 +1,8 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/lib/toast';
-import { fetchInteractions } from '@/lib/api/interactions';
+import { useInvalidate } from '@/lib/invalidate';
+import { deleteInteraction, fetchInteractions } from '@/lib/api/interactions';
 import {
   createRenovation,
   updateRenovation,
@@ -23,20 +24,23 @@ export function useRenovationEntries(zoneId: string) {
   });
 }
 
-function invalidateRenovation(qc: ReturnType<typeof useQueryClient>) {
-  void qc.invalidateQueries({ queryKey: renovationKeys.all });
-  // An entry is an Interaction attached to zones — refresh zone activity + lists.
-  void qc.invalidateQueries({ queryKey: ['zones'] });
-  void qc.invalidateQueries({ queryKey: ['interactions'] });
+/**
+ * Une entrée du carnet **est** une `Interaction` attachée à des zones : c'est
+ * cette racine qu'on déclare, et le graphe (`lib/invalidate`) en déduit le reste
+ * — activité de la zone, journal, dashboard.
+ */
+function useInvalidateRenovation() {
+  const invalidate = useInvalidate();
+  return () => invalidate('renovation', 'interactions');
 }
 
 export function useCreateRenovation() {
-  const qc = useQueryClient();
+  const invalidateRenovation = useInvalidateRenovation();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: (payload: RenovationCreateInput) => createRenovation(payload),
     onSuccess: () => {
-      invalidateRenovation(qc);
+      invalidateRenovation();
       toast({ description: t('renovation.created'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
@@ -44,15 +48,24 @@ export function useCreateRenovation() {
 }
 
 export function useUpdateRenovation() {
-  const qc = useQueryClient();
+  const invalidateRenovation = useInvalidateRenovation();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: RenovationUpdateInput }) =>
       updateRenovation(id, payload),
     onSuccess: () => {
-      invalidateRenovation(qc);
+      invalidateRenovation();
       toast({ description: t('renovation.updated'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/** Mutation nue — l'onglet l'emballe dans `useDeleteWithUndo`. */
+export function useDeleteRenovation() {
+  const invalidateRenovation = useInvalidateRenovation();
+  return useMutation({
+    mutationFn: (id: string) => deleteInteraction(id),
+    onSuccess: invalidateRenovation,
   });
 }

--- a/ui/src/features/settings/components/AvatarSection.tsx
+++ b/ui/src/features/settings/components/AvatarSection.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/design-system/button';
 import { SettingsSection } from './SettingsSection';
 import type { UserProfile } from '@/lib/api/users';
-import { uploadAvatar, deleteAvatar } from '@/lib/api/users';
+import { useDeleteAvatar, useUploadAvatar } from '../hooks';
 import { useToast } from '@/lib/toast';
 
 interface AvatarSectionProps {
@@ -17,44 +17,42 @@ export function AvatarSection({ user, onUserUpdate }: AvatarSectionProps) {
   const { toast } = useToast();
 
   const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const [saving, setSaving] = React.useState(false);
+
+  // Par les hooks : eux invalident le cache `settings.me`, que l'ancien appel
+  // direct laissait sur l'avatar d'avant. Le `profile-updated` reste — il
+  // prévient le contexte d'auth, qui n'est pas un cache react-query.
+  const uploadMutation = useUploadAvatar();
+  const deleteMutation = useDeleteAvatar();
+  const saving = uploadMutation.isPending || deleteMutation.isPending;
 
   const currentAvatarUrl = user.avatar;
   const initials = (user.display_name || user.email).slice(0, 2).toUpperCase();
 
-  async function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleAvatarChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
     if (!file.type.startsWith('image/')) {
       toast({ description: t('settings.avatarUnsupportedType'), variant: 'destructive' });
       return;
     }
-    setSaving(true);
-    try {
-      const result = await uploadAvatar(file);
-      onUserUpdate({ ...user, avatar: result.avatar_url });
-      document.body.dispatchEvent(new CustomEvent('profile-updated'));
-      toast({ description: t('settings.avatarUpdated'), variant: 'success' });
-    } catch (err) {
-      toast({ description: err instanceof Error ? err.message : t('settings.avatarUploadFailed'), variant: 'destructive' });
-    } finally {
-      setSaving(false);
-      if (fileInputRef.current) fileInputRef.current.value = '';
-    }
+    uploadMutation.mutate(file, {
+      onSuccess: (result) => {
+        onUserUpdate({ ...user, avatar: result.avatar_url });
+        document.body.dispatchEvent(new CustomEvent('profile-updated'));
+      },
+      onSettled: () => {
+        if (fileInputRef.current) fileInputRef.current.value = '';
+      },
+    });
   }
 
-  async function handleAvatarDelete() {
-    setSaving(true);
-    try {
-      await deleteAvatar();
-      onUserUpdate({ ...user, avatar: null });
-      document.body.dispatchEvent(new CustomEvent('profile-updated'));
-      toast({ description: t('settings.avatarRemoved'), variant: 'success' });
-    } catch (err) {
-      toast({ description: err instanceof Error ? err.message : t('settings.avatarDeleteFailed'), variant: 'destructive' });
-    } finally {
-      setSaving(false);
-    }
+  function handleAvatarDelete() {
+    deleteMutation.mutate(undefined, {
+      onSuccess: () => {
+        onUserUpdate({ ...user, avatar: null });
+        document.body.dispatchEvent(new CustomEvent('profile-updated'));
+      },
+    });
   }
 
   return (

--- a/ui/src/features/settings/hooks.ts
+++ b/ui/src/features/settings/hooks.ts
@@ -93,7 +93,7 @@ export function useUploadAvatar() {
     },
     onError: (err) => {
       toast({
-        description: err instanceof Error ? err.message : t('settings.requestFailed'),
+        description: err instanceof Error ? err.message : t('settings.avatarUploadFailed'),
         variant: 'destructive',
       });
     },
@@ -110,7 +110,7 @@ export function useDeleteAvatar() {
       void qc.invalidateQueries({ queryKey: settingsKeys.me() });
       toast({ description: t('settings.avatarRemoved'), variant: 'success' });
     },
-    onError: () => toast({ description: t('settings.requestFailed'), variant: 'destructive' }),
+    onError: () => toast({ description: t('settings.avatarDeleteFailed'), variant: 'destructive' }),
   });
 }
 

--- a/ui/src/features/stock/hooks.ts
+++ b/ui/src/features/stock/hooks.ts
@@ -1,4 +1,5 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useInvalidate } from '@/lib/invalidate';
 import { useTranslation } from 'react-i18next';
 import {
   fetchStockItems,
@@ -84,53 +85,52 @@ export function useStockCategories() {
 export { useZones } from '@/features/zones/hooks';
 
 export function useCreateStockItem() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: createStockItem,
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 
 export function useUpdateStockItem() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Parameters<typeof updateStockItem>[1] }) =>
       updateStockItem(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 
 export function useDeleteStockItem() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (id: string) => deleteStockItem(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 
 export function usePurchaseStockItem() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: StockPurchasePayload }) =>
       purchaseStockItem(id, payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: stockKeys.all });
-      qc.invalidateQueries({ queryKey: ['interactions'] });
-      toast({ description: t('stock.purchase.created'), variant: 'success' });
+      invalidate('stock', 'interactions');
+            toast({ description: t('stock.purchase.created'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }
 
 export function useRecordInventory() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   const { t } = useTranslation();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: StockInventoryPayload }) =>
       recordStockInventory(id, payload),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: stockKeys.all });
+      invalidate('stock');
       toast({ description: t('stock.inventory.recorded'), variant: 'success' });
     },
     onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
@@ -138,15 +138,15 @@ export function useRecordInventory() {
 }
 
 export function useCreateCategory() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: createStockCategory,
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 
 export function useUpdateCategory() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({
       id,
@@ -155,15 +155,15 @@ export function useUpdateCategory() {
       id: string;
       payload: Parameters<typeof updateStockCategory>[1];
     }) => updateStockCategory(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 
 export function useDeleteCategory() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: (id: string) => deleteStockCategory(id),
-    onSuccess: () => qc.invalidateQueries({ queryKey: stockKeys.all }),
+    onSuccess: () => invalidate('stock'),
   });
 }
 

--- a/ui/src/features/tasks/NewTaskDialog.tsx
+++ b/ui/src/features/tasks/NewTaskDialog.tsx
@@ -16,9 +16,10 @@ import { fetchDocuments, fetchPhotoDocuments, type DocumentItem } from '@/lib/ap
 import { fetchInteractions, type InteractionListItem } from '@/lib/api/interactions';
 import { fetchZones } from '@/lib/api/zones';
 import {
-  createTask, updateTask,
+  type CreateTaskInput,
   type Zone, type Task, type HouseholdMember, type TaskPriority, type TaskStatus,
 } from '@/lib/api/tasks';
+import { useCreateTask, useUpdateTask } from './hooks';
 
 interface NewTaskDialogProps {
   open: boolean;
@@ -53,6 +54,8 @@ export default function NewTaskDialog({
   const isEditing = Boolean(existingTask);
   const { disabled } = useDisabledModules();
   const weatherEnabled = !disabled.has('weather');
+  const createMutation = useCreateTask();
+  const updateMutation = useUpdateTask();
 
   const priorityOptions = [
     { value: '1', label: t('tasks.priorityHigh_label') },
@@ -186,7 +189,8 @@ export default function NewTaskDialog({
     };
 
     if (isEditing && existingTask) {
-      updateTask(existingTask.id, payload)
+      updateMutation
+        .mutateAsync({ id: existingTask.id, payload })
         .then((updated) => {
           setLoading(false);
           onOpenChange(false);
@@ -197,13 +201,13 @@ export default function NewTaskDialog({
           setError(t('tasks.updateFailed'));
         });
     } else {
-      createTask({
+      createMutation.mutateAsync({
         ...payload,
         status: status as TaskStatus,
         document_ids: selectedDocumentIds.length > 0 ? selectedDocumentIds : undefined,
         interaction_ids: selectedInteractionIds.length > 0 ? selectedInteractionIds : undefined,
         source_interaction: sourceInteractionId ?? undefined,
-      } as Parameters<typeof createTask>[0])
+      } as CreateTaskInput)
         .then(() => {
           setLoading(false);
           onOpenChange(false);

--- a/ui/src/features/tasks/hooks.ts
+++ b/ui/src/features/tasks/hooks.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/lib/auth/useAuth';
+import { useInvalidate } from '@/lib/invalidate';
 import {
   fetchTasks, fetchTask, fetchHouseholdMembers, fetchProjectTasks,
   updateTaskStatus, updateTask, createTask, deleteTask,
@@ -74,6 +75,7 @@ export { useZones } from '@/features/zones/hooks';
 
 export function useUpdateTaskStatus() {
   const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, status }: { id: string; status: TaskStatus }) =>
       updateTaskStatus(id, status),
@@ -88,29 +90,30 @@ export function useUpdateTaskStatus() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.previous) qc.setQueryData(taskKeys.list(), ctx.previous);
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: taskKeys.all }),
+    onSettled: () => invalidate('tasks'),
   });
 }
 
 export function useCreateTask() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: createTask,
-    onSuccess: () => qc.invalidateQueries({ queryKey: taskKeys.all }),
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
 export function useUpdateTask() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, payload }: { id: string; payload: Parameters<typeof updateTask>[1] }) =>
       updateTask(id, payload),
-    onSuccess: () => qc.invalidateQueries({ queryKey: taskKeys.all }),
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
 export function useUpdateTaskAssignee() {
   const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ id, assignedToId }: { id: string; assignedToId: string | null }) =>
       updateTask(id, { assigned_to_id: assignedToId }),
@@ -125,15 +128,15 @@ export function useUpdateTaskAssignee() {
     onError: (_err, _vars, ctx) => {
       if (ctx?.previous) qc.setQueryData(taskKeys.list(), ctx.previous);
     },
-    onSettled: () => qc.invalidateQueries({ queryKey: taskKeys.all }),
+    onSettled: () => invalidate('tasks'),
   });
 }
 
 export function useDeleteTask() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: deleteTask,
-    onSuccess: () => qc.invalidateQueries({ queryKey: taskKeys.all }),
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
@@ -157,26 +160,20 @@ export function useTaskDocuments(taskId: string) {
 }
 
 export function useLinkDocument() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ taskId, documentId }: { taskId: string; documentId: string | number }) =>
       linkDocumentToTask(taskId, documentId),
-    onSuccess: (_data, { taskId }) => {
-      qc.invalidateQueries({ queryKey: [...taskKeys.all, taskId, 'documents'] });
-      qc.invalidateQueries({ queryKey: taskKeys.all });
-    },
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
 export function useUnlinkDocument() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ linkId }: { linkId: number; taskId: string }) =>
       unlinkDocumentFromTask(linkId),
-    onSuccess: (_data, { taskId }) => {
-      qc.invalidateQueries({ queryKey: [...taskKeys.all, taskId, 'documents'] });
-      qc.invalidateQueries({ queryKey: taskKeys.all });
-    },
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
@@ -189,25 +186,19 @@ export function useTaskInteractions(taskId: string) {
 }
 
 export function useLinkInteraction() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ taskId, interactionId }: { taskId: string; interactionId: string }) =>
       linkInteractionToTask(taskId, interactionId),
-    onSuccess: (_data, { taskId }) => {
-      qc.invalidateQueries({ queryKey: [...taskKeys.all, taskId, 'interactions'] });
-      qc.invalidateQueries({ queryKey: taskKeys.all });
-    },
+    onSuccess: () => invalidate('tasks'),
   });
 }
 
 export function useUnlinkInteraction() {
-  const qc = useQueryClient();
+  const invalidate = useInvalidate();
   return useMutation({
     mutationFn: ({ linkId }: { linkId: number; taskId: string }) =>
       unlinkInteractionFromTask(linkId),
-    onSuccess: (_data, { taskId }) => {
-      qc.invalidateQueries({ queryKey: [...taskKeys.all, taskId, 'interactions'] });
-      qc.invalidateQueries({ queryKey: taskKeys.all });
-    },
+    onSuccess: () => invalidate('tasks'),
   });
 }

--- a/ui/src/lib/api/tasks.ts
+++ b/ui/src/lib/api/tasks.ts
@@ -156,23 +156,28 @@ export async function updateTask(
   return data as Task;
 }
 
-export async function createTask(
-  payload: {
-    subject: string;
-    content?: string;
-    zone_ids: string[];
-    due_date?: string | null;
-    priority?: TaskPriority;
-    assigned_to_id?: string | null;
-    status?: TaskStatus;
-    project?: string | null;
-    is_private?: boolean;
-    needs_dry_weather?: boolean;
-    document_ids?: string[];
-    interaction_ids?: string[];
-    source_interaction?: string | null;
-  },
-): Promise<Task> {
+/**
+ * Nommé (et pas anonyme dans la signature) pour que le dialogue puisse typer
+ * son payload **sans importer `createTask`** : les fonctions d'écriture ne
+ * s'importent que dans un `hooks.ts` (voir `lib/invalidate.test.ts`).
+ */
+export interface CreateTaskInput {
+  subject: string;
+  content?: string;
+  zone_ids: string[];
+  due_date?: string | null;
+  priority?: TaskPriority;
+  assigned_to_id?: string | null;
+  status?: TaskStatus;
+  project?: string | null;
+  is_private?: boolean;
+  needs_dry_weather?: boolean;
+  document_ids?: string[];
+  interaction_ids?: string[];
+  source_interaction?: string | null;
+}
+
+export async function createTask(payload: CreateTaskInput): Promise<Task> {
   const { data } = await api.post('/tasks/tasks/', { status: 'pending', ...payload });
   return data as Task;
 }

--- a/ui/src/lib/components/DocumentSelector.tsx
+++ b/ui/src/lib/components/DocumentSelector.tsx
@@ -12,8 +12,8 @@ import {
   formatFileSize,
   type DocumentItem,
   type DocumentType,
-  uploadDocument,
 } from '@/lib/api/documents';
+import { useCreateDocument } from '@/features/documents/hooks';
 
 interface DocumentSelectorProps {
   selectedDocumentIds: string[];
@@ -59,6 +59,11 @@ export function DocumentSelector({
   const [uploadName, setUploadName] = React.useState('');
   const [uploadType, setUploadType] = React.useState<DocumentType | ''>('');
   const [uploadNotes, setUploadNotes] = React.useState('');
+
+  // Le document uploadé d'ici alimente aussi la page Documents et la galerie
+  // photos : il faut périmer leurs caches, pas seulement la liste locale de ce
+  // sélecteur — sinon le document existe et n'apparaît nulle part ailleurs.
+  const uploadMutation = useCreateDocument();
 
   const typeOptions = React.useMemo(
     () => DOCUMENT_TYPES.map((value) => ({ value, label: t(`documents.type.${value}`) })),
@@ -145,7 +150,7 @@ export function DocumentSelector({
     setUploadError(null);
 
     try {
-      const response = await uploadDocument({
+      const response = await uploadMutation.mutateAsync({
         file: selectedFile,
         name: uploadName || selectedFile.name,
         type: uploadType,

--- a/ui/src/lib/invalidate.test.ts
+++ b/ui/src/lib/invalidate.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest';
+import { QUERY_ROOTS, rootsInvalidatedBy, type QueryRoot } from './invalidate';
+
+/**
+ * Les deux garde-fous de la fraîcheur des données.
+ *
+ * Le symptôme corrigé : « j'édite le fournisseur d'une dépense, je reviens, et
+ * je dois recharger la page pour voir mon changement ». Il n'était pas isolé —
+ * dix composants écrivaient par l'API sans passer par un hook (donc sans
+ * toucher un seul cache), et trois racines dérivées (`dashboard`, `alerts`,
+ * `projects` vu depuis l'argent) n'étaient invalidées par personne.
+ *
+ * Ce défaut a deux propriétés qui le rendent récurrent, et c'est pourquoi il
+ * demande un test plutôt qu'une relecture :
+ *
+ * 1. **il est invisible en revue** — le diff d'un `onSuccess` qui oublie une
+ *    racine ressemble exactement à celui qui la liste ;
+ * 2. **il est invisible en développement** — Vite recharge le module, donc le
+ *    cache, à chaque sauvegarde : l'écran qu'on vient d'écrire est toujours
+ *    frais chez celui qui l'écrit.
+ *
+ * D'où le contrôle statique : le premier test tient la **discipline** (aucune
+ * écriture hors d'un hook), le second tient le **graphe** (ce qui dérive d'une
+ * racine se rafraîchit avec elle).
+ */
+
+/** Tout le front — pas une liste de dossiers choisis. */
+const sources = import.meta.glob<string>('../{features,components,lib,pages,design-system}/**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
+const apiModules = import.meta.glob<string>('../lib/api/*.ts', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+});
+
+/**
+ * Ce qui compte comme une écriture, par son préfixe.
+ *
+ * `send*` en est exclu à dessein : `sendTestWebPush` / `sendBriefingNow`
+ * déclenchent un envoi, ils ne changent aucune donnée lue par un écran.
+ */
+const WRITE_PREFIX =
+  /^(create|update|delete|patch|remove|add|set|link|unlink|upload|import|confirm|toggle|mark|attach|detach|archive|restore|bulk|reconcile|move|revoke|reprocess)[A-Z]/;
+
+/**
+ * Les fichiers autorisés à importer une écriture.
+ *
+ * La règle est « les mutations vivent dans le `hooks.ts` de leur feature » :
+ * c'est le seul endroit où l'invalidation se déclare une fois pour tous les
+ * appelants. Un composant qui appelle l'API en direct doit re-déclarer cette
+ * invalidation, et c'est ce doublon qui a dérivé dix fois.
+ */
+function isAllowed(file: string): boolean {
+  if (file.endsWith('/hooks.ts')) return true;
+  if (file.includes('/lib/api/')) return true;
+  if (file.endsWith('.test.ts') || file.endsWith('.test.tsx')) return true;
+  // Registry des modules — porte ses propres hooks (`useToggleModule`), pas un
+  // composant : le `patchMe` y est déjà encadré par son invalidation.
+  if (file.endsWith('/modules.ts')) return true;
+  return false;
+}
+
+function writeFunctions(): Set<string> {
+  const names = new Set<string>();
+  for (const source of Object.values(apiModules)) {
+    for (const match of source.matchAll(/export\s+(?:async\s+)?function\s+(\w+)/g)) {
+      if (WRITE_PREFIX.test(match[1])) names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+/** Les noms importés depuis `@/lib/api/…` par un fichier. */
+function importedFromApi(source: string): string[] {
+  const names: string[] = [];
+  for (const match of source.matchAll(/import\s+(?:type\s+)?\{([^}]*)\}\s+from\s+'@\/lib\/api\/[^']*'/gs)) {
+    for (const part of match[1].split(',')) {
+      const name = part.trim().split(/\s+as\s+/)[0].trim();
+      if (name && !name.startsWith('type ')) names.push(name);
+    }
+  }
+  return names;
+}
+
+describe('les écritures passent par un hook', () => {
+  const writes = writeFunctions();
+
+  it('le test lit bien tout le front et toute la couche API', () => {
+    expect(Object.keys(sources).length).toBeGreaterThan(300);
+    expect(writes.size).toBeGreaterThan(80);
+  });
+
+  it("aucun composant n'appelle l'API d'écriture en direct", () => {
+    const offenders: string[] = [];
+    for (const [file, source] of Object.entries(sources)) {
+      if (isAllowed(file)) continue;
+      const direct = importedFromApi(source).filter((name) => writes.has(name));
+      if (direct.length > 0) offenders.push(`${file} → ${direct.sort().join(', ')}`);
+    }
+    expect(offenders.sort()).toEqual([]);
+  });
+});
+
+describe('le graphe des caches', () => {
+  it('une écriture invalide toujours sa propre racine', () => {
+    for (const root of QUERY_ROOTS) {
+      expect(rootsInvalidatedBy(root)).toContain(root);
+    }
+  });
+
+  /**
+   * Les trois trous constatés en production, un cas chacun. Ce ne sont pas des
+   * exemples : ce sont les régressions.
+   */
+  it('le dashboard se rafraîchit après une tâche, une interaction ou un projet', () => {
+    expect(rootsInvalidatedBy('tasks')).toContain('dashboard');
+    expect(rootsInvalidatedBy('interactions')).toContain('dashboard');
+    expect(rootsInvalidatedBy('projects')).toContain('dashboard');
+  });
+
+  it('la pastille d’alertes se rafraîchit après une tâche, un équipement, un stock', () => {
+    expect(rootsInvalidatedBy('tasks')).toContain('alerts');
+    expect(rootsInvalidatedBy('equipment')).toContain('alerts');
+    expect(rootsInvalidatedBy('stock')).toContain('alerts');
+  });
+
+  it('le coût d’un projet se rafraîchit après une dépense', () => {
+    expect(rootsInvalidatedBy('interactions')).toContain('projects');
+  });
+
+  /**
+   * La dérivation se chaîne, donc la fermeture doit être transitive : ventiler
+   * une ligne bancaire crée des dépenses, qui changent le coût d'un projet, qui
+   * s'affiche sur le dashboard. Un seul saut s'arrêtait aux dépenses.
+   */
+  it('la fermeture est transitive — une ligne bancaire va jusqu’au dashboard', () => {
+    const stale = rootsInvalidatedBy('banking');
+    expect(stale).toContain('projects');
+    expect(stale).toContain('dashboard');
+  });
+
+  it("l'argent reste une seule donnée à cinq caches", () => {
+    const money: QueryRoot[] = ['banking', 'interactions', 'expenses', 'budget', 'compliance'];
+    for (const written of money) {
+      for (const stale of money) {
+        expect(rootsInvalidatedBy(written)).toContain(stale);
+      }
+    }
+  });
+
+  it('un cycle déclaré ne boucle pas (photos ↔ documents)', () => {
+    expect(rootsInvalidatedBy('photos')).toContain('documents');
+    expect(rootsInvalidatedBy('documents')).toContain('photos');
+  });
+});

--- a/ui/src/lib/invalidate.test.ts
+++ b/ui/src/lib/invalidate.test.ts
@@ -38,13 +38,32 @@ const apiModules = import.meta.glob<string>('../lib/api/*.ts', {
 });
 
 /**
- * Ce qui compte comme une écriture, par son préfixe.
+ * Ce qui compte comme une écriture — **détecté sur l'implémentation**, jamais
+ * sur le nom.
  *
- * `send*` en est exclu à dessein : `sendTestWebPush` / `sendBriefingNow`
- * déclenchent un envoi, ils ne changent aucune donnée lue par un écran.
+ * Première version de ce test : une liste de préfixes (`create*`, `update*`,
+ * `set*`…). Elle ratait **trente-trois** fonctions, dont la totalité des
+ * écritures de l'argent — `recordCashExpense`, `creditBudgetFromRefund`,
+ * `qualifyTransaction`, `withdrawToCash`, `registerProjectPurchase`,
+ * `purchaseStockItem`, `logEggs`, `adjustStockQuantity`… Un garde-fou qui
+ * dépend d'une convention de nommage protège ce dont on s'est souvenu en
+ * l'écrivant, c'est-à-dire précisément pas les cas oubliés : `recordCashExpense`
+ * n'a jamais eu l'air d'une écriture, et c'en est une.
+ *
+ * Le verbe HTTP, lui, ne s'oublie pas — on ne poste pas par distraction.
  */
-const WRITE_PREFIX =
-  /^(create|update|delete|patch|remove|add|set|link|unlink|upload|import|confirm|toggle|mark|attach|detach|archive|restore|bulk|reconcile|move|revoke|reprocess)[A-Z]/;
+const MUTATING_CALL = /\bapi\.(post|patch|put|delete)\b|\b(post|patch|put)Multipart\b/;
+
+/**
+ * Une déclaration de fonction, de sa signature à l'accolade qui la ferme en
+ * colonne 0.
+ *
+ * ⚠️ `^\}$` et pas `^\}` : une signature dont le paramètre est un objet inline
+ * (`function f(params: {`) porte un `}` en colonne 0 **au milieu** de sa propre
+ * signature. Avec `^\}`, le corps d'`importStatementFile` s'arrêtait là et son
+ * `postMultipart` passait inaperçu.
+ */
+const FUNCTION_DECLARATION = /^(export )?(?:async )?function (\w+)[\s\S]*?^\}$/gm;
 
 /**
  * Les fichiers autorisés à importer une écriture.
@@ -64,14 +83,61 @@ function isAllowed(file: string): boolean {
   return false;
 }
 
+/**
+ * Les deux écritures qui n'ont **rien à invalider**, et pourquoi.
+ *
+ * Une exception se justifie par un fait vérifiable, pas par une préférence —
+ * sinon cette liste devient l'endroit où l'on range ce qu'on ne veut pas
+ * corriger.
+ */
+const NOTHING_TO_INVALIDATE: Record<string, string> = {
+  // Rejoindre un foyer se termine par `window.location.assign('/app/dashboard')`
+  // — un chargement complet, qui jette le cache entier. Un hook n'aurait rien à
+  // périmer, et le foyer change de sous les pieds de toutes les clés à la fois.
+  joinHousehold: 'features/auth/JoinHouseholdPage.tsx — suivi d’un rechargement complet',
+  // L'abonnement push vit dans le navigateur (permission + `PushSubscription`),
+  // pas dans une requête en cache : la seule `useQuery` de l'écran lit la clé
+  // VAPID, qui est de la configuration statique.
+  subscribeWebPush: 'features/settings/components/WebPushSection.tsx — état navigateur, aucun cache lecteur',
+  unsubscribeWebPush: 'features/settings/components/WebPushSection.tsx — idem',
+  sendTestWebPush: 'features/settings/components/WebPushSection.tsx — un envoi, aucune donnée changée',
+};
+
 function writeFunctions(): Set<string> {
-  const names = new Set<string>();
+  const bodies = new Map<string, string>();
+  const exported = new Set<string>();
   for (const source of Object.values(apiModules)) {
-    for (const match of source.matchAll(/export\s+(?:async\s+)?function\s+(\w+)/g)) {
-      if (WRITE_PREFIX.test(match[1])) names.add(match[1]);
+    for (const match of source.matchAll(FUNCTION_DECLARATION)) {
+      bodies.set(match[2], match[0]);
+      if (match[1]) exported.add(match[2]);
     }
   }
-  return names;
+
+  const writes = new Set<string>();
+  for (const [name, body] of bodies) {
+    if (MUTATING_CALL.test(body)) writes.add(name);
+  }
+
+  // Point fixe : **déléguer à une écriture est écrire.** `restoreBankAccount`
+  // ne poste rien lui-même, il appelle `updateBankAccount` — et il en a tous
+  // les effets. Même chose pour les helpers non exportés du module.
+  let grew = true;
+  while (grew) {
+    grew = false;
+    for (const [name, body] of bodies) {
+      if (writes.has(name)) continue;
+      for (const write of writes) {
+        // `[<(]` : capter aussi un appel générique — `postMultipart<Foo>(…)`.
+        if (new RegExp(`\\b${write}\\s*[<(]`).test(body)) {
+          writes.add(name);
+          grew = true;
+          break;
+        }
+      }
+    }
+  }
+
+  return new Set([...writes].filter((name) => exported.has(name)));
 }
 
 /** Les noms importés depuis `@/lib/api/…` par un fichier. */
@@ -91,17 +157,50 @@ describe('les écritures passent par un hook', () => {
 
   it('le test lit bien tout le front et toute la couche API', () => {
     expect(Object.keys(sources).length).toBeGreaterThan(300);
-    expect(writes.size).toBeGreaterThan(80);
+    // 173 au moment d'écrire ces lignes. Le plancher est là pour attraper une
+    // détection qui retomberait à vide (regex cassée, glob qui ne matche plus) —
+    // un test qui ne teste rien passe, et c'est le pire des deux mondes.
+    expect(writes.size).toBeGreaterThan(150);
+  });
+
+  it('les écritures se reconnaissent par leur verbe HTTP, pas par leur nom', () => {
+    // Les cas que la détection par préfixe ratait : aucun ne « ressemble » à une
+    // écriture, tous en sont une.
+    for (const name of [
+      'recordCashExpense',
+      'creditBudgetFromRefund',
+      'qualifyTransaction',
+      'withdrawToCash',
+      'registerProjectPurchase',
+      'purchaseStockItem',
+      'logEggs',
+      'importStatementFile', // via `postMultipart`
+      'restoreBankAccount', // via `updateBankAccount`
+    ]) {
+      expect(writes, name).toContain(name);
+    }
+    // Et une lecture reste une lecture.
+    expect(writes).not.toContain('fetchInteractions');
   });
 
   it("aucun composant n'appelle l'API d'écriture en direct", () => {
     const offenders: string[] = [];
     for (const [file, source] of Object.entries(sources)) {
       if (isAllowed(file)) continue;
-      const direct = importedFromApi(source).filter((name) => writes.has(name));
+      const direct = importedFromApi(source)
+        .filter((name) => writes.has(name))
+        .filter((name) => !(name in NOTHING_TO_INVALIDATE));
       if (direct.length > 0) offenders.push(`${file} → ${direct.sort().join(', ')}`);
     }
     expect(offenders.sort()).toEqual([]);
+  });
+
+  it('la liste des exceptions ne survit pas à ce qu’elle nomme', () => {
+    // Une exception qui désigne une fonction disparue est un commentaire faux
+    // qu'aucune relecture ne remarquera.
+    for (const name of Object.keys(NOTHING_TO_INVALIDATE)) {
+      expect(writes, `${name} n'est plus une écriture`).toContain(name);
+    }
   });
 });
 

--- a/ui/src/lib/invalidate.ts
+++ b/ui/src/lib/invalidate.ts
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 /**
@@ -188,9 +189,15 @@ export function rootsInvalidatedBy(...written: readonly QueryRoot[]): QueryRoot[
  */
 export function useInvalidate() {
   const queryClient = useQueryClient();
-  return (...written: readonly QueryRoot[]) => {
-    for (const root of rootsInvalidatedBy(...written)) {
-      void queryClient.invalidateQueries({ queryKey: [root] });
-    }
-  };
+  // `useCallback` pour que la fonction soit stable d'un rendu à l'autre : elle
+  // est appelée depuis tant d'endroits qu'elle finira dans un tableau de
+  // dépendances, et une fonction recréée à chaque rendu y boucle.
+  return React.useCallback(
+    (...written: readonly QueryRoot[]) => {
+      for (const root of rootsInvalidatedBy(...written)) {
+        void queryClient.invalidateQueries({ queryKey: [root] });
+      }
+    },
+    [queryClient],
+  );
 }

--- a/ui/src/lib/invalidate.ts
+++ b/ui/src/lib/invalidate.ts
@@ -1,0 +1,196 @@
+import { useQueryClient } from '@tanstack/react-query';
+
+/**
+ * Ce qu'une écriture rend périmé — **déclaré une fois, pour toute l'app**.
+ *
+ * Une donnée du foyer n'est presque jamais lue par un seul écran. Une tâche
+ * cochée change la liste des tâches, « Ma semaine » du dashboard, le compteur
+ * d'onglets de son projet et la pastille d'alertes. Tant que chaque mutation
+ * énumérait *elle-même* les caches à rafraîchir, ces listes ont dérivé — et
+ * toujours dans le même sens, celui de l'oubli :
+ *
+ * - **rien n'invalidait `dashboard`** hors la création de tâche depuis les
+ *   actions rapides : cocher une tâche, saisir une note ou créer un projet
+ *   laissait le tableau de bord sur ses chiffres d'avant ;
+ * - **rien n'invalidait `alerts`** : une tâche en retard terminée gardait sa
+ *   pastille ;
+ * - **rien n'invalidait `projects` depuis l'argent**, alors que le coût réel
+ *   d'un chantier est la somme de ses dépenses ;
+ * - et neuf composants appelaient l'API d'écriture **en direct**, sans passer
+ *   par un hook : là, aucun cache n'était touché du tout.
+ *
+ * Le symptôme est toujours le même et toujours invisible en revue : « je dois
+ * recharger la page pour voir mon changement ». Il est amplifié par le
+ * `staleTime` de cinq minutes du `QueryClient` (et par `refetchOnWindowFocus:
+ * false`) : sans invalidation, rien ne rattrape l'oubli avant l'expiration.
+ * Baisser ce `staleTime` masquerait le défaut au prix d'une requête à chaque
+ * montage — on préfère le corriger.
+ *
+ * D'où la règle, identique à celle de l'argent (`money/invalidate.ts`, dont ce
+ * module est la généralisation) : **une écriture déclare la racine qu'elle
+ * écrit, jamais la liste des caches à rafraîchir.** Ce qui se déduit de cette
+ * racine est calculé ici, à partir du graphe ci-dessous.
+ */
+
+/**
+ * Les racines de cache de l'app — le premier segment de toute `queryKey`.
+ *
+ * Déclarées en dur pour que `useInvalidate('taks')` soit une erreur de
+ * compilation et pas un rafraîchissement silencieusement sans effet.
+ */
+export const QUERY_ROOTS = [
+  'agent',
+  'alerts',
+  'banking',
+  'briefings',
+  'budget',
+  'chickens',
+  'compliance',
+  'contacts',
+  'dashboard',
+  'digest',
+  'documents',
+  'electricity',
+  'equipment',
+  'expenses',
+  'household-members',
+  'households',
+  'insurance',
+  'interactions',
+  'notifications',
+  'photos',
+  'projects',
+  'recap',
+  'renovation',
+  'settings',
+  'shopping',
+  'stock',
+  'structures',
+  'tasks',
+  'trackers',
+  'water',
+  'zones',
+] as const;
+
+export type QueryRoot = (typeof QUERY_ROOTS)[number];
+
+/** Les cinq caches que l'argent partage — voir `money/invalidate.ts`. */
+const MONEY_ROOTS = ['banking', 'interactions', 'expenses', 'budget', 'compliance'] as const;
+
+/**
+ * Ce que chaque racine **lit chez les autres**.
+ *
+ * Le sens de lecture compte : on déclare « le dashboard est construit à partir
+ * des tâches, des interactions et des projets », pas « une tâche rafraîchit le
+ * dashboard ». C'est la question à laquelle on sait répondre en écrivant un
+ * écran, et c'est donc celle qui ne sera pas oubliée.
+ *
+ * **Ajouter une vue dérivée, c'est ajouter sa ligne ici.** Sans elle, l'écran
+ * s'affichera juste après sa première écriture puis mentira jusqu'à la fin du
+ * `staleTime`. Le sens inverse (« qu'est-ce que mon écriture périme ? ») est
+ * calculé — c'est lui qu'on oubliait.
+ */
+const DERIVED_FROM: Partial<Record<QueryRoot, readonly QueryRoot[]>> = {
+  /** « Ma semaine », l'activité récente, les projets actifs. */
+  dashboard: ['tasks', 'interactions', 'projects'],
+  /** Retards, garanties, entretiens, seuils de stock — `apps/alerts/services.py`. */
+  alerts: ['tasks', 'equipment', 'stock'],
+  /** `actual_cost` = somme des dépenses ; `tab_counts` compte les tâches. */
+  projects: ['interactions', 'tasks'],
+  /** Le carnet de rénovation *est* une liste d'`Interaction` (kind=renovation). */
+  renovation: ['interactions'],
+  /** La fiche d'une zone montre son activité, ses tâches et ses photos. */
+  zones: ['interactions', 'tasks', 'photos'],
+  /** Une photo est un `Document` : les deux vues lisent la même table. */
+  photos: ['documents'],
+  documents: ['photos'],
+  /** Les suggestions de courses viennent des seuils de stock… */
+  shopping: ['stock'],
+  /** …et cocher un article de la liste ajuste la quantité en stock. */
+  stock: ['shopping', 'interactions'],
+  /** La fiche d'un équipement montre son historique d'achats et d'entretiens. */
+  equipment: ['interactions'],
+  /** L'argent : cinq caches pour une seule donnée. */
+  banking: MONEY_ROOTS,
+  interactions: MONEY_ROOTS,
+  expenses: MONEY_ROOTS,
+  budget: MONEY_ROOTS,
+  compliance: MONEY_ROOTS,
+};
+
+/** Graphe inversé — pour une racine écrite, ce qui la lit (un seul saut). */
+const READERS: Map<QueryRoot, Set<QueryRoot>> = (() => {
+  const readers = new Map<QueryRoot, Set<QueryRoot>>(
+    QUERY_ROOTS.map((root) => [root, new Set<QueryRoot>()]),
+  );
+  for (const [derived, sources] of Object.entries(DERIVED_FROM)) {
+    for (const source of sources ?? []) {
+      readers.get(source)?.add(derived as QueryRoot);
+    }
+  }
+  return readers;
+})();
+
+const CLOSURE = new Map<QueryRoot, readonly QueryRoot[]>();
+
+/**
+ * Fermeture transitive : ce qu'une écriture sur `root` rend périmé, `root`
+ * compris.
+ *
+ * Transitive et pas directe, parce que la dérivation se chaîne : ventiler une
+ * ligne bancaire écrit des dépenses, qui changent le coût d'un projet, qui
+ * s'affiche sur le dashboard. Un seul saut se serait arrêté aux dépenses, et
+ * l'écart aurait reparu deux écrans plus loin.
+ */
+function staleAfterWriting(root: QueryRoot): readonly QueryRoot[] {
+  const cached = CLOSURE.get(root);
+  if (cached) return cached;
+
+  const seen = new Set<QueryRoot>([root]);
+  const queue: QueryRoot[] = [root];
+  while (queue.length > 0) {
+    const current = queue.shift() as QueryRoot;
+    for (const reader of READERS.get(current) ?? []) {
+      if (seen.has(reader)) continue;
+      seen.add(reader);
+      queue.push(reader);
+    }
+  }
+
+  const result = [...seen];
+  CLOSURE.set(root, result);
+  return result;
+}
+
+/**
+ * Les racines à rafraîchir après avoir écrit `written` — exposé pour les tests
+ * et pour les rares appelants hors composant.
+ */
+export function rootsInvalidatedBy(...written: readonly QueryRoot[]): QueryRoot[] {
+  const all = new Set<QueryRoot>();
+  for (const root of written) {
+    for (const stale of staleAfterWriting(root)) all.add(stale);
+  }
+  return [...all];
+}
+
+/**
+ * Rafraîchir ce qu'une écriture périme.
+ *
+ * ```ts
+ * const invalidate = useInvalidate();
+ * useMutation({ mutationFn: createTask, onSuccess: () => invalidate('tasks') });
+ * ```
+ *
+ * On passe **ce qu'on écrit**, pas ce qu'on veut rafraîchir : une mutation qui
+ * touche deux entités (acheter un article de stock crée une dépense) les
+ * déclare toutes les deux — `invalidate('stock', 'interactions')`.
+ */
+export function useInvalidate() {
+  const queryClient = useQueryClient();
+  return (...written: readonly QueryRoot[]) => {
+    for (const root of rootsInvalidatedBy(...written)) {
+      void queryClient.invalidateQueries({ queryKey: [root] });
+    }
+  };
+}


### PR DESCRIPTION
Closes #481

## Quoi

Le symptôme signalé : corriger le fournisseur d'une dépense, revenir en
arrière, et retrouver l'ancienne valeur dans la liste. La cause y était nue —
[`InteractionEditPage`](ui/src/features/interactions/InteractionEditPage.tsx)
appelait `updateInteraction()`, la fonction API brute, au lieu du hook
`useUpdateInteraction` : la requête part, **aucun cache n'est périmé**, et le
`staleTime` de 5 min du `QueryClient` (avec `refetchOnWindowFocus: false`) fait
qu'aucun rafraîchissement ne rattrape l'oubli. Seul un rechargement de page.

L'audit a montré deux familles de défauts, pas un cas isolé.

**Dix composants écrivaient par l'API sans passer par un hook** — donc sans
toucher un cache, ou en re-déclarant une invalidation partielle :
`InteractionEditPage`, `ContactDialog`, `StructureDialog`, `ProjectDialog`,
`GroupDialog`, `NewTaskDialog`, `RecurringPage` (annulation d'une confirmation),
`AvatarSection`, `DocumentSelector`, `EntityAttachDocumentDialog`,
`RenovationTab`.

**Trois racines de cache que personne n'invalidait :**

- `dashboard` — un **seul** point d'appel dans toute l'app (les actions
  rapides), et il ne rafraîchissait que « Ma semaine ». Cocher une tâche,
  saisir une note ou créer un projet laissait le tableau de bord sur ses
  chiffres d'avant.
- `alerts` — **zéro** invalidation. Terminer une tâche en retard gardait sa
  pastille.
- `projects` depuis l'argent — `useInvalidateMoney` ne touchait pas les projets,
  alors que `actual_cost` est une somme de dépenses.

Trouvés en chemin : renommer un groupe de projets n'invalidait que `groups()`
alors que `project_group_name` est dénormalisé sur chaque carte ; annuler une
confirmation d'échéance faisait un `refetch()` des trois requêtes de sa page,
donc les compteurs de budget et la conformité restaient sur place ; l'avatar ne
périmait pas le cache `settings.me`.

## Comment

Deux règles, **tenues par `ui/src/lib/invalidate.test.ts`** :

1. **Une mutation vit dans le `hooks.ts` de sa feature.** Une fonction
   d'écriture de `lib/api/` ne s'importe que là — le test scanne tout le front
   et refuse l'import ailleurs. C'est ce contrôle qui aurait attrapé le bug
   signalé.
2. **Le `onSuccess` déclare la racine écrite, pas la liste des caches** :
   `invalidate('tasks')`, via `useInvalidate` de `ui/src/lib/invalidate.ts`. Ce
   qui **dérive** de cette racine est déclaré une fois dans le graphe
   `DERIVED_FROM`, et la fermeture est **transitive** — ventiler une ligne
   bancaire crée des dépenses, qui changent le coût d'un projet, qui s'affiche
   sur le dashboard.

Le graphe se lit dans le sens de la lecture (« le dashboard est construit à
partir des tâches, des interactions et des projets »), parce que c'est la
question à laquelle on sait répondre en écrivant un écran — et donc celle qui ne
sera pas oubliée. Le sens inverse, « qu'est-ce que mon écriture périme ? », est
calculé : c'est lui qu'on oubliait.

`useInvalidateMoney` devient un cas particulier de ce graphe, et garde sa
doctrine (« toute écriture sur l'argent invalide tout l'argent ») en y gagnant
ce qu'elle périmait sans le dire : les projets et le dashboard.

### Pourquoi un test et pas une relecture

Le défaut est invisible deux fois, et c'est ce qui le rend récurrent :

- **en revue** — le diff d'un `onSuccess` qui oublie une racine ressemble
  exactement à celui qui la liste ;
- **en développement** — Vite recharge le module, donc le cache, à chaque
  sauvegarde : l'écran qu'on vient d'écrire est toujours frais chez celui qui
  l'écrit.

Il ne se voit qu'en prod, et il se dit toujours pareil : « je dois recharger la
page ». La règle est documentée dans `CLAUDE.md`, avec la conséquence pour la
suite : **ajouter un écran qui lit les données d'une autre feature = ajouter sa
ligne dans `DERIVED_FROM`.**

Le `staleTime` de 5 min n'est pas touché : c'est l'amplificateur, pas la cause.
Le baisser coûterait une requête à chaque montage pour **masquer** un cache mal
invalidé au lieu de le corriger.

## Critères de l'issue

- [x] Corriger le fournisseur (ou le budget) d'une dépense met à jour la liste
      au retour, sans rechargement.
- [x] Une écriture sur les tâches, les interactions ou les projets rafraîchit le
      dashboard.
- [x] Terminer une tâche en retard retire sa pastille d'alerte.
- [x] Une dépense affectée à un projet met à jour son coût réel.
- [x] Renommer un groupe de projets met à jour les cartes qui portent son nom.
- [x] Aucun composant n'importe une fonction d'écriture de `lib/api/` — tenu par
      un test, pas par une relecture.
- [x] Ce qui dérive d'une racine de cache est déclaré une fois, et la déduction
      est transitive.

## Hors scope

- **`search` reste hors du graphe** : ses clés sont par terme de recherche et
  re-frappées à chaque ouverture de la palette. À y faire entrer le jour où un
  résultat périmé se voit.
- **Les invalidations résiduelles aux points d'appel** (`handleProjectSaved` et
  ses pareilles, qui invalident déjà `xKeys.all`) sont laissées en place : elles
  sont désormais des sur-ensembles redondants et sans effet de bord. Les retirer
  changerait la signature `onSaved` de plusieurs dialogues, pour un gain nul sur
  le comportement.
- **`AvatarSection` garde son `document.body.dispatchEvent('profile-updated')`** :
  le contexte d'auth n'est pas un cache react-query, l'événement reste son seul
  canal.

## Vérifications

- `pytest` : 3989 passés, 2 ignorés (base de test isolée — une session parallèle
  partageait `test_house` et produisait 5 faux échecs).
- `vitest` : 214 passés, dont les 9 du nouveau garde-fou.
- `npx tsc -b ui/tsconfig.json` : propre.
- `npm run lint` : 0 erreur (5 avertissements préexistants, aucun sur les
  fichiers touchés).
