### PR TITLE
docs(general): licence AGPL-3.0 et gouvernance du projet (lot 4, #490)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Bug report
+description: Something is broken or behaves wrongly
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time. Answers in **English or French** are both fine.
+
+        ⚠️ **Found a security vulnerability?** Do not report it here — use
+        [Security → Report a vulnerability](https://github.com/jammindev/house/security/advisories/new).
+        See [SECURITY.md](https://github.com/jammindev/house/blob/main/SECURITY.md).
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you saw, and what you expected instead.
+      placeholder: |
+        I imported a bank statement and the balance shown afterwards was 40 € short.
+        I expected it to match the last printed balance.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: The shortest path from a working app to the problem.
+      placeholder: |
+        1. Go to Money → Accounts
+        2. Import the attached CSV
+        3. Open the Control tab — the counter reads 0 discrepancies
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The release tag or commit you are running (`docker compose images`, or the version shown in Settings).
+      placeholder: "v0.2.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install
+    attributes:
+      label: How is it installed
+      options:
+        - Docker Compose (self-hosted)
+        - Development setup (venv + npm)
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: |
+        Logs (`docker compose logs web`), screenshots, browser and version.
+
+        **Please redact real data** — amounts, account numbers, names, addresses.
+        A screenshot of your actual bank statement helps nobody once it is on a
+        public issue tracker.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🔒 Security vulnerability
+    url: https://github.com/jammindev/house/security/advisories/new
+    about: Report privately, never in a public issue. See SECURITY.md.
+
+  - name: 🇫🇷 The documentation is in French — start here
+    url: https://github.com/jammindev/house/blob/main/docs/README.en.md
+    about: An English guide to what each French document contains, and what is worth translating.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,48 @@
+name: Feature request
+description: Suggest something Maisonnée should do
+labels: ["idea"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Answers in **English or French** are both fine.
+
+        Two things worth knowing before you write, so the answer is not a surprise:
+
+        - Maisonnée is maintained by **one person**. Every accepted feature is a
+          thing to maintain for years, so "no" is a frequent and normal answer —
+          it is not a judgement on the idea.
+        - This app was built for one household's real life. The strongest case you
+          can make is a concrete situation, not a capability.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you hitting
+      description: |
+        Describe the situation, not the solution. What are you doing today instead?
+      placeholder: |
+        Every month I check whether the electricity bill matches the meter reading,
+        and I do it in a spreadsheet because I cannot see the two side by side.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: What you had in mind
+      description: Optional. If you already have a shape in mind, describe it.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you like to implement it
+      description: Entirely fine either way — this just tells the maintainer whether to discuss the design in detail.
+      options:
+        - "No — just suggesting"
+        - "Maybe, if the direction is agreed first"
+        - "Yes, I would like to open a pull request"
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,41 @@
+<!--
+English or French, both are fine.
+
+If this pull request is more than a typo or an obvious bug fix and there is no
+issue behind it, please open one first — see CONTRIBUTING.md. It is not
+bureaucracy: it avoids a refusal after you have already spent the weekend.
+-->
+
+Closes #
+
+## What this does, and why
+
+<!-- The problem, then the change. The "why" is what gets reviewed. -->
+
+## How it was verified
+
+<!-- What you ran, and what you saw. Not "tests pass" — which test, covering what. -->
+
+- [ ] `pytest`
+- [ ] `npm run lint`
+- [ ] `npx tsc -b ui/tsconfig.json`
+- [ ] Tried it in the running app
+
+## Checklist
+
+- [ ] Commits are signed off (`git commit -s`) — [DCO](https://developercertificate.org/), no CLA
+- [ ] Commit subjects follow `type(scope): description`
+- [ ] New user-facing text has keys in **all four** locales, with **no `defaultValue`**
+- [ ] No fixed Tailwind colours — design-system tokens only
+- [ ] Any new decimal input uses `DecimalInput`, not `<input type="number">`
+- [ ] A regression test exists for the defect being fixed, and it is named after it
+
+<!--
+The last one matters more than it looks. Tests here are named after the defect
+they prevent (TestTheTwoScreensAgree, TestSavingASplitNeverUndoesAReconciliation)
+so that whoever breaks an invariant is told which one, and why it exists.
+-->
+
+## Anything the reviewer should push back on
+
+<!-- Optional, and genuinely useful: the part you are least sure about. -->

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,16 @@
+Maisonnée
+Copyright (C) 2025-2026 Benjamin Vandamme
+
+Licensed under the GNU Affero General Public License v3.0 only.
+See LICENSE for the full text.
+
+The copyright is held by a single author. Contributions are accepted under the
+same licence, with authorship retained by their contributors (see CONTRIBUTING.md
+— this project uses the Developer Certificate of Origin, not a CLA).
+
+The name "Maisonnée" and the project's logo are not covered by the licence.
+
+Contributors
+------------
+
+Benjamin Vandamme <https://github.com/jammindev>

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,136 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported **privately**, through either channel:
+
+- GitHub's private reporting form, at
+  [Security → Report a vulnerability](https://github.com/jammindev/house/security/advisories/new)
+  — it is enabled on this repository and works for conduct reports too;
+- or by contacting [@jammindev](https://github.com/jammindev) directly on GitHub.
+
+Please do not open a public issue for a conduct report.
+
+All complaints will be reviewed and investigated promptly and fairly. This is a
+one-person project: expect an acknowledgement within a week.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.fr.md
+++ b/CONTRIBUTING.fr.md
@@ -1,0 +1,132 @@
+# Contribuer à Maisonnée
+
+*English version: [CONTRIBUTING.md](CONTRIBUTING.md)*
+
+Merci d'être là. Quelques points avant d'y passer du temps.
+
+## Ce qu'est ce projet, et ce qu'il n'est pas
+
+Maisonnée est un système d'exploitation du foyer : argent, tâches, documents,
+compteurs, équipements, chantiers — et les poules. Il a été écrit pour la vie
+réelle d'une famille, pas pour un marché. Ça décide de ce qui est accepté.
+
+Il est maintenu par **une seule personne**, à côté d'un travail à plein temps.
+Attends des réponses réfléchies, pas rapides.
+
+## Avant d'écrire du code : ouvre une issue
+
+**Ouvre une issue avant de commencer**, pour tout ce qui dépasse une faute de
+frappe ou un bug évident.
+
+Ce n'est pas de la bureaucratie. Refuser une PR sur laquelle quelqu'un a passé un
+week-end est franchement désagréable, et ça arrive quand la feature ne colle pas à
+une direction qui n'avait jamais été écrite. Cinq lignes d'issue d'abord évitent
+ça.
+
+Attends une réponse franche, y compris un « non » motivé. Un non ne juge pas
+l'idée — il veut généralement dire une chose de plus à maintenir pendant dix ans.
+
+## Faire tourner le projet
+
+> **Le `docker compose up` en une commande est en cours de construction** et
+> n'existe pas encore. En attendant, l'installation de développement ci-dessous
+> est le seul chemin supporté.
+
+En développement (Django sur `:8001`, Vite sur `:5174`) :
+
+```bash
+python -m venv venv && source venv/bin/activate
+pip install -r requirements/dev.txt
+npm install
+python manage.py runserver 8001
+npm run dev
+```
+
+## Lancer les tests
+
+Les trois doivent être verts avant qu'une PR soit revue :
+
+```bash
+pytest                              # backend, ~4000 tests
+npm run lint                        # ESLint sur ui/src
+npx tsc -b ui/tsconfig.json         # typecheck
+```
+
+Les tests E2E ont besoin du serveur Django sur `:8001` :
+
+```bash
+npm run test:e2e
+```
+
+## Les règles qui reviendront en revue
+
+Ce ne sont pas des préférences de style. Chacune existe parce que quelque chose a
+cassé en production, et chacune est tenue par un test.
+
+- **Jamais de `defaultValue` dans un `t()`.** Une clé manquante doit s'afficher
+  brute, pas passer pour de l'anglais acceptable. Toute clé existe dans les quatre
+  catalogues (`ui/src/locales/keys.test.ts`).
+- **Jamais de couleur Tailwind fixe.** Les tokens du design-system (`bg-card`,
+  `text-muted-foreground`, `border-border`…), jamais `bg-white`.
+- **Jamais d'`<input type="number">` pour un décimal.** `DecimalInput`. Taper
+  « 12,5 » au clavier français donnait **512 €** sur un moteur et **5 €** sur un
+  autre — un montant faux enregistré sans un mot.
+- **Jamais de `toISOString()` pour une date de calendrier.** `toLocalISODate` /
+  `todayISO` : le passage en UTC recule d'un jour tout ce qui se produit entre
+  minuit et 2 h.
+- **Une mutation vit dans le `hooks.ts` de sa feature**, et son `onSuccess`
+  déclare la racine écrite, pas la liste des caches.
+- **L'argent se lit par `interactions.queries.expenses()`.** Jamais un cast JSON
+  pour sommer un montant.
+
+Le raisonnement complet — avec le bug qui l'a causé — est dans
+[`CLAUDE.md`](CLAUDE.md).
+
+## Commits
+
+```
+<type>(<scope>): <description>
+```
+
+`feat`, `fix` et `perf` apparaissent dans le changelog ; `refactor`, `chore`,
+`docs`, `test`, `ci`, `build`, `style` sont internes. **Toujours un scope** — le
+module concerné, qui devient le filtre de l'entrée.
+
+## Signe tes commits (DCO)
+
+Ce projet utilise le [Developer Certificate of Origin](https://developercertificate.org/)
+plutôt qu'un CLA. Tu gardes ton copyright ; tu attestes simplement avoir le droit
+de proposer ce code :
+
+```bash
+git commit -s -m "fix(tasks): ..."
+```
+
+Pas de CLA, délibérément : céder des droits est un coût réel pour un contributeur,
+et ça n'achèterait que la possibilité de relicencier plus tard — une option
+lointaine contre une friction immédiate.
+
+## Licence
+
+Maisonnée est en **AGPL-3.0-only**. Les contributions sont acceptées sous cette
+licence.
+
+Concrètement : tu peux l'utiliser, le modifier et le partager librement, y compris
+pour ton propre foyer. Si tu *héberges une version modifiée pour d'autres
+personnes*, tu dois publier tes modifications. S'auto-héberger pour sa famille
+n'est pas « héberger pour d'autres » — c'est l'usage normal de ce logiciel.
+
+**Le nom et le logo ne sont pas couverts par la licence.** Le code est libre,
+l'identité non. Un fork qui n'est pas ce projet doit porter son propre nom.
+
+## Sécurité
+
+Pas d'issue publique pour une vulnérabilité. Voir [SECURITY.md](SECURITY.md).
+
+## Un mot sur les droits d'écriture
+
+Le déploiement de production tourne sur le serveur du mainteneur, déclenché par
+les push sur `main`. **Un accès write à ce dépôt est donc un accès shell à cette
+machine** — d'où le passage par fork et pull request, qui est de toute façon le
+fonctionnement normal d'un projet open source. Rien de personnel : c'est une
+propriété de l'installation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,155 @@
+# Contributing to Maisonnée
+
+*Version française : [CONTRIBUTING.fr.md](CONTRIBUTING.fr.md)*
+
+> **This project was built for one real household, in French.** The interface
+> speaks English, French, German and Spanish; the internal documentation and some
+> code comments are in French. Issues and pull requests in English are welcome.
+>
+> If that sounds like a wall, start with **[docs/README.en.md](docs/README.en.md)**:
+> an English guide to what each French document contains, and why you might want
+> to read it.
+
+Thanks for being here. A few things worth knowing before you spend time on this.
+
+## What this project is, and what it is not
+
+Maisonnée is a household operating system: money, tasks, documents, meters,
+equipment, projects — and yes, chickens. It was written for one family's actual
+life, not for a market. That shapes what gets accepted.
+
+It is maintained by **one person**, alongside a full-time job. Expect thoughtful
+answers, not fast ones.
+
+## Before writing code: open an issue
+
+Please **open an issue before starting work** on anything beyond a typo or an
+obvious bug fix.
+
+This is not bureaucracy. Refusing a pull request that someone spent a weekend on
+is genuinely unpleasant, and it happens when the feature does not fit a direction
+that was never written down. A five-line issue first saves that.
+
+Expect a plain answer, including "no" with a reason. A no is not a judgement on
+the idea — it usually means one more thing to maintain for ten years.
+
+## Getting it running
+
+> **A one-command `docker compose up` is being built** and is not there yet. Until
+> it lands, the development setup below is the only supported way to run the
+> project. Sorry about the venv.
+
+Development setup (Django on `:8001`, Vite on `:5174`):
+
+```bash
+python -m venv venv && source venv/bin/activate
+pip install -r requirements/dev.txt
+npm install
+python manage.py runserver 8001    # backend
+npm run dev                        # frontend
+```
+
+## Running the tests
+
+All three must be green before a pull request is reviewed:
+
+```bash
+pytest                              # backend, ~4000 tests
+npm run lint                        # ESLint over ui/src
+npx tsc -b ui/tsconfig.json         # typecheck
+```
+
+End-to-end tests need the Django server running on `:8001`:
+
+```bash
+npm run test:e2e
+```
+
+## House rules that will come up in review
+
+These are not style preferences. Each one exists because something broke in
+production, and each is enforced by a test.
+
+- **Never use `defaultValue` in a `t()` call.** A missing key must show as a raw
+  key, not as silently acceptable English. Every key must exist in all four
+  locale files. (`ui/src/locales/keys.test.ts`)
+- **Never use a fixed Tailwind colour.** Use design-system tokens (`bg-card`,
+  `text-muted-foreground`, `border-border`…), never `bg-white` or `text-slate-900`.
+- **Never use `<input type="number">` for a decimal.** Use `DecimalInput`. Typing
+  "12,5" on a French keyboard in a number field produced **512 €** in one browser
+  and **5 €** in another — a wrong amount saved silently.
+- **Never use `toISOString()` for a calendar date.** Use `toLocalISODate` /
+  `todayISO`. UTC conversion moves anything between midnight and 2 a.m. to the
+  previous day.
+- **A mutation lives in its feature's `hooks.ts`,** and its `onSuccess` declares
+  the data root it wrote — not the list of caches to refresh.
+- **Money is queried through `interactions.queries.expenses()`.** Never cast a
+  JSON field to sum an amount.
+
+The full reasoning for each — with the bug that caused it — is in
+[`CLAUDE.md`](CLAUDE.md). It is in French, and it is the single most useful file
+in the repository.
+
+## Commits
+
+Commit subjects follow the conventional format, because they feed the changelog
+automatically:
+
+```
+<type>(<scope>): <description>
+```
+
+`feat`, `fix` and `perf` appear in the changelog; `refactor`, `chore`, `docs`,
+`test`, `ci`, `build` and `style` are internal. **Always set a scope** — it is the
+module concerned (`money`, `tasks`, `agent`…), and it becomes the entry's filter.
+
+Commit messages are written in French in this repository. **Yours may be in
+English** — the structure is what matters, and descriptions are rewritten for the
+public changelog anyway.
+
+## Sign your commits off (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/)
+rather than a contributor licence agreement. You keep your copyright; you simply
+state that you have the right to submit the code:
+
+```bash
+git commit -s -m "fix(tasks): ..."
+```
+
+which appends `Signed-off-by: Your Name <your@email>` to the message.
+
+No CLA, deliberately: signing away rights is a real cost for a contributor, and it
+would only buy the ability to relicense later — a distant option against immediate
+friction.
+
+## Licence
+
+Maisonnée is **AGPL-3.0-only**. Contributions are accepted under that licence.
+
+In practice: you can run it, modify it and share it freely, including for your own
+household. If you *host a modified version for other people*, you must publish
+your modifications. Self-hosting for your own family is not "hosting for others" —
+it is the normal use of this software.
+
+The **name and the logo are not covered by the licence.** The code is free; the
+identity is not. A fork that is not this project should carry its own name.
+
+## Translations
+
+The documentation is in French. Translating any of it is a genuinely useful
+contribution — see [docs/README.en.md](docs/README.en.md) for what exists and the
+two rules that keep translations from going stale.
+
+## Security
+
+Please do not open a public issue for a vulnerability. See
+[SECURITY.md](SECURITY.md).
+
+## One thing about repository access
+
+The production deployment runs on the maintainer's own server, triggered by
+pushes to `main`. **Write access to this repository is therefore shell access to
+that machine**, which is why contributions go through forks and pull requests —
+the normal open-source flow — and why write access is not granted. Nothing
+personal; it is a property of the setup.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,662 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published
+    by the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.
+

--- a/README.md
+++ b/README.md
@@ -136,3 +136,26 @@ Configuration dans `pytest.ini` avec couverture sur l’app `accounts`.
 - Lookup bidirectionnel: `/api/electricity/mapping/lookup/?ref=<label>`
 - Soft delete lien: `POST /api/electricity/links/<id>/deactivate/`
 - Permissions: owner écriture, member lecture (même foyer uniquement)
+
+## Licence et contribution
+
+Maisonnée est un **logiciel libre** sous licence
+[GNU AGPL-3.0-only](LICENSE) — vous pouvez l'utiliser, l'étudier, le modifier et
+le partager, y compris pour votre propre foyer. Héberger une version *modifiée*
+pour d'autres personnes impose d'en publier les modifications ; s'auto-héberger
+pour sa famille est l'usage normal du logiciel, pas une distribution.
+
+Le **nom « Maisonnée » et le logo ne sont pas couverts par la licence** : le code
+est libre, l'identité non.
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — comment contribuer (en anglais),
+  [version française](CONTRIBUTING.fr.md)
+- [`SECURITY.md`](SECURITY.md) — signaler une vulnérabilité (jamais en issue
+  publique)
+- [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- [`docs/README.en.md`](docs/README.en.md) — guide anglais de la documentation
+  française, pour les visiteurs anglophones
+
+> Ce README s'adresse encore à un développeur du projet. Il sera réécrit pour
+> s'adresser à un visiteur — promesse d'abord, captures ensuite, stack en
+> dernier — au lot 6 du [parcours 28](docs/parcours/PARCOURS_28_OUVRIR_MAISONNEE.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security policy
+
+Maisonnée holds a household's bank statements, invoices, insurance contracts and
+address. A scoping bug here is not "my partner saw my shopping list" — it is "a
+stranger read my bank statements". Reports are taken seriously and answered.
+
+## Reporting a vulnerability
+
+**Please do not open a public issue.**
+
+Use GitHub's private reporting form:
+**[Security → Report a vulnerability](https://github.com/jammindev/house/security/advisories/new)**
+
+It is enabled on this repository. The report stays private between you and the
+maintainer until a fix is published.
+
+Useful in a report, roughly in order of value:
+
+1. what an attacker can reach that they should not (a household's data, a file, an
+   endpoint);
+2. the steps to reproduce it, ideally against a local `docker compose` instance;
+3. the version or commit you tested;
+4. whether the issue is already public somewhere.
+
+A proof of concept is welcome but never required — a clear description of the flaw
+is enough.
+
+## What to expect
+
+This is a **one-person project**, maintained alongside a full-time job. The
+commitments below are deliberately modest, because a promise that cannot be kept
+is worse than no promise:
+
+| Step | Target |
+|---|---|
+| Acknowledgement of your report | within **7 days** |
+| First assessment (confirmed / not a vulnerability / need more info) | within **14 days** |
+| Fix released for a confirmed, exploitable issue | as fast as possible; you will be told what "as fast as possible" means in practice |
+
+If you have not heard back after 14 days, assume the message was missed rather
+than ignored, and ping [@jammindev](https://github.com/jammindev) on GitHub.
+
+## Disclosure
+
+Coordinated disclosure, without a fixed deadline imposed on you: publish whenever
+you judge it right. Being told beforehand is appreciated, so that a fix and the
+report can land together.
+
+Credit is given in the release notes unless you prefer to stay anonymous — just
+say so.
+
+## Supported versions
+
+Only the **latest release** is supported. There is no long-term support branch:
+one person cannot maintain several. Self-hosted instances should track the latest
+tag.
+
+Users who self-host are the ones who apply updates, so a security fix is only
+useful once it reaches them: security releases are announced in the repository's
+releases feed, which is worth subscribing to.
+
+## Scope
+
+**In scope** — anything that lets someone reach data belonging to a household
+they are not a member of; authentication and session handling; the file-serving
+paths; the conversational agent's read and write tools; the default configuration
+shipped by `docker-compose.yml`.
+
+**Out of scope** — findings that require an already-compromised server or
+database; missing hardening headers with no demonstrated impact; automated
+scanner output without an exploitable scenario; and vulnerabilities in a
+self-hoster's own reverse proxy, network or operating system.
+
+A note on the default configuration: it is designed for a home network. Exposing
+an instance directly to the internet is a deliberate choice made by its operator,
+and hardening beyond what ships by default is theirs to do.

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -1,0 +1,65 @@
+# A guide to this project's documentation (which is in French)
+
+Maisonnée was built for one real household, in French. The interface speaks
+English, French, German and Spanish — but the documentation, the architecture
+notes and some code comments are in French, and they will stay that way. Keeping
+one accurate document beats maintaining a translation that quietly drifts.
+
+**This page is not a translation.** It is a map: what each French document holds,
+and why it might be worth running through a translator. Most of it is unusual
+enough to be worth the detour — this repository documents *why* far more than
+*what*.
+
+## Where the reasoning lives
+
+| Where | What it is | Why you may care |
+|---|---|---|
+| **`CLAUDE.md`** (root) | The project's rulebook. Every rule is tied to a bug that actually happened in production, with the reasoning kept and the name of the regression test that guards it. | The fastest way to understand *why* the code looks like it does — and the file to read before changing anything. It is the single most useful file here. |
+| **`docs/fiches/`** | Concept notes — "the lesson". Each one states the problem, the concept in two sentences, how it was applied here, the trade-offs, and **what was rejected and why**. Covers RAG, embeddings, idempotent bank-statement import, expense mapping, PWA push, self-hosting. | Background on the non-obvious parts, and the decisions you would otherwise re-litigate in a pull request. |
+| **`docs/parcours/`** | One set of documents per body of work ("parcours"): a product document (what problem, for whom, what is deliberately excluded) and a technical backlog split into independently shippable lots. | What is planned, what is out of scope on purpose, and where the current work sits. |
+| **`docs/MODULES/`** | Status of each Django app: what to fix, what to build, what to improve. | Where to start on a given module. |
+| **`docs/journal/`** | Dated notes from working sessions — decisions as they were made, including the ones that were later reversed. | Archaeology: why a given choice was made on a given day. |
+| **`DEPLOYMENT.md`** (root) | The maintainer's own VPS deployment, including a networking primer. | The only deployment guide that exists today. A self-hosting guide in English (`docs/self-hosting/`) is being written; until then, this is it — and it is written for one specific server, so read it as an example rather than as instructions. |
+| **Commit messages & issues** | French, conventional commits (`type(scope): description`). | The changelog is generated from them. |
+
+## What is already in English
+
+- the **interface**, in four languages (`ui/src/locales/`);
+- **code identifiers, function names and test names** — and the test names are
+  worth a look on their own: they are named after the defect they prevent
+  (`TestTheTwoScreensAgree`, `TestSavingASplitNeverUndoesAReconciliation`,
+  `TestTheMarkerAgreesWithTheControl`). Break an invariant and the failing test
+  tells you which one, and why it exists;
+- `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md`, the issue
+  templates, and the self-hosting documentation.
+
+## If you only read three things
+
+1. **`CLAUDE.md`, the "Argent" (money) section** — the invariants that make the
+   financial side trustworthy: nothing is counted twice, nothing sits in a silent
+   in-between state, a counter cannot have two definitions, a discrepancy is never
+   stated twice in two voices.
+2. **`docs/fiches/AUTO_HEBERGEMENT.md`** — what changes when software leaves its
+   author's machine: the threat model, optional capabilities, the licence, and why
+   backups are a feature rather than a piece of advice.
+3. **The parcours document for whatever you are touching** — it usually says, in
+   plain words, what the feature refuses to do and why.
+
+## Translating
+
+**Translating any of these is a genuinely useful contribution** — probably the
+easiest way to make a first, meaningful one. Two rules keep it from backfiring:
+
+1. **The French file stays the source of truth.** A correction goes into the
+   original first; a translation is never edited in its place.
+2. **A translation records the date and commit of the version it mirrors**, and
+   lives next to its original as `<NAME>.en.md` — never in a parallel `en/`
+   directory, which makes drift invisible.
+
+And the part people find surprising: **a translation nobody updates is worse than
+no translation at all.** It looks authoritative while being wrong, and the file
+someone reads is never the file someone fixes. If one goes stale and you cannot
+refresh it, delete it — that is a contribution too.
+
+This is the same rule the rest of the project follows for numbers: two things that
+disagree do not average out, they discredit each other.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
+  "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {
     "dev": "vite --config ui/vite.config.ts",

--- a/ui/src/features/settings/SettingsPage.tsx
+++ b/ui/src/features/settings/SettingsPage.tsx
@@ -13,6 +13,7 @@ import { ChangePasswordSection } from './components/ChangePasswordSection';
 import { HouseholdManagement } from './components/HouseholdManagement';
 import { ModulesSection } from './components/ModulesSection';
 import { PendingInvitations } from './components/PendingInvitations';
+import { AboutSection } from './components/AboutSection';
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -48,6 +49,7 @@ export default function SettingsPage() {
       <ThemeSection />
       <AgentMemorySection />
       <ChangePasswordSection />
+      <AboutSection />
     </div>
   );
 }

--- a/ui/src/features/settings/components/AboutSection.tsx
+++ b/ui/src/features/settings/components/AboutSection.tsx
@@ -1,0 +1,47 @@
+import { ExternalLink } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { SettingsSection } from './SettingsSection';
+
+const REPOSITORY_URL = 'https://github.com/jammindev/house';
+const LICENSE_URL = `${REPOSITORY_URL}/blob/main/LICENSE`;
+
+/**
+ * Licence et lien vers le code source.
+ *
+ * Ce n'est pas une section « à propos » décorative : l'AGPL §13 impose qu'un
+ * utilisateur qui interagit avec une instance à travers le réseau puisse en
+ * obtenir la source. Une instance auto-hébergée sans ce lien n'est pas conforme.
+ * D'où sa place dans les réglages, visible par tout membre du foyer, et pas
+ * seulement dans un README que personne n'ouvre depuis l'app.
+ */
+export function AboutSection() {
+  const { t } = useTranslation();
+
+  return (
+    <SettingsSection title={t('settings.about.title')} description={t('settings.about.description')}>
+      <div className="space-y-3 text-sm">
+        <p className="text-muted-foreground">{t('settings.about.license')}</p>
+        <div className="flex flex-wrap gap-4">
+          <a
+            href={REPOSITORY_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 text-primary hover:underline"
+          >
+            {t('settings.about.sourceCode')}
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+          <a
+            href={LICENSE_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            className="inline-flex items-center gap-1.5 text-primary hover:underline"
+          >
+            {t('settings.about.licenseLink')}
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1129,6 +1129,13 @@
     "notifications": {
       "title": "Benachrichtigungen",
       "description": "Wählen Sie, was in Ihrer Glocke landet. Abwählen, um eine Art von Benachrichtigung nicht mehr zu erhalten."
+    },
+    "about": {
+      "title": "Über Maisonnée",
+      "description": "Lizenz und Quellcode dieser Instanz.",
+      "license": "Maisonnée ist freie Software unter der GNU Affero General Public License v3.0. Sie dürfen sie nutzen, untersuchen, verändern und weitergeben.",
+      "sourceCode": "Quellcode",
+      "licenseLink": "Lizenz lesen"
     }
   },
   "tutorials": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1129,6 +1129,13 @@
     "notifications": {
       "title": "Notifications",
       "description": "Choose what lands in your bell. Untick to stop receiving a kind of notification."
+    },
+    "about": {
+      "title": "About Maisonnée",
+      "description": "Licence and source code of this instance.",
+      "license": "Maisonnée is free software, licensed under the GNU Affero General Public License v3.0. You may run, study, modify and share it.",
+      "sourceCode": "Source code",
+      "licenseLink": "Read the licence"
     }
   },
   "tutorials": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1129,6 +1129,13 @@
     "notifications": {
       "title": "Notificaciones",
       "description": "Elija qué llega a su campana. Desmarque para dejar de recibir un tipo de notificación."
+    },
+    "about": {
+      "title": "Acerca de Maisonnée",
+      "description": "Licencia y código fuente de esta instancia.",
+      "license": "Maisonnée es software libre, bajo licencia GNU Affero General Public License v3.0. Puede usarlo, estudiarlo, modificarlo y compartirlo.",
+      "sourceCode": "Código fuente",
+      "licenseLink": "Leer la licencia"
     }
   },
   "tutorials": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1129,6 +1129,13 @@
     "notifications": {
       "title": "Notifications",
       "description": "Choisissez ce qui arrive dans votre cloche. Décochez pour ne plus recevoir un type de notification."
+    },
+    "about": {
+      "title": "À propos de Maisonnée",
+      "description": "Licence et code source de cette instance.",
+      "license": "Maisonnée est un logiciel libre, sous licence GNU Affero General Public License v3.0. Vous pouvez l'utiliser, l'étudier, le modifier et le partager.",
+      "sourceCode": "Code source",
+      "licenseLink": "Lire la licence"
     }
   },
   "tutorials": {


### PR DESCRIPTION
Closes #490

## Quoi

Le code est public depuis dix mois **sans licence** — donc sous « tous droits réservés » par défaut. Visible mais légalement inutilisable : la plus mauvaise des deux situations. C'est l'écart que ce lot ferme.

### Licence : AGPL-3.0-only

Le copyleft *réseau* est le seul adapté à un produit dont l'usage normal est d'être hébergé. Concrètement :

- l'**auto-hébergement familial reste totalement libre** — ce n'est pas « héberger pour d'autres » ;
- un tiers qui héberge une version **modifiée** pour d'autres doit publier ses modifications ;
- l'option d'un **hébergement payant** reste ouverte, le copyright étant détenu par un seul auteur.

Licence de Nextcloud, Mastodon, Immich. **DCO plutôt que CLA** : céder des droits est un coût immédiat pour un contributeur, et n'achèterait qu'une option lointaine de relicenciement.

Le **nom et le logo ne sont pas couverts** : le code est libre, l'identité non.

### Conformité AGPL §13 — la seule partie qui touche l'app

Une instance doit permettre à ses utilisateurs d'**obtenir sa source**. D'où une section « À propos » dans les réglages (`AboutSection.tsx`), visible par tout membre du foyer — pas seulement un README que personne n'ouvre depuis l'app. Clés i18n dans les **quatre** catalogues, sans `defaultValue`.

### Sécurité et conduite : aucun email publié

`SECURITY.md` et `CODE_OF_CONDUCT.md` passent par le **signalement privé de GitHub** (activé sur le dépôt dans cette PR). L'email de l'auteur est déjà dans les 787 commits, mais l'imprimer sur une page « écrivez ici pour signaler » n'est pas la même exposition — ça se fait scraper.

Les délais annoncés sont volontairement modestes (accusé de réception sous 7 jours, évaluation sous 14) : **une promesse intenable vaut moins que pas de promesse**, et c'est un projet maintenu par une personne.

### `docs/README.en.md` — le mur devient un menu

Pas une traduction : un **index anglais commenté** de la doc française. Pour chaque famille (`CLAUDE.md`, `fiches/`, `parcours/`, `MODULES/`, `journal/`), ce que c'est et pourquoi ça peut valoir la peine d'aller la lire.

Il invite explicitement à traduire, avec les deux garde-fous sans lesquels l'invitation se retourne : **le français reste la source de vérité**, et **une traduction périmée se supprime** — elle a l'air de faire autorité en étant fausse. C'est « un compteur ne peut pas avoir deux définitions » appliqué à la prose.

### Ce que CONTRIBUTING dit d'inhabituel

Que les **droits d'écriture ne se donnent pas** : le deploy tourne sur le serveur de l'auteur au push sur `main`, donc un accès write est un accès shell sur cette machine. Les contributions passent par fork + PR — le flux normal de l'open source, ici avec une raison concrète.

## Ne promet que ce qui existe

Défaut attrapé en relecture : `CONTRIBUTING` annonçait un `docker compose up` que le lot 2 n'a pas encore livré, et le sélecteur d'issue pointait vers `docs/self-hosting/` qui n'existe pas. Un contributeur serait tombé sur du vide. Corrigé : le compose est annoncé **comme à venir**, et le lien mort est retiré.

## Critères de l'issue

- [x] Bandeau « AGPL-3.0 » sur la page GitHub (`LICENSE` canonique, détecté par GitHub)
- [x] L'app expose son code source depuis l'interface (conformité §13)
- [x] `docs/README.en.md` couvre toutes les familles de docs, avec l'invitation à traduire et ses deux garde-fous
- [x] `CONTRIBUTING.md` permet à un inconnu de lancer les tests sans poser de question, et annonce la langue du projet dès le premier paragraphe
- [x] Le canal de `SECURITY.md` aboutit réellement (signalement privé activé)
- [x] Les modèles d'issue reprennent les labels existants (`bug`, `idea`)

## Vérifications

- `pytest` : 3992 passés, 2 skippés
- `vitest` : 224 passés (dont les 6 du garde-fou i18n)
- `npm run lint` : 0 erreur (5 warnings préexistants)
- `npx tsc -b` : propre