### PR TITLE
fix(agent): la recherche de l'assistant expose les documents privés (#501)

### DIFF
--- a/apps/agent/context.py
+++ b/apps/agent/context.py
@@ -72,7 +72,7 @@ class ContextItem:
     available: bool = True
 
 
-def describe_conversation_context(conversation, household) -> list[ContextItem]:
+def describe_conversation_context(conversation, household, viewer=None) -> list[ContextItem]:
     """Resolve a conversation's full injected context into display items.
 
     Single source of truth for the "what I know" panel: it walks the exact same
@@ -96,7 +96,7 @@ def describe_conversation_context(conversation, household) -> list[ContextItem]:
     items: list[ContextItem] = []
     seen: set[tuple[str, str]] = set()
     for origin, entity_type, object_id in roots:
-        ctx = build_entity_context(entity_type, object_id, household)
+        ctx = build_entity_context(entity_type, object_id, household, viewer)
         if ctx is None:
             # Unresolved anchor is silent (structural); a dangling pin stays
             # visible so the user can remove it.
@@ -137,14 +137,17 @@ def build_entity_context(
     entity_type: str,
     object_id: str,
     household,
+    viewer=None,
 ) -> EntityContext | None:
     """Build the pre-injected context for one anchor entity, or None.
 
     Returns ``None`` when the anchor can't be resolved (unknown type, malformed
-    id, or the row no longer exists — an orphaned anchor). The caller then runs
-    the agent without a pre-injected context, exactly like an unanchored chat.
+    id, the row no longer exists — an orphaned anchor — or ``viewer`` may not read
+    it). An anchor one may not read is indistinguishable from an orphaned one, on
+    purpose: the conversation simply proceeds unanchored rather than announcing
+    that something is being withheld.
     """
-    resolved, _error = resolve_entity(entity_type, object_id, household)
+    resolved, _error = resolve_entity(entity_type, object_id, household, viewer)
     if resolved is None:
         logger.info(
             "agent.context: unresolved anchor %s:%s for household %s",
@@ -158,7 +161,7 @@ def build_entity_context(
     # Anchor first (full content), then everything linked to it — each item as
     # its own citable Hit, mirroring get_entity + get_related.
     hits: list[Hit] = [retrieval.hit_from_instance(spec, obj)]
-    hits.extend(_related_hits(spec, obj, household))
+    hits.extend(_related_hits(spec, obj, household, viewer))
 
     rendered = render_context_block(
         hits,
@@ -173,21 +176,28 @@ def build_entity_context(
     )
 
 
-def _related_hits(spec, obj, household) -> list[Hit]:
+def _related_hits(spec, obj, household, viewer=None) -> list[Hit]:
     """Turn the anchor's related instances into citable hits (scoped, bounded).
 
     Same walk and guards as ``tools._get_related_handler``: cap the count, skip
-    unregistered types, and never surface an item from another household. Linked
-    documents are included automatically via ``gather_related``.
+    unregistered types, never surface an item from another household, and drop
+    what ``viewer`` may not read. Linked documents are included automatically via
+    ``gather_related`` — which is precisely why the viewer guard belongs here too:
+    a private invoice attached to a shared project would otherwise ride into the
+    context of anyone who opens that project.
     """
     from .related import gather_related
 
-    hits: list[Hit] = []
+    candidates = []
     for rel in gather_related(spec, obj)[:RELATED_MAX_ITEMS]:
         rel_spec = searchables.find_spec_for_instance(rel)
         if rel_spec is None:
             continue
         if getattr(rel, "household_id", household.id) != household.id:
             continue
-        hits.append(retrieval.hit_from_instance(rel_spec, rel))
-    return hits
+        candidates.append((rel_spec, rel))
+
+    return [
+        retrieval.hit_from_instance(rel_spec, rel)
+        for rel_spec, rel in retrieval.filter_visible_instances(candidates, viewer)
+    ]

--- a/apps/agent/retrieval.py
+++ b/apps/agent/retrieval.py
@@ -83,6 +83,52 @@ def _spec_url(spec: SearchableSpec, instance) -> str:
     return spec.url_template.format(id=instance.pk)
 
 
+def apply_visibility(spec: SearchableSpec, queryset, viewer):
+    """Narrow ``queryset`` to what ``viewer`` may read, per the spec's declaration.
+
+    The single application point of ``SearchableSpec.visibility``. Every read path
+    of the agent funnels through here, so a spec that declares a rule is filtered
+    on all of them at once — the alternative (a filter added at each call site) is
+    exactly how the household scope stayed right while privacy was forgotten.
+    """
+    if spec.visibility is None:
+        return queryset
+    return spec.visibility(queryset, viewer)
+
+
+def filter_visible_instances(pairs: list[tuple[SearchableSpec, Any]], viewer):
+    """Keep only the ``(spec, instance)`` pairs ``viewer`` may read.
+
+    The instance-level counterpart of ``apply_visibility``, for the paths that
+    already hold objects rather than a queryset (``get_related`` walks a project's
+    whole neighbourhood through ``spec.related``). Grouped by entity type so the
+    cost is one query per *type* present, never one per item.
+
+    Both helpers read the same ``spec.visibility``: there is no second rule here
+    that could drift from the queryset one.
+    """
+    guarded = [(spec, obj) for spec, obj in pairs if spec.visibility is not None]
+    if not guarded:
+        return list(pairs)
+
+    allowed: dict[str, set] = {}
+    for spec, _ in guarded:
+        if spec.entity_type in allowed:
+            continue
+        pks = [obj.pk for other, obj in guarded if other.entity_type == spec.entity_type]
+        allowed[spec.entity_type] = set(
+            apply_visibility(spec, spec.model.objects.filter(pk__in=pks), viewer).values_list(
+                "pk", flat=True
+            )
+        )
+
+    return [
+        (spec, obj)
+        for spec, obj in pairs
+        if spec.visibility is None or obj.pk in allowed[spec.entity_type]
+    ]
+
+
 def _build_query(query: str) -> SearchQuery:
     """Turn a free-form user query into a tsquery suitable for `simple` config.
 
@@ -108,7 +154,9 @@ def _vector_for_fields(fields: tuple[str, ...]) -> SearchVector:
     return vector
 
 
-def _search_one(spec: SearchableSpec, household_id: UUID, query: str, limit: int) -> list[Hit]:
+def _search_one(
+    spec: SearchableSpec, household_id: UUID, query: str, limit: int, viewer=None
+) -> list[Hit]:
     """Run the search for a single registered model and return hits."""
     if not spec.search_fields:
         return []
@@ -135,7 +183,7 @@ def _search_one(spec: SearchableSpec, household_id: UUID, query: str, limit: int
     }
 
     qs = (
-        spec.model.objects.filter(household_id=household_id)
+        apply_visibility(spec, spec.model.objects.filter(household_id=household_id), viewer)
         .annotate(_search_vector=vector)
         .annotate(
             _rank=SearchRank(
@@ -222,11 +270,18 @@ def search(
     disabled: frozenset[str] | None = None,
     *,
     hybrid: bool | None = None,
+    viewer=None,
 ) -> list[Hit]:
     """Return up to `limit` hits across all registered entities, ranked desc.
 
     Specs of household-disabled modules are skipped. ``disabled`` lets callers
     that loop over several queries (``search_multi``) fetch the set once.
+
+    ``viewer`` is the user asking. The household says *whose* data this is; the
+    viewer says *which of it they may read* — a document one member marked private
+    belongs to the household but is not theirs to see. Omitting it is fail-closed
+    (``core.visibility.visible_to_creator`` then returns public rows only), so a
+    forgotten call site under-reports instead of leaking.
 
     ``hybrid`` overrides ``AGENT_HYBRID_RETRIEVAL_ENABLED`` for this call. The
     global flag is the right default for a *question* asked to the agent, where one
@@ -245,7 +300,7 @@ def search(
     for spec in REGISTRY:
         if spec_disabled(spec, disabled):
             continue
-        all_hits.extend(_search_one(spec, household_id, query, limit))
+        all_hits.extend(_search_one(spec, household_id, query, limit, viewer))
 
     all_hits.sort(key=lambda h: h.rank, reverse=True)
     fulltext_hits = all_hits[:limit]
@@ -253,7 +308,7 @@ def search(
     if not (_hybrid_enabled() if hybrid is None else hybrid):
         return fulltext_hits
 
-    vector_hits = _vector_search(household_id, query, limit, disabled=disabled)
+    vector_hits = _vector_search(household_id, query, limit, disabled=disabled, viewer=viewer)
     if not vector_hits:
         # No semantic leg (embeddings disabled/unavailable/empty index) → behave
         # exactly like pure full-text. Never worse than today.
@@ -271,6 +326,8 @@ def semantic_only(
     query: str,
     limit: int = 20,
     disabled: frozenset[str] | None = None,
+    *,
+    viewer=None,
 ) -> list[Hit]:
     """The semantic leg alone, minus everything the lexical leg already finds.
 
@@ -297,13 +354,15 @@ def semantic_only(
     if disabled is None:
         disabled = disabled_modules_for(household_id)
 
-    vector_hits = _vector_search(household_id, query, limit, disabled=disabled)
+    vector_hits = _vector_search(household_id, query, limit, disabled=disabled, viewer=viewer)
     if not vector_hits:
         return []
 
     already_shown = {
         (hit.entity_type, hit.id)
-        for hit in search(household_id, query, limit=limit, disabled=disabled, hybrid=False)
+        for hit in search(
+            household_id, query, limit=limit, disabled=disabled, hybrid=False, viewer=viewer
+        )
     }
     return [hit for hit in vector_hits if (hit.entity_type, hit.id) not in already_shown]
 
@@ -313,6 +372,8 @@ def _vector_search(
     query: str,
     limit: int,
     disabled: frozenset[str] | None = None,
+    *,
+    viewer=None,
 ) -> list[Hit]:
     """Semantic leg: embed the query, k-NN over `EmbeddingChunk`, dedupe to entities.
 
@@ -351,10 +412,16 @@ def _vector_search(
         spec = find_spec(chunk.entity_type)
         if spec is None or spec_disabled(spec, disabled):
             continue
-        instance = spec.model.objects.filter(
-            household_id=household_id, pk=chunk.object_id
+        instance = apply_visibility(
+            spec,
+            spec.model.objects.filter(household_id=household_id, pk=chunk.object_id),
+            viewer,
         ).first()
-        if instance is None:  # stale chunk (source deleted) — skip
+        if instance is None:
+            # Stale chunk (source deleted) or a row this viewer may not read.
+            # Marked seen either way: the entity is settled, and its remaining
+            # chunks would each re-run the same lookup for the same answer.
+            seen.add(key)
             continue
         seen.add(key)
         hit = hit_from_instance(spec, instance, rank=1.0 - float(chunk.distance))
@@ -395,7 +462,9 @@ def _fuse_rrf(rankings: list[list[Hit]], k: int | None = None) -> list[Hit]:
     return fused
 
 
-def search_multi(household_id: UUID, queries: list[str], limit: int = 20) -> list[Hit]:
+def search_multi(
+    household_id: UUID, queries: list[str], limit: int = 20, *, viewer=None
+) -> list[Hit]:
     """Run `search` for each query string and merge the results.
 
     Used by query expansion: a natural-language question is rewritten into
@@ -411,7 +480,7 @@ def search_multi(household_id: UUID, queries: list[str], limit: int = 20) -> lis
     for query in queries:
         if not query or not query.strip():
             continue
-        for hit in search(household_id, query, limit=limit, disabled=disabled):
+        for hit in search(household_id, query, limit=limit, disabled=disabled, viewer=viewer):
             key = (hit.entity_type, hit.id)
             existing = best.get(key)
             if existing is None or hit.rank > existing.rank:

--- a/apps/agent/search_api.py
+++ b/apps/agent/search_api.py
@@ -80,25 +80,31 @@ def _clamp_limit(raw: str | None) -> int:
     return max(1, min(limit, MAX_LIMIT))
 
 
-def search_household_entities(household_id, query: str, limit: int) -> list[dict]:
+def search_household_entities(household_id, query: str, limit: int, viewer=None) -> list[dict]:
     """Stage one — the lexical search, serialized. One entry point, two URLs.
 
     Strips and gates the query here rather than trusting callers to: this is the
     shared door, and a caller that forgot would send whitespace to the retrieval.
+
+    ``viewer`` is who is asking; it is what keeps this door as narrow as the
+    entity's own list endpoint (a private document belongs to the household but
+    not to every member).
     """
     query = (query or "").strip()
     if len(query) < MIN_QUERY_LENGTH:
         return []
-    hits = retrieval.search(household_id, query, limit=limit, hybrid=False)
+    hits = retrieval.search(household_id, query, limit=limit, hybrid=False, viewer=viewer)
     return serialize_hits(hits)
 
 
-def semantic_household_entities(household_id, query: str, limit: int) -> list[dict]:
+def semantic_household_entities(household_id, query: str, limit: int, viewer=None) -> list[dict]:
     """Stage two — what only the meaning finds, minus stage one's results."""
     query = (query or "").strip()
     if len(query) < MIN_QUERY_LENGTH:
         return []
-    return serialize_hits(retrieval.semantic_only(household_id, query, limit=limit))
+    return serialize_hits(
+        retrieval.semantic_only(household_id, query, limit=limit, viewer=viewer)
+    )
 
 
 def _wants_semantic(request) -> bool:
@@ -130,6 +136,6 @@ class GlobalSearchView(APIView):
         limit = _clamp_limit(request.query_params.get("limit"))
         run = semantic_household_entities if _wants_semantic(request) else search_household_entities
         return Response(
-            {"results": run(household.id, query, limit)},
+            {"results": run(household.id, query, limit, request.user)},
             status=status.HTTP_200_OK,
         )

--- a/apps/agent/searchables.py
+++ b/apps/agent/searchables.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Callable
+from typing import Any, Callable
 
 from django.db.models import Model
 
@@ -44,6 +44,23 @@ class SearchableSpec:
     household has disabled that module, the spec is skipped by retrieval and
     tools — the agent behaves as if the entity type did not exist. None = core,
     never filtered."""
+
+    visibility: Callable[[Any, Any], Any] | None = None
+    """Optional: narrow a queryset to what one **viewer** may read.
+
+    Signature ``(queryset, viewer) -> queryset``. ``None`` (the common case) means
+    every member of the household sees every row — household scoping is the whole
+    rule. A model carrying a privacy flag declares the narrowing here, from its own
+    app, exactly like ``related``: the retrieval layer must never grow a list of
+    which models happen to be private.
+
+    Retrieval applies it on **every** read path — lexical, semantic, ``get_entity``,
+    ``get_related``, ``list_entities`` and the anchored context — so declaring it
+    once closes every door at once. That is the point: the leak it exists to
+    prevent was a door nobody had thought to enumerate.
+
+    Shared implementation for the `is_private` / `created_by` pair:
+    ``core.visibility.visible_to_creator``."""
 
     embed: bool = True
     """Whether this entity is embedded into the vector index (parcours 21). Same

--- a/apps/agent/serializers.py
+++ b/apps/agent/serializers.py
@@ -95,9 +95,16 @@ class ConversationDetailSerializer(serializers.ModelSerializer):
         read_only_fields = ["id", "last_message_at", "created_at", "web_search_enabled", "messages"]
 
     def get_injected_context(self, obj) -> list[dict]:
+        # The reader is the conversation's owner — conversations are scoped
+        # ``(household, created_by)``. Falling back to it rather than requiring a
+        # request keeps the panel honest when the serializer runs outside a view:
+        # a chip must appear iff the model actually receives that item, and the
+        # model receives it as this user.
+        request = self.context.get("request")
+        viewer = getattr(request, "user", None) or obj.created_by
         return [
             dataclasses.asdict(item)
-            for item in describe_conversation_context(obj, obj.household)
+            for item in describe_conversation_context(obj, obj.household, viewer)
         ]
 
 

--- a/apps/agent/service.py
+++ b/apps/agent/service.py
@@ -146,8 +146,8 @@ def ask_stream(
     # Resolve the anchor + any pinned contexts before building the conversation
     # so they lead the messages and their hits are citable from the first answer.
     # The anchor comes first; each pinned entity is injected just like it.
-    anchor_context = _resolve_context(context_entity, household)
-    pinned_contexts = _resolve_contexts(pinned_entities, household)
+    anchor_context = _resolve_context(context_entity, household, user)
+    pinned_contexts = _resolve_contexts(pinned_entities, household, user)
     entity_contexts = ([anchor_context] if anchor_context else []) + pinned_contexts
     anchored = bool(entity_contexts)
     for ctx in entity_contexts:
@@ -355,21 +355,22 @@ def _is_duplicate_write(name: str, tool_input: dict, seen: set) -> bool:
     return False
 
 
-def _resolve_context(context_entity, household):
+def _resolve_context(context_entity, household, viewer=None):
     """Resolve an ``(entity_type, object_id)`` anchor into an EntityContext or None.
 
-    Never raises into ``ask``: an unknown/malformed/orphaned anchor just yields
-    ``None`` and the conversation proceeds unanchored.
+    Never raises into ``ask``: an unknown/malformed/orphaned anchor — or one
+    ``viewer`` may not read — just yields ``None`` and the conversation proceeds
+    unanchored.
     """
     if not context_entity:
         return None
     entity_type, object_id = context_entity
     if not entity_type or not object_id:
         return None
-    return context_builder.build_entity_context(entity_type, object_id, household)
+    return context_builder.build_entity_context(entity_type, object_id, household, viewer)
 
 
-def _resolve_contexts(entities, household):
+def _resolve_contexts(entities, household, viewer=None):
     """Resolve a list of ``(entity_type, object_id)`` into EntityContexts.
 
     Unresolvable entries (unknown type, orphaned pin) are silently dropped, same
@@ -377,7 +378,7 @@ def _resolve_contexts(entities, household):
     """
     contexts = []
     for entity in entities or []:
-        ctx = _resolve_context(entity, household)
+        ctx = _resolve_context(entity, household, viewer)
         if ctx is not None:
             contexts.append(ctx)
     return contexts

--- a/apps/agent/tests/test_private_visibility.py
+++ b/apps/agent/tests/test_private_visibility.py
@@ -1,0 +1,251 @@
+"""La confidentialité d'un document vaut aussi pour l'assistant.
+
+Un document `is_private=True` n'est visible que de son déposant : l'API documents
+l'applique depuis toujours (`documents.views.get_documents_queryset_for_request`).
+La couche de retrieval de l'agent, elle, ne connaissait que le **foyer** — pas le
+**lecteur**. L'OCR d'un document privé était donc cherchable et citable par
+n'importe quel autre membre, par trois portes qui ne le disaient nulle part : la
+palette du haut, le tool `search_household`, et `get_entity`.
+
+C'est la règle « un écart ne se dit jamais deux fois avec deux voix » appliquée à
+la visibilité : deux définitions de ce qu'un utilisateur a le droit de voir, et
+c'est la plus permissive qui gagnait en silence.
+
+Le test qui compte est le dernier — celui qui compare les deux ensembles plutôt
+que d'énumérer des cas. Les autres nomment chaque porte pour que l'échec dise
+laquelle a cédé.
+"""
+from __future__ import annotations
+
+import pytest
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from agent import tools
+from agent.context import build_entity_context
+from documents.models import Document
+from households.models import Household, HouseholdMember
+
+SEARCH_URL = "/api/search/"
+DOCUMENTS_URL = "/api/documents/documents/"
+
+# Un mot qui n'apparaît nulle part ailleurs dans les fixtures du foyer : ce qui
+# est cherché doit être trouvable, sinon le test passerait pour une mauvaise
+# raison (rien trouvé = rien fuité).
+NEEDLE = "myrtille"
+
+
+def _client_for(user) -> APIClient:
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client
+
+
+@pytest.fixture
+def shared_household(db):
+    return Household.objects.create(name="Foyer partagé")
+
+
+def _member(household, email, role=HouseholdMember.Role.MEMBER):
+    user = UserFactory(email=email)
+    HouseholdMember.objects.create(user=user, household=household, role=role)
+    user.active_household = household
+    user.save(update_fields=["active_household"])
+    return user
+
+
+@pytest.fixture
+def alice(shared_household):
+    """Déposante du document privé. Membre simple — le rôle ne doit rien changer."""
+    return _member(shared_household, "alice-private@example.com")
+
+
+@pytest.fixture
+def bob(shared_household):
+    """Owner du foyer : s'il voyait le privé d'Alice, ce serait par son rôle.
+
+    Le filtre porte sur `created_by`, pas sur le rôle — un owner n'est pas un
+    lecteur privilégié du privé des autres.
+    """
+    return _member(shared_household, "bob-owner@example.com", role=HouseholdMember.Role.OWNER)
+
+
+@pytest.fixture
+def private_doc(shared_household, alice):
+    return Document.objects.create(
+        household=shared_household,
+        created_by=alice,
+        file_path="documents/bail.pdf",
+        name="Contrat confidentiel",
+        mime_type="application/pdf",
+        type="document",
+        ocr_text=f"Clause de confidentialité concernant la {NEEDLE}.",
+        notes="",
+        is_private=True,
+    )
+
+
+@pytest.fixture
+def public_doc(shared_household, alice):
+    """Témoin : même mot-clé, mais partagé. Il doit rester trouvable par tous."""
+    return Document.objects.create(
+        household=shared_household,
+        created_by=alice,
+        file_path="documents/notice.pdf",
+        name="Notice partagée",
+        mime_type="application/pdf",
+        type="document",
+        # Le mot doit apparaître **tel quel** : la config de recherche est
+        # `simple_unaccent`, sans stemming — « myrtillier » ne matche pas
+        # « myrtille », et le témoin passerait pour caché alors qu'il n'a
+        # simplement jamais été trouvé.
+        ocr_text=f"Entretien de la {NEEDLE} en hiver.",
+        notes="",
+        is_private=False,
+    )
+
+
+def _palette_ids(user) -> set[str]:
+    resp = _client_for(user).get(SEARCH_URL, {"q": NEEDLE})
+    assert resp.status_code == 200
+    return {
+        r["object_id"]
+        for r in resp.json()["results"]
+        if r["entity_type"] == "document"
+    }
+
+
+def _documents_api_ids(user) -> set[str]:
+    resp = _client_for(user).get(DOCUMENTS_URL)
+    assert resp.status_code == 200
+    payload = resp.json()
+    rows = payload["results"] if isinstance(payload, dict) else payload
+    return {str(row["id"]) for row in rows}
+
+
+def _tool_search_text(user, household) -> str:
+    return tools.dispatch(
+        "search_household",
+        {"query": NEEDLE},
+        household=household,
+        user=user,
+        client=_NoExpansionClient(),
+    ).rendered
+
+
+class _NoExpansionClient:
+    """L'expansion de requête appelle le LLM ; ici on veut juste le retrieval.
+
+    Renvoyer une réponse vide fait retomber `query_expansion.expand` sur le terme
+    d'origine — donc la recherche porte exactement sur `NEEDLE`.
+    """
+
+    def run(self, *args, **kwargs):  # pragma: no cover - trivial
+        return type("R", (), {"text": "", "blocks": [], "stop_reason": "end_turn"})()
+
+    def run_stream(self, *args, **kwargs):  # pragma: no cover - trivial
+        yield from ()
+
+
+@pytest.mark.django_db
+class TestTheAssistantHonoursDocumentPrivacy:
+    def test_the_palette_does_not_return_another_members_private_document(
+        self, bob, private_doc, public_doc
+    ):
+        found = _palette_ids(bob)
+        assert str(private_doc.id) not in found
+        assert str(public_doc.id) in found, "le témoin partagé doit rester trouvable"
+
+    def test_the_search_tool_does_not_surface_another_members_private_document(
+        self, bob, shared_household, private_doc, public_doc
+    ):
+        rendered = _tool_search_text(bob, shared_household)
+        assert "Contrat confidentiel" not in rendered
+        assert "Notice partagée" in rendered, "le témoin partagé doit rester cité"
+
+    def test_get_entity_refuses_another_members_private_document(
+        self, bob, shared_household, private_doc
+    ):
+        result = tools.dispatch(
+            "get_entity",
+            {"entity_type": "document", "id": str(private_doc.id)},
+            household=shared_household,
+            user=bob,
+        )
+        assert "Contrat confidentiel" not in result.rendered
+        assert not result.hits
+
+    def test_the_context_picker_does_not_offer_another_members_private_document(
+        self, bob, private_doc, public_doc
+    ):
+        resp = _client_for(bob).get(
+            "/api/agent/conversations/search_context/", {"q": NEEDLE}
+        )
+        assert resp.status_code == 200
+        offered = {row["object_id"] for row in resp.json() if row["entity_type"] == "document"}
+        assert str(private_doc.id) not in offered
+        assert str(public_doc.id) in offered
+
+    def test_a_private_document_does_not_ride_into_a_shared_projects_context(
+        self, bob, alice, shared_household, private_doc
+    ):
+        """La porte la plus discrète : le contexte ancré d'un projet partagé.
+
+        `gather_related` remonte les documents liés. Une facture privée attachée à
+        un chantier que tout le foyer consulte serait injectée dans la conversation
+        de n'importe qui ouvre ce chantier — sans passer par aucune recherche.
+        """
+        from documents.services import link_document
+        from projects.models import Project
+
+        project = Project.objects.create(
+            household=shared_household, created_by=alice, title="Chantier partagé"
+        )
+        link_document(entity=project, document=private_doc, user=alice)
+
+        for viewer, expected in ((bob, False), (alice, True)):
+            ctx = build_entity_context(
+                "project", str(project.id), shared_household, viewer
+            )
+            assert ctx is not None
+            labels = {hit.label for hit in ctx.hits}
+            assert ("Contrat confidentiel" in labels) is expected, (
+                f"contexte du projet pour {viewer.email} : {labels}"
+            )
+
+    def test_the_depositor_still_finds_her_own_private_document(
+        self, alice, shared_household, private_doc
+    ):
+        assert str(private_doc.id) in _palette_ids(alice)
+        assert "Contrat confidentiel" in _tool_search_text(alice, shared_household)
+
+        result = tools.dispatch(
+            "get_entity",
+            {"entity_type": "document", "id": str(private_doc.id)},
+            household=shared_household,
+            user=alice,
+        )
+        assert result.hits, "sa propre pièce privée reste lisible et citable"
+
+
+@pytest.mark.django_db
+class TestTheTwoDoorsAgree:
+    """Le garde-fou de forme : deux définitions de la visibilité finissent par diverger.
+
+    Plutôt que d'énumérer les portes une à une — la prochaine ne serait pas
+    couverte — on compare l'ensemble que l'assistant peut trouver à l'ensemble que
+    la liste documents affiche, pour le même lecteur.
+    """
+
+    @pytest.mark.parametrize("who", ["alice", "bob"])
+    def test_the_search_never_returns_a_document_the_list_hides(
+        self, who, request, private_doc, public_doc
+    ):
+        user = request.getfixturevalue(who)
+        visible_in_app = _documents_api_ids(user)
+        found_by_the_assistant = _palette_ids(user)
+
+        leaked = found_by_the_assistant - visible_in_app
+        assert not leaked, (
+            f"l'assistant renvoie à {who} des documents que la liste lui cache : {leaked}"
+        )

--- a/apps/agent/tools.py
+++ b/apps/agent/tools.py
@@ -184,7 +184,9 @@ def _search_household_handler(
         household_id=household.id,
         user_id=getattr(user, "id", None),
     )
-    hits = retrieval.search_multi(household.id, terms, limit=SEARCH_RETRIEVAL_LIMIT)
+    hits = retrieval.search_multi(
+        household.id, terms, limit=SEARCH_RETRIEVAL_LIMIT, viewer=user
+    )
     return ToolResult(rendered=render_context_block(hits), hits=hits)
 
 
@@ -242,12 +244,16 @@ def _module_disabled_result(entity_type: str) -> "ToolResult":
     )
 
 
-def resolve_entity(entity_type: str, raw_id: str, household):
+def resolve_entity(entity_type: str, raw_id: str, household, viewer=None):
     """Shared (entity_type, id) → instance resolution for get_entity/get_related.
 
     Also reused by ``agent.context`` to resolve a conversation's anchor entity.
     Returns ``((spec, obj), None)`` on success or ``(None, ToolResult)`` with a
     recoverable message the model can read (unknown type, malformed id, no row).
+
+    ``viewer`` applies the spec's visibility rule. A row the viewer may not read
+    is reported as **not found** rather than as refused: « il existe un document
+    privé que je ne peux pas te montrer » is itself a disclosure.
     """
     if not entity_type or not raw_id:
         return None, ToolResult(rendered="(needs both entity_type and id)")
@@ -259,7 +265,9 @@ def resolve_entity(entity_type: str, raw_id: str, household):
         return None, _module_disabled_result(entity_type)
 
     try:
-        obj = spec.model.objects.filter(household_id=household.id, pk=raw_id).first()
+        obj = retrieval.apply_visibility(
+            spec, spec.model.objects.filter(household_id=household.id, pk=raw_id), viewer
+        ).first()
     except (ValueError, TypeError, DjangoValidationError):
         # Malformed id (e.g. not a valid UUID) — recoverable, tell the model.
         return None, ToolResult(rendered=f"(invalid id for {entity_type}: {raw_id})")
@@ -283,7 +291,7 @@ def _get_entity_handler(
     entity_type = (tool_input.get("entity_type") or "").strip()
     raw_id = (tool_input.get("id") or "").strip()
 
-    resolved, error = resolve_entity(entity_type, raw_id, household)
+    resolved, error = resolve_entity(entity_type, raw_id, household, user)
     if error is not None:
         return error
     spec, obj = resolved
@@ -359,14 +367,14 @@ def _get_related_handler(
     entity_type = (tool_input.get("entity_type") or "").strip()
     raw_id = (tool_input.get("id") or "").strip()
 
-    resolved, error = resolve_entity(entity_type, raw_id, household)
+    resolved, error = resolve_entity(entity_type, raw_id, household, user)
     if error is not None:
         return error
     spec, obj = resolved
 
     from .related import gather_related
 
-    hits: list[Hit] = []
+    candidates: list[tuple[searchables.SearchableSpec, Any]] = []
     for rel in gather_related(spec, obj)[:RELATED_MAX_ITEMS]:
         rel_spec = searchables.find_spec_for_instance(rel)
         if rel_spec is None:
@@ -374,7 +382,12 @@ def _get_related_handler(
         # Defensive scope guard: never surface an item from another household.
         if getattr(rel, "household_id", household.id) != household.id:
             continue
-        hits.append(retrieval.hit_from_instance(rel_spec, rel))
+        candidates.append((rel_spec, rel))
+
+    hits: list[Hit] = [
+        retrieval.hit_from_instance(rel_spec, rel)
+        for rel_spec, rel in retrieval.filter_visible_instances(candidates, user)
+    ]
 
     if not hits:
         return ToolResult(rendered=f"(no items linked to {entity_type} {raw_id})")
@@ -722,6 +735,11 @@ def _list_entities_handler(
         return ToolResult(rendered="(filters must be an object)")
 
     qs = spec.model.objects.filter(household_id=household.id)
+    # A listable type may also be searchable; when it is, the same visibility rule
+    # applies — enumerating an entity must not reveal what searching it hides.
+    search_spec = searchables.find_spec(entity_type)
+    if search_spec is not None:
+        qs = retrieval.apply_visibility(search_spec, qs, user)
     known = {f.name: f for f in spec.filters}
     ignored: list[str] = []
     for name, value in raw_filters.items():

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -298,7 +298,7 @@ class ConversationViewSet(viewsets.ModelViewSet):
         household = self._resolve_household()
         # The anchor must be a real entity of this household — otherwise any id
         # would silently create an orphan-anchored conversation row.
-        resolved, _error = tools.resolve_entity(entity_type, object_id, household)
+        resolved, _error = tools.resolve_entity(entity_type, object_id, household, request.user)
         if resolved is None:
             raise NotFound(f"No {entity_type} with id {object_id} in this household.")
         conversation, _created = AgentConversation.objects.get_or_create(
@@ -325,7 +325,9 @@ class ConversationViewSet(viewsets.ModelViewSet):
             raise ValidationError("entity_type and object_id are required.")
         if searchables.find_spec(entity_type) is None:
             raise ValidationError(f"Unknown entity_type: {entity_type}")
-        resolved, _error = tools.resolve_entity(entity_type, object_id, conversation.household)
+        resolved, _error = tools.resolve_entity(
+            entity_type, object_id, conversation.household, request.user
+        )
         if resolved is None:
             raise NotFound(f"No {entity_type} with id {object_id} in this household.")
         return entity_type, object_id
@@ -386,7 +388,7 @@ class ConversationViewSet(viewsets.ModelViewSet):
         household = self._resolve_household()
         return Response(
             search_api.search_household_entities(
-                household.id, query, search_api.DEFAULT_LIMIT
+                household.id, query, search_api.DEFAULT_LIMIT, request.user
             ),
             status=status.HTTP_200_OK,
         )

--- a/apps/core/visibility.py
+++ b/apps/core/visibility.py
@@ -1,0 +1,34 @@
+"""Qui a le droit de voir quoi — une seule définition, partagée.
+
+``is_private`` veut dire la même chose partout où le champ existe : seul le
+déposant voit sa pièce. Cette règle vivait en deux exemplaires — le queryset de
+l'API documents et la permission objet ``core.permissions.CanViewPrivateContent``
+— et manquait entièrement à la couche de retrieval de l'agent, qui ne connaissait
+que le **foyer**, jamais le **lecteur**.
+
+Deux définitions d'une même visibilité ne divergent pas symétriquement : c'est
+toujours la plus permissive qui l'emporte, et elle le fait en silence. D'où une
+fonction unique, que les specs de recherche déclarent et que le retrieval
+applique sans savoir quel modèle porte un drapeau de confidentialité.
+"""
+from __future__ import annotations
+
+from django.db.models import Q
+
+
+def visible_to_creator(queryset, viewer):
+    """Restreindre ``queryset`` à ce que ``viewer`` a le droit de lire.
+
+    Tout ce qui est public, plus les lignes privées dont il est l'auteur.
+
+    ``viewer=None`` — un appel sans utilisateur : évaluation hors ligne, commande
+    de fond, test bas niveau — ne voit **que** le public. Le défaut est fermé
+    exprès : un chemin qui oublierait de passer le lecteur montre alors moins que
+    prévu, jamais plus. Un manque se remarque et se corrige ; une fuite, non.
+
+    Le filtre porte sur ``created_by``, jamais sur le rôle : un owner de foyer
+    n'est pas un lecteur privilégié du privé des autres.
+    """
+    if viewer is None or not getattr(viewer, "is_authenticated", True):
+        return queryset.filter(is_private=False)
+    return queryset.filter(Q(is_private=False) | Q(created_by=viewer))

--- a/apps/documents/apps.py
+++ b/apps/documents/apps.py
@@ -9,6 +9,7 @@ class DocumentsConfig(AppConfig):
         import documents.signals  # noqa: F401
 
         from agent.searchables import SearchableSpec, register
+        from core.visibility import visible_to_creator
         from .models import Document
 
         register(SearchableSpec(
@@ -17,4 +18,9 @@ class DocumentsConfig(AppConfig):
             search_fields=('name', 'notes', 'ocr_text'),
             label_attr='name',
             url_template='/app/documents/{id}',
+            # Même règle que `views.get_documents_queryset_for_request` : un
+            # document privé n'appartient qu'à son déposant. Sans cette ligne, le
+            # foyer était le seul filtre du retrieval et l'OCR d'une pièce privée
+            # était citable par tout le monde.
+            visibility=visible_to_creator,
         ))

--- a/docs/MODULES/agent.md
+++ b/docs/MODULES/agent.md
@@ -93,6 +93,46 @@ Chaque app déclare ses entités depuis `apps.py::ready()` via
 search_fields, label_attr, url_template, `related` optionnel). L'agent ne connaît
 pas la liste — ajouter un module = ~5 lignes, zéro touche à `apps/agent/`.
 
+### Confidentialité — le foyer dit à qui, le lecteur dit à quoi
+
+`SearchableSpec.visibility` est un `(queryset, viewer) -> queryset` optionnel,
+déclaré par l'app propriétaire au même titre que `related`. `None` (le cas
+courant) = tout membre du foyer voit toute ligne.
+
+- **Le point d'application est unique** : `retrieval.apply_visibility` pour les
+  chemins qui tiennent un queryset (lexical, sémantique, `resolve_entity`,
+  `list_entities`), `retrieval.filter_visible_instances` pour ceux qui tiennent
+  déjà des objets (`get_related`, contexte ancré — groupé par type, donc une
+  requête par type présent, jamais une par item). Les deux lisent le **même**
+  `spec.visibility` : pas de seconde règle qui pourrait dériver.
+- **`viewer` omis est fermé, pas ouvert.** `core.visibility.visible_to_creator`
+  ne renvoie alors que le public. Un appelant qui oublie le lecteur montre moins,
+  jamais plus — un manque se remarque, une fuite non.
+- **Une ligne non lisible est « introuvable », jamais « refusée ».** Répondre
+  « il existe un document privé que je ne peux pas te montrer » est déjà une
+  divulgation ; une ancre non lisible est donc traitée exactement comme une ancre
+  orpheline, et la conversation continue sans contexte.
+- **Le filtre porte sur `created_by`, jamais sur le rôle** : un owner de foyer
+  n'est pas un lecteur privilégié du privé des autres.
+
+**Pourquoi ce mécanisme plutôt qu'un filtre au point d'appel.** La couche de
+retrieval ne connaissait que le **foyer** ; le privé d'un document n'était appliqué
+que dans `documents/views.py`. Trois portes le contournaient — la palette du haut,
+`search_household`, `get_entity` — plus une quatrième que personne n'aurait pensé à
+énumérer : une facture privée attachée à un projet partagé entrait dans le contexte
+ancré de quiconque ouvrait ce projet. C'est « un écart ne se dit jamais deux fois
+avec deux voix » appliqué à la visibilité, avec une asymétrie propre à la sécurité :
+**des deux définitions, c'est toujours la plus permissive qui gagne, et en silence.**
+Régression : `agent/tests/test_private_visibility.py`, dont le test de forme
+`TestTheTwoDoorsAgree` compare l'ensemble trouvable par l'assistant à celui que la
+liste affiche, plutôt que d'énumérer des portes — la prochaine ne serait pas couverte.
+
+> ⚠️ **`Task.is_private` et `Interaction.is_private` ne sont appliqués nulle part**,
+> ni par leur propre API ni par le retrieval. L'assistant n'y est donc pas plus
+> permissif que l'app — il n'y a pas de contournement, il y a une règle absente.
+> Traité à part : l'y appliquer par le seul `visibility` rendrait l'assistant plus
+> strict que la liste, soit le même désaccord à deux voix, dans l'autre sens.
+
 ### Gating par modules du foyer (parcours 15)
 
 Les trois specs (`SearchableSpec`, `ListableSpec`, `WritableSpec`) portent un champ

--- a/docs/MODULES/documents.md
+++ b/docs/MODULES/documents.md
@@ -56,6 +56,15 @@
 
 Permissions : `IsHouseholdMember` partout. Seul le `created_by` peut changer `is_private` (`views.py:140-144`).
 
+**`is_private` vaut aussi pour l'assistant.** La règle est déclarée une fois, sur le
+`SearchableSpec` de `apps/documents/apps.py` (`visibility=core.visibility.visible_to_creator`),
+et le retrieval de l'agent l'applique sur tous ses chemins. Elle ne vivait auparavant
+que dans `get_documents_queryset_for_request` : l'`ocr_text` d'une pièce privée était
+donc cherchable et citable par tout le foyer via la palette, `search_household`,
+`get_entity`, et le contexte ancré d'un projet auquel la pièce était attachée. Détail
+du mécanisme et de ce qu'il refuse de faire : `docs/MODULES/agent.md`, section
+« Confidentialité ».
+
 ### Phase avant/après sur un lien (`DocumentLink.phase`, parcours 20)
 
 - `DocumentLink.phase` : `CharField` (`before` / `during` / `after`, vide = non


### PR DESCRIPTION
Closes #501.

## Le défaut

La couche de retrieval de l'agent ne connaissait que le **foyer**, jamais le **lecteur**. `is_private` n'était appliqué que dans `documents.views.get_documents_queryset_for_request` : l'`ocr_text` d'un document privé était donc cherchable et citable par n'importe quel autre membre du foyer, par quatre portes.

| Porte | Fuite |
|---|---|
| Palette du haut (`GET /api/search/`) | le document apparaît dans les résultats |
| Tool `search_household` | l'assistant lit l'OCR et le cite |
| `get_entity` | le contenu complet est rendu |
| Picker « Ajouter du contexte » | le document est proposé à l'épinglage |
| **Contexte ancré** | une facture privée attachée à un projet partagé entrait chez **quiconque ouvrait ce projet**, sans passer par aucune recherche |

La dernière est celle qu'on n'aurait pas pensé à chercher : elle ne demande aucune requête de l'utilisateur.

C'est « un écart ne se dit jamais deux fois avec deux voix » appliqué à la visibilité, avec l'asymétrie propre à la sécurité : **des deux définitions, c'est toujours la plus permissive qui gagne, et en silence.**

## Le correctif

`SearchableSpec.visibility` — un `(queryset, viewer) -> queryset` optionnel, déclaré par l'app propriétaire exactement comme `related`. La couche de retrieval n'apprend jamais quels modèles portent un drapeau de confidentialité.

- **Un point d'application, pas un filtre par appel** : `retrieval.apply_visibility` pour les chemins qui tiennent un queryset (lexical, sémantique, `resolve_entity`, `list_entities`), `retrieval.filter_visible_instances` pour ceux qui tiennent déjà des objets (`get_related`, contexte ancré). Le second groupe par type d'entité : **une requête par type présent, jamais une par item**. Les deux lisent le même `spec.visibility` — pas de seconde règle qui puisse dériver.
- **`viewer` omis est fermé** : `core.visibility.visible_to_creator` ne renvoie alors que le public. Un appelant oublié montre moins, jamais plus — un manque se remarque, une fuite non.
- **Non lisible = « introuvable », jamais « refusé »** : répondre « il existe un document privé que je ne peux pas te montrer » est déjà une divulgation. Une ancre non lisible est traitée comme une ancre orpheline, et la conversation continue sans contexte.
- **Le filtre porte sur `created_by`, pas sur le rôle** : un owner n'est pas un lecteur privilégié du privé des autres. Testé explicitement (le témoin Bob **est** owner).
- `documents` déclare la règle en une ligne, avec le helper que son API utilisait déjà.

## Régression

`apps/agent/tests/test_private_visibility.py` — 8 tests, une porte par test plus un garde-fou de forme.

`TestTheTwoDoorsAgree` compare l'**ensemble** que l'assistant peut trouver à l'**ensemble** que la liste documents affiche, pour le même lecteur, plutôt que d'énumérer les portes — la prochaine ne serait pas couverte.

Probant par bascule : en commentant la seule ligne `visibility=visible_to_creator`, **les 6 assertions de confidentialité tombent** ; avec elle, les 8 passent.

## Vérifications

- `pytest` : 4063 passés. Les 5 échecs de `apps/core/tests/test_selfhost_settings.py` **préexistent sur `main`** (vérifié en stashant cette branche) et sont sans rapport.
- `npm run lint` : 0 erreur (5 warnings préexistants). `tsc -b` : propre.
- Aucune migration, aucune UI, aucune clé i18n.

## Hors périmètre, à traiter à part

**`Task.is_private` et `Interaction.is_private` ne sont appliqués nulle part** — ni par le retrieval, ni par leur propre API (`for_user_households` ne scope que le foyer, et `is_private` n'est qu'un `filterset_field`). Les deux modèles sont pourtant searchables.

L'assistant n'y est donc **pas** plus permissif que l'app : il n'y a pas de contournement, il y a une règle absente. Les soumettre ici par le seul `visibility` rendrait l'assistant plus strict que la liste — le même désaccord à deux voix, dans l'autre sens. Le correctif cohérent (queryset + spec, dans le même mouvement) mérite son issue.