### PR TITLE
fix(documents): les photos et documents d'avant la disposition actuelle se rouvrent (#517)

### DIFF
--- a/apps/core/tests/test_media_isolation.py
+++ b/apps/core/tests/test_media_isolation.py
@@ -214,3 +214,96 @@ class TestTheDocumentRulesStillHold:
         """401 et 403 disent deux choses différentes ; le front s'en sert."""
         path = self._doc(household_a, alice)
         assert client.get(media_url(path)).status_code == 401
+
+
+@pytest.mark.django_db
+class TestADocumentWrittenBeforeTodaysLayoutStaysReadable:
+    """Régression : le *default-deny* a fermé l'accès à l'existant.
+
+    Le durcissement précédent n'autorise que les préfixes ``documents/`` et
+    ``avatars/`` — ceux que ``Document.build_upload_path`` produit
+    **aujourd'hui**. Or les documents plus anciens sont rangés sous
+    ``<foyer>/<dossier>/…``, une disposition que plus aucune ligne de code
+    n'écrit mais que la base porte toujours : en production, 177 documents sur
+    202 sont devenus invisibles d'un coup, vignettes comprises.
+
+    ⚠️ **Ce que ces tests corrigent tient moins au code qu'à leur propre
+    fabrication.** Toute la classe voisine construit ses fixtures avec
+    ``build_upload_path`` : elle vérifie donc le service des fichiers contre ce
+    que le code écrit, jamais contre ce que le foyer possède. Un contrôle qui ne
+    connaît qu'un seul schéma de chemin ne peut pas voir mourir les autres —
+    d'où les chemins écrits **en dur** ici, exactement sous la forme trouvée en
+    base.
+
+    L'attribution ne se déduit pas du chemin : elle se **résout en base**, par le
+    document dont c'est le fichier. Un chemin qu'aucun document ne réclame reste
+    donc refusé, et le default-deny garde son sens.
+    """
+
+    def _legacy_paths(self, household):
+        """La forme réellement présente en base — jamais celle du builder."""
+        folder = "44e6e84b-b680-428d-982e-3b5e0c9a1f27"
+        file_path = f"{household.id}/{folder}/e997edd3_IMG_2212.jpg"
+        thumb_path = f"{household.id}/{folder}/.thumbnails/thumb/e997edd3_IMG_2212.jpg"
+        return file_path, thumb_path
+
+    def _legacy_doc(self, household, owner, *, private=False):
+        file_path, thumb_path = self._legacy_paths(household)
+        default_storage.save(file_path, ContentFile(b"\xff\xd8\xff fake jpeg"))
+        default_storage.save(thumb_path, ContentFile(b"\xff\xd8\xff fake jpeg"))
+        Document.objects.create(
+            household=household,
+            created_by=owner,
+            name="IMG_2212",
+            file_path=file_path,
+            is_private=private,
+        )
+        return file_path, thumb_path
+
+    def test_a_member_reads_it(self, client, household_a, alice, amelie):
+        file_path, _ = self._legacy_doc(household_a, alice)
+        client.force_login(amelie)
+        assert client.get(media_url(file_path)).status_code == 200
+
+    def test_a_member_reads_its_thumbnail(self, client, household_a, alice, amelie):
+        """La grille de photos ne montre que des vignettes : sans elles, page vide."""
+        _, thumb_path = self._legacy_doc(household_a, alice)
+        client.force_login(amelie)
+        assert client.get(media_url(thumb_path)).status_code == 200
+
+    def test_a_stranger_still_does_not(self, client, household_a, alice, bob):
+        file_path, _ = self._legacy_doc(household_a, alice)
+        client.force_login(bob)
+        assert client.get(media_url(file_path)).status_code == 403
+
+    def test_a_stranger_does_not_get_the_thumbnail_either(
+        self, client, household_a, alice, bob
+    ):
+        _, thumb_path = self._legacy_doc(household_a, alice)
+        client.force_login(bob)
+        assert client.get(media_url(thumb_path)).status_code == 403
+
+    def test_privacy_still_holds_between_members(
+        self, client, household_a, alice, amelie
+    ):
+        file_path, thumb_path = self._legacy_doc(household_a, alice, private=True)
+        client.force_login(amelie)
+        assert client.get(media_url(file_path)).status_code == 403
+        assert client.get(media_url(thumb_path)).status_code == 403
+
+    def test_a_file_no_document_claims_is_still_refused(self, client, household_a, alice):
+        """Le default-deny reste entier : on sert ce qu'un document réclame.
+
+        Un fichier posé sous un chemin d'apparence légitime, mais qu'aucune ligne
+        de la base ne rattache à un foyer, n'est attribuable à personne — donc
+        refusé. C'est ce qui distingue « rouvrir l'ancien » de « rouvrir tout ».
+        """
+        path = f"{household_a.id}/orphelin/inconnu.jpg"
+        default_storage.save(path, ContentFile(b"\xff\xd8\xff fake jpeg"))
+        client.force_login(alice)
+        assert client.get(media_url(path)).status_code == 403
+
+    def test_an_unknown_prefix_is_still_refused(self, client, alice):
+        """Le garde-fou de la classe voisine, rejoué depuis cette porte-ci."""
+        client.force_login(alice)
+        assert client.get(media_url("exports/2026/tout.csv")).status_code == 403

--- a/apps/core/views_media.py
+++ b/apps/core/views_media.py
@@ -32,6 +32,23 @@ D'où deux règles structurantes, tenues par
 2. **Un contrôle porte sur ce qu'on sert, pas sur ce qu'on croit servir.** La
    vignette d'un document privé est *le* document pour un scan ou une photo ;
    la faire échapper au contrôle rendait ``is_private`` décoratif.
+
+⚠️ **Un préfixe déclaré dit ce que le code écrit, jamais ce que le foyer
+possède.** La règle 1, appliquée aux seuls préfixes que
+``Document.build_upload_path`` produit *aujourd'hui*, a fermé l'accès aux
+documents rangés sous ``<foyer>/<dossier>/…`` — une disposition que plus aucune
+ligne n'écrit mais que la base porte toujours. En production, 177 documents sur
+202 sont devenus invisibles d'un coup, vignettes comprises, et rien dans les
+tests ne pouvait le voir : ils fabriquaient leurs fixtures avec le builder,
+c'est-à-dire dans la seule disposition qui marchait encore (issue #517).
+
+D'où la troisième règle, qui est la forme durable des deux premières :
+
+3. **Un fichier se rattache à un foyer en base, pas par la forme de son
+   chemin.** Ce qu'aucun document ne réclame reste refusé — le default-deny est
+   intact —, mais ce qu'un document réclame est contrôlé sur *son* foyer et
+   *sa* confidentialité, quelle que soit la disposition sous laquelle il a été
+   écrit. Un schéma de nommage change ; l'appartenance, non.
 """
 from urllib.parse import quote
 
@@ -60,6 +77,26 @@ def _is_member(user, household_id) -> bool:
         raise Http404
 
 
+def _document_at(path: str, **filters) -> Document | None:
+    """Le document dont ``path`` est le fichier — ou sa vignette.
+
+    La vignette vit à un autre chemin que l'original ; ``source_path_prefix``
+    est l'inverse exact de la fonction qui l'a produit, et rend ``None`` sur un
+    chemin qui n'en est pas une. C'est le **seul** endroit où l'on traduit un
+    chemin en document, pour que les deux portes ci-dessous ne se mettent pas à
+    répondre différemment sur le même fichier.
+    """
+    prefix = source_path_prefix(path)
+    if prefix is not None:
+        return Document.objects.filter(file_path__startswith=prefix, **filters).first()
+    return Document.objects.filter(file_path=path, **filters).first()
+
+
+def _is_readable_by(document: Document, user) -> bool:
+    """Un document privé n'appartient qu'à qui l'a déposé."""
+    return not document.is_private or document.created_by_id == user.id
+
+
 def _check_document(user, path: str) -> int | None:
     """``None`` si l'accès est permis, sinon le code HTTP à renvoyer."""
     parts = path.split("/")
@@ -70,13 +107,11 @@ def _check_document(user, path: str) -> int | None:
         return FORBIDDEN
 
     # Confidentialité — sur l'original comme sur sa vignette.
-    prefix = source_path_prefix(path)
-    if prefix is not None:
-        document = Document.objects.filter(
-            household_id=household_id, file_path__startswith=prefix
-        ).first()
-    else:
-        document = Document.objects.filter(file_path=path).first()
+    document = (
+        _document_at(path, household_id=household_id)
+        if source_path_prefix(path) is not None
+        else _document_at(path)
+    )
 
     if document is None:
         # Chemin sous `documents/<foyer>/` sans document en base : orphelin de
@@ -84,9 +119,29 @@ def _check_document(user, path: str) -> int | None:
         # refuser casserait les fichiers importés hors du modèle.
         return None
 
-    if document.is_private and document.created_by_id != user.id:
+    return None if _is_readable_by(document, user) else FORBIDDEN
+
+
+def _check_by_ownership(user, path: str) -> int | None:
+    """Le contrôle de dernier recours — voir la règle 3 en tête de module.
+
+    Aucune hypothèse sur la forme du chemin : on demande à la base **quel
+    document réclame ce fichier**, et on contrôle sur le foyer de ce
+    document-là. C'est ce qui rend le service indifférent à la disposition de
+    stockage, présente comme passée.
+
+    La différence avec ``_check_document`` tient en une ligne, et c'est la plus
+    importante : ici, **un fichier que personne ne réclame est refusé**. Là-bas
+    l'orphelin est servi, parce que l'appartenance au foyer était déjà établie
+    par le chemin lui-même ; ici on ne sait rien du chemin, donc l'absence de
+    document n'est pas un détail de stockage — c'est un fichier non attribuable.
+    """
+    document = _document_at(path)
+    if document is None:
         return FORBIDDEN
-    return None
+    if not _is_member(user, document.household_id):
+        return FORBIDDEN
+    return None if _is_readable_by(document, user) else FORBIDDEN
 
 
 def _check_avatar(user, path: str) -> int | None:
@@ -116,7 +171,8 @@ def _check_avatar(user, path: str) -> int | None:
 
 
 # Préfixe → contrôleur. Ajouter un emplacement de fichiers, c'est ajouter sa
-# ligne ici : sans elle il est refusé, ce qui est le bon défaut.
+# ligne ici : sans elle, le chemin doit se faire reconnaître en base
+# (`_check_by_ownership`) ou il est refusé — ce qui reste le bon défaut.
 _CHECKS = {
     "documents": _check_document,
     "avatars": _check_avatar,
@@ -132,10 +188,9 @@ def serve_protected_media(request, path):
         raise Http404
 
     prefix = path.split("/", 1)[0]
-    check = _CHECKS.get(prefix)
-    if check is None:
-        # Default-deny : voir la règle 1 en tête de module.
-        return HttpResponse(status=FORBIDDEN)
+    # Un préfixe déclaré porte son propre contrôle ; tout le reste doit se faire
+    # reconnaître par un document en base, sinon c'est 403 (règles 1 et 3).
+    check = _CHECKS.get(prefix, _check_by_ownership)
 
     denied = check(request.user, path)
     if denied is not None:

--- a/docs/MODULES/security.md
+++ b/docs/MODULES/security.md
@@ -146,10 +146,30 @@ Deux défauts y ont été trouvés et corrigés au lot 1 :
   remonte de la vignette au document vit **à côté** de celle qui produit le
   chemin (`documents/thumbnails.py`), pour qu'elles ne puissent pas se désaligner.
 
+⚠️ **Et le durcissement lui-même a produit le troisième défaut** (issue #517) :
+`_CHECKS` déclare les préfixes que `Document.build_upload_path` écrit
+**aujourd'hui**, alors que la base porte encore ceux d'hier. Les documents rangés
+sous `<foyer>/<dossier>/…` sont tombés en 403 d'un bloc — **177 sur 202 en
+production**, vignettes comprises, donc la page Photos vide et aucun document
+consultable. Personne n'a pu le voir : les tests d'isolation fabriquaient leurs
+fixtures avec le builder, c'est-à-dire dans la seule disposition qui marchait
+encore. **Un test qui ne connaît qu'un schéma de chemin ne peut pas voir mourir
+les autres** — d'où des chemins écrits en dur, sous la forme trouvée en base.
+
+D'où la règle qui porte les deux premières :
+
+> **Un fichier se rattache à un foyer en base, pas par la forme de son chemin.**
+
+Un préfixe déclaré garde son contrôle ; tout le reste passe par
+`_check_by_ownership`, qui demande à la base **quel document réclame ce
+fichier** et contrôle sur le foyer *de ce document*. Ce qu'aucun document ne
+réclame reste refusé — le default-deny est intact, et il ne dépend plus d'un
+schéma de nommage qui, lui, changera encore.
+
 Régression : `apps/core/tests/test_media_isolation.py`.
 
 **Ajouter un emplacement de fichiers = ajouter sa ligne dans `_CHECKS`.** Sans
-elle il est refusé, ce qui est le bon défaut.
+elle, le chemin doit se faire reconnaître en base ou il est refusé.
 
 ### La révocation d'accès — un invariant sur un fil
 


### PR DESCRIPTION
Corrige #517 — régression du lot 1 du parcours 28 (`9e6360b5`, PR #497).

## Ce qui s'est passé

Le durcissement en *default-deny* du service de fichiers n'autorise que les préfixes que `Document.build_upload_path` écrit **aujourd'hui** (`documents/`, `avatars/`). La base porte encore ceux d'hier : en production, **177 documents sur 202** sont rangés sous `<foyer>/<dossier>/…` — 471 fichiers, originaux et vignettes, tombés en 403 d'un bloc. Page Photos vide, aucun document consultable.

Reproduit dans le conteneur `web`, en requête authentifiée :

```
200  documents/<foyer>/2026/07/…     (25 documents)
403  <uuid-foyer>/<uuid>/…           (177 documents)
```

## Pourquoi les tests étaient verts

Ils fabriquent leurs fixtures avec `build_upload_path`, c'est-à-dire dans la seule disposition qui marchait encore. **Un test qui ne connaît qu'un schéma de chemin ne peut pas voir mourir les autres.** Les nouveaux écrivent le chemin en dur, sous la forme trouvée en base.

## Le correctif

> Un fichier se rattache à un foyer **en base**, pas par la forme de son chemin.

Un préfixe déclaré garde son contrôle ; tout le reste passe par `_check_by_ownership`, qui demande à la base quel document réclame ce fichier et contrôle sur le foyer **de ce document**. Ce qu'aucun document ne réclame reste refusé : le default-deny est intact, il ne dépend simplement plus d'un schéma de nommage qui changera encore.

## Vérifications

- 7 tests de régression dans `test_media_isolation.py` — rouges avant, verts après ; l'isolation entre foyers, la confidentialité entre membres et le refus d'un fichier non attribuable sont rejoués depuis cette porte-ci
- Suite complète verte (4081 passés)
- Aucun fichier front touché