### PR TITLE
feat(general): installer Maisonnée en une commande (lot 2, #488)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -33,6 +33,12 @@ htmlcov/
 .git/
 .github/
 
+# Sessions et worktrees de l'assistant. `.claude/worktrees/` contient des COPIES
+# COMPLÈTES du dépôt : sans cette ligne, le contexte de build enfle d'un dépôt
+# entier par branche en cours, et l'image publiée emporterait des branches non
+# fusionnées de l'auteur chez tous ceux qui l'installent.
+.claude/
+
 # Tests E2E
 playwright-report/
 test-results/

--- a/.env.example
+++ b/.env.example
@@ -1,47 +1,74 @@
-# Django
-SECRET_KEY=your-secret-key-here-generate-with-get_random_secret_key
+# ─────────────────────────────────────────────────────────────────────────────
+# Développement local (venv + `python manage.py runserver`).
+#
+# Pour AUTO-HÉBERGER Maisonnée, ce fichier n'est pas le bon point de départ :
+# `docker compose up` ne demande rien du tout. Voir l'en-tête de
+# `docker-compose.yml` pour les quelques variables facultatives.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Le minimum vital ─────────────────────────────────────────────────────────
+
+SECRET_KEY=dev-only-change-me
 DEBUG=True
 ALLOWED_HOSTS=127.0.0.1,localhost
 CSRF_TRUSTED_ORIGINS=http://127.0.0.1:8000,http://localhost:8000
-
-# Database
 DATABASE_URL=postgres://username:password@localhost:5432/house
 
+# En développement, les e-mails partent dans la console plutôt que nulle part.
+EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
+DEFAULT_FROM_EMAIL=noreply@house.local
+
+# URL de la SPA — sert à fabriquer les liens des e-mails transactionnels.
+FRONTEND_URL=http://localhost:5174
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# OPTIONNEL — tout ce qui suit peut rester vide.
+#
+# Chaque bloc absent désactive une capacité, jamais l'application entière.
+# Rendre cette dégradation visible à l'écran est l'objet du lot 3 du parcours 28.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# ── Transport HTTPS (production uniquement) ──────────────────────────────────
 SECURE_HSTS_SECONDS=0
 SECURE_HSTS_INCLUDE_SUBDOMAINS=False
 SECURE_HSTS_PRELOAD=False
 USE_X_FORWARDED_PROTO=False
 
-# Email
-EMAIL_BACKEND=django.core.mail.backends.console.EmailBackend
-DEFAULT_FROM_EMAIL=noreply@house.local
-
-# SMTP (production) — laissé vide en dev car le backend console ne les utilise pas.
+# ── SMTP — invitations et réinitialisations de mot de passe ──────────────────
+# Vide = les e-mails restent dans la console.
 # Exemple Brevo :
 #   EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
 #   EMAIL_HOST=smtp-relay.brevo.com
-#   EMAIL_PORT=587
-#   EMAIL_HOST_USER=<your-brevo-login>
-#   EMAIL_HOST_PASSWORD=<your-brevo-master-password>
-#   EMAIL_USE_TLS=True
+#   EMAIL_HOST_USER=<login>
+#   EMAIL_HOST_PASSWORD=<master password>
 EMAIL_HOST=
 EMAIL_PORT=587
 EMAIL_HOST_USER=
 EMAIL_HOST_PASSWORD=
 EMAIL_USE_TLS=True
 
-# Frontend SPA URL — used to build links in transactional emails
-FRONTEND_URL=http://localhost:5174
+# ── Assistant, lecture des documents, résumés — clé Anthropic ───────────────
+# Vide = ces trois capacités sont indisponibles. Le reste fonctionne entièrement.
+ANTHROPIC_API_KEY=
 
-# Telegram bot channel (optional — leave empty to disable)
-# Token + @username from @BotFather; secret = any random string, passed to
-# `manage.py telegram_set_webhook` and checked on every webhook call.
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_BOT_USERNAME=
-TELEGRAM_WEBHOOK_SECRET=
+# ── Recherche sémantique — clé d'embeddings ─────────────────────────────────
+# Vide = la recherche reste lexicale (mots-clés), ce qui couvre déjà l'essentiel.
+# `EMBEDDING_PROVIDER=ollama` permet de tout faire tourner en local.
+VOYAGE_API_KEY=
+EMBEDDING_INDEXING_ENABLED=False
+AGENT_HYBRID_RETRIEVAL_ENABLED=False
 
-# Web Push (VAPID) — notifications push sur la PWA (optional — vide = désactivé)
+# ── Notifications push sur la PWA (VAPID) ───────────────────────────────────
 # Générer une paire : `python manage.py generate_vapid_keys`
+# Vide = les notifications restent dans l'application.
 VAPID_PUBLIC_KEY=
 VAPID_PRIVATE_KEY=
 VAPID_ADMIN_EMAIL=
+
+# ── Canal Telegram (bot conversationnel) ────────────────────────────────────
+# Token + @username fournis par @BotFather ; le secret est une chaîne aléatoire
+# au choix, passée à `manage.py telegram_set_webhook` et vérifiée à chaque appel.
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_BOT_USERNAME=
+TELEGRAM_WEBHOOK_SECRET=

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+# Publication de l'image que les autres installent.
+#
+# Le déploiement de l'auteur ne passe PAS par ici : il construit l'image sur son
+# VPS depuis `docker-compose.prod.yml` (job `deploy` de `ci.yml`), et rien dans
+# ce fichier ne le touche. Ce workflow n'existe que pour le `docker compose up`
+# d'un inconnu, qui doit tirer une image déjà construite — personne ne va
+# compiler un bundle React sur un Raspberry Pi pour essayer un produit.
+#
+# Déclenché par un tag `v*`, jamais par un push sur `main` : une image que
+# quelqu'un installe est une **release**, c'est-à-dire une chose datée qu'on peut
+# nommer, à laquelle on peut revenir, et dont on peut dire ce qu'elle contient.
+# Republier `latest` à chaque commit rendrait « j'ai la dernière version » une
+# phrase sans contenu, et un `docker compose pull` un pari.
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Pour republier une image sans re-tagger (échec de registre, par exemple).
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag git à publier (ex. v0.1.0)"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  image:
+    name: Publier l'image multi-architecture
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Le seul droit d'écriture du job, et il ne porte que sur le registre.
+      packages: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      # arm64 sans machine arm64 : le Raspberry Pi et le NAS sont la moitié du
+      # public de l'auto-hébergement, et une image amd64 seule leur répond
+      # « exec format error » — un message qui n'apprend rien à personne.
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/maisonnee
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+
+      - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Une image qu'on n'a pas démarrée n'est pas une image publiée, c'est un
+      # espoir publié. Le test est minuscule et il attrape ce qui casse vraiment
+      # : une dépendance native absente de l'architecture, un `collectstatic`
+      # raté au build, un module qui ne s'importe pas.
+      - name: L'image démarre et se connaît
+        run: |
+          docker run --rm \
+            -e DJANGO_SETTINGS_MODULE=config.settings.selfhost \
+            -e MAISONNEE_STATE_DIR=/tmp/state \
+            -e DATABASE_URL=postgres://u:p@127.0.0.1:5432/none \
+            ghcr.io/${{ github.repository_owner }}/maisonnee:${{ steps.meta.outputs.version }} \
+            python manage.py check --deploy --fail-level ERROR

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # ─── Stage 1: Build React frontend ───────────────────────────────────────────
-FROM node:22-alpine AS frontend
+#
+# `--platform=$BUILDPLATFORM` : cette étape tourne sur l'architecture de la
+# MACHINE DE BUILD, jamais sur celle de l'image cible. Ce qu'elle produit — du
+# JavaScript et du CSS — est identique sur amd64 et arm64, alors que la produire
+# sous émulation qemu pour une image arm64 coûte des dizaines de minutes de
+# `npm ci` et de bundling. Sans cette ligne, publier une image pour Raspberry Pi
+# ferait tourner Node en émulation pour un résultat rigoureusement le même.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS frontend
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci

--- a/apps/core/management/commands/create_admin.py
+++ b/apps/core/management/commands/create_admin.py
@@ -1,0 +1,106 @@
+"""Le premier compte d'une instance, créé sans que personne n'ait rien à saisir.
+
+Il n'y a **pas d'inscription ouverte** dans Maisonnée : on entre dans un foyer
+par invitation. C'est la bonne règle pour un foyer, et elle laisse un trou d'une
+seule case — le premier compte, celui qui n'a personne pour l'inviter. Sans cette
+commande, une installation neuve affiche un écran de connexion qu'aucun mot de
+passe n'ouvre, et le lecteur en déduit que le produit est cassé.
+
+Ce que la commande crée, elle le crée **entier** : un compte *et* un foyer *et*
+l'appartenance qui les relie, avec le foyer actif positionné. Un compte sans
+foyer se connecte et arrive sur une application vide de tout — c'est un
+demi-succès qui ressemble exactement à un échec.
+
+Idempotente par la même règle que le reste du projet : relancée, elle ne fait
+rien et le dit. Le conteneur ``init`` du ``docker-compose.yml`` l'appelle à
+**chaque** démarrage.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+from django.db import transaction
+
+from households.models import Household, HouseholdMember
+
+DEFAULT_EMAIL = "admin@maisonnee.local"
+DEFAULT_HOUSEHOLD = "Ma maisonnée"
+
+
+class Command(BaseCommand):
+    help = "Create the first account and its household, once, from the environment."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--email", default=os.environ.get("MAISONNEE_ADMIN_EMAIL", ""))
+        parser.add_argument(
+            "--password", default=os.environ.get("MAISONNEE_ADMIN_PASSWORD", "")
+        )
+        parser.add_argument(
+            "--household", default=os.environ.get("MAISONNEE_HOUSEHOLD_NAME", "")
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        User = get_user_model()
+
+        # La condition d'idempotence porte sur « **un** compte existe », pas sur
+        # « **ce** compte existe » : quelqu'un qui a créé son vrai compte puis
+        # supprimé l'admin par défaut ne doit pas le voir réapparaître à chaque
+        # redémarrage, avec un mot de passe qu'il ne connaît pas.
+        if User.objects.exists():
+            self.stdout.write("create_admin: un compte existe déjà, rien à faire.")
+            return
+
+        email = (options["email"] or DEFAULT_EMAIL).strip().lower()
+        household_name = options["household"] or DEFAULT_HOUSEHOLD
+        password = options["password"]
+        generated = not password
+        if generated:
+            # Assez court pour être retapé depuis les logs, assez long pour ne
+            # pas être deviné (~77 bits).
+            password = secrets.token_urlsafe(12)
+
+        user = User.objects.create_superuser(
+            email=email,
+            password=password,
+            first_name="",
+            display_name=email.split("@")[0],
+        )
+        household = Household.objects.create(name=household_name)
+        HouseholdMember.objects.create(
+            household=household, user=user, role=HouseholdMember.Role.OWNER
+        )
+        user.active_household = household
+        user.save(update_fields=["active_household"])
+
+        self._announce(email, password, generated)
+
+    def _announce(self, email: str, password: str, generated: bool) -> None:
+        """Les identifiants doivent sauter aux yeux dans le flot de `compose up`.
+
+        Un mot de passe généré qui défile entre deux lignes de migration est un
+        mot de passe perdu : le lecteur ferait un ``docker compose down -v`` pour
+        recommencer, et détruirait son volume.
+        """
+        line = "─" * 64
+        self.stdout.write("")
+        self.stdout.write(self.style.SUCCESS(line))
+        self.stdout.write(self.style.SUCCESS("  Maisonnée — premier compte créé"))
+        self.stdout.write(self.style.SUCCESS(line))
+        self.stdout.write(f"  Identifiant : {email}")
+        if generated:
+            self.stdout.write(f"  Mot de passe : {password}")
+            self.stdout.write("")
+            self.stdout.write(
+                "  Note-le : il est généré une seule fois et n'est stocké nulle part."
+            )
+            self.stdout.write(
+                "  Pour le choisir toi-même : MAISONNEE_ADMIN_PASSWORD dans l'environnement."
+            )
+        else:
+            self.stdout.write("  Mot de passe : celui de MAISONNEE_ADMIN_PASSWORD.")
+        self.stdout.write(self.style.SUCCESS(line))
+        self.stdout.write("")

--- a/apps/core/management/commands/seed_demo_data.py
+++ b/apps/core/management/commands/seed_demo_data.py
@@ -46,12 +46,17 @@ Creates:
 - 9 zones (salon, cuisine, sdb, chambres, bureau, garage, jardin, cave)
 - 2 projects: rénovation salle de bain, aménagement jardin
 - 23 tasks avec statuts, priorités, assignations et zones variés
+- 1 installation électrique complète (tableau, circuits, points d'usage)
+- 1 compte bancaire + un relevé de deux mois importé par le vrai chemin
+  d'import, 10 enveloppes de budget, des ventilations, un remboursement,
+  et deux opérations laissées « à ranger » exprès
 """
 
 from datetime import date, datetime, timedelta
+from decimal import Decimal
 
 from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 from django.utils import timezone
 
@@ -67,8 +72,10 @@ from banking.models import (
     BankAccount,
     BankTransaction,
     ComplianceWaiver,
+    RefundAllocation,
     StatementImport,
 )
+from budget.models import Budget, BudgetCategory
 from interactions.models import Interaction
 from projects.models import Project
 from stock.models import StockCategory, StockItem
@@ -99,6 +106,7 @@ class Command(BaseCommand):
             projects = self._create_projects(household, claire, antoine, zones)
             self._create_tasks(household, claire, antoine, lea, zones, projects)
             self._create_electricity(household, claire, zones)
+            self._create_money(household, claire, projects)
 
         self.stdout.write(self.style.SUCCESS("Demo data seeded successfully."))
 
@@ -117,6 +125,9 @@ class Command(BaseCommand):
             ProtectiveDevice.objects.filter(board__household_id__in=household_ids).delete()
             ElectricityBoard.objects.filter(household_id__in=household_ids).delete()
             Interaction.objects.filter(household_id__in=household_ids).delete()
+            # Refund allocations point at both a transaction and a budget: they go
+            # before either, or the FK protecting them refuses the delete.
+            RefundAllocation.objects.filter(household_id__in=household_ids).delete()
             # Banking must go before the household: ``BankTransaction.account`` is
             # PROTECT (an account holding history is archived, never deleted), so a
             # household carrying a single statement line — or a cash expense typed
@@ -126,6 +137,8 @@ class Command(BaseCommand):
             ComplianceWaiver.objects.filter(household_id__in=household_ids).delete()
             StatementImport.objects.filter(household_id__in=household_ids).delete()
             BankAccount.objects.filter(household_id__in=household_ids).delete()
+            Budget.objects.filter(household_id__in=household_ids).delete()
+            BudgetCategory.objects.filter(household_id__in=household_ids).delete()
             StockItem.objects.filter(household_id__in=household_ids).delete()
             StockCategory.objects.filter(household_id__in=household_ids).delete()
             Zone.objects.filter(household_id__in=household_ids).delete()
@@ -865,3 +878,265 @@ class Command(BaseCommand):
         self.stdout.write(
             f"  Electricity: {dev_count} appareils, {cir_count} circuits, {up_count} points d'usage"
         )
+
+    # ------------------------------------------------------------------
+    # Argent — comptes, relevé importé, budgets, ventilations
+    # ------------------------------------------------------------------
+
+    def _create_money(self, household, user, projects):
+        """Le module Argent rempli comme il le serait après un vrai mois d'usage.
+
+        **Le relevé passe par le vrai chemin d'import** (``import_statement_file``
+        sur un CSV construit ici), jamais par des ``BankTransaction.objects.create``.
+        Trois raisons, dans l'ordre d'importance :
+
+        1. une seed qui écrit en base directement contourne exactement ce que la
+           démonstration doit montrer — le rapprochement, la déduplication, la
+           devinette de fournisseur, la chaîne des soldes ;
+        2. l'idempotence est gratuite : la contrainte ``unique(account, dedup_hash)``
+           fait que ré-importer le même relevé ne crée rien ;
+        3. une seed qui emprunte un chemin à elle est une seed qui vieillit sans
+           que rien ne le signale. Celle-ci casse le jour où l'import casse, ce qui
+           est précisément le jour où on veut le savoir.
+
+        Le foyer de démonstration n'est **pas** en règle, et c'est délibéré : deux
+        opérations restent sans budget. Une démo entièrement verte ne montre pas
+        l'écran qui fait le sel du module — le Contrôle — et laisse croire qu'un
+        foyer réel finit un mois sans une seule ligne en suspens.
+        """
+        from django.core.files.uploadedfile import SimpleUploadedFile
+
+        from banking.services import (
+            create_account,
+            credit_budget_from_refund,
+            import_statement_file,
+            set_allocations,
+        )
+        from core.timezones import household_today
+
+        today = household_today(household)
+        # Le relevé couvre le mois précédent et le mois courant : l'aperçu des
+        # budgets a donc quelque chose à montrer quel que soit le jour du mois
+        # où la démonstration est lancée.
+        first_of_month = today.replace(day=1)
+        period_start = (first_of_month - timedelta(days=1)).replace(day=1)
+
+        def d(offset_days: int) -> date:
+            return period_start + timedelta(days=offset_days)
+
+        account = BankAccount.objects.filter(household=household, name="Compte courant").first()
+        if account is None:
+            account = create_account(
+                household=household,
+                user=user,
+                name="Compte courant",
+                bank_label="Crédit Mutuel",
+                kind=BankAccount.Kind.BANK,
+                iban_last4="4417",
+                opening_balance="2480.00",
+                # Le solde d'ouverture précède la première ligne du relevé : sans
+                # ça la fenêtre de conformité est vide et le Contrôle se tait —
+                # la coche verte qui ne veut rien dire (CLAUDE.md, parcours 26).
+                opening_balance_date=(period_start - timedelta(days=1)).isoformat(),
+            )
+
+        # ── Les enveloppes ────────────────────────────────────────────────────
+        maison = self._budget_category(household, "Maison", None)
+        quotidien = self._budget_category(household, "Quotidien", None)
+
+        budgets = {
+            "courses": self._budget(household, "Courses", "450.00", quotidien),
+            "maison": self._budget(household, "Maison", "200.00", maison),
+            "bricolage": self._budget(household, "Bricolage", "150.00", maison),
+            "energie": self._budget(household, "Énergie", "180.00", maison),
+            "transport": self._budget(household, "Transport", "120.00", quotidien),
+            "sante": self._budget(household, "Santé", "80.00", quotidien),
+            # Sans plafond : « catégorie suivie, non plafonnée ». Elle existe pour
+            # montrer l'état `uncapped`, qui n'est ni « ok » ni « dépassé ».
+            "loisirs": self._budget(household, "Loisirs", None, quotidien),
+            "assurances": self._budget(household, "Assurances", "95.00", None),
+            "abonnements": self._budget(household, "Abonnements", "60.00", None),
+        }
+        self._global_budget(household, "1800.00")
+
+        # ── Le relevé ─────────────────────────────────────────────────────────
+        #
+        # (jour depuis le début de la période, libellé, montant signé)
+        lines = [
+            (1, "VIR SEPA RECU SALAIRE MERCIER C", "2410.00"),
+            (2, "PRLV CREDIT IMMOBILIER CM", "-892.40"),
+            (3, "PRLV EDF ENERGIE", "-134.20"),
+            (4, "CB CARREFOUR MARKET LYON", "-96.35"),
+            (6, "PRLV ORANGE FIXE ET INTERNET", "-42.99"),
+            (8, "CB LEROY MERLIN VENISSIEUX", "-150.00"),
+            (10, "CB TOTALENERGIES STATION", "-68.10"),
+            (12, "CB CARREFOUR MARKET LYON", "-112.80"),
+            (14, "PRLV MAIF ASSURANCE HABITATION", "-58.30"),
+            (16, "RETRAIT DAB CM PART DIEU", "-60.00"),
+            (18, "CB LE BISTROT DE LYON", "-74.50"),
+            (20, "VIR SEPA EMIS EPARGNE LIVRET A", "-300.00"),
+            (22, "CB CARREFOUR MARKET LYON", "-88.15"),
+            (24, "VIR SEPA RECU MUTUELLE REMB SOINS", "47.60"),
+            (32, "VIR SEPA RECU SALAIRE MERCIER C", "2410.00"),
+            (33, "PRLV CREDIT IMMOBILIER CM", "-892.40"),
+            (34, "PRLV EDF ENERGIE", "-141.75"),
+            (36, "CB CARREFOUR MARKET LYON", "-103.60"),
+            (38, "PRLV ORANGE FIXE ET INTERNET", "-42.99"),
+            (40, "CB CASTORAMA LYON EST", "-64.90"),
+        ]
+        # On ne sème que ce qui est déjà arrivé : un relevé qui contient des
+        # opérations futures n'existe pas, et fausserait tous les compteurs du
+        # mois en cours.
+        lines = [line for line in lines if d(line[0]) <= today]
+
+        rows = ["Date;Libelle;Montant;Solde"]
+        balance = Decimal("2480.00")
+        for offset, label, amount in lines:
+            balance += Decimal(amount)
+            rows.append(f"{d(offset).strftime('%d/%m/%Y')};{label};{amount};{balance:.2f}")
+
+        trace = import_statement_file(
+            household,
+            user,
+            account=account,
+            uploaded_file=SimpleUploadedFile(
+                "releve-demo.csv", "\n".join(rows).encode("utf-8"), content_type="text/csv"
+            ),
+            provider="generic_csv",
+            options={
+                "date_column": "Date",
+                "label_column": "Libelle",
+                "amount_column": "Montant",
+                "balance_column": "Solde",
+                "date_format": "%d/%m/%Y",
+                "decimal_separator": ".",
+                "delimiter": ";",
+            },
+        )
+        if trace.status != "completed":
+            raise CommandError(f"Import du relevé de démonstration échoué : {trace.error}")
+
+        # ── Les ventilations ──────────────────────────────────────────────────
+        #
+        # Chaque motif de libellé donne l'enveloppe. Deux libellés n'y sont pas
+        # (« LE BISTROT », « RETRAIT DAB ») : ce sont les écarts assumés.
+        by_pattern = {
+            "CARREFOUR": ("courses", "Carrefour Market"),
+            "EDF": ("energie", "EDF"),
+            "ORANGE": ("abonnements", "Orange"),
+            "TOTALENERGIES": ("transport", "TotalEnergies"),
+            "MAIF": ("assurances", "MAIF"),
+            "CREDIT IMMOBILIER": ("maison", "Crédit Mutuel"),
+            "CASTORAMA": ("bricolage", "Castorama"),
+        }
+
+        renovation = projects.get("sdb") if isinstance(projects, dict) else None
+        allocated = 0
+        for transaction in BankTransaction.objects.filter(account=account, direction="out"):
+            if transaction.is_internal or transaction.interactions.exists():
+                continue
+
+            label = transaction.label_raw.upper()
+
+            # La ligne Leroy Merlin est ventilée en deux, sur deux axes : 90 €
+            # sur le chantier salle de bain (donc dans son coût réel) et 60 € sur
+            # l'enveloppe Maison. C'est l'exemple qui montre qu'un budget et un
+            # projet ne sont pas la même question.
+            if "LEROY MERLIN" in label:
+                split = [
+                    {
+                        "subject": "Robinetterie et joints",
+                        "amount": "90.00",
+                        "budget_id": str(budgets["bricolage"].id),
+                        "supplier": "Leroy Merlin",
+                    },
+                    {
+                        "subject": "Ampoules et petit outillage",
+                        "amount": "60.00",
+                        "budget_id": str(budgets["maison"].id),
+                        "supplier": "Leroy Merlin",
+                    },
+                ]
+                if renovation is not None:
+                    split[0]["source_type"] = "projects.project"
+                    split[0]["source_id"] = str(renovation.id)
+                set_allocations(
+                    household=household, user=user, transaction=transaction, lines=split
+                )
+                allocated += 2
+                continue
+
+            match = next((v for k, v in by_pattern.items() if k in label), None)
+            if match is None:
+                continue
+            budget_key, supplier = match
+            set_allocations(
+                household=household,
+                user=user,
+                transaction=transaction,
+                lines=[
+                    {
+                        "subject": supplier,
+                        "amount": f"{transaction.outflow:.2f}",
+                        "budget_id": str(budgets[budget_key].id),
+                        "supplier": supplier,
+                    }
+                ],
+            )
+            allocated += 1
+
+        # ── Le remboursement ──────────────────────────────────────────────────
+        #
+        # Une recette qui recrédite une enveloppe, plutôt qu'une dépense négative :
+        # 47,60 € rendus par la mutuelle veulent dire que Santé a consommé
+        # d'autant moins, pas que le foyer a gagné de l'argent.
+        refund = (
+            BankTransaction.objects.filter(account=account, direction="in")
+            .filter(label_raw__icontains="MUTUELLE")
+            .first()
+        )
+        if refund is not None and not RefundAllocation.objects.filter(transaction=refund).exists():
+            credit_budget_from_refund(
+                household=household,
+                user=user,
+                transaction=refund,
+                budget_id=str(budgets["sante"].id),
+                amount=refund.inflow,
+            )
+
+        pending = (
+            BankTransaction.objects.filter(account=account, direction="out", is_internal=False)
+            .filter(interactions__isnull=True)
+            .count()
+        )
+        self.stdout.write(
+            f"  Argent : {len(lines)} opérations importées, {allocated} dépenses ventilées, "
+            f"{pending} à ranger, {len(budgets)} enveloppes"
+        )
+
+    def _budget_category(self, household, name, monthly_amount):
+        category, _ = BudgetCategory.objects.get_or_create(
+            household=household,
+            name=name,
+            defaults={"monthly_amount": monthly_amount},
+        )
+        return category
+
+    def _budget(self, household, name, monthly_amount, category):
+        budget, _ = Budget.objects.get_or_create(
+            household=household,
+            name=name,
+            defaults={"monthly_amount": monthly_amount, "category": category},
+        )
+        return budget
+
+    def _global_budget(self, household, monthly_amount):
+        budget = Budget.objects.filter(household=household, is_global=True).first()
+        if budget is None:
+            budget = Budget.objects.create(
+                household=household,
+                name="Budget global",
+                monthly_amount=monthly_amount,
+                is_global=True,
+            )
+        return budget

--- a/apps/core/tests/test_first_run.py
+++ b/apps/core/tests/test_first_run.py
@@ -1,0 +1,157 @@
+"""Le premier démarrage d'une instance auto-hébergée, vérifié de bout en bout.
+
+Ces tests couvrent ce qu'un inconnu voit dans les cinq premières minutes, et
+c'est le seul endroit du dépôt où ce chemin est exercé : il ne passe par aucune
+vue, aucun serializer, aucune URL. Il tient dans deux commandes de gestion
+lancées par un conteneur ``init``, et un défaut y ressemble à « le produit ne
+marche pas » plutôt qu'à une erreur.
+
+Le foyer de démonstration est ici aussi parce qu'il **est** la première
+impression du profil ``demo`` — et parce qu'il emprunte le vrai chemin d'import
+de relevé : cassé, il l'est le jour où l'import l'est.
+"""
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+
+from households.models import Household, HouseholdMember
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestTheFirstAccountOpensAUsableApp:
+    """Un compte sans foyer se connecte et n'a rien — un demi-succès qui se lit
+    exactement comme un échec."""
+
+    def test_it_creates_an_account_a_household_and_the_membership(self, capsys):
+        call_command("create_admin", email="pilote@exemple.fr", password="s3cret-de-test")
+
+        user = User.objects.get(email="pilote@exemple.fr")
+        assert user.is_superuser
+        household = Household.objects.get()
+        assert HouseholdMember.objects.filter(
+            user=user, household=household, role=HouseholdMember.Role.OWNER
+        ).exists()
+        assert user.active_household_id == household.id
+
+    def test_a_generated_password_is_printed_where_it_cannot_be_missed(self, capsys):
+        """Un mot de passe généré qui défile entre deux migrations est perdu.
+
+        Et un mot de passe perdu se répare, chez l'utilisateur, par un
+        ``docker compose down -v`` — c'est-à-dire en détruisant son volume.
+        """
+        call_command("create_admin", email="pilote@exemple.fr")
+
+        out = capsys.readouterr().out
+        assert "pilote@exemple.fr" in out
+        assert "Mot de passe" in out
+
+    def test_running_it_again_changes_nothing(self):
+        call_command("create_admin", email="pilote@exemple.fr", password="s3cret-de-test")
+        call_command("create_admin", email="autre@exemple.fr", password="autre")
+
+        assert User.objects.count() == 1
+        assert Household.objects.count() == 1
+
+    def test_it_stays_quiet_once_the_default_admin_has_been_deleted(self):
+        """La condition porte sur « un compte existe », pas « ce compte existe ».
+
+        Quelqu'un qui crée son vrai compte puis supprime l'admin par défaut ne
+        doit pas le voir revenir à chaque redémarrage du conteneur, avec un mot
+        de passe qu'il ne connaît pas.
+        """
+        call_command("create_admin", email="admin@maisonnee.local", password="x")
+        User.objects.filter(email="admin@maisonnee.local").delete()
+        vrai = User.objects.create_user(email="claire@exemple.fr", password="y")
+
+        call_command("create_admin")
+
+        assert list(User.objects.values_list("email", flat=True)) == [vrai.email]
+
+
+@pytest.mark.django_db
+class TestTheDemoHouseholdIsWorthVisiting:
+    """Le profil ``demo`` existe pour qu'on clique dans un produit rempli.
+
+    Un produit vide ne se juge pas : il se referme.
+    """
+
+    @pytest.fixture(autouse=True)
+    def seeded(self):
+        call_command("seed_demo_data")
+
+    def test_the_statement_went_through_the_real_import_path(self):
+        from banking.models import BankAccount, BankTransaction, StatementImport
+
+        account = BankAccount.objects.get(name="Compte courant")
+        trace = StatementImport.objects.get(account=account)
+        assert trace.status == "completed"
+        assert trace.created_count > 0
+        # Preuve que ce n'est pas un `objects.create` déguisé : l'import calcule
+        # un hash de déduplication, personne d'autre ne le fait.
+        assert all(t.dedup_hash for t in BankTransaction.objects.all())
+
+    def test_the_opening_balance_predates_the_statement(self):
+        """Sans ça la fenêtre de conformité est vide et le Contrôle se tait.
+
+        C'est le bug de production du parcours 26 : une coche verte qui veut
+        dire « rien d'évaluable » et se lit « tout est en règle ».
+        """
+        from banking.models import BankAccount, BankTransaction
+
+        account = BankAccount.objects.get(name="Compte courant")
+        first_line = BankTransaction.objects.order_by("booked_on").first()
+        assert account.opening_balance_date is not None
+        assert account.opening_balance_date < first_line.booked_on
+
+    def test_money_is_split_across_two_axes_at_once(self):
+        """La ligne Leroy Merlin : 90 € sur le chantier ET sur l'enveloppe.
+
+        C'est l'exemple qui montre qu'un budget et un projet répondent à deux
+        questions différentes — « de quelle nature » et « sur quoi ».
+        """
+        from interactions.models import Interaction
+
+        split = Interaction.objects.filter(supplier="Leroy Merlin")
+        assert split.count() == 2
+        assert {str(i.amount) for i in split} == {"90.00", "60.00"}
+        assert all(i.budget_id for i in split)
+        assert split.filter(source_object_id__isnull=False).exists()
+
+    def test_it_shows_a_household_that_is_not_perfectly_tidy(self):
+        """Deux opérations restent sans budget, exprès.
+
+        Une démo entièrement verte ne montre jamais le Contrôle — l'écran qui
+        fait le sel du module — et laisse croire qu'un vrai foyer termine un
+        mois sans une seule ligne en suspens.
+        """
+        from banking.models import BankTransaction
+
+        pending = BankTransaction.objects.filter(
+            direction="out", is_internal=False, interactions__isnull=True
+        )
+        assert pending.count() >= 2
+
+    def test_an_envelope_without_a_ceiling_exists(self):
+        """`uncapped` est un état à part, ni « ok » ni « dépassé »."""
+        from budget.models import Budget
+
+        assert Budget.objects.filter(name="Loisirs", monthly_amount__isnull=True).exists()
+
+    def test_a_refund_credits_an_envelope_rather_than_being_a_negative_expense(self):
+        from banking.models import RefundAllocation
+
+        allocation = RefundAllocation.objects.get()
+        assert allocation.budget.name == "Santé"
+        assert allocation.amount > 0
+
+    def test_running_it_twice_creates_nothing_new(self):
+        """L'idempotence n'est pas une politesse : le conteneur ``init`` la
+        rejoue à chaque démarrage."""
+        from banking.models import BankTransaction
+        from interactions.models import Interaction
+
+        before = (BankTransaction.objects.count(), Interaction.objects.count())
+        call_command("seed_demo_data")
+        assert (BankTransaction.objects.count(), Interaction.objects.count()) == before

--- a/apps/core/tests/test_production_settings.py
+++ b/apps/core/tests/test_production_settings.py
@@ -160,6 +160,39 @@ class TestTheSensitiveEndpointsAreThrottled:
         assert "LoginEmailRateThrottle" in source
 
 
+class TestTheBundleIsCompressedBeforeItIsShipped:
+    """Un réglage qui a l'air posé et ne fait rien est pire qu'un réglage absent.
+
+    ``STATICFILES_STORAGE`` a vécu ici des mois **sans aucun effet** : Django 5.1
+    l'a supprimé au profit de ``STORAGES``, silencieusement. Le bundle React
+    partait donc brut — 900 Ko à chaque visite froide — pendant que le fichier de
+    réglages affirmait le contraire. Derrière Nginx le ``gzip on`` masquait la
+    moitié du problème ; dans une pile auto-hébergée, qui n'a pas de Nginx, il
+    n'y a rien pour masquer.
+    """
+
+    def test_the_whitenoise_backend_is_declared_where_django_reads_it(self, settings):
+        backend = settings.STORAGES["staticfiles"]["BACKEND"]
+        assert backend.startswith("whitenoise.storage."), (
+            f"Le stockage des fichiers statiques est {backend} : la compression "
+            "au build n'a plus lieu."
+        )
+
+    def test_the_dead_setting_has_not_come_back(self):
+        from pathlib import Path
+
+        source = Path("config/settings/base.py").read_text(encoding="utf-8")
+        assert "STATICFILES_STORAGE = " not in source, (
+            "STATICFILES_STORAGE n'est plus lu par Django depuis la 5.1 — le "
+            "réintroduire donne l'illusion d'un réglage actif."
+        )
+
+    def test_brotli_is_installed(self):
+        """Sans lui, whitenoise ne produit que du gzip et l'écart est réel :
+        215 Ko en brotli contre 257 Ko en gzip, sur 900 Ko de bundle."""
+        import brotli  # noqa: F401
+
+
 class TestClickjackingIsBlocked:
     def test_the_middleware_is_installed(self, settings):
         assert (

--- a/apps/core/tests/test_selfhost_settings.py
+++ b/apps/core/tests/test_selfhost_settings.py
@@ -1,0 +1,193 @@
+"""Les réglages d'une instance auto-hébergée, et leur seul bouton.
+
+``config/settings/selfhost.py`` répond à une question que ``production.py`` n'a
+jamais eu à se poser : que faire quand **personne n'a rien configuré**. Ses
+défauts sont donc du code que personne ne relit — ils s'appliquent chez des gens
+qu'on ne connaît pas, sur des machines qu'on ne voit pas.
+
+Deux propriétés méritent d'être figées, et ce sont les deux qui ne se voient
+jamais à l'usage :
+
+1. **la liste d'hôtes se resserre quand l'exposition s'élargit** — un
+   ``ALLOWED_HOSTS`` permissif sur un réseau local est un choix, le même sur une
+   instance publique est un défaut ;
+2. **le durcissement vient de ``production.py``, jamais d'une copie** — le jour
+   où les deux divergent, aucun des deux ne fait plus autorité.
+"""
+import importlib
+import os
+
+import pytest
+
+
+@pytest.fixture
+def clean_environ():
+    """Le module écrit dans ``os.environ`` à l'import — il faut le rembobiner.
+
+    ``monkeypatch`` ne suffit pas : le module pose des clés **nouvelles** par
+    ``setdefault``, dont monkeypatch n'a pas gardé trace. Sans cette restauration,
+    le premier test qui importe le module léguerait son ``ALLOWED_HOSTS=*`` à
+    toute la session.
+    """
+    snapshot = dict(os.environ)
+    yield os.environ
+    os.environ.clear()
+    os.environ.update(snapshot)
+
+
+def _load(environ, tmp_path, **overrides):
+    """Charge le module de réglages avec un environnement donné.
+
+    ``importlib.reload`` seul ne suffit pas, et le piège vaut d'être nommé :
+    recharger ``selfhost`` ré-exécute son ``from .production import *``, mais
+    ``production`` reste **en cache** et n'est pas ré-évalué. On relirait donc
+    les valeurs du tout premier import, c'est-à-dire un test qui passe en
+    vérifiant l'environnement d'un autre. Les deux modules sortent du cache.
+    """
+    import sys
+    for key in (
+        "SECRET_KEY",
+        "ALLOWED_HOSTS",
+        "CORS_ALLOWED_ORIGINS",
+        "CSRF_TRUSTED_ORIGINS",
+        "DATABASE_URL",
+        "FRONTEND_URL",
+        "MAISONNEE_PUBLIC_URL",
+        "SESSION_COOKIE_SECURE",
+        "CSRF_COOKIE_SECURE",
+        "SECURE_SSL_REDIRECT",
+        "SECURE_HSTS_SECONDS",
+        "EMAIL_BACKEND",
+    ):
+        environ.pop(key, None)
+    environ["MAISONNEE_STATE_DIR"] = str(tmp_path)
+    environ.update(overrides)
+
+    sys.modules.pop("config.settings.selfhost", None)
+    sys.modules.pop("config.settings.production", None)
+    return importlib.import_module("config.settings.selfhost")
+
+
+class TestNothingHasToBeConfigured:
+    """Le critère du lot : une VM nue, trois lignes, aucun fichier édité."""
+
+    def test_it_loads_with_an_empty_environment(self, clean_environ, tmp_path):
+        settings = _load(clean_environ, tmp_path)
+
+        assert settings.SECRET_KEY
+        assert settings.DATABASES["default"]["NAME"]
+        assert settings.DEBUG is False
+
+    def test_the_secret_key_survives_a_restart(self, clean_environ, tmp_path):
+        """Trois conteneurs lisent la même clé, et elle vit plus longtemps qu'eux.
+
+        Une clé volatile par conteneur marcherait à l'écran — la connexion
+        réussit — et déconnecterait tout le monde au premier redémarrage sans
+        qu'une ligne ne dise pourquoi.
+        """
+        first = _load(clean_environ, tmp_path).SECRET_KEY
+        second = _load(clean_environ, tmp_path).SECRET_KEY
+
+        assert first == second
+        assert (tmp_path / "secret_key").exists()
+
+    def test_an_unwritable_state_directory_is_fatal(self, clean_environ, tmp_path):
+        """Échouer bruyamment plutôt que de fabriquer une clé jetable."""
+        from django.core.exceptions import ImproperlyConfigured
+
+        unwritable = tmp_path / "nope"
+        unwritable.write_text("je suis un fichier, pas un dossier")
+
+        with pytest.raises(ImproperlyConfigured):
+            _load(clean_environ, unwritable / "state")
+
+    def test_a_provided_secret_key_wins(self, clean_environ, tmp_path):
+        settings = _load(clean_environ, tmp_path, SECRET_KEY="fourni-par-l-hebergeur")
+
+        assert settings.SECRET_KEY == "fourni-par-l-hebergeur"
+        assert not (tmp_path / "secret_key").exists()
+
+
+class TestTheHostListNarrowsAsExposureWidens:
+    """La propriété centrale du fichier, et la seule qui protège quelqu'un."""
+
+    def test_without_a_public_url_any_host_is_accepted(self, clean_environ, tmp_path):
+        settings = _load(clean_environ, tmp_path)
+
+        assert "*" in settings.ALLOWED_HOSTS
+        # Sur une boîte de réseau local, servie en clair : marquer les cookies
+        # `Secure` les ferait jeter par le navigateur, donc personne ne pourrait
+        # se connecter.
+        assert settings.SESSION_COOKIE_SECURE is False
+        assert settings.SECURE_HSTS_SECONDS == 0
+
+    def test_declaring_a_public_url_locks_the_host_down(self, clean_environ, tmp_path):
+        settings = _load(
+            clean_environ, tmp_path, MAISONNEE_PUBLIC_URL="https://maison.exemple.fr"
+        )
+
+        assert "*" not in settings.ALLOWED_HOSTS
+        assert "maison.exemple.fr" in settings.ALLOWED_HOSTS
+        assert settings.SESSION_COOKIE_SECURE is True
+        assert settings.CSRF_COOKIE_SECURE is True
+        assert settings.SECURE_HSTS_SECONDS >= 31536000
+        assert settings.CSRF_TRUSTED_ORIGINS == ["https://maison.exemple.fr"]
+        assert settings.FRONTEND_URL == "https://maison.exemple.fr"
+
+    def test_the_container_can_always_probe_itself(self, clean_environ, tmp_path):
+        """Sinon la sonde de vie se heurte à un 400 et le conteneur est déclaré
+        malade à perpétuité — sur une instance parfaitement saine."""
+        settings = _load(
+            clean_environ, tmp_path, MAISONNEE_PUBLIC_URL="https://maison.exemple.fr"
+        )
+
+        assert "127.0.0.1" in settings.ALLOWED_HOSTS
+        assert "localhost" in settings.ALLOWED_HOSTS
+
+
+class TestItNeverRedirectsToHttpsItself:
+    """Le piège classique de l'auto-hébergement, et il ne se voit que chez l'hôte.
+
+    Un proxy qui omet ``X-Forwarded-Proto`` fait croire à Django que la requête
+    est en clair ; Django renvoie vers ``https://`` ; le proxy repasse la requête
+    sans le header. Le navigateur tourne jusqu'à l'erreur, et l'utilisateur en
+    conclut que l'application est cassée.
+    """
+
+    def test_the_redirect_is_left_to_the_proxy(self, clean_environ, tmp_path):
+        for env in ({}, {"MAISONNEE_PUBLIC_URL": "https://maison.exemple.fr"}):
+            settings = _load(clean_environ, tmp_path, **env)
+            assert settings.SECURE_SSL_REDIRECT is False
+
+
+class TestTheHardeningIsInheritedNotCopied:
+    def test_it_imports_production_rather_than_redeclaring_it(self):
+        """Deux textes qui divergent font perdre leur crédit aux deux.
+
+        ``test_production_settings.py`` ne surveille qu'un fichier ; il faut donc
+        que ce soit celui que les deux déploiements utilisent réellement.
+        """
+        from pathlib import Path
+
+        source = Path("config/settings/selfhost.py").read_text(encoding="utf-8")
+        assert "from .production import *" in source
+
+    def test_the_inherited_hardening_is_actually_present(self, clean_environ, tmp_path):
+        settings = _load(clean_environ, tmp_path)
+
+        assert settings.SECURE_CONTENT_TYPE_NOSNIFF is True
+        assert settings.SECURE_REFERRER_POLICY == "same-origin"
+        assert "login_email" in settings.REST_FRAMEWORK["DEFAULT_THROTTLE_RATES"]
+
+
+class TestFilesAreServedByDjangoWhenThereIsNoNginx:
+    def test_the_accel_mechanism_is_off(self, clean_environ, tmp_path):
+        """La pile auto-hébergée n'a pas de Nginx à qui déléguer.
+
+        Laisser ce mécanisme actif renverrait au navigateur une réponse vide
+        portant un en-tête que personne n'interprète : une image cassée, sans
+        une ligne d'erreur nulle part.
+        """
+        settings = _load(clean_environ, tmp_path)
+
+        assert settings.PROTECTED_MEDIA_ACCEL is False

--- a/apps/core/tests/test_views_media.py
+++ b/apps/core/tests/test_views_media.py
@@ -43,7 +43,7 @@ class TestServeProtectedMedia:
 
     # ── Avatars : auth suffisante ─────────────────────────────────────────────
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_user_can_access_their_own_avatar(self, client, member_user):
         """Un avatar vit sous ``avatars/<user_pk>/<fichier>``.
 
@@ -62,7 +62,7 @@ class TestServeProtectedMedia:
 
     # ── Documents : vérification du foyer ────────────────────────────────────
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_member_can_access_household_document(self, client, member_user, household):
         client.force_login(member_user)
         path = f'documents/{household.id}/2025/01/abc-invoice.pdf'
@@ -70,21 +70,21 @@ class TestServeProtectedMedia:
         assert response.status_code == 200
         assert response.get('X-Accel-Redirect') == f'/_protected_media/{path}'
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_non_member_cannot_access_household_document(self, client, other_user, household):
         client.force_login(other_user)
         path = f'documents/{household.id}/2025/01/secret.pdf'
         response = client.get(media_url(path))
         assert response.status_code == 403
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_malformed_document_path_raises_404(self, client, member_user):
         client.force_login(member_user)
         response = client.get(media_url('documents/'))
         # No household_id in path
         assert response.status_code == 404
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_invalid_household_uuid_in_path_raises_404(self, client, member_user):
         client.force_login(member_user)
         response = client.get(media_url('documents/not-a-uuid/file.pdf'))
@@ -92,7 +92,7 @@ class TestServeProtectedMedia:
 
     # ── X-Accel-Redirect header ───────────────────────────────────────────────
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_x_accel_redirect_points_to_protected_location(self, client, member_user, household):
         client.force_login(member_user)
         path = f'documents/{household.id}/2025/03/file.pdf'
@@ -100,7 +100,7 @@ class TestServeProtectedMedia:
         assert response['X-Accel-Redirect'] == f'/_protected_media/{path}'
         assert response['Content-Type'] == ''
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_x_accel_redirect_url_encodes_non_ascii_filename(self, client, member_user, household):
         # A non-ASCII filename must be percent-encoded in X-Accel-Redirect. WSGI
         # serializes headers as latin-1, so sending "é" raw would emit the wrong

--- a/apps/core/views_media.py
+++ b/apps/core/views_media.py
@@ -1,8 +1,22 @@
 """Service de fichiers protégés, avec contrôle d'accès.
 
-Production : Django authentifie la requête puis renvoie un ``X-Accel-Redirect``
-pour que Nginx serve le fichier depuis un emplacement interne
-(``/_protected_media/``). Développement : Django sert le fichier directement.
+Django authentifie toujours la requête. Ce qui change, c'est **qui envoie les
+octets** une fois l'accès accordé, et c'est réglé par ``PROTECTED_MEDIA_ACCEL`` :
+
+- ``True`` (défaut, déploiement de l'auteur) — Django répond un en-tête
+  ``X-Accel-Redirect`` et Nginx sert le fichier depuis un emplacement interne
+  (``/_protected_media/``), sans occuper un worker gunicorn ;
+- ``False`` — Django sert le fichier lui-même. C'est le cas du développement, et
+  celui d'une **instance auto-hébergée** : la pile ``docker compose up`` tient en
+  trois conteneurs et n'a pas de Nginx à qui déléguer.
+
+⚠️ **Ce réglage se déclare, il ne se déduit pas de ``DEBUG``.** C'est ce qu'il
+faisait, et le raccourci était faux dès qu'on sortait des deux seuls
+déploiements connus : ``DEBUG=False`` sans Nginx en face — exactement la pile
+auto-hébergée — renvoyait au navigateur une réponse **vide** portant un en-tête
+que personne n'allait interpréter. Une image cassée sans une ligne d'erreur, et
+un réglage de confidentialité qui décide d'un mécanisme de transport n'a aucune
+raison de rester lisible six mois.
 
 ⚠️ **Cette vue est la seule porte du foyer qui ne passe ni par un viewset ni par
 un queryset** : elle reçoit un chemin et rend des octets. Les cinquante-sept
@@ -127,7 +141,7 @@ def serve_protected_media(request, path):
     if denied is not None:
         return HttpResponse(status=denied)
 
-    if settings.DEBUG:
+    if not settings.PROTECTED_MEDIA_ACCEL:
         from django.views.static import serve as static_serve
 
         return static_serve(request, path, document_root=settings.MEDIA_ROOT)

--- a/apps/documents/tests/test_api_documents.py
+++ b/apps/documents/tests/test_api_documents.py
@@ -636,7 +636,7 @@ class TestDocumentPrivacy:
     #    private document
     # ------------------------------------------------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_serve_protected_media_owner_can_access_private_document(self, owner, household):
         file_path = f"documents/{household.id}/2026/03/private-owner.pdf"
         self._create_document(household, owner, is_private=True, file_path=file_path)
@@ -653,7 +653,7 @@ class TestDocumentPrivacy:
     # 8. serve_protected_media: non-owner member gets 403 on private document
     # ------------------------------------------------------------------
 
-    @override_settings(DEBUG=False)
+    @override_settings(PROTECTED_MEDIA_ACCEL=True)
     def test_serve_protected_media_non_owner_gets_403_on_private_document(self, owner, household):
         file_path = f"documents/{household.id}/2026/03/private-other.pdf"
         self._create_document(household, owner, is_private=True, file_path=file_path)

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -147,11 +147,35 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_DIRS = [
     BASE_DIR / "static",  # Custom static files (compiled React components)
 ]
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+# ⚠️ `STATICFILES_STORAGE` vivait ici et **ne faisait rien depuis Django 5.1**,
+# qui l'a supprimé au profit de `STORAGES`. Le réglage avait donc l'air d'être en
+# place et ne l'était pas : le bundle React partait brut, 900 Ko à chaque visite
+# froide. Derrière Nginx ça se voyait peu (`gzip on` le recompressait à la
+# volée) ; dans une pile auto-hébergée, qui n'a pas de Nginx, ça se voit tout de
+# suite — et c'est la première seconde de quelqu'un qui essaie le produit.
+#
+# `CompressedStaticFilesStorage` et pas `CompressedManifest…` : les noms de
+# fichiers portent déjà l'empreinte que Vite y met, donc le manifeste de Django
+# n'ajouterait qu'un second schéma de nommage par-dessus le premier — et
+# django-vite lit le sien. On veut la compression, pas le renommage.
+#
+# La compression se fait au `collectstatic`, donc **au build de l'image** : le
+# démarrage n'en porte rien.
+STORAGES = {
+    "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},
+    "staticfiles": {"BACKEND": "whitenoise.storage.CompressedStaticFilesStorage"},
+}
 
 # Media files (user-uploaded content, e.g. avatars)
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
+
+# Qui envoie les octets d'un fichier une fois l'accès accordé — voir
+# `core.views_media`. `False` = Django lui-même ; `True` = délégué à Nginx par
+# `X-Accel-Redirect`, ce que seul un déploiement avec Nginx devant peut promettre.
+# Le défaut prudent est donc `False` : un mécanisme absent doit se déclarer, pas
+# se deviner.
+PROTECTED_MEDIA_ACCEL = False
 
 # Custom user model
 AUTH_USER_MODEL = "accounts.User"

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -108,6 +108,10 @@ TELEGRAM_BOT_TOKEN = env("TELEGRAM_BOT_TOKEN", default="")
 TELEGRAM_BOT_USERNAME = env("TELEGRAM_BOT_USERNAME", default="")
 TELEGRAM_WEBHOOK_SECRET = env("TELEGRAM_WEBHOOK_SECRET", default="")
 
+# Nginx est devant : il sert les fichiers protégés par `X-Accel-Redirect`, sans
+# occuper un worker gunicorn. Voir `core.views_media`.
+PROTECTED_MEDIA_ACCEL = env.bool("PROTECTED_MEDIA_ACCEL", default=True)
+
 # Django Vite Configuration (compiled assets in production)
 DJANGO_VITE = {
     "default": {

--- a/config/settings/selfhost.py
+++ b/config/settings/selfhost.py
@@ -1,0 +1,165 @@
+"""Réglages d'une instance auto-hébergée : la production, avec ses défauts remplis.
+
+Ce module n'est **pas** un troisième jeu de réglages de sécurité. Il importe
+``production`` et ne fait qu'une chose avant : donner une valeur par défaut à
+tout ce que le déploiement de l'auteur exige explicitement — clé secrète, base,
+hôtes, origines. Un inconnu lance ``docker compose up`` et n'édite aucun fichier ;
+le durcissement qu'il obtient est **celui de la production**, mot pour mot, et
+tout durcissement futur ajouté à ``production.py`` le suivra sans qu'on y pense.
+
+Dupliquer les réglages plutôt que les importer aurait produit deux textes qui
+divergent — et le jour où ils divergent, aucun des deux ne fait plus autorité.
+``test_production_settings.py`` ne surveille qu'un fichier ; il faut que ce soit
+celui que tout le monde utilise.
+
+Un seul bouton, et il est facultatif
+------------------------------------
+
+``MAISONNEE_PUBLIC_URL`` — l'adresse publique de l'instance, si elle en a une :
+
+- **absent** — boîte sur un réseau local, servie en clair sur ``:8000``. Les
+  cookies ne sont pas marqués ``Secure`` (le navigateur les jetterait), HSTS est
+  à zéro, et ``ALLOWED_HOSTS`` accepte n'importe quel nom.
+- **``https://maisonnee.exemple.fr``** — l'instance est exposée. Cookies
+  ``Secure``, HSTS d'un an, et ``ALLOWED_HOSTS`` réduit à **ce seul hôte**.
+
+C'est le point important de ce fichier : **la liste d'hôtes se resserre au moment
+exact où l'exposition s'élargit.** Un ``ALLOWED_HOSTS`` permissif sur un réseau
+local est un choix raisonnable — la machine se joint par IP, par nom ``.local``,
+par nom Tailscale, et aucun de ces noms n'est connu à l'avance ; le même réglage
+sur une instance publique ne l'est pas. Laisser l'utilisateur deviner qu'il doit
+resserrer, c'est garantir qu'il ne le fera pas.
+
+Ce que le fichier ne fait pas
+-----------------------------
+
+Il ne redirige **pas** vers HTTPS (``SECURE_SSL_REDIRECT`` reste à ``False``,
+alors que la production le laisse à ``True``). Le TLS d'une instance
+auto-hébergée se termine dans le reverse proxy de l'hébergeur — Caddy, Traefik,
+le routeur de la box — qui redirige déjà. Rediriger une deuxième fois depuis
+Django est au mieux inutile, au pire une **boucle infinie** : un proxy qui omet
+``X-Forwarded-Proto`` fait croire à Django que la requête est en clair, Django
+renvoie vers ``https://``, le proxy repasse la requête sans le header, et le
+navigateur tourne jusqu'à l'erreur. C'est le piège classique de
+l'auto-hébergement, et il ne se manifeste que chez celui qui héberge.
+"""
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import environ
+from django.core.exceptions import ImproperlyConfigured
+
+from .base import BASE_DIR
+
+# ── Répertoire d'état ────────────────────────────────────────────────────────
+#
+# Le volume que l'utilisateur ne doit jamais perdre : il porte la clé secrète.
+STATE_DIR = Path(os.environ.get("MAISONNEE_STATE_DIR", "/data"))
+
+# Un `.env` monté par l'hébergeur doit gagner sur tous les défauts ci-dessous.
+# `read_env` pose ses valeurs par `setdefault`, donc l'ordre décide : on le lit
+# **avant** de remplir quoi que ce soit. (`production.py` le relira ensuite, sans
+# effet — tout est déjà dans l'environnement.)
+environ.Env.read_env(BASE_DIR / ".env")
+
+
+def _persisted_secret_key() -> str:
+    """La clé secrète de l'instance, générée une fois puis relue.
+
+    Elle vit dans un fichier plutôt que dans l'environnement parce que personne
+    ne doit avoir à en fabriquer une pour démarrer — et parce que trois
+    conteneurs (``init``, ``web``, les schedulers) doivent lire **la même**.
+
+    Ne pas pouvoir l'écrire est une **erreur fatale**, pas un repli silencieux.
+    Générer une clé volatile par conteneur marcherait à l'écran : l'application
+    démarre, la connexion réussit, et les sessions sautent au premier
+    redémarrage sans que rien ne dise pourquoi.
+    """
+    path = STATE_DIR / "secret_key"
+    try:
+        existing = path.read_text(encoding="utf-8").strip()
+    except OSError:
+        existing = ""
+    if existing:
+        return existing
+
+    key = secrets.token_urlsafe(64)
+    try:
+        STATE_DIR.mkdir(parents=True, exist_ok=True)
+        # Écriture atomique : deux conteneurs qui démarrent ensemble ne doivent
+        # pas pouvoir lire un fichier à moitié écrit.
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(key, encoding="utf-8")
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except OSError as exc:
+        raise ImproperlyConfigured(
+            f"Impossible d'écrire la clé secrète dans {STATE_DIR} ({exc}). "
+            "Monte un volume inscriptible sur ce chemin (ou fixe MAISONNEE_STATE_DIR), "
+            "ou fournis SECRET_KEY dans l'environnement."
+        ) from exc
+    return key
+
+
+# ── L'unique bouton ──────────────────────────────────────────────────────────
+
+PUBLIC_URL = os.environ.get("MAISONNEE_PUBLIC_URL", "").strip().rstrip("/")
+_public_host = urlsplit(PUBLIC_URL).hostname if PUBLIC_URL else ""
+_is_public_https = PUBLIC_URL.startswith("https://")
+
+# Sans adresse publique, l'instance se joint en clair sur le port publié.
+_local_url = f"http://localhost:{os.environ.get('MAISONNEE_PORT', '8000')}"
+
+if not os.environ.get("SECRET_KEY"):
+    os.environ["SECRET_KEY"] = _persisted_secret_key()
+
+_DEFAULTS = {
+    # `db` est le nom du service dans le compose livré ; les identifiants aussi.
+    "DATABASE_URL": "postgres://maisonnee:maisonnee@db:5432/maisonnee",
+    # Voir la docstring : la liste se resserre quand l'exposition s'élargit.
+    "ALLOWED_HOSTS": _public_host or "*",
+    # La SPA est servie par Django lui-même : le CORS ne sert qu'à un front
+    # lancé à part en développement. Une valeur est quand même requise —
+    # `production.py` refuse de démarrer sans, et c'est une bonne chose.
+    "CORS_ALLOWED_ORIGINS": PUBLIC_URL or _local_url,
+    "FRONTEND_URL": PUBLIC_URL or _local_url,
+    "SESSION_COOKIE_SECURE": str(_is_public_https),
+    "CSRF_COOKIE_SECURE": str(_is_public_https),
+    # Voir la docstring : la redirection appartient au proxy qui termine le TLS.
+    "SECURE_SSL_REDIRECT": "False",
+    "SECURE_HSTS_SECONDS": "31536000" if _is_public_https else "0",
+    "SECURE_HSTS_INCLUDE_SUBDOMAINS": str(_is_public_https),
+    "SECURE_HSTS_PRELOAD": "False",
+    # Sans clé SMTP, un e-mail part dans les logs du conteneur plutôt que nulle
+    # part. Le lot 3 rendra cette dégradation visible dans l'interface.
+    "EMAIL_BACKEND": "django.core.mail.backends.console.EmailBackend",
+}
+if PUBLIC_URL:
+    _DEFAULTS["CSRF_TRUSTED_ORIGINS"] = PUBLIC_URL
+
+for _key, _value in _DEFAULTS.items():
+    os.environ.setdefault(_key, _value)
+
+from .production import *  # noqa: E402,F401,F403  (après les défauts, exprès)
+
+# ── Ce qui ne passe pas par l'environnement ──────────────────────────────────
+
+# La sonde de vie du conteneur tape sa propre boucle locale. Sans ces deux noms,
+# une instance qui déclare `MAISONNEE_PUBLIC_URL` réduit `ALLOWED_HOSTS` à son
+# seul domaine public et se déclare malade à perpétuité — Django refusant en 400
+# la requête que le conteneur s'adresse à lui-même. Ce ne sont pas des hôtes
+# supplémentaires exposés : rien d'extérieur ne peut se présenter comme la
+# boucle locale du conteneur.
+ALLOWED_HOSTS = list(dict.fromkeys([*ALLOWED_HOSTS, "127.0.0.1", "localhost"]))  # noqa: F405
+
+# Pas de Nginx dans la pile auto-hébergée : Django sert les fichiers lui-même.
+# Déclaré ici plutôt que déduit de `DEBUG` — voir `core.views_media`.
+PROTECTED_MEDIA_ACCEL = False
+
+# Les fichiers du foyer vivent dans le volume d'état, avec la clé secrète : ce
+# sont les deux choses qu'une sauvegarde doit prendre en plus de la base.
+MEDIA_ROOT = STATE_DIR / "media"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,162 @@
+# Maisonnée — auto-hébergement, en une commande.
+#
+#   curl -O https://raw.githubusercontent.com/jammindev/house/main/docker-compose.yml
+#   docker compose up
+#
+# Puis http://localhost:8000. Les identifiants du premier compte s'affichent dans
+# la sortie de la commande, encadrés. Rien à éditer, aucune clé à souscrire.
+#
+# Avec un foyer de démonstration pré-rempli, pour visiter avant de saisir :
+#   docker compose --profile demo up
+#
+# ── Ce fichier n'est PAS celui du déploiement de l'auteur ────────────────────
+#
+# `docker-compose.prod.yml` est un autre fichier, inchangé, avec ses propres
+# hypothèses (Traefik, TLS, domaine public, migration hors du démarrage). Les
+# deux partagent la même image et le même code ; ils ne partagent pas leurs
+# hypothèses, et c'est la raison pour laquelle ils restent deux fichiers.
+#
+# ── Réglages facultatifs ─────────────────────────────────────────────────────
+#
+# Tous ont un défaut qui marche. À poser dans un fichier `.env` à côté de
+# celui-ci, ou dans l'environnement :
+#
+#   MAISONNEE_PUBLIC_URL   l'adresse publique, si l'instance est exposée
+#                          (ex. https://maison.exemple.fr). En la déclarant, les
+#                          cookies passent en Secure, HSTS s'active et les hôtes
+#                          autorisés se réduisent à celui-là. Le certificat TLS
+#                          se termine dans TON reverse proxy (Caddy, Traefik…) —
+#                          cette pile sert en clair sur le port publié.
+#   MAISONNEE_PORT         port publié sur l'hôte (défaut : 8000)
+#   MAISONNEE_ADMIN_EMAIL  identifiant du premier compte (défaut :
+#                          admin@maisonnee.local)
+#   MAISONNEE_ADMIN_PASSWORD  son mot de passe (défaut : généré et affiché une
+#                          seule fois au premier démarrage)
+#   MAISONNEE_IMAGE        image à utiliser (défaut : ghcr.io/jammindev/maisonnee:latest)
+#   POSTGRES_PASSWORD      mot de passe de la base. La base n'est jamais publiée
+#                          hors du réseau interne ; le changer avant le premier
+#                          démarrage n'en reste pas moins une bonne idée.
+#
+# ── Sauvegarder ──────────────────────────────────────────────────────────────
+#
+# Deux volumes, et il faut les deux : `postgres-data` (les données) et
+# `maisonnee-state` (la clé secrète et les fichiers téléversés). Perdre le second
+# déconnecte tout le monde et perd les documents, base intacte.
+
+x-app: &app
+  image: ${MAISONNEE_IMAGE:-ghcr.io/jammindev/maisonnee:latest}
+  environment:
+    DJANGO_SETTINGS_MODULE: config.settings.selfhost
+    DATABASE_URL: postgres://maisonnee:${POSTGRES_PASSWORD:-maisonnee}@db:5432/maisonnee
+    MAISONNEE_STATE_DIR: /data
+    MAISONNEE_PUBLIC_URL: ${MAISONNEE_PUBLIC_URL:-}
+    MAISONNEE_PORT: ${MAISONNEE_PORT:-8000}
+    MAISONNEE_ADMIN_EMAIL: ${MAISONNEE_ADMIN_EMAIL:-}
+    MAISONNEE_ADMIN_PASSWORD: ${MAISONNEE_ADMIN_PASSWORD:-}
+    MAISONNEE_HOUSEHOLD_NAME: ${MAISONNEE_HOUSEHOLD_NAME:-}
+  volumes:
+    # La clé secrète ET les fichiers du foyer. Un seul volume pour les deux :
+    # ce qu'une sauvegarde doit prendre en plus de la base est ainsi un seul nom
+    # à retenir, pas deux à oublier.
+    - maisonnee-state:/data
+  networks:
+    - maisonnee
+
+services:
+  db:
+    # pgvector/pgvector:pg16 = postgres:16 + l'extension `vector` préinstallée,
+    # dont la recherche sémantique a besoin. Publiée en amd64 et arm64, donc un
+    # Raspberry Pi la tire sans rien changer.
+    image: pgvector/pgvector:pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: maisonnee
+      POSTGRES_USER: maisonnee
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-maisonnee}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - maisonnee
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U maisonnee -d maisonnee"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  # Conteneur jetable : migre, crée le premier compte, sort. `web` ne démarre
+  # qu'une fois qu'il a réussi — le serveur ne sert donc jamais sur un schéma
+  # non migré, ce qui rend `docker compose pull && up -d` sûr par construction.
+  init:
+    <<: *app
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["sh", "scripts/selfhost-init.sh"]
+
+  web:
+    <<: *app
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      init:
+        condition: service_completed_successfully
+    ports:
+      - "${MAISONNEE_PORT:-8000}:8000"
+    # Deux workers, pas quatre : cette pile doit tenir sur un Raspberry Pi. Le
+    # `CMD` de l'image vise un VPS ; on le remplace ici, ce que l'absence
+    # d'ENTRYPOINT rend possible.
+    command:
+      - gunicorn
+      - config.wsgi:application
+      - --bind=0.0.0.0:8000
+      - --workers=${GUNICORN_WORKERS:-2}
+      - --timeout=60
+      - --access-logfile=-
+      - --error-logfile=-
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request as u; u.urlopen('http://127.0.0.1:8000/health/', timeout=5)"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 40s
+
+  # Rappels proactifs et briefings — des ticks au repos tant que personne n'en a
+  # programmé. Ils sont là dès le premier démarrage exprès : une échéance qu'on
+  # règle dans l'interface et qui ne part jamais est pire que pas d'échéance.
+  scheduler:
+    <<: *app
+    restart: unless-stopped
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    command: ["python", "manage.py", "send_scheduled_pings", "--loop"]
+
+  scheduler-briefings:
+    <<: *app
+    restart: unless-stopped
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    command: ["python", "manage.py", "send_due_briefings", "--loop"]
+
+  # `docker compose --profile demo up` — le foyer « Famille Mercier », pour
+  # cliquer dans un produit rempli au lieu de lire une promesse. Jamais lancé
+  # sans le profil : il n'a rien à faire dans une instance qui a de vraies
+  # données.
+  demo:
+    <<: *app
+    profiles: ["demo"]
+    restart: "no"
+    depends_on:
+      init:
+        condition: service_completed_successfully
+    command: ["python", "manage.py", "seed_demo_data"]
+
+volumes:
+  postgres-data:
+  maisonnee-state:
+
+networks:
+  maisonnee:

--- a/docs/journal/2026-07-31_parcours-28_lot2_installation-en-une-commande.md
+++ b/docs/journal/2026-07-31_parcours-28_lot2_installation-en-une-commande.md
@@ -1,0 +1,117 @@
+# Lot 2 — `docker compose up` : ce que le plan n'avait pas vu
+
+**2026-07-31** · parcours 28 · issue #488
+
+Le lot devait produire un fichier. Il a produit un fichier et **deux réparations**
+que rien n'aurait signalées autrement — parce qu'aucun des deux défauts ne se voit
+sur le déploiement de l'auteur.
+
+## Le plan disait « db + web + nginx + scheduler ». C'est faux d'un service.
+
+Le compose devait embarquer nginx, comme la production. Sauf qu'un nginx a besoin
+de sa configuration, et une configuration se monte depuis un répertoire — donc
+depuis un dépôt cloné. Le critère du lot est `curl -O docker-compose.yml`, **un
+seul fichier**. Les deux seules issues étaient de recopier la conf nginx dans le
+compose (deux textes, dont un dérivera de l'autre — exactement ce que le projet
+refuse partout ailleurs) ou de se passer de nginx.
+
+On s'en passe. Et il s'avère qu'on ne perd presque rien : whitenoise est dans le
+middleware **depuis toujours** et sert déjà les fichiers statiques en production —
+nginx ne fait que proxifier `/static/` vers Django. Restait le service des médias
+protégés, qui délègue à nginx par `X-Accel-Redirect`.
+
+## Défaut n° 1 — un mécanisme de transport déduit d'un réglage de débogage
+
+`views_media` choisissait son mécanisme sur `settings.DEBUG` :
+
+```python
+if settings.DEBUG:
+    return static_serve(...)          # Django sert
+response["X-Accel-Redirect"] = ...    # sinon, nginx sert
+```
+
+Le raccourci est juste tant qu'il n'existe que deux déploiements : le dev
+(`DEBUG=True`, pas de nginx) et la prod (`DEBUG=False`, nginx). Il devient faux à
+la troisième combinaison — `DEBUG=False` **sans** nginx, qui est précisément la
+pile auto-hébergée. Le navigateur y recevait une réponse **vide** portant un
+en-tête que personne n'allait interpréter : une image cassée, aucune erreur nulle
+part, dans les logs pas plus qu'à l'écran.
+
+Le mécanisme se déclare maintenant (`PROTECTED_MEDIA_ACCEL`). Ce n'est pas un
+renommage : `DEBUG` répond à « est-ce que j'affiche les tracebacks », et rien dans
+cette question ne dit qui envoie les octets d'un PDF.
+
+## Défaut n° 2 — un réglage qui avait l'air posé et ne faisait rien
+
+Le premier chargement de l'instance a servi **900 546 octets** de JavaScript brut.
+`config/settings/base.py` déclarait pourtant :
+
+```python
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+```
+
+Django **5.1 a supprimé ce réglage** au profit de `STORAGES`. Il ne provoque ni
+erreur, ni avertissement : il est simplement ignoré. Le fichier de configuration
+affirmait donc depuis des mois quelque chose de faux, et en production le `gzip on`
+de nginx recompressait à la volée — masquant la moitié du problème et payant du
+CPU pour chaque visiteur.
+
+Rétabli sous la forme que Django lit, avec brotli : **215 636 octets**, compressés
+une fois au `collectstatic`, c'est-à-dire au build de l'image. Quatre fois moins,
+et plus rien à faire à l'exécution.
+
+C'est le même motif que le test d'isolation du lot 1 qui passait sans rien
+vérifier : **un contrôle qu'on n'a jamais vu échouer n'est pas un contrôle**, et un
+réglage qu'on n'a jamais vu agir n'est pas un réglage.
+
+## Ce qui remplace nginx pour la configuration : un module de réglages
+
+`config/settings/selfhost.py` remplit les défauts puis **importe**
+`production.py`. Le durcissement de l'auteur et celui d'un inconnu sont le même
+texte — donc `test_production_settings.py` continue de surveiller le seul fichier
+qui compte, et tout durcissement futur suivra sans qu'on y pense. Une copie aurait
+divergé, et le jour où deux textes divergent, aucun des deux ne fait plus autorité.
+
+Un seul bouton, facultatif : `MAISONNEE_PUBLIC_URL`. Absent, l'instance est une
+boîte sur un réseau local — `ALLOWED_HOSTS` permissif (elle se joint par IP, par
+nom `.local`, par nom Tailscale, et aucun n'est connu d'avance), cookies non
+`Secure` puisque le navigateur les jetterait. Déclaré, `ALLOWED_HOSTS` se réduit à
+**ce seul hôte**, cookies `Secure` et HSTS d'un an.
+
+> **La liste d'hôtes se referme au moment exact où l'exposition s'élargit.**
+
+C'est le point du fichier. Laisser l'utilisateur deviner qu'il doit resserrer,
+c'est garantir qu'il ne le fera pas.
+
+Et ce module ne redirige **jamais** vers HTTPS lui-même : un proxy qui omet
+`X-Forwarded-Proto` fait croire à Django que la requête est en clair, Django
+renvoie vers `https://`, le proxy repasse sans le header, et le navigateur tourne
+jusqu'à l'erreur. C'est le piège classique de l'auto-hébergement, et il ne se
+manifeste que chez celui qui héberge — donc jamais chez celui qui l'a écrit.
+
+## Ce qui a été vérifié, et comment
+
+Pas par relecture. La pile a tourné :
+
+| Critère | Résultat |
+|---|---|
+| `curl -O` puis `docker compose up`, sans éditer un fichier | app en 200 sur `:8000`, identifiants encadrés dans la sortie |
+| Connexion avec le mot de passe généré | jeton JWT obtenu |
+| `down` puis `up` | migrations « no migrations to apply », `create_admin` silencieux, **le même mot de passe fonctionne** — donc même clé secrète, donc volume d'état correct |
+| Profil `demo` | 20 opérations importées, 15 dépenses ventilées, 2 à ranger, 9 enveloppes |
+| Compression | 900 546 → 215 636 octets, `Content-Encoding: br` |
+
+Et le test des réglages a été **cassé volontairement** avant d'être cru : forcer
+`ALLOWED_HOSTS` à `*` fait bien échouer le test qui prétend que l'exposition le
+resserre.
+
+## Le foyer de démonstration n'est pas en règle, exprès
+
+Deux opérations restent sans budget. Une démo entièrement verte ne montre jamais le
+Contrôle — l'écran qui fait le sel du module Argent — et laisse croire qu'un vrai
+foyer termine un mois sans une seule ligne en suspens.
+
+Le relevé passe par le **vrai chemin d'import** (`import_statement_file` sur un CSV
+construit à la volée), jamais par des `objects.create`. L'idempotence vient alors
+gratuitement de `unique(account, dedup_hash)` — et surtout, la seed casse le jour
+où l'import casse, ce qui est exactement le jour où on veut le savoir.

--- a/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
@@ -1,13 +1,13 @@
 # Parcours 28 — Backlog technique : ouvrir Maisonnée
 
-> **État au 2026-07-31** — cadrage terminé, aucun lot démarré.
+> **État au 2026-07-31** — lots 0, 1, 2 et 4 livrés ; lot 1bis partiel.
 > Chantier technique transverse : rendre le projet publiable, installable par un
 > tiers et défendable une fois exposé. Aucune feature métier.
 
 Doc produit : [PARCOURS_28_OUVRIR_MAISONNEE.md](./PARCOURS_28_OUVRIR_MAISONNEE.md)
 Fiche concept (le cours) : [docs/fiches/AUTO_HEBERGEMENT.md](../fiches/AUTO_HEBERGEMENT.md)
 Socle dont on hérite : `DEPLOYMENT.md` (§3.4 résilience du proxy), `CLAUDE.md`
-(§ Déploiement), `nginx/test-resilience.sh`, `apps/tasks/management/commands/seed_demo_data.py`
+(§ Déploiement), `nginx/test-resilience.sh`, `apps/core/management/commands/seed_demo_data.py`
 
 ## Tableau de bord
 
@@ -18,7 +18,7 @@ Issue ombrelle : **#485**
 | 0 | Hygiène du dépôt + durcissement CI (**urgent — dépôt déjà public**) | ✅ Livré (PR #495) | #486 |
 | 1 | Durcissement multi-tenant + test générique d'isolation (**bloquant**) | ✅ Livré (PR #497) | #487 |
 | 1bis | Isolation **en écriture** : FK de serializer ✅ (PR #499) ; actions custom + 26 `APIView` restants | 🔄 Partiel | #498 |
-| 2 | `docker compose up` — première installation en une commande | ⬜ À faire | #488 |
+| 2 | `docker compose up` — première installation en une commande | ✅ Livré | #488 |
 | 3 | Dégradation propre sans service tiers (IA, SMTP, push, Telegram) | ⬜ À faire | #489 |
 | 4 | LICENSE AGPL-3.0 + gouvernance (CONTRIBUTING, SECURITY, DCO, templates) | ✅ Livré (PR #496) | #490 |
 | 5 | Exploitation par un tiers : sauvegarde, restauration testée, mises à jour, releases | ⬜ À faire | #491 |
@@ -284,13 +284,42 @@ ferme l'onglet.
   section « optionnel » clairement séparée
 - `apps/core/management/commands/create_admin.py` (nouveau) — création du premier
   compte depuis des variables d'environnement, idempotente
-- `apps/tasks/management/commands/seed_demo_data.py` — **déplacer** vers
+- `apps/tasks/management/commands/seed_demo_data.py` → **déplacée** vers
   `apps/core/management/commands/` (la seed couvre 30 apps, pas les tâches) et
   vérifier qu'elle couvre les modules Argent (relevé bancaire fictif, budgets,
   ventilations) — c'est ce que la démo doit montrer en premier
 - `.github/workflows/release.yml` (nouveau) — build multi-arch amd64/arm64 +
   publication `ghcr.io` sur tag `v*`
 - `docker-compose.prod.yml` — inchangé (le déploiement de l'auteur ne bouge pas)
+
+> **Livré — trois écarts au plan, tous assumés.**
+>
+> **① Pas de Nginx dans la pile auto-hébergée.** Le plan en prévoyait un ; il
+> aurait fallu monter sa configuration, donc distribuer un dépôt au lieu d'un
+> fichier — ou en recopier le contenu dans le compose, c'est-à-dire créer un
+> second texte qui dérive du premier. La pile tient en **db + init + web +
+> deux schedulers** : whitenoise sert les fichiers statiques (il est déjà dans le
+> middleware, la production s'y appuie depuis toujours), et Django sert les
+> médias protégés lui-même. Le TLS d'une instance exposée se termine dans le
+> reverse proxy de l'hébergeur, qui existe déjà chez tous ceux qui exposent.
+>
+> **② Un module de réglages, pas des variables dans le compose.**
+> `config/settings/selfhost.py` **importe** `production.py` après avoir rempli
+> ses défauts. Le durcissement de l'auteur et celui d'un inconnu sont donc le
+> même texte, et `test_production_settings.py` continue de surveiller le seul
+> fichier qui compte. Un unique bouton facultatif, `MAISONNEE_PUBLIC_URL` : le
+> déclarer resserre `ALLOWED_HOSTS` à ce seul hôte et rallume cookies `Secure` et
+> HSTS — **la liste d'hôtes se referme au moment exact où l'exposition
+> s'élargit**.
+>
+> **③ Deux défauts trouvés en chemin, réparés ici.** Le mécanisme de service des
+> médias se déduisait de `DEBUG` : `DEBUG=False` sans Nginx — la pile
+> auto-hébergée exactement — renvoyait une réponse vide portant un
+> `X-Accel-Redirect` que personne n'allait interpréter. Il se déclare désormais
+> (`PROTECTED_MEDIA_ACCEL`). Et `STATICFILES_STORAGE` ne faisait **rien** depuis
+> Django 5.1, qui l'a supprimé au profit de `STORAGES` : le bundle React partait
+> brut, 900 Ko par visite froide, masqué en production par le `gzip on` de Nginx.
+> Rétabli en brotli au `collectstatic`, donc au build : **215 Ko**.
 
 **Critères**
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,3 +31,7 @@ sqlparse==0.5.5
 typing_extensions==4.15.0
 uritemplate==4.2.0
 whitenoise==6.11.0
+# Brotli — whitenoise ne produit des .br qu'avec lui. Le bundle React tombe de
+# 900 Ko à ~215 Ko, contre ~257 Ko en gzip, et le travail est fait une fois au
+# build plutôt qu'à chaque requête.
+Brotli==1.1.0

--- a/scripts/selfhost-init.sh
+++ b/scripts/selfhost-init.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Mise en état d'une instance auto-hébergée, avant que quoi que ce soit ne serve.
+#
+# Lancé par le service `init` du `docker-compose.yml`, dont `web` dépend en
+# `service_completed_successfully` : le serveur ne démarre donc jamais sur un
+# schéma non migré.
+#
+# ⚠️ Ce script n'est PAS un ENTRYPOINT, et ne doit jamais le devenir.
+#
+# Le `Dockerfile` porte la note complète ; l'essentiel tient en deux phrases. Le
+# `CMD` de l'image doit rester remplaçable pour que le déploiement de l'auteur
+# puisse lancer `compose run --rm web python manage.py migrate` sur l'image
+# neuve — c'est-à-dire migrer AVANT de basculer le trafic. Un entrypoint qui
+# migre au démarrage ferait migrer le conteneur au moment même où il commence à
+# servir, et supprimerait la seule garantie que le déploiement en place existe
+# pour tenir.
+#
+# Ce que ça donne : une même image, deux façons de l'installer, aucune des deux
+# n'ayant à connaître l'autre.
+set -eu
+
+echo "→ Maisonnée : mise en état de l'instance"
+
+# ── 1. Attendre la base ──────────────────────────────────────────────────────
+#
+# Le compose déclare déjà `depends_on: db: condition: service_healthy`, donc ce
+# n'est pas la première ligne de défense. Elle sert au cas que le healthcheck ne
+# couvre pas : PostgreSQL accepte les connexions, puis se redémarre une fois
+# pendant sa toute première initialisation.
+attempt=0
+until python -c "
+import django, os
+django.setup()
+from django.db import connection
+connection.ensure_connection()
+" 2>/dev/null; do
+    attempt=$((attempt + 1))
+    if [ "$attempt" -ge 60 ]; then
+        echo "✗ La base ne répond pas après 60 tentatives. Vérifie le service 'db'." >&2
+        exit 1
+    fi
+    [ "$attempt" -eq 1 ] && echo "   en attente de la base…"
+    sleep 2
+done
+echo "   base disponible"
+
+# ── 2. Le schéma ─────────────────────────────────────────────────────────────
+python manage.py migrate --noinput
+
+# ── 3. Le premier compte ─────────────────────────────────────────────────────
+#
+# Idempotent : ne fait rien si un compte existe (voir core/management/commands).
+python manage.py create_admin
+
+# Le foyer de démonstration n'est PAS ici : il est un service à part, sous le
+# profil `demo` du compose. Le semer d'office réveillerait « Famille Mercier »
+# dans l'instance de quelqu'un qui a commencé à saisir ses vraies données.
+
+echo "✓ Instance prête"


### PR DESCRIPTION
Closes #488.

## Quoi

Une machine avec Docker, trois lignes copiées, une application fonctionnelle :

```bash
curl -O https://raw.githubusercontent.com/jammindev/house/main/docker-compose.yml
docker compose up
```

Aucun fichier à éditer, aucune clé à souscrire, aucun `SECRET_KEY` à fabriquer. Les identifiants du premier compte s'affichent encadrés dans la sortie de la commande. `docker compose --profile demo up` ajoute le foyer « Famille Mercier » pour cliquer dans un produit rempli plutôt que lire une promesse.

**Le déploiement de l'auteur ne bouge pas** : `docker-compose.prod.yml`, le job `deploy`, la séquence `--no-deps`, la migration sur conteneur jetable et `nginx/test-resilience.sh` sont intacts. Deux fichiers touchent son chemin — voir « Ce qui touche la prod » plus bas.

## Trois écarts au plan, tous assumés

**① Pas de nginx dans la pile.** Le plan en prévoyait un. Un nginx a besoin de sa configuration, donc d'un répertoire monté — donc d'un dépôt cloné, là où le critère est **un fichier unique**. L'autre issue était de recopier la conf dans le compose : un second texte qui dérive du premier, exactement ce que le projet refuse partout ailleurs. On s'en passe presque sans perte — whitenoise est dans le middleware depuis toujours et sert déjà les statiques en production ; nginx ne fait que proxifier `/static/` vers Django. Le TLS d'une instance exposée se termine dans le reverse proxy de l'hébergeur, qui existe déjà chez tous ceux qui exposent.

**② Un module de réglages plutôt que des variables dans le compose.** `config/settings/selfhost.py` remplit ses défauts puis **importe** `production.py`. Le durcissement de l'auteur et celui d'un inconnu sont donc le même texte, et `test_production_settings.py` continue de surveiller le seul fichier qui compte.

Un seul bouton, facultatif : `MAISONNEE_PUBLIC_URL`.

| | absent (réseau local) | `https://maison.exemple.fr` |
|---|---|---|
| `ALLOWED_HOSTS` | `*` | ce seul hôte |
| Cookies `Secure` | non (le navigateur les jetterait) | oui |
| HSTS | 0 | un an |

> **La liste d'hôtes se referme au moment exact où l'exposition s'élargit.** Laisser l'utilisateur deviner qu'il doit resserrer, c'est garantir qu'il ne le fera pas.

Et le module ne redirige **jamais** vers HTTPS lui-même : un proxy qui omet `X-Forwarded-Proto` fait croire à Django que la requête est en clair, Django renvoie vers `https://`, le proxy repasse sans le header. Boucle infinie, chez l'hébergeur et jamais chez celui qui l'a écrit.

**③ Deux défauts trouvés en chemin.** Les deux invisibles sur la prod, les deux réparés ici.

- **Le service des médias déduisait son mécanisme de `DEBUG`.** Le raccourci tient tant qu'il n'existe que deux déploiements ; il devient faux à la troisième combinaison — `DEBUG=False` **sans** nginx, c'est-à-dire la pile auto-hébergée. Le navigateur recevait une réponse **vide** portant un `X-Accel-Redirect` que personne n'allait interpréter : image cassée, aucune erreur nulle part. Le mécanisme se déclare désormais (`PROTECTED_MEDIA_ACCEL`).
- **`STATICFILES_STORAGE` ne faisait rien depuis Django 5.1**, qui l'a supprimé au profit de `STORAGES` — sans erreur ni avertissement. Le bundle React partait brut, **900 546 octets** par visite froide, masqué en production par le `gzip on` de nginx qui recompressait à la volée, pour chaque visiteur. Rétabli sous la forme que Django lit, avec brotli : **215 636 octets**, compressés une fois au `collectstatic`, donc au build de l'image.

C'est le même motif que le test d'isolation du lot 1 qui passait sans rien vérifier : un contrôle qu'on n'a jamais vu échouer n'est pas un contrôle, et un réglage qu'on n'a jamais vu agir n'est pas un réglage.

## Ce qui touche la prod (à relire en priorité)

- `config/settings/base.py` — `STATICFILES_STORAGE` → `STORAGES`. La prod servira désormais du brotli pré-compressé au lieu du gzip à la volée de nginx. Le module `gzip` de nginx laisse passer une réponse portant déjà un `Content-Encoding`, et l'`Accept-Encoding` du navigateur est transmis à l'amont (aucun `proxy_set_header Accept-Encoding ""` dans la conf). Vérifié sur la pile réelle : `Content-Encoding: br`, 215 Ko.
- `config/settings/production.py` — une ligne additive : `PROTECTED_MEDIA_ACCEL = env.bool(..., default=True)`. Comportement inchangé.
- `Dockerfile` — `--platform=$BUILDPLATFORM` sur l'étage frontend. La sortie est du JS/CSS, identique sur amd64 et arm64 ; sans cette ligne, publier pour Raspberry Pi ferait tourner Node en émulation qemu pour un résultat rigoureusement le même.

## Critères de l'issue

- ✅ **1.** VM neuve + Docker : `curl -O`, `docker compose up`, app sur `:8000` sans éditer un fichier — *vérifié sur une pile vierge, répertoire vide, un seul fichier copié*
- ✅ **2.** Le profil `demo` montre un relevé importé et ventilé — *20 opérations importées, 15 dépenses ventilées, 2 à ranger, 9 enveloppes*
- ✅ **3.** Aucune variable obligatoire avant le premier écran
- ⚠️ **4.** Démarre sur arm64 — *l'image a été construite et exercée nativement en arm64 (Apple Silicon). Le build multi-arch amd64+arm64 ne sera prouvé qu'au premier tag `v*` : le workflow `release.yml` ne se déclenche pas sur une PR*
- ✅ **5.** `down && up` conserve les données ; `pull && up -d` migre tout seul — *au second démarrage : « no migrations to apply », `create_admin` silencieux, et **le même mot de passe fonctionne** — donc même clé secrète, donc volume d'état correct*
- ✅ **6.** Le déploiement existant reste vert et inchangé

## Vérifié en exécutant, pas en relisant

| Vérification | Résultat |
|---|---|
| Pile vierge, `docker compose up` | 200 sur `/` et `/health/` |
| Connexion avec le mot de passe généré | jeton JWT obtenu |
| `down` puis `up` | données et identifiants conservés |
| Profil `demo` | foyer rempli, module Argent inclus |
| Compression | 900 546 → 215 636 octets, `Content-Encoding: br` |
| Test des réglages **cassé volontairement** | forcer `ALLOWED_HOSTS=*` fait bien échouer le test qui prétend l'inverse |

`pytest` : **4060 passés, 2 ignorés**. Lint et `tsc -b` propres.

## Sur la seed

`seed_demo_data` passe de `apps/tasks/` à `apps/core/` (elle couvre trente apps) et gagne le volet Argent. Le relevé emprunte le **vrai chemin d'import** (`import_statement_file` sur un CSV construit à la volée), jamais des `objects.create` : l'idempotence vient alors gratuitement de `unique(account, dedup_hash)`, et surtout la seed casse le jour où l'import casse — c'est exactement le jour où on veut le savoir.

Le foyer de démonstration **n'est pas en règle**, exprès : deux opérations restent sans budget. Une démo entièrement verte ne montre jamais le Contrôle — l'écran qui fait le sel du module — et laisse croire qu'un vrai foyer termine un mois sans une seule ligne en suspens.

## Hors scope

- La documentation d'exploitation (`docs/self-hosting/`), la sauvegarde et la restauration testée sont le **lot 5** (#491).
- Rendre visible à l'écran ce qui manque sans clé d'API est le **lot 3** (#489). Ici, une capacité absente reste silencieuse.
- Le README et les captures sont le **lot 6** (#492).
- Réglage GitHub appliqué hors dépôt : les cinq actions `docker/*` ont été ajoutées à la liste blanche `selected_actions`, sans quoi `release.yml` serait refusé au premier tag.
