### PR TITLE
feat(general): isolation multi-foyer vérifiée en continu (lot 1, #487)

### DIFF
--- a/apps/core/tests/test_media_isolation.py
+++ b/apps/core/tests/test_media_isolation.py
@@ -1,0 +1,216 @@
+"""Isolation des fichiers servis — un chemin deviné ne doit rien rendre.
+
+Le service de médias est la seule porte du foyer qui ne passe **ni** par un
+viewset **ni** par un queryset : elle prend un chemin et rend des octets. Les
+57 viewsets peuvent tous filtrer parfaitement sans que ça protège un seul
+fichier — c'est pourquoi elle a ses propres tests de régression.
+
+Chaque classe ici est nommée d'après le défaut qu'elle empêche.
+"""
+import pytest
+from django.core.files.base import ContentFile
+from django.core.files.storage import default_storage
+
+from accounts.tests.factories import UserFactory
+from documents.models import Document
+from households.models import Household, HouseholdMember
+
+
+def media_url(path):
+    return f"/media/{path}"
+
+
+@pytest.fixture
+def household_a(db):
+    return Household.objects.create(name="Foyer A")
+
+
+@pytest.fixture
+def household_b(db):
+    return Household.objects.create(name="Foyer B")
+
+
+@pytest.fixture
+def alice(db, household_a):
+    user = UserFactory()
+    HouseholdMember.objects.create(
+        household=household_a, user=user, role=HouseholdMember.Role.OWNER
+    )
+    return user
+
+
+@pytest.fixture
+def amelie(db, household_a):
+    """Deuxième membre du foyer A — pour la confidentialité *entre* membres."""
+    user = UserFactory()
+    HouseholdMember.objects.create(
+        household=household_a, user=user, role=HouseholdMember.Role.MEMBER
+    )
+    return user
+
+
+@pytest.fixture
+def bob(db, household_b):
+    user = UserFactory()
+    HouseholdMember.objects.create(
+        household=household_b, user=user, role=HouseholdMember.Role.OWNER
+    )
+    return user
+
+
+@pytest.mark.django_db
+class TestAPrivateDocumentThumbnailStaysPrivate:
+    """Régression : la vignette d'un document privé échappait au contrôle.
+
+    Le contrôle de confidentialité cherchait le document par ``file_path``
+    exact. Une vignette vit à un **autre** chemin
+    (``…/.thumbnails/thumb/<stem>.jpg``), donc la recherche levait
+    ``DoesNotExist`` et le code tombait dans un ``pass`` — servant l'aperçu.
+
+    Pour un document scanné ou une photo, l'aperçu *est* le document. Le
+    marquer privé ne protégeait donc que l'original, jamais ce qu'on voit.
+    """
+
+    def _private_doc(self, household, owner):
+        file_path = Document.build_upload_path(
+            household_id=household.id, filename="rib.pdf"
+        )
+        default_storage.save(file_path, ContentFile(b"%PDF-1.4 fake"))
+        doc = Document.objects.create(
+            household=household,
+            created_by=owner,
+            name="RIB",
+            file_path=file_path,
+            is_private=True,
+        )
+        from documents.thumbnails import thumbnail_storage_path
+
+        thumb_path = thumbnail_storage_path(file_path, "thumb")
+        default_storage.save(thumb_path, ContentFile(b"\xff\xd8\xff fake jpeg"))
+        return doc, file_path, thumb_path
+
+    def test_the_creator_still_sees_the_thumbnail(self, client, household_a, alice):
+        _, _, thumb_path = self._private_doc(household_a, alice)
+        client.force_login(alice)
+        assert client.get(media_url(thumb_path)).status_code == 200
+
+    def test_another_member_cannot_read_the_original(self, client, household_a, alice, amelie):
+        _, file_path, _ = self._private_doc(household_a, alice)
+        client.force_login(amelie)
+        assert client.get(media_url(file_path)).status_code == 403
+
+    def test_another_member_cannot_read_the_thumbnail_either(
+        self, client, household_a, alice, amelie
+    ):
+        """Le défaut lui-même : l'original refusé, l'aperçu servi."""
+        _, _, thumb_path = self._private_doc(household_a, alice)
+        client.force_login(amelie)
+        assert client.get(media_url(thumb_path)).status_code == 403
+
+    def test_a_stranger_cannot_read_the_thumbnail(self, client, household_a, alice, bob):
+        _, _, thumb_path = self._private_doc(household_a, alice)
+        client.force_login(bob)
+        assert client.get(media_url(thumb_path)).status_code == 403
+
+
+@pytest.mark.django_db
+class TestAnUnknownMediaPrefixIsRefused:
+    """Régression : le service était en *default-allow*.
+
+    Seul ``documents/`` était contrôlé ; tout autre préfixe tombait jusqu'au
+    ``X-Accel-Redirect`` final et était servi à n'importe quel utilisateur
+    authentifié. Un préfixe ajouté plus tard (exports, sauvegardes, pièces
+    jointes) aurait donc été public par défaut, sans une ligne de code pour
+    le trahir.
+
+    La règle est inversée : ce qui n'est pas explicitement autorisé est refusé.
+    """
+
+    def test_an_unknown_prefix_is_refused(self, client, alice):
+        client.force_login(alice)
+        assert client.get(media_url("exports/2026/tout.csv")).status_code == 403
+
+    def test_even_a_path_that_looks_like_a_document_is_refused(self, client, alice):
+        client.force_login(alice)
+        assert client.get(media_url("documents-backup/secret.pdf")).status_code == 403
+
+    def test_a_traversal_attempt_is_refused(self, client, alice):
+        client.force_login(alice)
+        response = client.get(media_url("../../etc/passwd"))
+        assert response.status_code in (403, 404)
+
+
+@pytest.mark.django_db
+class TestAnAvatarStaysInsideItsHouseholds:
+    """Un avatar est la photo d'une personne, pas un fichier public.
+
+    Il était servi à tout utilisateur authentifié, quel que soit son foyer —
+    et un ancien membre gardait donc l'accès pour toujours. La règle retenue
+    est la plus permissive qui reste vraie : on voit l'avatar de quelqu'un
+    avec qui on partage un foyer, et le sien.
+    """
+
+    def _avatar_path(self, user):
+        path = f"avatars/{user.pk}/portrait.jpg"
+        default_storage.save(path, ContentFile(b"\xff\xd8\xff fake jpeg"))
+        return path
+
+    def test_you_can_see_your_own_avatar(self, client, alice):
+        path = self._avatar_path(alice)
+        client.force_login(alice)
+        assert client.get(media_url(path)).status_code == 200
+
+    def test_a_household_member_can_see_it(self, client, alice, amelie):
+        path = self._avatar_path(alice)
+        client.force_login(amelie)
+        assert client.get(media_url(path)).status_code == 200
+
+    def test_someone_from_another_household_cannot(self, client, alice, bob):
+        path = self._avatar_path(alice)
+        client.force_login(bob)
+        assert client.get(media_url(path)).status_code == 403
+
+    def test_an_avatar_of_nobody_is_not_served(self, client, alice):
+        """Un chemin bien formé mais sans utilisateur derrière ne rend rien."""
+        client.force_login(alice)
+        response = client.get(media_url("avatars/00000000-0000-0000-0000-000000000000/x.jpg"))
+        assert response.status_code in (403, 404)
+
+    def test_a_malformed_avatar_path_is_not_served(self, client, alice):
+        client.force_login(alice)
+        response = client.get(media_url("avatars/pas-un-uuid/x.jpg"))
+        assert response.status_code in (403, 404)
+
+
+@pytest.mark.django_db
+class TestTheDocumentRulesStillHold:
+    """Les garanties déjà en place ne doivent pas régresser en durcissant."""
+
+    def _doc(self, household, owner, *, private=False):
+        file_path = Document.build_upload_path(
+            household_id=household.id, filename="facture.pdf"
+        )
+        default_storage.save(file_path, ContentFile(b"%PDF-1.4 fake"))
+        Document.objects.create(
+            household=household,
+            created_by=owner,
+            name="Facture",
+            file_path=file_path,
+            is_private=private,
+        )
+        return file_path
+
+    def test_a_member_reads_a_public_document(self, client, household_a, alice, amelie):
+        path = self._doc(household_a, alice)
+        client.force_login(amelie)
+        assert client.get(media_url(path)).status_code == 200
+
+    def test_a_stranger_does_not(self, client, household_a, alice, bob):
+        path = self._doc(household_a, alice)
+        client.force_login(bob)
+        assert client.get(media_url(path)).status_code == 403
+
+    def test_anonymous_gets_401_not_403(self, client, household_a, alice):
+        """401 et 403 disent deux choses différentes ; le front s'en sert."""
+        path = self._doc(household_a, alice)
+        assert client.get(media_url(path)).status_code == 401

--- a/apps/core/tests/test_production_settings.py
+++ b/apps/core/tests/test_production_settings.py
@@ -1,0 +1,176 @@
+"""Les garanties de configuration de production, tenues par un test.
+
+Le durcissement de ce dépôt était **déjà largement en place** avant le parcours
+28 : `DEBUG` en dur, `ALLOWED_HOSTS` sans défaut, cookies `Secure`, HSTS d'un an,
+throttling sur l'authentification. Ce fichier n'ajoute donc pas de protection —
+il empêche qu'elles disparaissent.
+
+Pourquoi c'est nécessaire alors que le code est juste : une valeur de sécurité se
+désactive d'une seule ligne, souvent pour une bonne raison locale (« juste pour
+déboguer ce soir »), et rien ne la rallume. Ce sont des réglages dont l'absence
+ne se voit **jamais** à l'usage — l'app marche exactement pareil sans HSTS, sans
+cookie `Secure` et sans throttle. Le jour où ça se remarque, c'est trop tard.
+
+Le dépôt étant public, ces réglages sont aussi ce qu'un lecteur peut inspecter
+avant de tenter quoi que ce soit contre une instance.
+"""
+import importlib
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def production_settings():
+    """Charge le module de settings de production sans l'activer.
+
+    On l'importe directement plutôt que de le rendre actif : l'activer
+    exigerait un `.env` complet et transformerait un test de configuration en
+    test d'environnement.
+    """
+    import os
+
+    os.environ.setdefault("SECRET_KEY", "test-only-not-a-real-secret")
+    os.environ.setdefault("ALLOWED_HOSTS", "example.test")
+    os.environ.setdefault(
+        "DATABASE_URL", "postgres://user:pass@localhost:5432/placeholder"
+    )
+    # Le module refuse de se charger sans celle-ci — un durcissement à part
+    # entière, vérifié par `TestTheModuleRefusesAnIncompleteEnvironment`.
+    os.environ.setdefault("CORS_ALLOWED_ORIGINS", "https://example.test")
+    return importlib.import_module("config.settings.production")
+
+
+class TestDebugCannotBeTurnedOnInProduction:
+    """`DEBUG` en production expose les tracebacks, les settings et les requêtes."""
+
+    def test_debug_is_hardcoded_off(self, production_settings):
+        assert production_settings.DEBUG is False
+
+    def test_debug_is_not_readable_from_the_environment(self):
+        """Le point important : ce n'est pas une valeur par défaut.
+
+        `DEBUG = env.bool("DEBUG", default=False)` aurait la même tête et
+        laisserait une variable d'environnement rallumer le mode debug en
+        production. Ici c'est une constante — il faut éditer le fichier.
+        """
+        from pathlib import Path
+
+        source = Path("config/settings/production.py").read_text(encoding="utf-8")
+        assert "DEBUG = False" in source, (
+            "DEBUG doit rester une constante dans production.py, jamais une "
+            "valeur lue de l'environnement."
+        )
+
+
+class TestTheModuleRefusesAnIncompleteEnvironment:
+    """Un réglage de sécurité manquant doit empêcher le démarrage, pas se deviner.
+
+    `config/settings/production.py` lève sur `CORS_ALLOWED_ORIGINS` absent. C'est
+    le bon comportement et il mérite d'être figé : la tentation, un jour de
+    déploiement qui coince, est de lui donner une valeur par défaut permissive.
+    Un serveur qui refuse de démarrer se remarque en trente secondes ; un
+    serveur qui accepte toutes les origines ne se remarque jamais.
+    """
+
+    def test_missing_cors_origins_raises_at_import(self):
+        from pathlib import Path
+
+        source = Path("config/settings/production.py").read_text(encoding="utf-8")
+        assert "CORS_ALLOWED_ORIGINS must be set in production" in source, (
+            "La garde sur CORS_ALLOWED_ORIGINS a disparu : une origine par "
+            "défaut permissive ne se voit pas à l'usage."
+        )
+
+
+class TestTheHostsAreDeclared:
+    def test_allowed_hosts_has_no_default(self):
+        """Sans `ALLOWED_HOSTS`, le démarrage doit échouer, pas passer en `*`.
+
+        Un `*` accepte n'importe quel `Host:` et ouvre l'empoisonnement de
+        cache et les liens de réinitialisation forgés. Échouer au démarrage est
+        bruyant ; accepter tout est silencieux.
+        """
+        from pathlib import Path
+
+        source = Path("config/settings/production.py").read_text(encoding="utf-8")
+        assert 'ALLOWED_HOSTS = env.list("ALLOWED_HOSTS")' in source, (
+            "ALLOWED_HOSTS ne doit pas avoir de valeur par défaut."
+        )
+        assert '"*"' not in source.split("ALLOWED_HOSTS")[1][:200]
+
+
+class TestTheTransportIsProtected:
+    def test_cookies_are_secure_by_default(self, production_settings):
+        assert production_settings.SESSION_COOKIE_SECURE is True
+        assert production_settings.CSRF_COOKIE_SECURE is True
+
+    def test_https_is_enforced(self, production_settings):
+        assert production_settings.SECURE_SSL_REDIRECT is True
+
+    def test_health_stays_reachable_without_https(self, production_settings):
+        """`/health/` est la sonde du deploy : une redirection la casserait."""
+        assert any(
+            "health" in pattern for pattern in production_settings.SECURE_REDIRECT_EXEMPT
+        )
+
+    def test_hsts_is_at_least_a_year(self, production_settings):
+        assert production_settings.SECURE_HSTS_SECONDS >= 31536000
+
+    def test_content_type_sniffing_is_off(self, production_settings):
+        """Sur une app qui sert des fichiers de l'utilisateur, le sniffing
+        transforme un fichier téléversé en script exécuté par le navigateur."""
+        assert production_settings.SECURE_CONTENT_TYPE_NOSNIFF is True
+
+
+class TestTheSensitiveEndpointsAreThrottled:
+    """Un mot de passe se devine, sauf si on ne peut essayer que cinq fois."""
+
+    REQUIRED_SCOPES = {
+        "login_ip",
+        "login_email",
+        "change_password",
+        "password_reset",
+        "invitation_join",
+    }
+
+    def test_every_sensitive_scope_has_a_rate(self, settings):
+        rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+        missing = self.REQUIRED_SCOPES - set(rates)
+        assert not missing, f"Portées de throttle disparues : {sorted(missing)}"
+
+    def test_login_is_throttled_per_email_not_only_per_ip(self, settings):
+        """Le throttle par IP seul ne protège pas d'un attaquant distribué.
+
+        C'est le throttle **par email** qui borne les tentatives sur un compte
+        donné, quelle que soit l'origine.
+        """
+        rates = settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+        attempts, _, period = rates["login_email"].partition("/")
+        assert int(attempts) <= 10, (
+            f"login_email autorise {attempts} essais par {period} : trop pour "
+            "borner une attaque par dictionnaire."
+        )
+
+    def test_the_login_view_actually_uses_them(self):
+        """Une portée déclarée mais jamais branchée ne protège rien."""
+        from accounts.views.api import AuthViewSet
+
+        source = __import__("inspect").getsource(AuthViewSet)
+        assert "LoginIPRateThrottle" in source
+        assert "LoginEmailRateThrottle" in source
+
+
+class TestClickjackingIsBlocked:
+    def test_the_middleware_is_installed(self, settings):
+        assert (
+            "django.middleware.clickjacking.XFrameOptionsMiddleware"
+            in settings.MIDDLEWARE
+        )
+
+    def test_framing_is_denied(self, settings):
+        """Django vaut « DENY » par défaut ; ce test le fige.
+
+        Passer à `SAMEORIGIN` « pour un widget » suffirait à rouvrir le
+        détournement de clic sur toute l'app.
+        """
+        assert getattr(settings, "X_FRAME_OPTIONS", "DENY") == "DENY"

--- a/apps/core/tests/test_tenant_isolation.py
+++ b/apps/core/tests/test_tenant_isolation.py
@@ -1,0 +1,299 @@
+"""Isolation multi-foyer — le contrôle qui ne se périme pas.
+
+Un audit est vrai le jour où on le fait. Ce fichier est l'inverse : il parcourt
+le **routeur DRF réel** et vérifie, pour chaque endpoint enregistré, que la
+requête qu'il produit est bornée au foyer du demandeur. Ajouter un viewset non
+scopé fait échouer ce test sans que personne ait à y penser — même mécanique que
+``banking.compliance.REGISTRY`` (« ajouter un mécanisme à l'argent = ajouter son
+détecteur ») ou que la parité des catalogues i18n.
+
+Ce que ce test prouve et ne prouve pas
+--------------------------------------
+
+Il **prouve** qu'aucun endpoint enregistré ne construit une requête capable
+d'atteindre un autre foyer. C'est la classe de faille la plus probable, et la
+seule qui se glisse dans une revue sans se voir : le diff d'un ``get_queryset``
+qui oublie le foyer ressemble exactement à celui qui le pose.
+
+Il **ne prouve pas** l'absence de faille. Une action ``@action`` custom qui
+ouvre son propre chemin, un fichier servi par son chemin, un tool d'agent : rien
+de tout ça ne passe par un queryset. Ces surfaces ont leurs propres tests —
+``test_media_isolation.py`` pour les fichiers, ``agent/tests/`` pour l'agent.
+Ne jamais lire un succès ici comme un satisfecit général.
+"""
+import pytest
+from django.urls import URLPattern, URLResolver, get_resolver
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from accounts.tests.factories import UserFactory
+from core.models import HouseholdScopedModel
+from households.models import Household, HouseholdMember
+
+# ── Exemptions ───────────────────────────────────────────────────────────────
+#
+# Une exemption est une **dette nommée**, pas un contournement : chacune dit
+# pourquoi l'endpoint n'est pas borné par un foyer, et ce qui le protège à la
+# place. Sans justification, il n'y a pas de dispense — la liste est le seul
+# endroit où un « oui mais c'est normal » se dépose, et il doit se relire.
+
+EXEMPT_UNSCOPED = {
+    # Modèle **global** et assumé (cf. CLAUDE.md § Changelog) : infra
+    # applicative, pas donnée de foyer. Protégé par `IsAdminUser`, vérifié
+    # ci-dessous par `test_the_global_endpoints_are_staff_only`.
+    "releases.views.ChangelogViewSet",
+}
+
+EXEMPT_USER_SCOPED = {
+    # Une notification appartient à une **personne**, pas à un foyer : deux
+    # membres du même foyer n'ont pas la même liste. Borner par foyer serait
+    # ici plus permissif, pas moins.
+    "notifications.views.NotificationViewSet",
+}
+
+# Vues sans queryset (APIView, endpoints JWT) : ce test ne peut rien en dire.
+# Elles ne sont pas dispensées de scoping — elles relèvent d'un autre contrôle.
+SKIP_NO_QUERYSET = True
+
+
+def _registered_api_views():
+    """Toutes les classes de vue montées sous ``/api/``, depuis le routeur réel."""
+    found = {}
+
+    def walk(resolver, prefix=""):
+        for pattern in resolver.url_patterns:
+            if isinstance(pattern, URLResolver):
+                walk(pattern, prefix + str(pattern.pattern))
+            elif isinstance(pattern, URLPattern):
+                cls = getattr(pattern.callback, "cls", None)
+                if cls is not None:
+                    found.setdefault(cls, prefix + str(pattern.pattern))
+
+    walk(get_resolver())
+    return {cls: path for cls, path in found.items() if path.startswith("api/")}
+
+
+def _dotted(cls):
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+def _constraints_of(sql: str) -> str:
+    """Ce qui *contraint* la requête : tout ce qui suit le premier ``FROM``.
+
+    ⚠️ **Ne jamais chercher dans le SQL entier.** La liste de colonnes d'un
+    ``SELECT`` sur un modèle household-scoped contient toujours
+    ``"table"."household_id"`` : un test qui cherche « household » n'importe où
+    passe donc au vert sur un ``Model.objects.all()`` sans le moindre ``WHERE``.
+    Ce fichier a eu ce défaut, et il ne s'est vu qu'en sabotant volontairement
+    un viewset pour vérifier que le test mordait. Un contrôle qu'on n'a pas vu
+    échouer une fois n'est pas un contrôle.
+
+    Ce qui suit le ``FROM`` couvre les conditions de jointure **et** le
+    ``WHERE`` — les deux façons légitimes de borner au foyer (la jointure
+    traverse souvent ``households_householdmember``).
+    """
+    lowered = sql.lower()
+    marker = " from "
+    index = lowered.find(marker)
+    return lowered[index + len(marker):] if index != -1 else ""
+
+
+@pytest.fixture
+def two_households(db):
+    """Deux foyers étanches, et un utilisateur dans chacun."""
+    household_a = Household.objects.create(name="Foyer A")
+    household_b = Household.objects.create(name="Foyer B")
+    alice = UserFactory()
+    bob = UserFactory()
+    HouseholdMember.objects.create(
+        household=household_a, user=alice, role=HouseholdMember.Role.OWNER
+    )
+    HouseholdMember.objects.create(
+        household=household_b, user=bob, role=HouseholdMember.Role.OWNER
+    )
+    bob.active_household = household_b
+    bob.save(update_fields=["active_household"])
+    return household_a, household_b, alice, bob
+
+
+def _queryset_for(cls, user, household):
+    """Le queryset que ce viewset produirait pour ``user`` dans ``household``.
+
+    On pose ``request.household`` à la main : c'est ce que fait
+    ``ActiveHouseholdMiddleware``, et ce test porte sur les vues, pas sur lui.
+    Le middleware a ses propres tests (``test_active_household_is_revoked``).
+    """
+    raw = APIRequestFactory().get("/api/probe/")
+    force_authenticate(raw, user=user)
+    raw.household = household
+    request = Request(raw)
+    request.user = user
+    request.household = household
+
+    view = cls()
+    view.request = request
+    view.format_kwarg = None
+    view.kwargs = {}
+    view.action = "list"
+    return view.get_queryset()
+
+
+@pytest.mark.django_db
+class TestEveryRegisteredEndpointIsBoundToOneHousehold:
+    """Le contrôle central : aucun endpoint ne peut atteindre un autre foyer."""
+
+    def test_the_router_is_actually_discovered(self):
+        """Garde-fou du garde-fou.
+
+        Si la découverte casse (renommage d'URL, changement de routeur), le
+        test principal passerait en ne vérifiant **rien**. Un contrôle qui ne
+        contrôle plus rien et une absence d'écart se ressemblent trop.
+        """
+        views = _registered_api_views()
+        assert len(views) > 50, (
+            f"Seulement {len(views)} vues découvertes sous /api/ — la découverte "
+            "est probablement cassée, pas le dépôt subitement plus petit."
+        )
+
+    def test_no_endpoint_escapes_its_household(self, two_households):
+        household_a, household_b, _alice, bob = two_households
+
+        escaping = []
+        for cls in _registered_api_views():
+            name = _dotted(cls)
+            if name in EXEMPT_UNSCOPED or name in EXEMPT_USER_SCOPED:
+                continue
+            if not hasattr(cls, "get_queryset") and getattr(cls, "queryset", None) is None:
+                continue
+
+            try:
+                queryset = _queryset_for(cls, bob, household_b)
+                sql, params = queryset.query.sql_with_params()
+            except AssertionError:
+                # DRF lève quand la vue n'a ni queryset ni get_queryset
+                # (endpoints JWT) : hors du périmètre de ce test.
+                continue
+
+            constraints = _constraints_of(sql)
+            values = {str(p) for p in params}
+            bound_by_household = "household" in constraints or str(household_b.id) in values
+            bound_by_user = str(bob.id) in values or "user_id" in constraints
+
+            if not (bound_by_household or bound_by_user):
+                escaping.append(f"{name}  →  {queryset.model._meta.label}")
+
+        assert not escaping, (
+            "Ces endpoints produisent une requête qui n'est bornée ni par foyer "
+            "ni par utilisateur — donc lisible par n'importe qui :\n  "
+            + "\n  ".join(escaping)
+            + "\n\nBorner le queryset, ou ajouter une exemption **justifiée** "
+            "dans EXEMPT_UNSCOPED en haut de ce fichier."
+        )
+
+    def test_household_scoped_models_are_bound_by_household_not_merely_by_user(
+        self, two_households
+    ):
+        """Un modèle de foyer se borne par foyer, jamais seulement par user.
+
+        Borner par ``created_by`` sur une donnée de foyer paraît sûr et ne
+        l'est pas : ça cache aux **autres membres** ce qui leur appartient
+        aussi, et ça cesse de protéger dès qu'une ligne change de créateur.
+        """
+        _household_a, household_b, _alice, bob = two_households
+
+        weakly_bound = []
+        for cls in _registered_api_views():
+            name = _dotted(cls)
+            if name in EXEMPT_UNSCOPED or name in EXEMPT_USER_SCOPED:
+                continue
+
+            model = None
+            queryset_attr = getattr(cls, "queryset", None)
+            if queryset_attr is not None:
+                model = queryset_attr.model
+            else:
+                meta = getattr(getattr(cls, "serializer_class", None), "Meta", None)
+                model = getattr(meta, "model", None)
+            if model is None or not issubclass(model, HouseholdScopedModel):
+                continue
+
+            try:
+                queryset = _queryset_for(cls, bob, household_b)
+                sql, params = queryset.query.sql_with_params()
+            except AssertionError:
+                continue
+
+            if "household" not in _constraints_of(sql) and str(household_b.id) not in {
+                str(p) for p in params
+            }:
+                weakly_bound.append(f"{name}  →  {model._meta.label}")
+
+        assert not weakly_bound, (
+            "Ces endpoints servent un modèle household-scoped sans borner par "
+            "le foyer :\n  " + "\n  ".join(weakly_bound)
+        )
+
+    def test_the_global_endpoints_are_staff_only(self):
+        """Ce qui est dispensé de foyer doit être protégé autrement.
+
+        Une exemption sans contrepartie serait juste un trou avec un
+        commentaire.
+        """
+        from rest_framework.permissions import IsAdminUser
+
+        by_name = {_dotted(cls): cls for cls in _registered_api_views()}
+        for name in EXEMPT_UNSCOPED:
+            cls = by_name.get(name)
+            assert cls is not None, (
+                f"{name} est exempté mais n'existe plus — retirer l'exemption, "
+                "sinon la liste protège un fantôme."
+            )
+            assert IsAdminUser in cls.permission_classes, (
+                f"{name} n'est borné par aucun foyer : il doit rester réservé au "
+                "staff, sinon l'exemption devient une faille."
+            )
+
+
+@pytest.mark.django_db
+class TestLosingMembershipRevokesAccessImmediately:
+    """``request.household`` vient de ``User.active_household``, sans revérifier.
+
+    Le middleware charge le foyer actif par son id **sans** repasser par
+    l'appartenance : la révocation ne tient donc qu'au signal ``post_delete``
+    qui remet ce champ à zéro. C'est un invariant sur un fil, et un fil se coupe
+    — un ``bulk_delete`` brut ou un `_raw_delete` le sectionnerait sans bruit.
+    D'où ce test.
+    """
+
+    def test_removing_a_member_clears_their_active_household(self, two_households):
+        household_a, _household_b, alice, _bob = two_households
+        alice.refresh_from_db()
+        assert str(alice.active_household_id) == str(household_a.id)
+
+        HouseholdMember.objects.get(household=household_a, user=alice).delete()
+
+        alice.refresh_from_db()
+        assert alice.active_household_id is None, (
+            "Un membre retiré garde son foyer actif : le middleware le "
+            "resservirait, donc l'exclu continuerait de tout lire."
+        )
+
+    def test_a_queryset_delete_revokes_too(self, two_households):
+        """La suppression en masse doit révoquer comme la suppression unitaire."""
+        household_a, _household_b, alice, _bob = two_households
+
+        HouseholdMember.objects.filter(household=household_a, user=alice).delete()
+
+        alice.refresh_from_db()
+        assert alice.active_household_id is None
+
+    def test_a_member_of_two_households_falls_back_to_the_other(self, two_households):
+        household_a, household_b, alice, _bob = two_households
+        HouseholdMember.objects.create(
+            household=household_b, user=alice, role=HouseholdMember.Role.MEMBER
+        )
+
+        HouseholdMember.objects.get(household=household_a, user=alice).delete()
+
+        alice.refresh_from_db()
+        assert str(alice.active_household_id) == str(household_b.id)

--- a/apps/core/tests/test_views_media.py
+++ b/apps/core/tests/test_views_media.py
@@ -44,11 +44,21 @@ class TestServeProtectedMedia:
     # ── Avatars : auth suffisante ─────────────────────────────────────────────
 
     @override_settings(DEBUG=False)
-    def test_authenticated_user_can_access_avatar(self, client, member_user):
+    def test_user_can_access_their_own_avatar(self, client, member_user):
+        """Un avatar vit sous ``avatars/<user_pk>/<fichier>``.
+
+        Ce test attendait auparavant qu'un utilisateur authentifié quelconque
+        puisse lire *n'importe quel* avatar, sur un chemin (``avatars/photo.jpg``)
+        qui ne correspondait même pas au format produit par
+        ``User._avatar_upload_path``. La règle est désormais : le sien, et ceux
+        des personnes avec qui on partage un foyer. Voir
+        ``test_media_isolation.py::TestAnAvatarStaysInsideItsHouseholds``.
+        """
         client.force_login(member_user)
-        response = client.get(media_url('avatars/photo.jpg'))
+        path = f'avatars/{member_user.pk}/photo.jpg'
+        response = client.get(media_url(path))
         assert response.status_code == 200
-        assert response.get('X-Accel-Redirect') == '/_protected_media/avatars/photo.jpg'
+        assert response.get('X-Accel-Redirect') == f'/_protected_media/{path}'
 
     # ── Documents : vérification du foyer ────────────────────────────────────
 

--- a/apps/core/views_media.py
+++ b/apps/core/views_media.py
@@ -1,10 +1,23 @@
-"""
-Protected media serving with permission checks.
+"""Service de fichiers protégés, avec contrôle d'accès.
 
-Production: Django authenticates the request, then returns X-Accel-Redirect
-so Nginx serves the file from an internal-only location (/_protected_media/).
+Production : Django authentifie la requête puis renvoie un ``X-Accel-Redirect``
+pour que Nginx serve le fichier depuis un emplacement interne
+(``/_protected_media/``). Développement : Django sert le fichier directement.
 
-Development: Django serves the file directly (standard static serve).
+⚠️ **Cette vue est la seule porte du foyer qui ne passe ni par un viewset ni par
+un queryset** : elle reçoit un chemin et rend des octets. Les cinquante-sept
+viewsets peuvent tous filtrer parfaitement sans que ça protège un seul fichier.
+D'où deux règles structurantes, tenues par
+``apps/core/tests/test_media_isolation.py`` :
+
+1. **Ce qui n'est pas explicitement autorisé est refusé.** Le dispatch ci-dessous
+   ne connaît que des préfixes déclarés ; tout le reste tombe en 403. La version
+   précédente ne contrôlait que ``documents/`` et laissait passer le reste, si
+   bien qu'un préfixe ajouté plus tard (exports, sauvegardes, pièces jointes)
+   aurait été public par défaut — sans une ligne de code pour le trahir.
+2. **Un contrôle porte sur ce qu'on sert, pas sur ce qu'on croit servir.** La
+   vignette d'un document privé est *le* document pour un scan ou une photo ;
+   la faire échapper au contrôle rendait ``is_private`` décoratif.
 """
 from urllib.parse import quote
 
@@ -12,48 +25,118 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, Http404
 
-from households.models import HouseholdMember
 from documents.models import Document
+from documents.thumbnails import source_path_prefix
+from households.models import HouseholdMember
+
+FORBIDDEN = 403
+UNAUTHORIZED = 401
+
+
+def _is_member(user, household_id) -> bool:
+    if not household_id:
+        return False
+    try:
+        return HouseholdMember.objects.filter(
+            household_id=household_id, user=user
+        ).exists()
+    except (ValueError, ValidationError):
+        # Un identifiant qui n'est pas un UUID n'est pas une erreur serveur :
+        # c'est quelqu'un qui essaie un chemin.
+        raise Http404
+
+
+def _check_document(user, path: str) -> int | None:
+    """``None`` si l'accès est permis, sinon le code HTTP à renvoyer."""
+    parts = path.split("/")
+    household_id = parts[1] if len(parts) >= 2 else ""
+    if not household_id:
+        raise Http404
+    if not _is_member(user, household_id):
+        return FORBIDDEN
+
+    # Confidentialité — sur l'original comme sur sa vignette.
+    prefix = source_path_prefix(path)
+    if prefix is not None:
+        document = Document.objects.filter(
+            household_id=household_id, file_path__startswith=prefix
+        ).first()
+    else:
+        document = Document.objects.filter(file_path=path).first()
+
+    if document is None:
+        # Chemin sous `documents/<foyer>/` sans document en base : orphelin de
+        # stockage. L'appartenance au foyer a été vérifiée, on laisse servir —
+        # refuser casserait les fichiers importés hors du modèle.
+        return None
+
+    if document.is_private and document.created_by_id != user.id:
+        return FORBIDDEN
+    return None
+
+
+def _check_avatar(user, path: str) -> int | None:
+    """Un avatar est la photo d'une personne, pas un fichier public.
+
+    Règle retenue — la plus permissive qui reste vraie : on voit l'avatar de
+    quelqu'un avec qui on partage un foyer, et le sien. Auparavant tout
+    utilisateur authentifié voyait tous les avatars, ce qui donnait à un ancien
+    membre un accès permanent.
+    """
+    parts = path.split("/")
+    owner_id = parts[1] if len(parts) >= 2 else ""
+    if not owner_id:
+        raise Http404
+    if str(owner_id) == str(user.pk):
+        return None
+    try:
+        shares_household = HouseholdMember.objects.filter(
+            user_id=owner_id,
+            household_id__in=HouseholdMember.objects.filter(user=user).values(
+                "household_id"
+            ),
+        ).exists()
+    except (ValueError, ValidationError):
+        raise Http404
+    return None if shares_household else FORBIDDEN
+
+
+# Préfixe → contrôleur. Ajouter un emplacement de fichiers, c'est ajouter sa
+# ligne ici : sans elle il est refusé, ce qui est le bon défaut.
+_CHECKS = {
+    "documents": _check_document,
+    "avatars": _check_avatar,
+}
 
 
 def serve_protected_media(request, path):
     if not request.user.is_authenticated:
-        return HttpResponse(status=401)
+        return HttpResponse(status=UNAUTHORIZED)
 
-    # Documents are stored under documents/{household_id}/...
-    # Verify the requesting user is a member of that household.
-    if path.startswith('documents/'):
-        parts = path.split('/')
-        household_id = parts[1] if len(parts) >= 2 else ''
-        if not household_id:
-            raise Http404
-        try:
-            is_member = HouseholdMember.objects.filter(
-                household_id=household_id,
-                user=request.user,
-            ).exists()
-        except (ValueError, ValidationError):
-            raise Http404
-        if not is_member:
-            return HttpResponse(status=403)
+    # Aucune remontée d'arborescence, aucun chemin absolu.
+    if ".." in path.split("/") or path.startswith("/"):
+        raise Http404
 
-        # Second check: respect document-level privacy.
-        try:
-            doc = Document.objects.get(file_path=path)
-            if doc.is_private and doc.created_by != request.user:
-                return HttpResponse(status=403)
-        except Document.DoesNotExist:
-            pass
+    prefix = path.split("/", 1)[0]
+    check = _CHECKS.get(prefix)
+    if check is None:
+        # Default-deny : voir la règle 1 en tête de module.
+        return HttpResponse(status=FORBIDDEN)
+
+    denied = check(request.user, path)
+    if denied is not None:
+        return HttpResponse(status=denied)
 
     if settings.DEBUG:
         from django.views.static import serve as static_serve
+
         return static_serve(request, path, document_root=settings.MEDIA_ROOT)
 
     response = HttpResponse()
-    # The path must be URL-encoded: WSGI serializes headers as latin-1, so a
-    # non-ASCII filename (e.g. "carte-identité.pdf") would be sent as the wrong
-    # bytes and Nginx would 404. quote() keeps "/" as separators and percent-
-    # encodes the rest as UTF-8, which Nginx decodes back to the on-disk name.
-    response['X-Accel-Redirect'] = '/_protected_media/' + quote(path)
-    response['Content-Type'] = ''  # Let Nginx detect from the file extension
+    # Le chemin doit être encodé : WSGI sérialise les en-têtes en latin-1, donc
+    # un nom de fichier non-ASCII (« carte-identité.pdf ») partirait avec les
+    # mauvais octets et Nginx renverrait 404. quote() garde « / » comme
+    # séparateur et encode le reste en UTF-8, que Nginx redécode.
+    response["X-Accel-Redirect"] = "/_protected_media/" + quote(path)
+    response["Content-Type"] = ""  # Nginx déduit le type de l'extension
     return response

--- a/apps/documents/thumbnails.py
+++ b/apps/documents/thumbnails.py
@@ -47,6 +47,29 @@ def thumbnail_storage_path(file_path: str, size: str) -> str:
     return str(p.parent / THUMBNAIL_DIR / size / f"{p.stem}.jpg")
 
 
+def source_path_prefix(thumbnail_path: str) -> str | None:
+    """Inverse de :func:`thumbnail_storage_path` — le préfixe du document source.
+
+    Rend ``"<dossier>/<stem>."`` pour un chemin de vignette, ``None`` sinon.
+    On ne peut pas rendre le chemin exact : l'extension d'origine est perdue
+    dans le nom de la vignette (toujours ``.jpg``). Le préfixe suffit, le
+    ``stem`` contenant déjà un uuid — il identifie donc le document.
+
+    **Pourquoi cette fonction vit ici et pas dans la vue qui l'appelle** :
+    elle doit rester le miroir exact de la fonction juste au-dessus. Les
+    séparer, c'est laisser le contrôle de confidentialité se désaligner en
+    silence du jour où le schéma de nommage change — et un contrôle désaligné
+    ne refuse plus rien.
+    """
+    if not thumbnail_path:
+        return None
+    p = PurePosixPath(thumbnail_path)
+    # <dossier>/.thumbnails/<taille>/<stem>.jpg
+    if p.parent.name not in THUMBNAIL_SIZES or p.parent.parent.name != THUMBNAIL_DIR:
+        return None
+    return f"{p.parent.parent.parent}/{p.stem}."
+
+
 def thumbnail_exists(file_path: str, size: str) -> bool:
     path = thumbnail_storage_path(file_path, size)
     return bool(path) and default_storage.exists(path)

--- a/docs/MODULES/security.md
+++ b/docs/MODULES/security.md
@@ -1,0 +1,181 @@
+# Sécurité — modèle de menace et surfaces
+
+> Écrit au **lot 1 du [parcours 28](../parcours/PARCOURS_28_OUVRIR_MAISONNEE.md)**
+> (issue #487), après instrumentation des 88 classes de vue de l'API.
+> Fiche concept associée : [`AUTO_HEBERGEMENT.md`](../fiches/AUTO_HEBERGEMENT.md).
+
+## Ce qui a changé de nature
+
+Le scoping `household` traverse 33 apps. Tant que le code était privé, il séparait
+des gens qui vivent sous le même toit et se font confiance. Le dépôt étant public
+depuis le 2025-09-21, il sépare désormais des inconnus dont l'un peut être
+hostile — et **un trou de scoping ne se devine plus, il se lit**.
+
+La bascule ne concerne pas que de futurs utilisateurs : l'instance de production
+de l'auteur tourne pendant que ses sources sont lisibles.
+
+## L'état réel, mesuré
+
+Instrumentation des 88 classes de vue montées sous `/api/`, en inspectant le SQL
+réellement produit :
+
+| | |
+|---|---|
+| Contraintes par foyer | **57** |
+| Contraintes par utilisateur seul | 1 — `NotificationViewSet` |
+| Non contraintes | 1 — `ChangelogViewSet` |
+| Sans queryset (`APIView`, JWT) | 26 |
+
+Les 44 viewsets servant un modèle `HouseholdScopedModel` sont **tous** bornés, y
+compris les cinq tables de liaison (`ProjectZone`, `TaskInteraction`,
+`InteractionContact`, `InteractionStructure`, `EquipmentInteraction`) — l'endroit
+où le scoping s'oublie d'ordinaire, ici traversé par `project__household` ou
+`task__household`.
+
+Les deux écarts sont **assumés et testés** :
+
+- `NotificationViewSet` — une notification appartient à une **personne**, pas à un
+  foyer. Borner par foyer serait plus permissif, pas moins.
+- `ChangelogViewSet` — modèle global par conception (infra applicative, cf.
+  `CLAUDE.md` § Changelog), protégé par `IsAdminUser`. Le test vérifie que cette
+  permission est toujours là : une exemption sans contrepartie serait un trou
+  avec un commentaire.
+
+## Comment la propriété est tenue
+
+`apps/core/tests/test_tenant_isolation.py` parcourt le **routeur DRF réel** et
+vérifie, pour chaque endpoint enregistré, que la requête produite est bornée.
+Ajouter un viewset non scopé le fait échouer sans que personne ait à y penser —
+même mécanique que `banking.compliance.REGISTRY` ou que la parité i18n.
+
+Trois choses à savoir avant d'y toucher :
+
+1. **L'inspection porte sur ce qui suit le `FROM`, jamais sur le SQL entier.**
+   La liste de colonnes d'un `SELECT` sur un modèle scoped contient toujours
+   `"table"."household_id"` : chercher « household » n'importe où rendait le test
+   vert sur un `Model.objects.all()` sans le moindre `WHERE`. Le fichier a eu ce
+   défaut et il ne s'est vu qu'en **sabotant volontairement** un viewset. Un
+   contrôle qu'on n'a jamais vu échouer n'est pas un contrôle.
+2. **Un garde-fou vérifie que la découverte trouve encore plus de 50 vues.** Si un
+   renommage d'URL cassait le parcours du routeur, le test passerait en ne
+   vérifiant rien — et un contrôle qui ne contrôle plus ressemble exactement à une
+   absence d'écart.
+3. **Une exemption est une dette nommée.** Elle vit en tête du fichier, avec sa
+   raison et sa contrepartie.
+
+## Les surfaces qui ne passent pas par un queryset
+
+Le test ci-dessus ne peut rien dire de ce qui n'interroge pas la base par un
+viewset. Ces surfaces ont leurs propres contrôles.
+
+### Les fichiers — `apps/core/views_media.py`
+
+**C'est la seule porte du foyer qui ne passe ni par un viewset ni par un
+queryset** : elle reçoit un chemin et rend des octets. Les 57 querysets peuvent
+être parfaits sans que ça protège un seul fichier.
+
+Deux défauts y ont été trouvés et corrigés au lot 1 :
+
+- **Default-allow.** Seul `documents/` était contrôlé ; tout autre préfixe était
+  servi à n'importe quel utilisateur authentifié. Les avatars fuyaient d'un foyer
+  à l'autre, et un préfixe ajouté plus tard (exports, sauvegardes, pièces
+  jointes) aurait été public par défaut, sans une ligne de code pour le trahir.
+  La règle est inversée : **ce qui n'est pas déclaré dans `_CHECKS` est refusé**.
+- **La vignette d'un document privé échappait au contrôle.** La confidentialité
+  cherchait le document par `file_path` exact ; une vignette vit à un autre
+  chemin, donc `DoesNotExist` puis `pass`. Pour un scan ou une photo, **l'aperçu
+  *est* le document** : `is_private` ne protégeait que l'original. La fonction qui
+  remonte de la vignette au document vit **à côté** de celle qui produit le
+  chemin (`documents/thumbnails.py`), pour qu'elles ne puissent pas se désaligner.
+
+Régression : `apps/core/tests/test_media_isolation.py`.
+
+**Ajouter un emplacement de fichiers = ajouter sa ligne dans `_CHECKS`.** Sans
+elle il est refusé, ce qui est le bon défaut.
+
+### La révocation d'accès — un invariant sur un fil
+
+`request.household` vient de `User.active_household`, que
+`ActiveHouseholdMiddleware` charge **par son id, sans revérifier l'appartenance**.
+La révocation ne tient donc qu'au signal `post_delete` qui remet le champ à zéro
+quand une adhésion disparaît.
+
+Ça fonctionne — vérifié — mais c'est un fil, et un fil se coupe : un
+`_raw_delete`, une suppression en SQL brut ou un `bulk_delete` mal branché le
+sectionnerait sans bruit, et un membre exclu continuerait de tout lire. D'où trois
+tests dans `test_tenant_isolation.py::TestLosingMembershipRevokesAccessImmediately`,
+dont un sur la suppression en masse.
+
+**Alternative écartée** : revérifier l'appartenance à chaque requête dans le
+middleware. C'est une requête de plus sur *chaque* appel API pour couvrir un
+événement rare. Le test est moins cher et attrape la même chose — mais si le
+middleware devait changer, c'est la première option à reconsidérer.
+
+### L'agent
+
+Ses tools s'adressent en `entity_type:id`, ce qui contourne les URLs. Le scoping
+est appliqué aux trois points d'entrée : `agent/tools.py::resolve_entity`
+(`filter(household_id=household.id, pk=raw_id)`), la résolution des relations, et
+les listes. Le tool d'écriture `create_entity` passe par les services métier, qui
+portent la même contrainte.
+
+### Les liaisons polymorphes
+
+`interactions.services.resolve_allocation_source` **récupère l'objet et compare
+son `household_id`** plutôt que de faire confiance à l'identifiant reçu. Sans ça
+un client gonflerait le coût d'un chantier qu'il ne peut pas voir. C'est
+documenté dans la fonction elle-même, et c'est le modèle à suivre pour toute
+future FK polymorphe.
+
+## La configuration de production
+
+Elle était déjà solide avant ce lot — le travail a consisté à la **figer**, pas à
+la construire (`apps/core/tests/test_production_settings.py`) :
+
+- `DEBUG = False` est une **constante**, pas une valeur d'environnement : rallumer
+  le mode debug en production demande d'éditer un fichier ;
+- `ALLOWED_HOSTS` n'a **pas de défaut** — sans lui, le démarrage échoue au lieu
+  d'accepter n'importe quel `Host:` ;
+- `CORS_ALLOWED_ORIGINS` **lève à l'import** s'il manque ;
+- cookies `Secure`, HSTS d'un an avec sous-domaines et preload, `nosniff`,
+  referrer policy `same-origin`, redirection HTTPS — avec `/health/` exempté,
+  sinon la sonde du deploy casse ;
+- clickjacking : `XFrameOptionsMiddleware` + `DENY`.
+
+**Ces réglages sont exactement ceux dont l'absence ne se voit jamais à l'usage** :
+l'app fonctionne à l'identique sans HSTS et sans cookie `Secure`. C'est pourquoi
+ils sont testés plutôt que relus.
+
+### Throttling
+
+Déjà en place et vérifié : `login_ip` (20/min) **et** `login_email` (5/min) —
+c'est le second qui borne une attaque par dictionnaire sur un compte, quelle que
+soit l'origine ; plus `change_password`, `password_reset`, `invitation_join`,
+`agent_burst`/`agent_sustained`, `search`.
+
+Le test vérifie aussi que les portées déclarées sont **réellement branchées** sur
+la vue de connexion : une portée définie mais jamais utilisée ne protège rien et
+se lit comme une protection.
+
+## Ce que tout ça ne prouve pas
+
+Le lot ferme les classes de failles **connues** et installe les contrôles qui les
+empêchent de revenir. Il ne démontre pas l'absence de faille — une `@action`
+custom qui ouvre son propre chemin, un cas limite d'OCR, un tool d'agent détourné
+par un prompt : rien de tout ça ne se prouve par un test paramétré.
+
+C'est aussi la partie où l'ouverture aide : **des yeux extérieurs sur ce code
+valent mieux que ceux de son auteur seul.** Le canal de signalement est dans
+[`SECURITY.md`](../../SECURITY.md), et il est privé.
+
+## Le risque qui n'est pas technique
+
+Le job `deploy` s'exécute sur le VPS dès qu'un push atterrit sur `main`. **Donner
+un accès write au dépôt revient donc à donner un shell sur cette machine.** Les
+contributions extérieures passent par fork et pull request — le fonctionnement
+normal d'un projet open source, ici avec une raison concrète. C'est écrit dans
+`CONTRIBUTING.md`.
+
+Si un contributeur régulier devait un jour obtenir les droits, il faut **d'abord**
+sortir le deploy du runner : un VPS qui *tire* (webhook + `git pull`) au lieu d'un
+GitHub qui *pousse* supprime la classe entière de problèmes.

--- a/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
@@ -15,11 +15,12 @@ Issue ombrelle : **#485**
 
 | Lot | Sujet | Statut | Issue |
 |---|---|---|---|
-| 0 | Hygiène du dépôt + durcissement CI (**urgent — dépôt déjà public**) | ⬜ À faire | #486 |
-| 1 | Durcissement multi-tenant + test générique d'isolation (**bloquant**) | ⬜ À faire | #487 |
+| 0 | Hygiène du dépôt + durcissement CI (**urgent — dépôt déjà public**) | ✅ Livré (PR #495) | #486 |
+| 1 | Durcissement multi-tenant + test générique d'isolation (**bloquant**) | 🔄 En revue (PR #497) | #487 |
+| 1bis | Isolation **en écriture** : FK de serializer, actions custom, APIView (**bloquant**) | ⬜ À faire | #498 |
 | 2 | `docker compose up` — première installation en une commande | ⬜ À faire | #488 |
 | 3 | Dégradation propre sans service tiers (IA, SMTP, push, Telegram) | ⬜ À faire | #489 |
-| 4 | LICENSE AGPL-3.0 + gouvernance (CONTRIBUTING, SECURITY, DCO, templates) | ⬜ À faire | #490 |
+| 4 | LICENSE AGPL-3.0 + gouvernance (CONTRIBUTING, SECURITY, DCO, templates) | ✅ Livré (PR #496) | #490 |
 | 5 | Exploitation par un tiers : sauvegarde, restauration testée, mises à jour, releases | ⬜ À faire | #491 |
 | 6 | Façade Maisonnée : README bilingue, captures, GIF, identité | ⬜ À faire | #492 |
 | 7 | Recette pilote (5-10 foyers) puis annonce et mesure de la rétention | ⬜ À faire | #493 |


### PR DESCRIPTION
Closes #487

## Quoi

Le dépôt est public depuis dix mois : **un trou de scoping ne se devine plus, il se lit** — et l'instance de production tourne pendant ce temps. Ce lot ne protège donc pas de futurs utilisateurs, il protège les données réelles du foyer, maintenant.

### L'état mesuré : l'architecture tient

Instrumentation des **88 classes de vue** montées sous `/api/`, en inspectant le SQL réellement produit :

| | |
|---|---|
| Contraintes par foyer | **57** |
| Contraintes par user seul | 1 — `NotificationViewSet` (une notification appartient à une personne) |
| Non contrainte | 1 — `ChangelogViewSet` (global par conception, `IsAdminUser`) |
| Sans queryset (`APIView`, JWT) | 26 |

Les 44 viewsets sur modèle `HouseholdScopedModel` sont **tous** bornés, y compris les cinq tables de liaison — l'endroit où le scoping s'oublie d'ordinaire.

### Le livrable n'est pas cet audit, c'est le test qui le rejoue

`apps/core/tests/test_tenant_isolation.py` parcourt le **routeur DRF réel** et échoue sur tout endpoint non borné. Ajouter un viewset non scopé le fait échouer sans que personne y pense — même mécanique que `banking.compliance.REGISTRY`.

**Deux précautions, apprises en le cassant volontairement :**

- **L'inspection porte sur ce qui suit le `FROM`, jamais sur le SQL entier.** La liste de colonnes d'un modèle scoped contient toujours `"table"."household_id"` : le test passait au vert sur un `Model.objects.all()` sans le moindre `WHERE`. Il a fallu saboter `TagViewSet` pour s'en apercevoir. **Un contrôle qu'on n'a jamais vu échouer n'est pas un contrôle.**
- **Un garde-fou vérifie que la découverte trouve encore >50 vues.** Sans lui, un renommage d'URL ferait passer le test en ne vérifiant *rien* — et un contrôle qui ne contrôle plus ressemble exactement à une absence d'écart.

Les deux exemptions sont **justifiées et testées** : un test vérifie que `ChangelogViewSet` garde bien `IsAdminUser`, sinon l'exemption deviendrait un trou avec un commentaire.

## Deux vrais trous corrigés

Tous deux dans le service de fichiers — **la seule porte du foyer qui ne passe ni par un viewset ni par un queryset**. Les 57 querysets peuvent être parfaits sans protéger un seul fichier.

**1. Default-allow.** Seul `documents/` était contrôlé. Les **avatars** fuyaient d'un foyer à l'autre (un ancien membre gardait l'accès), et tout préfixe ajouté plus tard — exports, sauvegardes, pièces jointes — aurait été public par défaut, sans une ligne de code pour le trahir. Règle inversée : ce qui n'est pas déclaré dans `_CHECKS` est refusé.

**2. La vignette d'un document privé échappait au contrôle.** La confidentialité cherchait le document par `file_path` exact ; une vignette vit à un autre chemin → `DoesNotExist` → `pass` → servie. **Pour un scan ou une photo, l'aperçu *est* le document** : `is_private` ne protégeait que l'original. La fonction qui remonte de la vignette au document vit **à côté** de celle qui produit le chemin, pour qu'elles ne puissent pas se désaligner en silence.

## Une hypothèse vérifiée, et fausse

Le middleware pose `request.household` depuis `user.active_household_id` **sans revérifier l'appartenance**. J'ai cru tenir une faille — retirer un membre lui laisserait l'accès. Vérification faite : un signal `post_delete` remet le champ à zéro, la vue de switch valide l'appartenance. **Pas de trou.**

Mais l'invariant tient sur ce seul signal, sans filet : un `_raw_delete` ou un `bulk_delete` mal branché le sectionnerait sans bruit. D'où trois tests, dont un sur la suppression en masse.

## Configuration de production : rien à durcir

Tout était déjà en place — `DEBUG` en constante (pas une valeur d'environnement), `ALLOWED_HOSTS` sans défaut, `CORS_ALLOWED_ORIGINS` qui lève à l'import, cookies `Secure`, HSTS un an, `nosniff`, clickjacking `DENY`, throttling login **par email** autant que par IP.

Le travail a donc été de **figer**, pas de construire : 14 tests. Ce sont des réglages dont **l'absence ne se voit jamais à l'usage** — l'app marche à l'identique sans HSTS et sans cookie `Secure`. Un test vérifie même que les portées de throttle déclarées sont *réellement branchées* sur la vue de connexion : une portée jamais utilisée ne protège rien et se lit comme une protection.

**Aucune variable d'environnement nouvelle n'est requise : le déploiement existant ne bouge pas.**

## Changement de comportement assumé

`test_authenticated_user_can_access_avatar` assertait qu'un utilisateur quelconque pouvait lire *n'importe quel* avatar — sur un chemin qui ne correspondait même pas au format réel. Nouvelle règle : le sien, et ceux des personnes avec qui on partage un foyer.

## Critères de l'issue

- [x] Le test couvre tous les endpoints du routeur ; chaque exemption est justifiée
- [x] Le test échoue si on ajoute un viewset non scopé — **vérifié par sabotage**
- [x] `/security-review` passé, conclusions arbitrées (aucun finding HIGH/MEDIUM sur le diff)
- [x] Un fichier du foyer A est inaccessible au foyer B, même avec l'URL exacte
- [x] `DEBUG=True` en production est structurellement impossible
- [x] `docs/MODULES/security.md` créé

## Ce que ce lot ne prouve pas

Il ferme les classes de failles **connues** en lecture. Il ne couvre **pas** les écritures : cinq FK de serializer acceptent `Model.objects.all()`, et au moins une est exploitable (`link_document` documente que « household consistency is the caller's concern » — et l'appelant ne s'en occupe pas). Ni les actions custom, ni les 26 `APIView`.

Suite dans l'issue **lot 1bis — isolation en écriture**.

## Vérifications

- `pytest` : **4028 passés**, 2 skippés (3992 avant → +36 tests)
- `npm run lint` : 0 erreur · `npx tsc -b` : propre