### PR TITLE
feat(money): filtrer la liste de dépenses depuis la fiche d'un budget

### DIFF
--- a/apps/budget/insights.py
+++ b/apps/budget/insights.py
@@ -72,6 +72,7 @@ def compute_budget_insights(
           "granularity": "day" | "month",
           "buckets": [{"label": "2026-07-01", "total": "0.00"}, …],
           "suppliers": [{"supplier", "total", "count", "share"}, …],
+          "kinds": [{"kind", "total", "count"}, …],
           "budgets": [{"budget_id", "name", "total", "count", "share"}, …],
         }
 
@@ -111,6 +112,9 @@ def compute_budget_insights(
         "granularity": granularity,
         "buckets": _buckets(qs, household, start, end, granularity),
         "suppliers": _suppliers(qs, total),
+        # Les natures présentes dans la fenêtre. Ce ne sont pas des parts (voir
+        # `_kinds`) : c'est ce sur quoi la fiche propose de filtrer sa liste.
+        "kinds": _kinds(qs),
         "budgets": spent_rows,
         "budgets_returned": returned_rows,
         # Ce que l'anneau décompose. Égal au net de la carte du haut, **sauf**
@@ -275,6 +279,36 @@ def _suppliers(qs, total: Decimal) -> list[dict[str, Any]]:
             "total": str(row["total"] or ZERO),
             "count": row["count"],
             "share": round(float((row["total"] or ZERO) / total), 4),
+        }
+        for row in rows
+    ]
+
+
+def _kinds(qs) -> list[dict[str, Any]]:
+    """Les natures de dépense présentes dans la fenêtre — de quoi filtrer la liste.
+
+    Pas de ``share`` ici, et ce n'est pas un oubli : ceci n'est **pas** une
+    répartition mais la liste des valeurs sur lesquelles la fiche propose de
+    filtrer. Une part par nature ferait un second anneau qui décomposerait le
+    même total que celui des fournisseurs, sans que rien ne dise lequel lire.
+
+    Les options viennent du serveur, et de la **fenêtre entière** — jamais des
+    lignes de la page affichée : une pastille qui apparaît et disparaît en
+    tournant les pages fait douter de ce qu'on filtre. Une nature vide n'existe
+    pas côté dépense (le créateur la renseigne toujours), mais on la refuse
+    explicitement plutôt que de produire une pastille sans libellé.
+    """
+    rows = (
+        qs.exclude(kind="")
+        .values("kind")
+        .annotate(total=Coalesce(Sum("amount"), ZERO), count=Count("id"))
+        .order_by("-total")
+    )
+    return [
+        {
+            "kind": row["kind"],
+            "total": str(row["total"] or ZERO),
+            "count": row["count"],
         }
         for row in rows
     ]

--- a/apps/budget/tests/test_insights.py
+++ b/apps/budget/tests/test_insights.py
@@ -33,6 +33,7 @@ from budget.insights import compute_budget_insights
 from budget.models import Budget
 from households.models import HouseholdMember
 from interactions.aggregations import compute_expense_summary
+from interactions.models import Interaction
 from interactions.services import create_manual_expense_interaction
 
 from .factories import HouseholdFactory, HouseholdMemberFactory, UserFactory
@@ -351,6 +352,54 @@ class TestTheShareBySupplier:
 
         assert result["suppliers"] == []
         assert result["current"]["total"] == "0.00"
+
+
+@pytest.mark.django_db
+class TestTheFilterOptions:
+    """Ce sur quoi la fiche propose de filtrer sa liste, et d'où ça vient.
+
+    Les options viennent de la **fenêtre entière**, jamais des lignes de la page
+    affichée : une pastille qui apparaît en tournant les pages ferait douter de
+    ce qu'on filtre, et sur une enveloppe de trois cents dépenses la page 1 ne
+    connaît qu'un cinquième des natures.
+    """
+
+    def test_the_kinds_of_the_window_are_listed_heaviest_first(self, ctx):
+        household, owner, diy = ctx
+        light = _spend(household, owner, "10.00", on=date(2026, 7, 3), budget=diy)
+        heavy = _spend(household, owner, "90.00", on=date(2026, 7, 4), budget=diy)
+        Interaction.objects.filter(pk=light.pk).update(kind="stock_purchase")
+        Interaction.objects.filter(pk=heavy.pk).update(kind="bank")
+
+        result = _insights(household, diy, date(2026, 7, 1), date(2026, 7, 31))
+
+        assert [k["kind"] for k in result["kinds"]] == ["bank", "stock_purchase"]
+        assert result["kinds"][0]["total"] == "90.00"
+        assert result["kinds"][0]["count"] == 1
+
+    def test_a_kind_outside_the_window_is_not_an_option(self, ctx):
+        """Filtrer sur une nature qui ne rendrait aucune ligne n'aide personne."""
+        household, owner, diy = ctx
+        june = _spend(household, owner, "50.00", on=date(2026, 6, 15), budget=diy)
+        Interaction.objects.filter(pk=june.pk).update(kind="stock_purchase")
+        _spend(household, owner, "20.00", on=date(2026, 7, 4), budget=diy)
+
+        result = _insights(household, diy, date(2026, 7, 1), date(2026, 7, 31))
+
+        assert [k["kind"] for k in result["kinds"]] == ["manual"]
+
+    def test_an_empty_kind_never_becomes_a_pill(self, ctx):
+        """Une pastille sans libellé n'est pas un filtre, c'est un bouton muet."""
+        household, owner, diy = ctx
+        blank = _spend(household, owner, "30.00", on=date(2026, 7, 3), budget=diy)
+        Interaction.objects.filter(pk=blank.pk).update(kind="")
+
+        result = _insights(household, diy, date(2026, 7, 1), date(2026, 7, 31))
+
+        assert result["kinds"] == []
+        # La dépense reste comptée : elle n'est pas filtrable, elle n'est pas
+        # invisible.
+        assert result["current"]["total"] == "30.00"
 
 
 @pytest.mark.django_db

--- a/apps/budget/views.py
+++ b/apps/budget/views.py
@@ -252,6 +252,7 @@ _EMPTY_INSIGHTS = {
     "granularity": "day",
     "buckets": [],
     "suppliers": [],
+    "kinds": [],
     "budgets": [],
     "budgets_returned": [],
     "budgets_net_total": "0.00",

--- a/docs/MODULES/money.md
+++ b/docs/MODULES/money.md
@@ -139,6 +139,38 @@ par budget, répartition, fournisseurs, plus grosses dépenses) — le panneau
 Budgets ne regarde que le mois en cours. Détail du calcul et de ce qu'il refuse
 d'inventer : `docs/MODULES/budget.md`, section « Analyse fine ».
 
+### La fiche d'une enveloppe est le même écran que l'onglet Dépenses, moins le total
+
+`/app/money/budgets/:id` liste les dépenses avec **le composant de l'onglet
+Dépenses** (`ExpenseList`), le même endpoint, les mêmes filtres
+(`ExpenseFilters`), le même pager, la même sélection multiple et le même dialogue
+de correction en lot. Ajouter un geste à l'un doit le donner à l'autre, sinon les
+deux écrans divergent sur ce qu'on peut faire de la même ligne.
+
+Une seule chose ne se partage pas, et c'est la règle à ne pas casser :
+
+- ⚠️ **Les filtres réduisent la liste, jamais le bloc du haut.** Ce bloc compare
+  le dépensé à un **plafond** (« 340 € / 400 € ») : un sous-total filtré sous un
+  plafond entier dirait « tu es large » à quelqu'un qui vient de dépasser — même
+  famille de mensonge que le plafond qui recule. Le total, sa comparaison, la
+  courbe et l'anneau restent définis par la **seule période**, qui vit en tête de
+  page pour cette raison — et non dans le bloc de filtres, qui promettrait que
+  tout obéit à tout. Conséquence assumée : l'anneau des fournisseurs répond
+  « combien chez qui » sur toute la fenêtre. C'est la carte depuis laquelle on
+  filtre, pas une vue de ce qui est filtré.
+- **Les options de pastille viennent du serveur** (`insights.suppliers`,
+  `insights.kinds`), donc de la fenêtre entière — jamais des lignes de la page
+  affichée, qui n'en connaît que cinquante sur trois cents : une pastille qui
+  apparaît en tournant les pages fait douter de ce qu'on filtre. Elles ne se
+  réduisent pas non plus quand un filtre est actif, pour qu'on passe d'un
+  fournisseur à l'autre sans repasser par « Tous ».
+- **Filtrés jusqu'au vide, les filtres restent affichés** — sinon ils
+  disparaîtraient avec la liste et rien ne permettrait de les relâcher. Et le
+  message distingue les deux vides : une période sans dépense se règle en
+  changeant de période, une liste trop étroite en relâchant une pastille.
+
+Régressions : `ui/src/features/money/BudgetDetailPage.test.tsx`.
+
 `/app/money/categories/:id` est la fiche d'une **catégorie** de budget : l'anneau
 de répartition du dépensé **entre ses enveloppes**, la comparaison à la période
 précédente, la courbe, puis les enveloppes elles-mêmes (chacune ouvrant sa propre

--- a/ui/src/features/expenses/ExpenseFilters.tsx
+++ b/ui/src/features/expenses/ExpenseFilters.tsx
@@ -21,6 +21,18 @@ interface ExpenseFiltersProps {
   supplierOptions: string[];
   /** Distinct kind values from the current summary (for chips). */
   kindOptions: string[];
+  /**
+   * La période fait-elle partie de ce bloc ? Oui dans l'onglet Dépenses, où elle
+   * borne exactement la même chose que les pastilles.
+   *
+   * **Non sur la fiche d'un budget**, et pas par mise en page : là-bas la
+   * période pilote *toute* la page (le total, sa comparaison au plafond, la
+   * courbe, l'anneau) tandis que ces pastilles ne réduisent que la liste.
+   * Réunir les deux dans un même bloc promettrait que tout obéit à tout — or un
+   * sous-total filtré comparé à un plafond entier dit toujours « tu es large ».
+   * Elle reste donc en tête de page, où l'on voit ce qu'elle recalcule.
+   */
+  showPeriod?: boolean;
 }
 
 export default function ExpenseFilters({
@@ -34,12 +46,15 @@ export default function ExpenseFilters({
   onKindChange,
   supplierOptions,
   kindOptions,
+  showPeriod = true,
 }: ExpenseFiltersProps) {
   const { t } = useTranslation();
 
   return (
     <div className="space-y-3">
-      <PeriodPicker period={period} onChange={onPeriodChange} idPrefix="expenses" />
+      {showPeriod ? (
+        <PeriodPicker period={period} onChange={onPeriodChange} idPrefix="expenses" />
+      ) : null}
 
       {kindOptions.length > 0 ? (
         <div className="flex flex-wrap gap-1.5">

--- a/ui/src/features/expenses/ExpenseList.tsx
+++ b/ui/src/features/expenses/ExpenseList.tsx
@@ -23,10 +23,16 @@ interface ExpenseListProps {
   onToggleSelected?: (item: InteractionListItem) => void;
   isSelected?: (item: InteractionListItem) => boolean;
   /**
-   * Signale les dépenses auxquelles il manque un fournisseur — onglet Dépenses
-   * seulement. La fiche d'un budget réutilise cette liste et n'y pose pas la même
-   * question : une pastille de plus sur chaque ligne n'y avertirait de rien.
-   * Même règle que le `flagWithoutZone` de la galerie photos.
+   * Signale les dépenses auxquelles il manque un fournisseur. Même règle que le
+   * `flagWithoutZone` de la galerie photos : la pastille n'a de sens que là où
+   * le manque est **actionnable**.
+   *
+   * Elle a d'abord été réservée à l'onglet Dépenses, la fiche d'un budget ne
+   * posant pas cette question. Elle l'y pose depuis qu'elle porte le filtre
+   * « sans fournisseur » et la correction en lot : la pastille montre alors ce
+   * que le filtre irait chercher. Elle reste optionnelle pour les listes futures
+   * qui ne proposeront ni l'un ni l'autre — une pastille qui n'ouvre sur aucun
+   * geste n'avertit de rien.
    */
   flagWithoutSupplier?: boolean;
 }

--- a/ui/src/features/money/BudgetCategoryDetailPage.test.tsx
+++ b/ui/src/features/money/BudgetCategoryDetailPage.test.tsx
@@ -64,6 +64,7 @@ const insights: BudgetInsights = {
   granularity: 'day',
   buckets: [{ label: '2026-06-01', total: '150.00' }],
   suppliers: [],
+  kinds: [],
   budgets: [
     {
       budget_id: 'b-1',

--- a/ui/src/features/money/BudgetDetailPage.test.tsx
+++ b/ui/src/features/money/BudgetDetailPage.test.tsx
@@ -22,7 +22,14 @@ import BudgetDetailPage from './BudgetDetailPage';
  *    Arriver sur « Courses » remet bien le compteur à zéro sans rien de spécial
  *    (la sélection est dérivée des ids affichés), mais sans l'id dans la portée
  *    les lignes cochées sur « Bricolage » dorment dans le `Set` et se rallument
- *    au retour — un lot qu'on ne se sait plus tenir.
+ *    au retour — un lot qu'on ne se sait plus tenir. Même chose pour un filtre.
+ * 4. **⚠️ Les filtres réduisent la liste, jamais le total du haut.** Ce total est
+ *    comparé à un **plafond** : un sous-total filtré sous un plafond entier dit
+ *    « tu es large » à quelqu'un qui vient de dépasser.
+ * 5. **⚠️ Filtrés jusqu'au vide, les filtres restent à l'écran** — sinon ils
+ *    disparaîtraient avec la liste et rien ne permettrait de les relâcher. Et le
+ *    message vide dit *lequel* des deux vides on regarde : une période sans
+ *    dépense ne se règle pas comme une pastille trop étroite.
  */
 
 vi.mock('react-i18next', () => ({
@@ -57,7 +64,17 @@ const insights: BudgetInsights = {
   delta: { amount: '100.00', ratio: 0.125 },
   granularity: 'day',
   buckets: [],
-  suppliers: [],
+  // Les options de filtre, telles que le serveur les donne pour la **fenêtre
+  // entière**. Aucun des deux fournisseurs n'apparaît sur les lignes renvoyées
+  // plus bas : c'est le piège que ces tests tiennent fermé.
+  suppliers: [
+    { supplier: 'Leroy Merlin', total: '600.00', count: 60, share: 0.6667 },
+    { supplier: 'Castorama', total: '300.00', count: 60, share: 0.3333 },
+  ],
+  kinds: [
+    { kind: 'bank', total: '700.00', count: 80 },
+    { kind: 'manual', total: '200.00', count: 40 },
+  ],
   budgets: [],
   budgets_returned: [],
   budgets_net_total: '900.00',
@@ -102,7 +119,12 @@ function expense(id: string, subject: string): InteractionListItem {
 const TOTAL = 120;
 
 const fetchInteractions = vi.fn(
-  async (options: { budget?: string; offset?: number } = {}): Promise<FetchInteractionsResult> => {
+  async (
+    options: { budget?: string; offset?: number; supplier?: string } = {},
+  ): Promise<FetchInteractionsResult> => {
+    // Aucune dépense de « Castorama » sur cette enveloppe : c'est le filtre qui
+    // vide la liste, et il faut pouvoir le relâcher après ça.
+    if (options.supplier === 'Castorama') return { items: [], count: 0, next: null, previous: null };
     const offset = options.offset ?? 0;
     const prefix = options.budget === 'b-2' ? 'c' : 'e';
     const items = Array.from({ length: Math.min(50, TOTAL - offset) }, (_, i) =>
@@ -187,6 +209,69 @@ describe('BudgetDetailPage — la liste des dépenses', () => {
     await userEvent.click(screen.getByRole('button', { name: /expenses.bulk.action/ }));
 
     expect(screen.getByTestId('bulk-ids').textContent).toBe('e0,e2');
+  });
+
+  it('propose les filtres de la fenêtre, pas ceux de la page affichée', async () => {
+    renderPage();
+    await screen.findByText('Dépense e0');
+
+    // Aucune ligne rendue n'est de chez Castorama, et la page n'en connaît que
+    // cinquante sur cent vingt : les options ne peuvent venir que du serveur.
+    expect(screen.getByText('Castorama')).toBeInTheDocument();
+    expect(screen.getByText('expenses.kind.bank')).toBeInTheDocument();
+    expect(screen.getByText('expenses.filters.withoutSupplier')).toBeInTheDocument();
+  });
+
+  it('⚠️ filtre la liste sans toucher au total de la période', async () => {
+    renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByText('Castorama'));
+
+    await waitFor(() =>
+      expect(fetchInteractions).toHaveBeenCalledWith(
+        expect.objectContaining({ budget: 'b-1', supplier: 'Castorama' }),
+      ),
+    );
+    // Le chiffre de tête reste celui de la fenêtre entière : c'est lui qu'on
+    // compare au plafond, et un sous-total filtré sous un plafond entier dirait
+    // « tu es large » à quelqu'un qui vient de dépasser.
+    expect(document.body.textContent).toContain('900.00');
+  });
+
+  it('⚠️ garde les filtres à l’écran quand ils vident la liste', async () => {
+    renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByText('Castorama'));
+
+    // Sans ça, les pastilles disparaîtraient avec la liste et il ne resterait
+    // rien pour les relâcher.
+    await screen.findByText('budgetDetail.emptyFiltered');
+    expect(screen.getByText('Castorama')).toBeInTheDocument();
+    // Et le message ne dit pas « aucune dépense sur cette période », qui
+    // enverrait changer de période au lieu de relâcher la pastille.
+    expect(screen.queryByText('budgetDetail.empty')).not.toBeInTheDocument();
+  });
+
+  it('⚠️ vide la sélection quand un filtre change, retour compris', async () => {
+    renderPage();
+    await screen.findByText('Dépense e0');
+
+    await userEvent.click(screen.getByRole('button', { name: /common.select/ }));
+    await userEvent.click(screen.getByText('Dépense e0'));
+    expect(screen.getByText('expenses.bulk.selected:1')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Castorama'));
+    await screen.findByText('budgetDetail.emptyFiltered');
+
+    // Le retour au non-filtré ramène les mêmes ids : sans le filtre dans la
+    // portée, `e0` se rallumerait sur un lot composé avant le détour.
+    await userEvent.click(screen.getByText('expenses.filters.allSuppliers'));
+    await screen.findByText('Dépense e0');
+    await waitFor(() =>
+      expect(screen.getByText('expenses.bulk.selected:0')).toBeInTheDocument(),
+    );
   });
 
   it('⚠️ vide la sélection quand on change d’enveloppe, retour compris', async () => {

--- a/ui/src/features/money/BudgetDetailPage.test.tsx
+++ b/ui/src/features/money/BudgetDetailPage.test.tsx
@@ -124,7 +124,8 @@ const fetchInteractions = vi.fn(
   ): Promise<FetchInteractionsResult> => {
     // Aucune dépense de « Castorama » sur cette enveloppe : c'est le filtre qui
     // vide la liste, et il faut pouvoir le relâcher après ça.
-    if (options.supplier === 'Castorama') return { items: [], count: 0, next: null, previous: null };
+    if (options.supplier === 'Castorama' || options.supplier === 'Brico Dépôt')
+      return { items: [], count: 0, next: null, previous: null };
     const offset = options.offset ?? 0;
     const prefix = options.budget === 'b-2' ? 'c' : 'e';
     const items = Array.from({ length: Math.min(50, TOTAL - offset) }, (_, i) =>
@@ -252,6 +253,19 @@ describe('BudgetDetailPage — la liste des dépenses', () => {
     // Et le message ne dit pas « aucune dépense sur cette période », qui
     // enverrait changer de période au lieu de relâcher la pastille.
     expect(screen.queryByText('budgetDetail.empty')).not.toBeInTheDocument();
+  });
+
+  it('⚠️ un filtre actif garde sa pastille, même absent de la fenêtre', async () => {
+    // Le filtre survit à la fenêtre (même clé de session d'une enveloppe à
+    // l'autre, et un fournisseur peut n'avoir rien dépensé le mois d'avant). Sans
+    // épinglage, sa pastille disparaît des options mais le filtre reste actif :
+    // liste vide, « Tous » non surligné, et rien à l'écran ne nomme le coupable.
+    sessionStorage.setItem('budget.detail.supplier', JSON.stringify('Brico Dépôt'));
+    renderPage();
+
+    await screen.findByText('budgetDetail.emptyFiltered');
+
+    expect(screen.getByText('Brico Dépôt')).toBeInTheDocument();
   });
 
   it('⚠️ vide la sélection quand un filtre change, retour compris', async () => {

--- a/ui/src/features/money/BudgetDetailPage.tsx
+++ b/ui/src/features/money/BudgetDetailPage.tsx
@@ -25,6 +25,7 @@ import { useBudgetInsights, useBudgetOverview } from '@/features/budget/hooks';
 import { useTransactions } from '@/features/banking/hooks';
 import { resolvePeriod, type PeriodRange } from '@/features/expenses/period';
 import PeriodPicker from '@/features/expenses/PeriodPicker';
+import ExpenseFilters from '@/features/expenses/ExpenseFilters';
 import ExpenseList from '@/features/expenses/ExpenseList';
 import BulkEditDialog from '@/features/expenses/BulkEditDialog';
 import ShareChart, { type ShareRow } from './ShareChart';
@@ -82,6 +83,61 @@ export default function BudgetDetailPage() {
   const insights = insightsQuery.data;
 
   /**
+   * Les filtres de l'onglet Dépenses, moins la période : ici ils **réduisent la
+   * liste** et rien d'autre.
+   *
+   * ⚠️ Ils ne touchent pas au bloc du haut, et ce n'est pas une simplification.
+   * Ce bloc compare le dépensé à un **plafond** (« 340 € / 400 € ») : un
+   * sous-total filtré sous un plafond entier dirait « tu es large » à quelqu'un
+   * qui vient de dépasser — même famille de mensonge que le plafond qui recule.
+   * Le total, sa comparaison, la courbe et l'anneau restent donc définis par la
+   * seule période, qui vit en tête de page.
+   *
+   * La conséquence est voulue : l'anneau des fournisseurs continue de répondre
+   * « combien chez qui » sur toute la fenêtre. C'est la carte depuis laquelle on
+   * filtre, pas une vue de ce qui est filtré.
+   */
+  const [kind, setKind] = useSessionState<string>('budget.detail.kind', '');
+  const [supplier, setSupplier] = useSessionState<string>('budget.detail.supplier', '');
+  const [withoutSupplier, setWithoutSupplier] = useSessionState<boolean>(
+    'budget.detail.withoutSupplier',
+    false,
+  );
+
+  // Mêmes exclusions mutuelles que l'onglet Dépenses : « chez Leclerc » et « sans
+  // fournisseur » ensemble ne rendraient jamais qu'une liste vide, sans dire
+  // pourquoi.
+  const toggleWithoutSupplier = React.useCallback(() => {
+    const next = !withoutSupplier;
+    setWithoutSupplier(next);
+    if (next) setSupplier('');
+  }, [withoutSupplier, setWithoutSupplier, setSupplier]);
+
+  const chooseSupplier = React.useCallback(
+    (value: string) => {
+      setSupplier(value);
+      setWithoutSupplier(false);
+    },
+    [setSupplier, setWithoutSupplier],
+  );
+
+  /**
+   * Les options viennent d'`insights`, donc de la **fenêtre entière** et du
+   * serveur — jamais des lignes de la page affichée, qui n'en connaît qu'un
+   * cinquième sur une enveloppe chargée. Et elles ne se réduisent pas quand un
+   * filtre est actif : on peut passer d'un fournisseur à l'autre sans repasser
+   * par « Tous ».
+   */
+  const supplierOptions = React.useMemo(
+    () => (insights?.suppliers ?? []).map((s) => s.supplier).filter(Boolean).slice(0, 8),
+    [insights],
+  );
+  const kindOptions = React.useMemo(
+    () => (insights?.kinds ?? []).map((k) => k.kind),
+    [insights],
+  );
+
+  /**
    * La liste se **parcourt**, elle ne se plafonne pas.
    *
    * Elle s'arrêtait à 100 lignes avec une note de troncature. Sur une enveloppe
@@ -92,18 +148,24 @@ export default function BudgetDetailPage() {
    * le dégât qu'aucun écran ne rattrape. Le serveur plafonne d'ailleurs à 100
    * par requête — une fenêtre qu'on agrandit s'y serait arrêtée sans le dire.
    */
-  const pager = usePager(50, `${id}|${range.from}|${range.to}`);
+  const pager = usePager(
+    50,
+    `${id}|${range.from}|${range.to}|${kind}|${supplier}|${withoutSupplier}`,
+  );
 
   const listFilters = React.useMemo(
     () => ({
       type: 'expense' as const,
       budget: id,
+      ...(kind ? { kind } : {}),
+      ...(supplier ? { supplier } : {}),
+      ...(withoutSupplier ? { without_supplier: '1' } : {}),
       ...(range.from ? { start_date: range.from } : {}),
       ...(range.to ? { end_date: range.to } : {}),
       limit: pager.limit,
       offset: pager.offset,
     }),
-    [id, range.from, range.to, pager.limit, pager.offset],
+    [id, kind, supplier, withoutSupplier, range.from, range.to, pager.limit, pager.offset],
   );
 
   const listQuery = useQuery({
@@ -147,7 +209,9 @@ export default function BudgetDetailPage() {
    */
   const selection = useMultiSelect(
     React.useMemo(() => items.map((item) => item.id), [items]),
-    { scopeKey: `${id}|${range.from}|${range.to}|${pager.offset}` },
+    {
+      scopeKey: `${id}|${range.from}|${range.to}|${kind}|${supplier}|${withoutSupplier}|${pager.offset}`,
+    },
   );
 
   // Une page qui s'est vidée sous les doigts ramène à la première. Le cas est ici
@@ -195,6 +259,9 @@ export default function BudgetDetailPage() {
   );
 
   const hasSpending = Boolean(insights && Number(insights.current.total) > 0);
+  /** Une liste réduite par un choix de l'utilisateur — la période n'en fait pas
+   *  partie, elle définit la fenêtre plutôt qu'elle ne la restreint. */
+  const isFiltered = Boolean(kind || supplier || withoutSupplier);
   const [bulkOpen, setBulkOpen] = React.useState(false);
 
   return (
@@ -320,18 +387,31 @@ export default function BudgetDetailPage() {
             </section>
           ) : null}
 
-          {items.length === 0 ? (
-            <EmptyState
-              icon={Receipt}
-              title={t('budgetDetail.empty')}
-              description={t('budgetDetail.emptyDescription')}
-            />
-          ) : (
-            <>
-              {/* Le bouton vit ici, contre la liste, et non en tête de page avec
-                  la période : entrer en sélection est un geste qui porte sur les
-                  lignes, et deux graphiques le séparent de son objet s'il monte. */}
-              <div className="flex justify-end">
+          {/* ⚠️ Les filtres se rendent **au-dessus** de la branche vide, et non
+              dedans : filtrés jusqu'à zéro ligne, ils disparaîtraient avec la
+              liste et il n'y aurait plus rien pour les relâcher. Ils s'affichent
+              dès que l'enveloppe a dépensé quelque chose sur la période —
+              `insights` ignorant les filtres, ce test reste vrai quand la liste
+              est vide *à cause* d'eux. */}
+          {hasSpending ? (
+            <div className="flex flex-wrap items-end justify-between gap-3">
+              <ExpenseFilters
+                period={period}
+                onPeriodChange={setPeriod}
+                supplier={supplier}
+                onSupplierChange={chooseSupplier}
+                withoutSupplier={withoutSupplier}
+                onWithoutSupplierToggle={toggleWithoutSupplier}
+                kind={kind}
+                onKindChange={setKind}
+                supplierOptions={supplierOptions}
+                kindOptions={kindOptions}
+                showPeriod={false}
+              />
+              {/* Entrer en sélection est un geste qui porte sur les lignes : le
+                  bouton reste contre elles, pas en tête de page où deux
+                  graphiques le sépareraient de son objet. */}
+              {items.length > 0 ? (
                 <Button
                   type="button"
                   variant="outline"
@@ -342,9 +422,32 @@ export default function BudgetDetailPage() {
                   <CheckSquare className="h-4 w-4" />
                   {selection.active ? t('common.cancel') : t('common.select')}
                 </Button>
-              </div>
+              ) : null}
+            </div>
+          ) : null}
+
+          {items.length === 0 ? (
+            <EmptyState
+              icon={Receipt}
+              // Filtrée jusqu'au vide, la liste ne dit pas la même chose qu'une
+              // période sans dépense : l'une se règle en relâchant une pastille,
+              // l'autre en changeant de période. Un seul message pour les deux
+              // enverrait la moitié des lecteurs au mauvais endroit.
+              title={isFiltered ? t('budgetDetail.emptyFiltered') : t('budgetDetail.empty')}
+              description={
+                isFiltered
+                  ? t('budgetDetail.emptyFilteredDescription')
+                  : t('budgetDetail.emptyDescription')
+              }
+            />
+          ) : (
+            <>
               <ExpenseList
                 items={items}
+                // La pastille a sa place ici depuis que la page porte le filtre
+                // « sans fournisseur » et la correction en lot : elle montre ce
+                // que le filtre irait chercher.
+                flagWithoutSupplier
                 onToggleSelected={
                   selection.active ? (item) => selection.toggle(item.id) : undefined
                 }

--- a/ui/src/features/money/BudgetDetailPage.tsx
+++ b/ui/src/features/money/BudgetDetailPage.tsx
@@ -127,15 +127,23 @@ export default function BudgetDetailPage() {
    * cinquième sur une enveloppe chargée. Et elles ne se réduisent pas quand un
    * filtre est actif : on peut passer d'un fournisseur à l'autre sans repasser
    * par « Tous ».
+   *
+   * ⚠️ **La valeur active est épinglée dans les options**, même absente de la
+   * fenêtre. Elle peut l'être de deux façons : les filtres sont gardés d'une
+   * enveloppe à l'autre (une seule clé de session, comme la période), et un
+   * fournisseur du mois en cours peut n'avoir rien dépensé le mois d'avant. Sans
+   * cet épinglage la pastille disparaît des options alors que le filtre reste
+   * actif : liste vide, « Tous » non surligné, et rien à l'écran ne nomme le
+   * coupable — un filtre qu'on subit sans le voir.
    */
-  const supplierOptions = React.useMemo(
-    () => (insights?.suppliers ?? []).map((s) => s.supplier).filter(Boolean).slice(0, 8),
-    [insights],
-  );
-  const kindOptions = React.useMemo(
-    () => (insights?.kinds ?? []).map((k) => k.kind),
-    [insights],
-  );
+  const supplierOptions = React.useMemo(() => {
+    const top = (insights?.suppliers ?? []).map((s) => s.supplier).filter(Boolean).slice(0, 8);
+    return supplier && !top.includes(supplier) ? [supplier, ...top] : top;
+  }, [insights, supplier]);
+  const kindOptions = React.useMemo(() => {
+    const all = (insights?.kinds ?? []).map((k) => k.kind);
+    return kind && !all.includes(kind) ? [kind, ...all] : all;
+  }, [insights, kind]);
 
   /**
    * La liste se **parcourt**, elle ne se plafonne pas.

--- a/ui/src/lib/api/budget.ts
+++ b/ui/src/lib/api/budget.ts
@@ -240,6 +240,13 @@ export interface InsightBudget {
   share: number;
 }
 
+/** Une nature de dépense présente dans la fenêtre — une option de filtre. */
+export interface InsightKind {
+  kind: string;
+  total: string;
+  count: number;
+}
+
 export interface BudgetInsights {
   period: { from: string | null; to: string | null };
   previous_period: { from: string | null; to: string | null };
@@ -250,6 +257,16 @@ export interface BudgetInsights {
   /** La fenêtre entière, **trous compris** : un jour vide vaut `"0.00"`. */
   buckets: InsightBucket[];
   suppliers: InsightSupplier[];
+  /**
+   * Les natures présentes dans la fenêtre, la plus lourde d'abord — **des
+   * options de filtre, pas une répartition** (donc pas de `share` : un second
+   * anneau décomposerait le même total que celui des fournisseurs sans que rien
+   * ne dise lequel lire).
+   *
+   * Elles viennent de la fenêtre entière et non de la page affichée : une
+   * pastille qui apparaît en tournant les pages fait douter de ce qu'on filtre.
+   */
+  kinds: InsightKind[];
   /** Rempli sur un scope de catégorie seulement : une enveloppe ne se répartit
    *  pas entre elle-même. Net **positif**, la plus grosse part d'abord. */
   budgets: InsightBudget[];

--- a/ui/src/lib/api/expenses.test.ts
+++ b/ui/src/lib/api/expenses.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('@/lib/axios', () => ({ api: { get } }));
+
+import { fetchExpenseSummary } from './expenses';
+
+/**
+ * ⚠️ **Un filtre qui n'est pas transmis ne se voit pas.**
+ *
+ * L'onglet Dépenses composait bien `without_supplier` dans ses filtres et
+ * documentait que « le résumé porte le même filtre que la liste » — mais cette
+ * fonction ne recopiait pas la clé dans la query string. Les cartes de total
+ * comptaient donc toute la période au-dessus d'une liste réduite aux dépenses
+ * sans fournisseur, et rien à l'écran ne disait lequel des deux chiffres se
+ * trompait. C'est le « compteur qui compte des lignes que la liste ne montre
+ * pas » que le module argent passe son temps à réparer, et il avait survécu à la
+ * revue parce que l'écran restait parfaitement plausible.
+ *
+ * D'où ces tests au niveau du **transport** : la clé de cache et l'intention de
+ * l'appelant étaient justes tous les deux, seul le passage de relais était
+ * cassé.
+ */
+describe('fetchExpenseSummary — les filtres partent bien au serveur', () => {
+  beforeEach(() => {
+    get.mockReset();
+    get.mockResolvedValue({ data: { total: '0.00', count: 0 } });
+  });
+
+  it('transmet « sans fournisseur »', async () => {
+    await fetchExpenseSummary({ from: '2026-07-01', to: '2026-07-31', without_supplier: '1' });
+
+    expect(get).toHaveBeenCalledWith(expect.any(String), {
+      params: { from: '2026-07-01', to: '2026-07-31', without_supplier: '1' },
+    });
+  });
+
+  it('transmet chacun des autres filtres', async () => {
+    await fetchExpenseSummary({ supplier: 'Leroy Merlin', kind: 'bank', budget: 'b-1' });
+
+    expect(get).toHaveBeenCalledWith(expect.any(String), {
+      params: { supplier: 'Leroy Merlin', kind: 'bank', budget: 'b-1' },
+    });
+  });
+
+  it("n'envoie pas les clés absentes", async () => {
+    // Le serveur lit `?without_supplier=0` comme un **non**, pas comme « absent » :
+    // envoyer une valeur vide serait un filtre qui ne filtre pas, à débusquer
+    // depuis les logs.
+    await fetchExpenseSummary({ from: '2026-07-01' });
+
+    expect(get).toHaveBeenCalledWith(expect.any(String), { params: { from: '2026-07-01' } });
+  });
+});

--- a/ui/src/lib/api/expenses.ts
+++ b/ui/src/lib/api/expenses.ts
@@ -40,6 +40,20 @@ export interface ExpenseSummaryFilters {
   kind?: string;
   /** Id d'un budget, ou `'none'` pour le seau « hors budget ». */
   budget?: string;
+  /**
+   * ⚠️ « Celles auxquelles il manque un fournisseur » — et il **doit** partir au
+   * serveur, qui le lit (`interactions.views::summary`).
+   *
+   * Il manquait ici : l'onglet Dépenses le composait bien dans ses filtres et
+   * documentait que « le résumé porte le même filtre que la liste », mais cette
+   * fonction ne transmettait pas la clé. Les cartes de total comptaient donc
+   * toute la période au-dessus d'une liste réduite aux dépenses sans
+   * fournisseur — exactement le « compteur qui compte des lignes que la liste ne
+   * montre pas » contre lequel le commentaire du serveur met en garde. Un filtre
+   * qui n'est pas transmis ne se voit pas : l'écran reste plausible, seulement
+   * faux.
+   */
+  without_supplier?: string;
 }
 
 export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): Promise<ExpenseSummary> {
@@ -49,6 +63,7 @@ export async function fetchExpenseSummary(filters: ExpenseSummaryFilters = {}): 
   if (filters.supplier) params.supplier = filters.supplier;
   if (filters.kind) params.kind = filters.kind;
   if (filters.budget) params.budget = filters.budget;
+  if (filters.without_supplier) params.without_supplier = filters.without_supplier;
   const { data } = await api.get<ExpenseSummary>('/interactions/interactions/expenses/summary/', { params });
   return data;
 }

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Das Blatt eines Budgets öffnen",
-            "body": "Tippe auf ein Budget, um sein Blatt zu öffnen. Wähle den Zeitraum — die vier Kürzel oder zwei freie Daten — und alles wird neu berechnet. Unter dem Betrag steht der Vergleich mit dem entsprechenden Vorzeitraum: ein Monat mit dem Vormonat, ein Jahr mit dem Vorjahr, ein freies Fenster mit derselben Dauer unmittelbar davor. Darunter der Ausgabenrhythmus Tag für Tag (bei langen Fenstern Monat für Monat) und der Anteil jedes Lieferanten in Prozent. Wurde zuvor nichts ausgegeben, schreibt House, dass es keinen Vergleich gibt, statt einen Prozentsatz zu erfinden. « Ohne Budget » öffnet sich genauso.\n\nUnten wird die Ausgabenliste des Zeitraums Seite für Seite durchblättert. Mit « Auswählen » hakst du mehrere Zeilen ab, dann ändert « Korrigieren… » Lieferant oder Budget auf einmal — so verschiebst du, was im falschen Budget liegt. Verschobene Zeilen verlassen das Blatt sofort: sie zählen jetzt anderswo."
+            "body": "Tippe auf ein Budget, um sein Blatt zu öffnen. Wähle den Zeitraum — die vier Kürzel oder zwei freie Daten — und alles wird neu berechnet. Unter dem Betrag steht der Vergleich mit dem entsprechenden Vorzeitraum: ein Monat mit dem Vormonat, ein Jahr mit dem Vorjahr, ein freies Fenster mit derselben Dauer unmittelbar davor. Darunter der Ausgabenrhythmus Tag für Tag (bei langen Fenstern Monat für Monat) und der Anteil jedes Lieferanten in Prozent. Wurde zuvor nichts ausgegeben, schreibt House, dass es keinen Vergleich gibt, statt einen Prozentsatz zu erfinden. « Ohne Budget » öffnet sich genauso.\n\nUnten wird die Ausgabenliste des Zeitraums Seite für Seite durchblättert. Mit « Auswählen » hakst du mehrere Zeilen ab, dann ändert « Korrigieren… » Lieferant oder Budget auf einmal — so verschiebst du, was im falschen Budget liegt. Verschobene Zeilen verlassen das Blatt sofort: sie zählen jetzt anderswo. Die Pillen über der Liste verengen sie — eine Art, ein Lieferant oder « ohne Lieferant », um zu finden, was noch fehlt. Die Summe oben lassen sie unberührt: sie bleibt die des ganzen Zeitraums, denn sie ist es, die mit dem Limit verglichen wird."
           },
           "analysis": {
             "title": "Sehen, wohin es wirklich geht",
@@ -3431,6 +3431,8 @@
     "count_other": "{{count}} Ausgaben",
     "empty": "Keine Ausgabe in diesem Zeitraum",
     "emptyDescription": "Ändere den Zeitraum oder ordne Ausgaben diesem Budget zu.",
+    "emptyFiltered": "Keine Ausgabe passt zu diesen Filtern",
+    "emptyFilteredDescription": "Lös eine Pille, um die Liste zu erweitern — die Summe oben bleibt die des ganzen Zeitraums.",
     "refundsTitle": "Erstattungen im Zeitraum",
     "trend": {
       "title": "Ausgabenrhythmus",

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Open a budget's sheet",
-            "body": "Tap a budget to open its sheet. Pick the period — the four shortcuts, or two free dates — and everything recomputes. Under the amount sits the comparison with the equivalent previous period: a month compares with the month before, a year with the year before, a free window with the same duration just before it. Below that, the spending rhythm day by day (month by month over a long window) and each supplier's share as a percentage. With nothing spent before, House says there is no comparison rather than inventing a percentage. « Unbudgeted » opens exactly the same way.\n\nAt the bottom, the period's expenses are browsed page by page. « Select » ticks several lines, then « Fix… » changes their supplier or their budget in one go — that is how you move what sits in the wrong envelope. Moved lines leave the sheet right away: they now count elsewhere."
+            "body": "Tap a budget to open its sheet. Pick the period — the four shortcuts, or two free dates — and everything recomputes. Under the amount sits the comparison with the equivalent previous period: a month compares with the month before, a year with the year before, a free window with the same duration just before it. Below that, the spending rhythm day by day (month by month over a long window) and each supplier's share as a percentage. With nothing spent before, House says there is no comparison rather than inventing a percentage. « Unbudgeted » opens exactly the same way.\n\nAt the bottom, the period's expenses are browsed page by page. « Select » ticks several lines, then « Fix… » changes their supplier or their budget in one go — that is how you move what sits in the wrong envelope. Moved lines leave the sheet right away: they now count elsewhere. The chips above the list narrow it down — a kind, a supplier, or « without supplier » to spot what is still to be filled in. They leave the total at the top alone: it keeps covering the whole period, because that is the figure compared with the ceiling."
           },
           "analysis": {
             "title": "See where it actually goes",
@@ -3431,6 +3431,8 @@
     "count_other": "{{count}} expenses",
     "empty": "No expense in this period",
     "emptyDescription": "Change the period, or sort some expenses into this budget.",
+    "emptyFiltered": "No expense matches these filters",
+    "emptyFilteredDescription": "Release a chip to widen the list — the total above keeps covering the whole period.",
     "refundsTitle": "Refunds over the period",
     "trend": {
       "title": "Spending rhythm",

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Abrir la ficha de un presupuesto",
-            "body": "Toca un presupuesto para abrir su ficha. Elige el periodo — los cuatro accesos rápidos o dos fechas libres — y todo se recalcula. Bajo el importe está la comparación con el periodo anterior equivalente: un mes se compara con el mes anterior, un año con el año anterior, una ventana libre con la misma duración justo antes. Debajo, el ritmo de gastos día a día (mes a mes en una ventana larga) y la parte de cada proveedor en porcentaje. Si antes no se gastó nada, House dice que no hay comparación en lugar de inventar un porcentaje. « Sin presupuesto » se abre exactamente igual.\n\nAbajo, la lista de gastos del periodo se recorre página a página. « Seleccionar » marca varias líneas y « Corregir… » cambia su proveedor o su presupuesto de una vez — es el gesto para mover lo que está en el sobre equivocado. Las líneas movidas salen de la ficha al instante: ahora cuentan en otro sitio."
+            "body": "Toca un presupuesto para abrir su ficha. Elige el periodo — los cuatro accesos rápidos o dos fechas libres — y todo se recalcula. Bajo el importe está la comparación con el periodo anterior equivalente: un mes se compara con el mes anterior, un año con el año anterior, una ventana libre con la misma duración justo antes. Debajo, el ritmo de gastos día a día (mes a mes en una ventana larga) y la parte de cada proveedor en porcentaje. Si antes no se gastó nada, House dice que no hay comparación en lugar de inventar un porcentaje. « Sin presupuesto » se abre exactamente igual.\n\nAbajo, la lista de gastos del periodo se recorre página a página. « Seleccionar » marca varias líneas y « Corregir… » cambia su proveedor o su presupuesto de una vez — es el gesto para mover lo que está en el sobre equivocado. Las líneas movidas salen de la ficha al instante: ahora cuentan en otro sitio. Las etiquetas sobre la lista la reducen — una naturaleza, un proveedor o « sin proveedor » para detectar lo que queda por rellenar. No tocan el total de arriba, que sigue siendo el del periodo completo: es el que se compara con el límite."
           },
           "analysis": {
             "title": "Ver adónde va de verdad",
@@ -3431,6 +3431,8 @@
     "count_other": "{{count}} gastos",
     "empty": "Ningún gasto en este periodo",
     "emptyDescription": "Cambia de periodo o clasifica gastos en este presupuesto.",
+    "emptyFiltered": "Ningún gasto coincide con estos filtros",
+    "emptyFilteredDescription": "Suelta una etiqueta para ampliar la lista — el total de arriba sigue siendo el del periodo completo.",
     "refundsTitle": "Reembolsos del periodo",
     "trend": {
       "title": "Ritmo de gastos",

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1682,7 +1682,7 @@
           },
           "sheet": {
             "title": "Ouvrir la fiche d'un budget",
-            "body": "Touche un budget pour ouvrir sa fiche. Choisis la période — les quatre raccourcis, ou deux dates libres — et tout se recalcule. Sous le montant, la comparaison avec la période précédente équivalente : un mois se compare au mois d'avant, une année à l'année d'avant, une fenêtre libre à la même durée juste avant. En dessous, le rythme des dépenses jour par jour (mois par mois sur une longue fenêtre) et la part de chaque fournisseur en pourcentage. Sans dépense avant, House écrit qu'il n'y a pas de comparaison plutôt que d'inventer un pourcentage. « Hors budget » s'ouvre exactement pareil.\n\nEn bas, la liste des dépenses de la période se parcourt page par page. « Sélectionner » y coche plusieurs lignes, puis « Corriger… » change leur fournisseur ou leur budget d'un coup — c'est le geste pour déplacer ce qui est rangé dans la mauvaise enveloppe. Les lignes déplacées quittent la fiche aussitôt : elles comptent désormais ailleurs."
+            "body": "Touche un budget pour ouvrir sa fiche. Choisis la période — les quatre raccourcis, ou deux dates libres — et tout se recalcule. Sous le montant, la comparaison avec la période précédente équivalente : un mois se compare au mois d'avant, une année à l'année d'avant, une fenêtre libre à la même durée juste avant. En dessous, le rythme des dépenses jour par jour (mois par mois sur une longue fenêtre) et la part de chaque fournisseur en pourcentage. Sans dépense avant, House écrit qu'il n'y a pas de comparaison plutôt que d'inventer un pourcentage. « Hors budget » s'ouvre exactement pareil.\n\nEn bas, la liste des dépenses de la période se parcourt page par page. « Sélectionner » y coche plusieurs lignes, puis « Corriger… » change leur fournisseur ou leur budget d'un coup — c'est le geste pour déplacer ce qui est rangé dans la mauvaise enveloppe. Les lignes déplacées quittent la fiche aussitôt : elles comptent désormais ailleurs. Les pastilles au-dessus de la liste la réduisent — une nature, un fournisseur, ou « sans fournisseur » pour repérer ce qui reste à renseigner. Elles ne touchent pas au total du haut, qui reste celui de la période entière : c'est lui qu'on compare au plafond."
           },
           "analysis": {
             "title": "Comprendre où ça part",
@@ -3431,6 +3431,8 @@
     "count_other": "{{count}} dépenses",
     "empty": "Aucune dépense sur cette période",
     "emptyDescription": "Change de période, ou range des dépenses dans ce budget.",
+    "emptyFiltered": "Aucune dépense avec ces filtres",
+    "emptyFilteredDescription": "Relâche une pastille pour élargir la liste — le total du haut, lui, reste celui de la période entière.",
     "refundsTitle": "Remboursements de la période",
     "trend": {
       "title": "Rythme des dépenses",


### PR DESCRIPTION
Closes #483

## Quoi

La fiche d'une enveloppe partageait déjà la liste, l'endpoint, le pager, la
sélection et la correction en lot de l'onglet Dépenses. Il lui manquait les
**filtres** : repérer les lignes sans fournisseur sur l'enveloppe où on est déjà
imposait d'aller refaire le filtre dans l'autre onglet. Les deux écrans sont
maintenant le même écran, à une chose près — et c'est cette exception qui porte
tout le raisonnement.

### ⚠️ Les filtres réduisent la liste, jamais le bloc du haut

Ce bloc compare le dépensé à un **plafond** (« 340 € / 400 € »). Un sous-total
filtré sous un plafond entier dirait « tu es large » à quelqu'un qui vient de
dépasser — même famille de mensonge que le plafond qui recule. Donc :

- la **période** reste en tête de page : elle recalcule tout (total, comparaison,
  courbe, anneau) et on voit ce qu'elle recalcule ;
- les **pastilles** vivent contre la liste : elles ne réduisent qu'elle. D'où le
  `showPeriod` d'`ExpenseFilters` — les réunir dans un seul bloc promettrait que
  tout obéit à tout.

Conséquence assumée : l'anneau des fournisseurs continue de répondre « combien
chez qui » sur toute la fenêtre. C'est la carte depuis laquelle on filtre, pas une
vue de ce qui est filtré.

### Le reste

- **Les options viennent du serveur** : `insights` sert désormais `kinds`,
  symétrique de `suppliers` mais **sans `share`** — ce sont des options de filtre,
  pas une seconde répartition du même total (deux anneaux sans rien qui dise lequel
  lire). Fenêtre entière, jamais la page affichée : sur trois cents dépenses la
  page 1 n'en connaît que cinquante, et une pastille qui apparaît en tournant les
  pages fait douter de ce qu'on filtre. Elles ne se réduisent pas non plus quand un
  filtre est actif, pour passer d'un fournisseur à l'autre sans repasser par
  « Tous ».
- **Filtrés jusqu'au vide, les filtres restent affichés** — sinon ils
  disparaîtraient avec la liste et rien ne permettrait de les relâcher. Et le
  message distingue les deux vides : une période sans dépense se règle en changeant
  de période, une liste trop étroite en relâchant une pastille.
- **Un changement de filtre vide la sélection**, retour compris.
- La pastille « sans fournisseur » des lignes s'affiche ici aussi, maintenant que
  la page porte le filtre et la correction en lot : elle montre ce que le filtre
  irait chercher.

## Le bug trouvé en route (2e commit)

`fetchExpenseSummary` ne recopiait pas `without_supplier` dans sa query string.
L'onglet Dépenses le composait bien dans ses filtres et documentait que « le résumé
porte le même filtre que la liste », mais la clé était jetée à l'appel : **en prod,
activer « Sans fournisseur » affiche les totaux de toute la période au-dessus d'une
liste réduite**, et rien ne dit lequel des deux chiffres se trompe. C'est le
« compteur qui compte des lignes que la liste ne montre pas » contre lequel le
serveur met en garde dans ce même code, livré par #477.

Il a survécu à la revue parce que l'intention de l'appelant et la clé de cache
étaient justes toutes les deux — seul le passage de relais était cassé, et l'écran
restait plausible. D'où une régression au niveau du **transport**
(`ui/src/lib/api/expenses.test.ts`), vérifiée dans les deux sens.

## Critères de l'issue

- ✅ mêmes pastilles via le même `ExpenseFilters`
- ✅ le bloc du haut ne suit pas les filtres
- ✅ options serveur, fenêtre entière
- ✅ filtres persistants sur liste vide + message distinct
- ✅ la sélection se vide au changement de filtre, retour compris
- ✅ tutoriel (4 locales) + `docs/MODULES/money.md`

## Vérifications

`pytest` complet 3992 passed / 2 skipped (base isolée), `apps/budget`+`apps/interactions`
rejoués après rebase (667) · `tsc -b` OK · vitest 223 passed · ESLint 0 erreur.
Les trois nouveaux tests de régression échouent bien sans leur correctif.
