### PR TITLE
fix(tasks): les tâches privées ne sont plus servies aux autres membres

### DIFF
--- a/apps/alerts/services.py
+++ b/apps/alerts/services.py
@@ -27,8 +27,16 @@ STOCK_CRITICAL_STATUSES = {StockItem.Status.OUT_OF_STOCK}
 
 
 def _overdue_tasks(household, today: date) -> list[dict]:
+    # Les tâches privées sont exclues **du compte**, pas masquées à l'affichage.
+    #
+    # ``build_alerts_summary`` prend un foyer, jamais un lecteur : le résumé est
+    # calculé une fois et lu par tout le monde, donc rien dont la visibilité varie
+    # selon le lecteur ne peut y entrer. Même raisonnement — et même formulation —
+    # que ``tasks.services.completion_summary`` pour le récap mensuel. Sans cette
+    # ligne le panneau d'alertes affichait le libellé des tâches privées des
+    # autres membres, ce que la liste des tâches, elle, refuse désormais.
     qs = (
-        Task.objects.filter(household=household, due_date__lt=today)
+        Task.objects.filter(household=household, due_date__lt=today, is_private=False)
         .exclude(status__in=[Task.Status.DONE, Task.Status.ARCHIVED])
         .order_by("due_date", "created_at")
     )

--- a/apps/alerts/tests/test_api_alerts.py
+++ b/apps/alerts/tests/test_api_alerts.py
@@ -207,3 +207,44 @@ class TestAlertsSummary:
         client = APIClient()
         response = client.get(self._url())
         assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+
+@pytest.mark.django_db
+class TestPrivateTasksNeverEnterTheHouseholdSummary:
+    """Une tâche privée est exclue **du compte**, pas masquée à l'affichage.
+
+    ``build_alerts_summary`` prend un foyer, jamais un lecteur : le résumé est
+    calculé une fois et lu par tout le monde. Rien dont la visibilité varie selon
+    le lecteur ne peut donc y entrer — même règle, et même raison, que
+    ``tasks.services.completion_summary`` pour le récap mensuel.
+
+    Avant ce correctif le panneau d'alertes affichait le **libellé** des tâches
+    privées des autres membres, y compris pour le membre qui ne pouvait pas les
+    ouvrir depuis la liste des tâches.
+    """
+
+    def _url(self):
+        return reverse("alerts-summary")
+
+    def test_private_overdue_task_is_absent_for_everyone(self, owner_client, household, owner):
+        _create_overdue_task(household, owner, days_overdue=5, subject="Visible")
+        private = _create_overdue_task(
+            household, owner, days_overdue=5, subject="Rendez-vous médical",
+        )
+        private.is_private = True
+        private.save(update_fields=["is_private"])
+
+        response = owner_client.get(self._url())
+        titles = [item["title"] for item in response.data["overdue_tasks"]]
+
+        # Absente même pour son autrice : un compteur foyer n'a qu'une valeur.
+        assert titles == ["Visible"]
+
+    def test_the_count_agrees_with_the_list(self, owner_client, household, owner):
+        private = _create_overdue_task(household, owner, days_overdue=5, subject="Privée")
+        private.is_private = True
+        private.save(update_fields=["is_private"])
+
+        response = owner_client.get(self._url())
+        assert response.data["overdue_tasks"] == []
+        assert response.data["total"] == 0

--- a/apps/core/tests/test_privacy_isolation.py
+++ b/apps/core/tests/test_privacy_isolation.py
@@ -1,0 +1,233 @@
+"""Isolation en confidentialité — un item privé ne sort pas de sa liste.
+
+Troisième volet de la famille ``test_tenant_isolation`` (lectures entre foyers)
+et ``test_write_isolation`` (FK de serializer). Celui-ci porte sur la frontière
+*à l'intérieur* d'un foyer : ``moi`` vs ``les autres membres``.
+
+Pourquoi un test transverse et pas trois tests locaux
+-----------------------------------------------------
+
+``is_private`` existait sur quatre modèles, avec son badge dans l'UI, sa
+contrainte DB et son exclusion du récap — et n'était filtré en liste que sur
+deux d'entre eux. Le drapeau était décoratif là où il comptait le plus, et
+personne ne l'a vu, parce que le défaut est invisible deux fois :
+
+- **en revue**, un ``get_queryset()`` qui oublie la clause ressemble trait pour
+  trait à celui qui la porte ;
+- **à l'usage**, il faut deux comptes dans le même foyer pour s'en apercevoir —
+  c'est-à-dire précisément ce qu'un développeur seul n'a jamais sous la main.
+
+D'où la forme : le test ne vérifie pas trois vues, il vérifie **la règle**, et
+refuse qu'un cinquième modèle privatisable arrive sans se déclarer.
+
+Les deux moitiés sont nécessaires
+---------------------------------
+
+1. **Structurelle** — aucune vue n'expose ``is_private`` en filtre. Sans ce
+   contrôle, la moitié n°2 se laisse contourner : le queryset a beau borner, un
+   ``?is_private=true`` ré-ouvre exactement ce qu'il bornait. C'est le même
+   rapport que la clé i18n et son ``defaultValue``.
+2. **Comportementale** — un second membre ne voit pas l'item privé du premier.
+   C'est le seul contrôle qui compare le *code* à ce que l'API sert vraiment.
+"""
+import inspect
+import importlib
+
+import pytest
+from django.apps import apps as django_apps
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient
+from rest_framework.viewsets import GenericViewSet
+
+from accounts.tests.factories import UserFactory
+from households.models import Household, HouseholdMember
+
+
+# ── Ce qui n'est pas encore filtré, et pourquoi ──────────────────────────────
+#
+# Même convention que ``EXEMPT_FIELDS`` dans ``test_write_isolation`` : une
+# exemption est une dette **nommée**, avec sa raison et ce qui protège à la
+# place. Le silence, lui, ne se relit pas.
+
+EXEMPT_MODELS: dict[str, str] = {
+    "interactions.Interaction": (
+        "Une interaction de type 'expense' alimente interactions.queries.expenses(), "
+        "point de vérité unique de sept agrégations (barre de budget, coverage_ratio, "
+        "Project.actual_cost, bilan mensuel, détecteurs de conformité). La masquer en "
+        "liste sans la retirer des totaux donnerait deux définitions au même compteur — "
+        "exactement ce que CLAUDE.md interdit. Filtrer ici suppose d'avoir décidé ce que "
+        "« dépense privée » veut dire ; tant que ce n'est pas tranché, la porte la plus "
+        "large (le filtre ?is_private=) est fermée par la moitié n°1 de ce fichier."
+    ),
+}
+
+
+def _models_with_is_private():
+    """Tous les modèles du projet portant un champ ``is_private``."""
+    found = []
+    for model in django_apps.get_models():
+        if not model._meta.app_config.name.startswith(("apps.", "")):
+            continue
+        if any(f.name == "is_private" for f in model._meta.get_fields()):
+            found.append(model)
+    return found
+
+
+def _label(model) -> str:
+    return f"{model._meta.app_label}.{model.__name__}"
+
+
+def _all_viewsets():
+    """Toutes les classes de viewset déclarées dans les modules ``views`` du projet."""
+    found = {}
+    for config in django_apps.get_app_configs():
+        for module_name in (f"{config.name}.views", f"{config.name}.views_media"):
+            try:
+                module = importlib.import_module(module_name)
+            except ModuleNotFoundError:
+                continue
+            for name, obj in inspect.getmembers(module, inspect.isclass):
+                if issubclass(obj, GenericViewSet) and obj.__module__ == module_name:
+                    found[f"{module_name}.{name}"] = obj
+    return found
+
+
+# ── 1. Structurel : aucun filtre ne ré-ouvre ce que le queryset borne ────────
+
+
+class TestNoViewExposesThePrivacyFlagAsAFilter:
+    def test_no_filterset_field_named_is_private(self):
+        offenders = [
+            name
+            for name, viewset in _all_viewsets().items()
+            if "is_private" in (getattr(viewset, "filterset_fields", None) or ())
+        ]
+        assert not offenders, (
+            "Ces vues exposent ?is_private= en filtre, c'est-à-dire l'endroit exact "
+            "où lire les items privés des autres membres : "
+            f"{offenders}. Un filtre ne doit jamais pouvoir élargir ce que borne le "
+            "queryset — pour retrouver ses propres items privés, filtrer côté client "
+            "ou ajouter un ?mine=true qui ne peut porter que sur soi."
+        )
+
+
+# ── 2. Comportemental : le second membre ne voit rien ────────────────────────
+
+
+@pytest.fixture
+def duo(db):
+    """Un foyer, deux membres : Alice écrit, Bob lit."""
+    household = Household.objects.create(name="Foyer privé")
+    alice = UserFactory(email="privacy-alice@example.com")
+    bob = UserFactory(email="privacy-bob@example.com")
+    HouseholdMember.objects.create(household=household, user=alice, role="owner")
+    HouseholdMember.objects.create(household=household, user=bob, role="member")
+    return household, alice, bob
+
+
+def _as(user, household):
+    client = APIClient()
+    client.force_authenticate(user=user)
+    return client, {"household_id": str(household.id)}
+
+
+def _labels(response, key):
+    payload = response.data
+    rows = payload if isinstance(payload, list) else (payload.get("results") or [])
+    return [row.get(key) for row in rows]
+
+
+@pytest.mark.django_db
+class TestAPrivateItemStaysWithItsAuthor:
+    """Pour chaque modèle couvert : Alice le voit, Bob ne le voit pas."""
+
+    def test_task(self, duo):
+        from tasks.models import Task
+
+        household, alice, bob = duo
+        Task.objects.create(
+            household=household, created_by=alice,
+            subject="Cadeau d'anniversaire de Bob", is_private=True,
+        )
+
+        client, params = _as(bob, household)
+        assert "Cadeau d'anniversaire de Bob" not in _labels(
+            client.get(reverse("task-list"), params), "subject"
+        )
+
+        client, params = _as(alice, household)
+        assert "Cadeau d'anniversaire de Bob" in _labels(
+            client.get(reverse("task-list"), params), "subject"
+        )
+
+    def test_document(self, duo):
+        from documents.models import Document
+
+        household, alice, bob = duo
+        Document.objects.create(
+            household=household, created_by=alice,
+            name="Bilan médical", file_path=f"{household.id}/documents/bilan.pdf",
+            is_private=True,
+        )
+
+        client, params = _as(bob, household)
+        assert "Bilan médical" not in _labels(
+            client.get(reverse("document-list"), params), "name"
+        )
+
+        client, params = _as(alice, household)
+        assert "Bilan médical" in _labels(
+            client.get(reverse("document-list"), params), "name"
+        )
+
+    def test_briefing(self, duo):
+        from briefings.models import Briefing
+
+        household, alice, bob = duo
+        Briefing.objects.create(
+            household=household, created_by=alice,
+            title="Mes rendez-vous", prompt="Résume mon agenda", is_private=True,
+        )
+
+        client, params = _as(bob, household)
+        assert "Mes rendez-vous" not in _labels(
+            client.get(reverse("briefing-list"), params), "title"
+        )
+
+        client, params = _as(alice, household)
+        assert "Mes rendez-vous" in _labels(
+            client.get(reverse("briefing-list"), params), "title"
+        )
+
+
+# ── 3. Le catalogue ne peut pas prendre de retard sur le code ────────────────
+
+
+class TestEveryPrivatisableModelIsAccountedFor:
+    """Un cinquième modèle portant ``is_private`` doit se déclarer ici.
+
+    Sans ce contrôle, les deux moitiés ci-dessus resteraient vertes en ignorant
+    le nouveau venu — c'est la même règle que ``banking.compliance.REGISTRY`` :
+    ajouter un mécanisme, c'est ajouter son détecteur.
+    """
+
+    COVERED = {"tasks.Task", "documents.Document", "briefings.Briefing"}
+
+    def test_no_model_carries_the_flag_without_a_test_or_a_named_exemption(self):
+        accounted = self.COVERED | set(EXEMPT_MODELS)
+        actual = {_label(model) for model in _models_with_is_private()}
+
+        unaccounted = actual - accounted
+        assert not unaccounted, (
+            f"Ces modèles portent is_private sans être couverts ni exemptés : "
+            f"{sorted(unaccounted)}. Ajouter un cas dans "
+            "TestAPrivateItemStaysWithItsAuthor, ou une entrée motivée dans "
+            "EXEMPT_MODELS."
+        )
+
+        stale = accounted - actual
+        assert not stale, (
+            f"Ces entrées ne correspondent plus à aucun modèle : {sorted(stale)}. "
+            "Une exemption périmée a l'air de faire autorité en étant fausse."
+        )

--- a/apps/core/tests/test_privacy_isolation.py
+++ b/apps/core/tests/test_privacy_isolation.py
@@ -20,28 +20,44 @@ personne ne l'a vu, parce que le défaut est invisible deux fois :
 D'où la forme : le test ne vérifie pas trois vues, il vérifie **la règle**, et
 refuse qu'un cinquième modèle privatisable arrive sans se déclarer.
 
-Les deux moitiés sont nécessaires
----------------------------------
+Les trois parties sont nécessaires
+----------------------------------
 
 1. **Structurelle** — aucune vue n'expose ``is_private`` en filtre. Sans ce
-   contrôle, la moitié n°2 se laisse contourner : le queryset a beau borner, un
+   contrôle, la partie n°2 se laisse contourner : le queryset a beau borner, un
    ``?is_private=true`` ré-ouvre exactement ce qu'il bornait. C'est le même
    rapport que la clé i18n et son ``defaultValue``.
 2. **Comportementale** — un second membre ne voit pas l'item privé du premier.
    C'est le seul contrôle qui compare le *code* à ce que l'API sert vraiment.
+3. **Complétude** — un modèle portant le drapeau doit être couvert ou exempté.
+   Sans elle, les deux premières restent vertes en ignorant le nouveau venu.
+
+Limite connue : la partie n°1 lit ``filterset_fields``, pas un éventuel
+``filterset_class`` (le dépôt n'en utilise aucun). Le jour où l'un apparaît, il
+faudra l'inspecter ici aussi — un filtre déclaré autrement reste un filtre.
 """
-import inspect
 import importlib
+import inspect
+from pathlib import Path
 
 import pytest
 from django.apps import apps as django_apps
+from django.conf import settings
 from django.urls import reverse
-from django.utils import timezone
 from rest_framework.test import APIClient
 from rest_framework.viewsets import GenericViewSet
 
 from accounts.tests.factories import UserFactory
 from households.models import Household, HouseholdMember
+
+#: Racine des apps du projet. Sert à ne parcourir que **notre** code : sans ce
+#: bornage on inspecterait aussi Django et DRF, dont les modèles et les vues ne
+#: nous regardent pas et feraient échouer la partie n°3 sur un faux positif.
+_PROJECT_APPS_DIR = Path(settings.BASE_DIR) / "apps"
+
+
+def _is_project_app(app_config) -> bool:
+    return Path(app_config.path).is_relative_to(_PROJECT_APPS_DIR)
 
 
 # ── Ce qui n'est pas encore filtré, et pourquoi ──────────────────────────────
@@ -67,7 +83,7 @@ def _models_with_is_private():
     """Tous les modèles du projet portant un champ ``is_private``."""
     found = []
     for model in django_apps.get_models():
-        if not model._meta.app_config.name.startswith(("apps.", "")):
+        if not _is_project_app(model._meta.app_config):
             continue
         if any(f.name == "is_private" for f in model._meta.get_fields()):
             found.append(model)
@@ -79,17 +95,27 @@ def _label(model) -> str:
 
 
 def _all_viewsets():
-    """Toutes les classes de viewset déclarées dans les modules ``views`` du projet."""
+    """Toutes les classes de viewset déclarées dans les modules ``views`` du projet.
+
+    ``startswith`` et non ``==`` sur ``__module__`` : ``accounts.views`` est un
+    **package**, et ses viewsets vivent dans ``accounts.views.api``. Une égalité
+    stricte les écartait — c'est-à-dire qu'elle ouvrait un angle mort exactement là
+    où le dépôt s'écarte déjà de la convention, et un garde-fou aveugle sur
+    l'exception est un garde-fou qui rassure à tort.
+    """
     found = {}
     for config in django_apps.get_app_configs():
-        for module_name in (f"{config.name}.views", f"{config.name}.views_media"):
+        if not _is_project_app(config):
+            continue
+        for suffix in ("views", "views_media"):
+            module_name = f"{config.name}.{suffix}"
             try:
                 module = importlib.import_module(module_name)
             except ModuleNotFoundError:
                 continue
             for name, obj in inspect.getmembers(module, inspect.isclass):
-                if issubclass(obj, GenericViewSet) and obj.__module__ == module_name:
-                    found[f"{module_name}.{name}"] = obj
+                if issubclass(obj, GenericViewSet) and obj.__module__.startswith(module_name):
+                    found[f"{obj.__module__}.{name}"] = obj
     return found
 
 

--- a/apps/interactions/views.py
+++ b/apps/interactions/views.py
@@ -114,7 +114,18 @@ class InteractionViewSet(viewsets.ModelViewSet):
     """
     permission_classes = [IsHouseholdMember]
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['type', 'is_private', 'created_by']
+    # ⚠️ Pas de ``is_private`` ici — voir la note jumelle de ``TaskViewSet``.
+    # Le filtre servait à lire les items privés des autres, et le front ne l'a
+    # jamais envoyé.
+    #
+    # Noter que le queryset de cette vue, lui, ne filtre **pas encore** la
+    # confidentialité, contrairement à celui des tâches : une ``Interaction`` de
+    # type ``expense`` alimente ``interactions.queries.expenses()``, point de
+    # vérité unique de sept agrégations, et la masquer en liste sans la retirer
+    # des totaux donnerait deux définitions au même compteur. Retirer le filtre
+    # ferme la porte la plus large sans rien décider de ce que « dépense privée »
+    # devrait vouloir dire.
+    filterset_fields = ['type', 'created_by']
     search_fields = ['subject', 'content', 'enriched_text', 'tags__tag__name']
     ordering_fields = ['occurred_at', 'created_at', 'subject']
     ordering = ['-occurred_at']

--- a/apps/tasks/views.py
+++ b/apps/tasks/views.py
@@ -5,6 +5,7 @@ from datetime import date
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import IntegrityError
+from django.db.models import Q
 from django.utils import timezone
 from rest_framework import viewsets, filters, status
 from rest_framework.exceptions import ValidationError, PermissionDenied
@@ -34,7 +35,12 @@ class TaskViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
     permission_classes = [IsHouseholdMember]
     serializer_class = TaskSerializer
     filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
-    filterset_fields = ['status', 'priority', 'assigned_to', 'project', 'is_private']
+    # ⚠️ Pas de ``is_private`` ici. Exposer le drapeau en filtre donne
+    # ``?is_private=true``, c'est-à-dire l'endroit exact où lire les items privés
+    # des autres. Le front n'en a jamais eu besoin : ``TasksPanel`` filtre côté
+    # client sur ce qui est déjà chargé, donc sur ce que le serveur a bien voulu
+    # servir. Un filtre ne doit jamais pouvoir élargir ce que borne le queryset.
+    filterset_fields = ['status', 'priority', 'assigned_to', 'project']
     search_fields = ['subject', 'content']
     ordering_fields = ['due_date', 'created_at', 'priority', 'status']
     ordering = ['due_date', 'created_at']
@@ -56,6 +62,20 @@ class TaskViewSet(DocumentLinkActionsMixin, viewsets.ModelViewSet):
 
         if self.request.household:
             qs = qs.filter(household=self.request.household)
+
+        # Confidentialité — une tâche privée n'appartient qu'à qui l'a écrite.
+        #
+        # Le scope foyer ci-dessus ne dit rien de la confidentialité : ``is_private``
+        # existait depuis l'origine, avec son badge dans l'UI, sa contrainte DB
+        # (« privée ⇒ non assignée ») et son exclusion du récap — mais **aucun
+        # filtre ici**, si bien que la tâche privée d'un membre était servie à tous
+        # les autres. Le drapeau était décoratif partout où il comptait le plus.
+        #
+        # Le filtre vit dans ``get_queryset`` et pas dans une permission objet :
+        # une permission ne se prononce que sur un objet déjà chargé, donc elle
+        # protège le détail et laisse passer la liste — qui est justement là où on
+        # lit les secrets des autres.
+        qs = qs.filter(Q(is_private=False) | Q(created_by=self.request.user))
 
         zone_id = self.request.query_params.get('zone', '').strip()
         if zone_id:


### PR DESCRIPTION
## Quoi

`is_private` existait sur quatre modèles (`Task`, `Interaction`, `Document`, `Briefing`)
— badge dans l'UI, contrainte DB « privée ⇒ non assignée », exclusion du récap mensuel —
mais le filtrage en liste n'était appliqué que sur `Document` et `Briefing`. Le drapeau
était décoratif là où il comptait le plus.

Vérifié par sonde (Alice owner, Bob membre du même foyer, item privé d'Alice) :

| Surface | Avant |
|---|---|
| `GET /api/tasks/` | servait la tâche privée d'Alice à Bob |
| `GET /api/interactions/` | servait la note privée d'Alice à Bob |
| `GET /api/search/` (⌘K) et RAG | servaient les trois types, **document compris** |
| Panneau d'alertes | affichait le libellé des tâches privées des autres |

Aggravant : `is_private` figurait dans les `filterset_fields` de deux vues, donc
`?is_private=true` listait les items privés de tout le monde — le filtre destiné à
retrouver ses propres secrets était l'endroit exact où lire ceux des autres. Le front ne
l'a jamais envoyé (`TasksPanel` filtre côté client sur ce qui est déjà chargé).

## Ce que fait cette PR

- **`is_private` retiré des `filterset_fields`** (tasks + interactions). Un filtre ne doit
  jamais pouvoir élargir ce que borne le queryset.
- **Filtre de confidentialité dans `TaskViewSet.get_queryset()`** — et pas dans une
  permission objet : une permission ne se prononce que sur un objet déjà chargé, donc elle
  protège le détail et laisse passer la liste, qui est justement là où on lit les secrets
  des autres.
- **Tâches privées exclues du résumé d'alertes.** Exclusion **du compte**, pas masquage par
  lecteur : `build_alerts_summary` prend un foyer et jamais un lecteur. Même règle et même
  raison que `tasks.services.completion_summary` pour le récap. Conséquence assumée : une
  tâche privée en retard n'alerte plus personne, pas même son autrice — un compteur de
  foyer n'a qu'une valeur.
- **Test transverse** `core/tests/test_privacy_isolation.py`, troisième volet de la famille
  `test_tenant_isolation` / `test_write_isolation`.

## Pourquoi un test transverse et pas trois tests locaux

Le défaut est invisible deux fois : en revue, un `get_queryset()` qui oublie la clause
ressemble trait pour trait à celui qui la porte ; à l'usage, il faut deux comptes dans le
même foyer pour s'en apercevoir — ce qu'un développeur seul n'a jamais sous la main.

Le fichier a trois moitiés, chacune nécessaire :

1. **structurelle** — aucune vue n'expose `is_private` en filtre (sans quoi la n°2 se
   laisse contourner : le queryset a beau borner, un `?is_private=true` ré-ouvre
   exactement ce qu'il bornait) ;
2. **comportementale** — un second membre ne voit pas l'item privé du premier, et son
   autrice le voit bien (`Task`, `Document`, `Briefing`) ;
3. **complétude** — tout modèle portant `is_private` doit être couvert ou exempté **avec sa
   raison**, sinon le test échoue. Même dispositif que `banking.compliance.REGISTRY` :
   ajouter un mécanisme, c'est ajouter son détecteur.

Chaque correctif a été vérifié en le neutralisant pour confirmer que le test tombe sans
lui — un test vert qui l'aurait été de toute façon ne prouve rien.

## Hors scope — la suite, à trancher

- **Interactions** : la liste n'est **pas** filtrée, et c'est délibéré. Une `Interaction`
  de type `expense` alimente `interactions.queries.expenses()`, point de vérité unique de
  sept agrégations (barre de budget, `coverage_ratio`, `Project.actual_cost`, bilan
  mensuel, détecteurs de conformité). La masquer en liste sans la retirer des totaux
  donnerait deux définitions au même compteur. Filtrer suppose d'avoir décidé ce que
  « dépense privée » veut dire. Exemption **nommée** dans `EXEMPT_MODELS`, avec sa raison.
- **RAG / recherche globale** : structurel — `SearchableSpec` et `retrieval.search()` n'ont
  pas de dimension utilisateur, aucun filtre de confidentialité n'y est *exprimable*.
  `EmbeddingChunk` stocke par ailleurs le texte des entités privées.
- **Écriture** : n'importe quel membre peut encore éditer ou supprimer la note privée d'un
  autre via l'API REST, alors que `interactions/services.py` le refuse déjà pour l'agent —
  la seconde couche défensive existe, la première n'a jamais été écrite.

## Vérifications

- `pytest` : **4103 passed, 2 skipped** sur ce code exact.
- `npm run lint` : 0 erreur (5 warnings préexistants).
- `npx tsc -b ui/tsconfig.json` : exit 0.
- Aucun `gen:api:refresh` nécessaire — le client généré n'exposait pas le paramètre retiré.
