### PR TITLE
feat(general): plancher d'isolation en écriture sur les FK de serializer (lot 1bis, #498)

### DIFF
--- a/apps/core/serializers.py
+++ b/apps/core/serializers.py
@@ -1,1 +1,78 @@
+"""Champs de serializer partagés — le plancher d'isolation en écriture.
 
+Une lecture mal bornée se voit : la liste montre ce qu'elle ne devrait pas.
+Une **écriture** mal bornée ne se voit pas : elle réussit, l'utilisateur lit
+« enregistré », et l'objet d'un autre foyer entre dans le graphe sans un mot.
+L'entrée a donc besoin de son propre garde-fou — ``test_tenant_isolation`` ne
+parcourt que les lectures.
+
+Le défaut que ce module supprime n'était pas une faille : les cinq champs
+concernés étaient tous rattrapés en aval. C'était **trois mécanismes différents
+pour la même garantie** — un ``validate()`` de serializer, un
+``validate_<champ>``, un ``perform_create`` de vue. Chacun juste, aucun garanti.
+Une sixième FK écrite demain n'aurait rien eu par défaut, et rien ne l'aurait
+signalé : le diff d'un champ protégé et celui d'un champ nu sont identiques.
+"""
+from rest_framework import serializers
+
+
+class HouseholdScopedPrimaryKeyRelatedField(serializers.PrimaryKeyRelatedField):
+    """Une FK qui n'accepte que des objets d'un foyer accessible.
+
+    Remplace ``PrimaryKeyRelatedField(queryset=Model.objects.all())``, qui
+    accepte n'importe quel identifiant de n'importe quel foyer et s'en remet à
+    une validation écrite ailleurs.
+
+    ::
+
+        from core.serializers import HouseholdScopedPrimaryKeyRelatedField as ScopedFK
+
+        document = ScopedFK(model=Document)
+
+    **C'est un plancher, pas un plafond.** Il garantit « l'objet est dans un
+    foyer accessible » ; il ne dit rien de « les deux objets sont dans le *même*
+    foyer », ni de « seul le créateur peut attacher ». Les validations existantes
+    qui vérifient ça restent nécessaires — poser ce champ ne les remplace pas.
+
+    Résolution du foyer, dans l'ordre :
+
+    1. ``context['household_id']`` — les services métier construisent leurs
+       serializers sans requête HTTP (ex. ``trackers.services.add_entry``) ;
+    2. ``request.household`` — posé par ``ActiveHouseholdMiddleware`` ;
+    3. à défaut, **tous les foyers de l'utilisateur** — un client qui n'a pas
+       encore de foyer actif ;
+    4. sinon, **rien**.
+
+    Le point 4 est le comportement important : sans contexte exploitable, le
+    champ n'accepte aucun identifiant. Un champ qui laisse passer quand il ne
+    sait pas protège exactement tant que personne ne l'attaque.
+    """
+
+    def __init__(self, *, model, **kwargs):
+        self.model = model
+        # DRF exige un queryset dès la construction ; le vrai périmètre est
+        # calculé par `get_queryset()`, qui a accès au contexte.
+        kwargs.setdefault("queryset", model._default_manager.none())
+        super().__init__(**kwargs)
+
+    def get_queryset(self):
+        base = self.model._default_manager.all()
+
+        household_id = self.context.get("household_id")
+        if household_id:
+            return base.filter(household_id=household_id)
+
+        request = self.context.get("request")
+        household = getattr(request, "household", None)
+        if household is not None:
+            return base.filter(household_id=household.id)
+
+        user = getattr(request, "user", None)
+        if user is not None and user.is_authenticated:
+            return base.filter(
+                household_id__in=user.householdmember_set.values_list(
+                    "household_id", flat=True
+                )
+            )
+
+        return base.none()

--- a/apps/core/tests/test_write_isolation.py
+++ b/apps/core/tests/test_write_isolation.py
@@ -1,0 +1,263 @@
+"""Isolation en écriture — aucune FK de serializer n'accepte un objet étranger.
+
+Pendant de ``test_tenant_isolation.py``, qui ne parcourt que les **lectures**.
+
+La différence de nature entre les deux compte : une lecture mal bornée se voit
+— la liste montre ce qu'elle ne devrait pas. Une écriture mal bornée **ne se
+voit pas** : elle réussit, l'utilisateur lit « enregistré », et l'objet d'un
+autre foyer entre dans le graphe sans un mot.
+
+Ce que ce fichier ne prétend pas être
+-------------------------------------
+
+Il ne ferme pas une faille. Au moment où il a été écrit, les cinq champs
+relationnels non bornés du dépôt étaient **tous** rattrapés en aval — mais par
+trois mécanismes différents, écrits indépendamment (un ``validate()``, un
+``validate_<champ>``, un ``perform_create``). Chacun juste, aucun garanti.
+
+Le test remplace « ça marche parce que quelqu'un y a pensé à chaque fois » par
+« ça ne peut pas ne pas marcher ». C'est la même bascule que
+``banking.compliance.REGISTRY`` pour l'argent, et que ``keys.test.ts`` pour l'i18n.
+"""
+import pytest
+from django.apps import apps as django_apps
+from rest_framework import serializers
+
+from accounts.tests.factories import UserFactory
+from core.models import HouseholdScopedModel
+from core.serializers import HouseholdScopedPrimaryKeyRelatedField
+from households.models import Household, HouseholdMember
+
+# ── Exemptions ───────────────────────────────────────────────────────────────
+#
+# Même règle qu'en lecture : une exemption est une dette nommée, avec sa raison
+# et ce qui protège à la place.
+
+EXEMPT_FIELDS: set[tuple[str, str]] = {
+    # (nom du serializer, nom du champ)
+}
+
+
+def _all_serializer_classes():
+    """Tous les serializers déclarés dans les apps du projet.
+
+    On importe les modules `serializers` de chaque app installée plutôt que de
+    parcourir les vues : un serializer utilisé par un service métier (donc sans
+    passer par une URL) doit être couvert aussi — c'est justement le cas de
+    ``TrackerEntrySerializer``, instancié par ``trackers.services.add_entry``.
+    """
+    import importlib
+    import inspect
+
+    found = {}
+    for config in django_apps.get_app_configs():
+        module_name = f"{config.name}.serializers"
+        try:
+            module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            continue
+        for name, obj in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(obj, serializers.BaseSerializer):
+                continue
+            if obj.__module__ != module_name:
+                continue  # importé d'ailleurs, il sera vu chez lui
+            found[f"{module_name}.{name}"] = obj
+    return found
+
+
+def _relational_fields(serializer_class):
+    """Les champs relationnels *déclarés* et leur queryset, sans instancier.
+
+    On lit ``_declared_fields`` : instancier un ``ModelSerializer`` construit
+    ses champs implicites, qui sont générés par DRF depuis le modèle et portent
+    déjà la contrainte de la FK. Ce sont les champs **écrits à la main** qui
+    posent un queryset explicite, et donc qui peuvent l'élargir.
+    """
+    # `_declared_fields` est posé par `SerializerMetaclass` : une classe qui
+    # hérite directement de `BaseSerializer` ne l'a pas, et n'a pas de champ
+    # déclaratif à vérifier.
+    for name, field in getattr(serializer_class, "_declared_fields", {}).items():
+        if isinstance(field, serializers.ManyRelatedField):
+            field = field.child_relation
+        if not isinstance(field, serializers.RelatedField):
+            continue
+        if field.read_only:
+            continue
+        yield name, field
+
+
+@pytest.fixture
+def two_households(db):
+    household_a = Household.objects.create(name="Foyer A")
+    household_b = Household.objects.create(name="Foyer B")
+    alice = UserFactory()
+    bob = UserFactory()
+    HouseholdMember.objects.create(
+        household=household_a, user=alice, role=HouseholdMember.Role.OWNER
+    )
+    HouseholdMember.objects.create(
+        household=household_b, user=bob, role=HouseholdMember.Role.OWNER
+    )
+    return household_a, household_b, alice, bob
+
+
+class TestNoWritableForeignKeyAcceptsAForeignObject:
+    """Le contrôle central : aucune FK écrite à la main n'est ouverte."""
+
+    def test_the_serializers_are_actually_discovered(self):
+        """Garde-fou du garde-fou — même raison qu'en lecture.
+
+        Si la découverte casse, le test principal passe en ne vérifiant rien,
+        et un contrôle muet ressemble exactement à une absence d'écart.
+        """
+        found = _all_serializer_classes()
+        assert len(found) > 40, (
+            f"Seulement {len(found)} serializers découverts — la découverte est "
+            "probablement cassée, pas le dépôt subitement plus petit."
+        )
+
+    def test_every_writable_relation_to_a_household_model_is_scoped(self):
+        unscoped = []
+        for label, serializer_class in _all_serializer_classes().items():
+            for name, field in _relational_fields(serializer_class):
+                if (serializer_class.__name__, name) in EXEMPT_FIELDS:
+                    continue
+
+                queryset = getattr(field, "queryset", None)
+                if queryset is None:
+                    continue
+                model = queryset.model
+                if not issubclass(model, HouseholdScopedModel):
+                    continue
+
+                if not isinstance(field, HouseholdScopedPrimaryKeyRelatedField):
+                    unscoped.append(f"{label}.{name}  →  {model._meta.label}")
+
+        assert not unscoped, (
+            "Ces champs de serializer acceptent l'identifiant de n'importe quel "
+            "foyer :\n  "
+            + "\n  ".join(unscoped)
+            + "\n\nUtiliser `core.serializers.HouseholdScopedPrimaryKeyRelatedField"
+            "(model=…)`, ou ajouter une exemption **justifiée** dans EXEMPT_FIELDS."
+        )
+
+
+@pytest.mark.django_db
+class TestTheScopedFieldRefusesWhatItCannotSee:
+    """Le comportement du champ lui-même, dans les quatre cas de contexte."""
+
+    def _field(self, context):
+        from tasks.models import Task
+
+        field = HouseholdScopedPrimaryKeyRelatedField(model=Task)
+        field._context = context
+        return field
+
+    def _task(self, household, user):
+        from tasks.models import Task
+
+        return Task.objects.create(
+            household=household, subject="Tondre la pelouse", created_by=user
+        )
+
+    def test_an_explicit_household_id_wins(self, two_households):
+        household_a, household_b, alice, _bob = two_households
+        task_a = self._task(household_a, alice)
+
+        assert self._field({"household_id": household_a.id}).get_queryset().filter(
+            pk=task_a.pk
+        ).exists()
+        assert not self._field({"household_id": household_b.id}).get_queryset().filter(
+            pk=task_a.pk
+        ).exists()
+
+    def test_the_request_household_is_used_when_there_is_no_explicit_id(
+        self, two_households
+    ):
+        household_a, household_b, alice, _bob = two_households
+        task_a = self._task(household_a, alice)
+
+        class FakeRequest:
+            household = household_b
+            user = alice
+
+        assert not self._field({"request": FakeRequest()}).get_queryset().filter(
+            pk=task_a.pk
+        ).exists()
+
+    def test_without_an_active_household_it_falls_back_to_the_users_own(
+        self, two_households
+    ):
+        household_a, _household_b, alice, bob = two_households
+        task_a = self._task(household_a, alice)
+
+        class AliceRequest:
+            household = None
+            user = alice
+
+        class BobRequest:
+            household = None
+            user = bob
+
+        assert self._field({"request": AliceRequest()}).get_queryset().filter(
+            pk=task_a.pk
+        ).exists()
+        assert not self._field({"request": BobRequest()}).get_queryset().filter(
+            pk=task_a.pk
+        ).exists()
+
+    def test_without_any_usable_context_it_accepts_nothing(self, two_households):
+        """Le cas qui compte : sans contexte, on refuse tout.
+
+        Un champ qui laisse passer quand il ne sait pas protège exactement tant
+        que personne ne l'attaque. Fermer par défaut rend le défaut bruyant —
+        un appelant qui oublie le contexte voit ses écritures refusées tout de
+        suite, au lieu de les voir réussir trop largement pendant des mois.
+        """
+        household_a, _household_b, alice, _bob = two_households
+        self._task(household_a, alice)
+
+        assert not self._field({}).get_queryset().exists()
+
+
+@pytest.mark.django_db
+class TestAForeignObjectIsRefusedEndToEnd:
+    """La garantie vue de l'API, pas seulement du champ."""
+
+    def test_attaching_another_households_document_to_my_task_fails(
+        self, client, two_households
+    ):
+        from django.core.files.base import ContentFile
+        from django.core.files.storage import default_storage
+
+        from documents.models import Document
+        from tasks.models import Task
+
+        household_a, household_b, alice, bob = two_households
+
+        # Le document d'Alice, dans le foyer A.
+        file_path = Document.build_upload_path(
+            household_id=household_a.id, filename="rib.pdf"
+        )
+        default_storage.save(file_path, ContentFile(b"%PDF-1.4"))
+        foreign_document = Document.objects.create(
+            household=household_a, created_by=alice, name="RIB", file_path=file_path
+        )
+
+        # La tâche de Bob, dans le foyer B.
+        own_task = Task.objects.create(
+            household=household_b, subject="Ranger le garage", created_by=bob
+        )
+
+        client.force_login(bob)
+        response = client.post(
+            "/api/tasks/task-documents/",
+            data={"task": str(own_task.id), "document": foreign_document.id},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 400, (
+            "Rattacher le document d'un autre foyer doit être refusé à la "
+            f"validation, pas accepté (reçu {response.status_code})."
+        )
+        assert "document" in response.json()

--- a/apps/interactions/serializers.py
+++ b/apps/interactions/serializers.py
@@ -6,6 +6,9 @@ from decimal import Decimal
 from django.db import transaction
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
+from core.serializers import (
+    HouseholdScopedPrimaryKeyRelatedField as ScopedFK,
+)
 from documents.models import Document
 from documents.services import link_document
 from tags.models import Tag, TagLink
@@ -591,8 +594,11 @@ class InteractionStructureSerializer(serializers.ModelSerializer):
 class InteractionDocumentSerializer(serializers.Serializer):
     """Interaction↔Document link, backed by DocumentLink (shape preserved)."""
 
-    interaction = serializers.PrimaryKeyRelatedField(queryset=Interaction.objects.all())
-    document = serializers.PrimaryKeyRelatedField(queryset=Document.objects.all())
+    # Plancher : la FK n'accepte qu'un objet d'un foyer accessible. Le
+    # `validate()` ci-dessous vérifie en plus que les deux sont dans le
+    # *même* foyer, ce que le bornage ne dit pas — les deux sont nécessaires.
+    interaction = ScopedFK(model=Interaction)
+    document = ScopedFK(model=Document)
     role = serializers.CharField(required=False, allow_blank=True, default='attachment')
     note = serializers.CharField(required=False, allow_blank=True, default='')
     created_at = serializers.DateTimeField(read_only=True)

--- a/apps/shopping/serializers.py
+++ b/apps/shopping/serializers.py
@@ -1,6 +1,9 @@
 """Shopping list serializers."""
 from django.utils import timezone
 from rest_framework import serializers
+from core.serializers import (
+    HouseholdScopedPrimaryKeyRelatedField as ScopedFK,
+)
 
 from stock.models import StockItem
 
@@ -38,9 +41,12 @@ class ShoppingListItemSerializer(serializers.ModelSerializer):
     """
 
     checked = serializers.BooleanField(required=False)
-    stock_item = serializers.PrimaryKeyRelatedField(
-        queryset=StockItem.objects.all(), required=False, allow_null=True
-    )
+    # Seul champ des six recensés au lot 1bis qui n'avait **aucun** filet :
+    # ni `validate_*`, ni contrôle dans la vue, ni dans `create_list_item`.
+    # Rattacher l'article de stock d'un autre foyer réussissait, et la réponse
+    # en divulguait le nom via `get_stock_item_name`. Non exploitable en
+    # pratique (il faut l'UUID), mais sans rien pour l'arrêter.
+    stock_item = ScopedFK(model=StockItem, required=False, allow_null=True)
     stock_item_name = serializers.SerializerMethodField()
     stock_item_status = serializers.SerializerMethodField()
     stock_item_emoji = serializers.SerializerMethodField()

--- a/apps/tasks/serializers.py
+++ b/apps/tasks/serializers.py
@@ -3,6 +3,9 @@ Task serializers — CRUD API.
 """
 from django.db import transaction
 from rest_framework import serializers
+from core.serializers import (
+    HouseholdScopedPrimaryKeyRelatedField as ScopedFK,
+)
 from households.models import HouseholdMember
 from documents.models import Document
 from documents.services import link_document
@@ -53,8 +56,11 @@ class TaskDocumentLinkSerializer(serializers.Serializer):
     """
 
     id = serializers.IntegerField(read_only=True)
-    task = serializers.PrimaryKeyRelatedField(queryset=Task.objects.all())
-    document = serializers.PrimaryKeyRelatedField(queryset=Document.objects.all())
+    # Plancher : la FK n'accepte qu'un objet d'un foyer accessible.
+    # `TaskDocumentViewSet.perform_create` vérifie en plus le même foyer et
+    # le fait que seul le créateur de la tâche peut attacher.
+    task = ScopedFK(model=Task)
+    document = ScopedFK(model=Document)
     note = serializers.CharField(required=False, allow_blank=True, default='')
     created_at = serializers.DateTimeField(read_only=True)
     created_by = serializers.PrimaryKeyRelatedField(read_only=True)

--- a/apps/trackers/serializers.py
+++ b/apps/trackers/serializers.py
@@ -3,6 +3,9 @@ Tracker serializers — CRUD API.
 """
 from django.utils import timezone
 from rest_framework import serializers
+from core.serializers import (
+    HouseholdScopedPrimaryKeyRelatedField as ScopedFK,
+)
 
 from .models import Tracker, TrackerEntry
 
@@ -10,7 +13,9 @@ from .models import Tracker, TrackerEntry
 class TrackerEntrySerializer(serializers.ModelSerializer):
     """Read/write serializer for tracker entries."""
 
-    tracker = serializers.PrimaryKeyRelatedField(queryset=Tracker.objects.all())
+    # Plancher : `validate_tracker` ci-dessous reste, il couvre le cas où le
+    # contexte porte un `household_id` explicite (services métier).
+    tracker = ScopedFK(model=Tracker)
     # Optional on input — validate() defaults it to now (quick-add from the card).
     occurred_at = serializers.DateTimeField(required=False)
 

--- a/docs/MODULES/security.md
+++ b/docs/MODULES/security.md
@@ -63,6 +63,64 @@ Trois choses à savoir avant d'y toucher :
 3. **Une exemption est une dette nommée.** Elle vit en tête du fichier, avec sa
    raison et sa contrepartie.
 
+## L'écriture — un plancher partagé, pas six vigilances
+
+> Ajouté au **lot 1bis** (issue #498).
+
+Le test ci-dessus ne parcourt que les **lectures**. La différence de nature
+compte : une lecture mal bornée se voit — la liste montre ce qu'elle ne devrait
+pas. Une **écriture** mal bornée ne se voit pas : elle réussit, l'utilisateur lit
+« enregistré », et l'objet d'un autre foyer entre dans le graphe sans un mot.
+
+Six champs relationnels de serializer acceptaient `Model.objects.all()`, donc
+n'importe quel identifiant. **Cinq étaient rattrapés en aval** — mais par trois
+mécanismes différents, écrits indépendamment :
+
+| Site | Ce qui protégeait |
+|---|---|
+| `InteractionDocumentSerializer` (×2) | `validate()` : les deux objets dans les foyers de l'user, même foyer, foyer sélectionné cohérent |
+| `TaskDocumentLinkSerializer` (×2) | `TaskDocumentViewSet.perform_create` : tâche accessible, **créateur seul**, document du même foyer |
+| `TrackerEntrySerializer` | `validate_tracker` + `services.add_entry` qui repasse toujours `household_id` |
+
+**Le sixième n'avait rien.** `ShoppingListItemSerializer.stock_item` : ni
+`validate_*`, ni contrôle dans la vue, ni dans `create_list_item`. Rattacher
+l'article de stock d'un autre foyer à sa liste réussissait, et la réponse en
+divulguait le **nom**, le statut et l'emoji via `get_stock_item_name`. Non
+exploitable en pratique — il faut connaître l'UUID — mais rien ne l'arrêtait.
+
+Il est révélateur de la manière dont il a été trouvé : **pas par relecture, pas
+par `grep`** (il était écrit sur trois lignes, le motif de recherche l'a raté),
+mais par le test générique, à sa première exécution.
+
+### Le champ partagé
+
+`core.serializers.HouseholdScopedPrimaryKeyRelatedField(model=…)` borne son
+queryset au foyer résolu — contexte explicite, puis `request.household`, puis
+les foyers de l'utilisateur, puis **rien**.
+
+Ce dernier point est le comportement important : **sans contexte exploitable, le
+champ n'accepte aucun identifiant.** Un champ qui laisse passer quand il ne sait
+pas protège exactement tant que personne ne l'attaque ; fermer par défaut rend le
+défaut bruyant, tout de suite, chez celui qui l'introduit.
+
+**C'est un plancher, pas un plafond.** Il garantit « l'objet est dans un foyer
+accessible » ; il ne dit rien de « les deux objets sont dans le *même* foyer » ni
+de « seul le créateur peut attacher ». Les validations existantes vérifient ces
+choses en plus et **n'ont pas été retirées** en posant le champ.
+
+Régression : `apps/core/tests/test_write_isolation.py`, vérifié par sabotage.
+
+### Ce qui reste ouvert en écriture
+
+- **Les actions custom.** `test_tenant_isolation` n'exerce que `list`. Le risque
+  n'est pas `get_object()`, qui passe par `get_queryset()` et est donc déjà
+  couvert : c'est une `@action` qui fait sa **propre** requête ORM. Ça ne se
+  détecte pas au SQL, seulement à la lecture.
+- **Les 26 `APIView`.** Sans queryset, donc invisibles pour les deux tests
+  génériques. À examiner une par une.
+
+Les deux restent dans l'issue #498.
+
 ## Les surfaces qui ne passent pas par un queryset
 
 Le test ci-dessus ne peut rien dire de ce qui n'interroge pas la base par un


### PR DESCRIPTION
Closes #498

## Correction préalable

**L'issue #498 annonçait une faille exploitable. C'était faux, et je l'ai corrigée avant de commencer.**

J'avais conclu d'un commentaire — `documents/services.py::link_document` : *« Household consistency is the caller's concern »* — que l'appelant ne vérifiait rien. Sans lire `TaskDocumentViewSet.perform_create`, qui fait exactement ce contrôle **et deux autres** (tâche accessible, créateur seul).

*Un commentaire qui délègue n'est pas la preuve que le délégataire s'en moque.*

## Le vrai problème

Six champs relationnels acceptaient `Model.objects.all()`. **Cinq étaient rattrapés** — par trois mécanismes différents, écrits indépendamment :

| Site | Ce qui protégeait |
|---|---|
| `InteractionDocumentSerializer` ×2 | `validate()` : objets accessibles, même foyer, foyer sélectionné cohérent |
| `TaskDocumentLinkSerializer` ×2 | `perform_create` : tâche accessible, **créateur seul**, document du même foyer |
| `TrackerEntrySerializer` | `validate_tracker` + `add_entry` qui repasse toujours `household_id` |

Chacun juste, **aucun garanti**. Une septième FK n'aurait rien eu par défaut — et le diff d'un champ protégé ressemble exactement à celui d'un champ nu.

## Le sixième n'avait aucun filet

`ShoppingListItemSerializer.stock_item` : ni `validate_*`, ni contrôle dans la vue, ni dans `create_list_item`. **Rattacher l'article de stock d'un autre foyer à sa liste réussissait**, et la réponse en divulguait le nom, le statut et l'emoji via `get_stock_item_name`.

Il faut connaître l'UUID, donc ce n'est **pas exploitable en pratique**. Mais rien ne l'arrêtait.

**Comment il a été trouvé compte autant que le défaut** : pas par relecture, et pas par `grep` — mon motif l'avait raté parce qu'il est écrit sur trois lignes. Par le test générique, à sa première exécution.

## Ce que la PR livre

`core.serializers.HouseholdScopedPrimaryKeyRelatedField(model=…)` borne son queryset au foyer résolu : contexte explicite → `request.household` → foyers de l'utilisateur → **rien**.

Ce dernier point est le comportement important : **sans contexte exploitable, le champ n'accepte aucun identifiant.** Un champ qui laisse passer quand il ne sait pas protège exactement tant que personne ne l'attaque ; fermer par défaut rend le défaut bruyant chez celui qui l'introduit, tout de suite.

**C'est un plancher, pas un plafond** — il ne dit rien de « les deux objets dans le *même* foyer » ni de « seul le créateur peut attacher ». Les validations existantes sont **conservées**.

Et le test générique interdit la septième : il énumère les serializers de toutes les apps (pas seulement ceux montés sur une URL — `TrackerEntrySerializer` n'est instancié que par un service) et échoue sur tout champ relationnel non borné vers un modèle household-scoped.

## Vérifié par sabotage

Comme au lot 1. J'ai remis le champ `stock_item` en `objects.all()` : le test échoue et le nomme. Restauré, il repasse.

C'est devenu la règle du parcours après que la première version du test d'isolation en **lecture** s'est révélée vide — elle passait au vert sur un `Model.objects.all()` sans le moindre `WHERE`.

## Ce qui reste ouvert, et pourquoi je ne l'ai pas fait

- **Les actions custom.** Le risque n'est pas `get_object()` — il passe par `get_queryset()`, donc déjà couvert par le lot 1. C'est une `@action` qui fait sa **propre** requête ORM, ce qui ne se détecte pas au SQL, seulement à la lecture.
- **Les 26 `APIView`.** Sans queryset, invisibles pour les deux tests génériques.

Les deux restent dans #498, qui n'est donc **pas fermée par cette PR** — je la rouvrirai avec le périmètre réduit après merge.

## Critères de l'issue

- [x] Un test énumère les champs relationnels et échoue sur tout queryset non borné
- [x] **Vérifié par sabotage**
- [x] Les six FK sont bornées, sans retirer les validations existantes
- [x] `docs/MODULES/security.md` à jour
- [ ] Actions custom — reste ouvert
- [ ] 26 `APIView` — reste ouvert

## Vérifications

- `pytest` : **4035 passés**, 2 skippés (4028 avant → +7)
- `npm run lint` : 0 erreur · `npx tsc -b` : propre