### PR TITLE
ci(tests): paralléliser la suite backend sur deux workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
 
     env:
       DATABASE_URL: postgres://house_user:test_password@localhost:5432/house_test
+      # Une seule définition du nombre de workers : l'étape qui crée les bases et
+      # celle qui lance pytest doivent toujours parler du même chiffre.
+      PYTEST_WORKERS: 2
 
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -44,8 +47,26 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements/test.txt
 
+      # La suite tourne en parallèle (`-n`), donc sur une base par worker :
+      # pytest-django suffixe `TEST['NAME']` (→ `house_test_gw0`, `house_test_gw1`).
+      #
+      # On les crée ici plutôt que de laisser Django le faire, et c'est le point à
+      # ne pas défaire : un `CREATE DATABASE` sans template explicite clone
+      # `template1`, or conftest.py y ouvre une connexion pour poser l'extension
+      # `vector` (contrepartie de --nomigrations, voir sa docstring). Postgres
+      # refuse de cloner une base à laquelle une autre session est connectée — deux
+      # workers qui démarrent ensemble, c'est un rouge intermittent, le genre qui
+      # coûte plus cher que les secondes gagnées. Bases pré-créées, `--reuse-db`
+      # (pytest.ini) les réutilise : aucun clone n'a lieu, et le conftest pose
+      # l'extension dans chacune par son chemin « la base existe déjà ».
+      - name: Create one test database per worker
+        run: |
+          for i in $(seq 0 $((PYTEST_WORKERS - 1))); do
+            psql "$DATABASE_URL" -c "CREATE DATABASE house_test_gw$i"
+          done
+
       - name: Run tests
-        run: pytest --no-cov-on-fail -q
+        run: pytest -n "$PYTEST_WORKERS" --no-cov-on-fail -q
 
   frontend:
     name: Frontend lint & build

--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,13 @@ def _create_vector_extension(host, port, user, password, dbname):
     except psycopg.OperationalError:
         # DB doesn't exist yet (it will be cloned from template1) — fine.
         pass
+    except (psycopg.errors.UniqueViolation, psycopg.errors.DuplicateObject):
+        # Deux workers xdist ont assuré l'extension sur la *même* base au même
+        # instant — `template1`, que tous partagent. `IF NOT EXISTS` ne protège
+        # pas de ça : les deux la voient absente, les deux insèrent, l'un perd
+        # sur `pg_extension_name_index`. Ce qu'on demandait est vrai quand même
+        # (l'extension existe), donc perdre la course n'est pas un échec.
+        pass
 
 
 @pytest.fixture(scope="session")

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 -r base.txt
 attrs==25.4.0
 coverage==7.13.4
+execnet==2.1.2
 factory_boy==3.3.3
 Faker==40.4.0
 iniconfig==2.3.0
@@ -8,3 +9,4 @@ pluggy==1.6.0
 pytest==8.4.2
 pytest-cov==4.1.0
 pytest-django==4.12.0
+pytest-xdist==3.8.0


### PR DESCRIPTION
## Pourquoi

Le job `backend` est le chemin critique de la CI — 3 min 28 contre 1 min 30 pour le front — et **163 s y sont du pur temps de tests** (run `30667738379`).

## Ce que ça change

- `pytest-xdist` (+ `execnet`) dans `requirements/test.txt` ;
- `pytest -n "$PYTEST_WORKERS"` dans le job `backend`, avec une base par worker créée en amont ;
- `conftest.py` tolère la course de deux workers sur l'extension `vector`.

## Mesuré en CI

| | tests | job `backend` |
|---|---|---|
| série (référence) | 163 s | 3 min 28 |
| **`-n 2`** | **130 s** | **2 min 51** |
| `-n 4` | 129 s | 2 min 54 |

Le runner a 4 vCPU, partagés avec le conteneur postgres : au-delà de deux workers le temps de tests ne bouge plus et le setup grossit (chaque worker construit son schéma, 32 s → 54 s). D'où deux, et pas `auto`.

## Les deux courses rencontrées

**Le clone de `template1`.** Un `CREATE DATABASE` sans template explicite clone `template1`, où `conftest.py` ouvre une connexion pour poser l'extension `vector` (contrepartie de `--nomigrations`). Postgres refuse de cloner une base à laquelle une autre session est connectée. D'où les bases pré-créées par une étape du job : `--reuse-db` les réutilise, aucun clone n'a lieu.

**L'extension elle-même.** `CREATE EXTENSION IF NOT EXISTS` n'est pas atomique : deux workers la voient absente de `template1`, tous deux insèrent, l'un perd sur `pg_extension_name_index` — et emporte les 1986 tests de son worker. Invisible en local, où l'extension était déjà là depuis un vieux `--create-db` ; reproduit en la retirant, corrigé, revérifié.

Le nombre de workers est défini une seule fois (`PYTEST_WORKERS`) : l'étape qui crée les bases et celle qui lance pytest ne peuvent pas diverger.