### PR TITLE
docs(documents): cadrer le parcours 29 — l'album du foyer (#526)

### DIFF
--- a/docs/MODULES/documents.md
+++ b/docs/MODULES/documents.md
@@ -189,6 +189,47 @@ date du déclenchement, lue dans l'EXIF.
 - **Upload multipart via action custom** : l'endpoint `POST /upload/` est une action custom séparée du `POST documents/` classique. Le `POST documents/` accepte un `file_path` manuel (cas import legacy). Les deux coexistent — ne pas confondre dans les tests ou le client.
 - Parcours 02 cadré dans `docs/parcours/PARCOURS_02_TRAITER_UN_DOCUMENT_ENTRANT_ET_LE_RELIER_AU_BON_CONTEXTE.md` et `PARCOURS_02_BACKLOG_TECHNIQUE.md`.
 
+### Envoyer des photos depuis un iPhone (feuille de partage)
+
+**Aucun code ne le permet — c'est déjà possible**, et c'est utile de savoir
+pourquoi : `ActiveHouseholdMiddleware` résout le foyer depuis
+`user.active_household_id`, **jamais depuis un en-tête**. Un client authentifié
+n'a donc rien d'autre à fournir que son jeton pour que `POST /upload/` sache dans
+quel foyer écrire. Sur iOS, la seule route est un raccourci Shortcuts : Safari ne
+prend pas en charge le *Web Share Target*, donc une PWA installée sur iPhone ne
+peut pas recevoir de contenu partagé (sur Android, un `share_target` dans le
+manifeste suffirait, sans jeton, la session étant déjà là).
+
+Le raccourci, dans l'ordre : `POST /api/auth/token/` en JSON (`email` +
+`password` — `USERNAME_FIELD` est l'email), on en tire la clé `access`, puis pour
+chaque image de l'entrée un `POST /api/documents/documents/upload/` avec
+`Authorization: Bearer …`, **corps de type Formulaire** (multipart), champs
+`file` et `type=photo`. Pas de champ `name` : chaque photo garde le nom de son
+fichier, même règle que le lot multiple.
+
+Deux points à ne pas perdre :
+
+- **`type=photo` n'est pas cosmétique** : `fetchDocuments` filtre les photos hors
+  de la page Documents et `fetchPhotoDocuments` les isole dans la galerie. Sans
+  lui, la photo atterrit dans les documents.
+- **L'access token vit 15 minutes**, donc le raccourci se réauthentifie à chaque
+  exécution et stocke les identifiants en clair. C'est la faiblesse assumée de
+  cette version, et la seule raison d'être du jeton d'appareil qui doit la
+  remplacer — un jeton révocable, sans mot de passe sur le téléphone.
+- **⚠️ Le piège du jeton d'appareil, à connaître avant de l'implémenter** :
+  `ActiveHouseholdMiddleware` s'exécute **avant** l'authentification DRF et ne
+  connaît que le JWT, la session Django et le `_force_auth_user` des tests. Une
+  simple classe d'authentification supplémentaire authentifierait l'utilisateur
+  au niveau de la vue, mais le middleware aurait déjà posé `request.household =
+  None` — et l'upload répondrait « A valid household context is required ». Le
+  jeton d'appareil se pose donc **aux deux endroits**, pas seulement dans
+  `DEFAULT_AUTHENTICATION_CLASSES`.
+- **À vérifier sur un vrai iPhone, jamais à supposer** : que les Raccourcis
+  préservent l'EXIF. Si `taken_at` revient vide, la galerie se range par date
+  d'import et non par date de prise de vue, et la date devra voyager comme champ
+  à part. Le contrôle se fait à l'œil : une photo envoyée doit afficher « Prise
+  le … », pas seulement « Ajoutée le … ».
+
 ---
 
 ## Violations CLAUDE.md identifiées (code en place)

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,5 +1,39 @@
 # Next steps
 
+> **Cadré au 2026-08-03 — Parcours 29 : l'album du foyer.** Chantier cadré ce
+> jour (doc produit, fiche concept, backlog en 7 lots, issues #526 → #534) ;
+> aucun lot démarré.
+>
+> Déclencheur : la livraison du téléversement multiple (#524) le matin même, et la
+> friction apparue à la première utilisation réelle — « les photos techniques sont
+> mélangées avec les photos souvenirs, les photos observation ». Une photo porte
+> trois axes (zone, entité liée, phase avant/après) et aucun ne dit **pourquoi
+> elle existe**. Le parcours ajoute cet axe, l'**intention**, et en fait la
+> première question de la galerie.
+>
+> **Arbitrage assumé** : l'ambition retenue est **l'album complet** — House vise à
+> devenir le point d'entrée photo, souvenirs inclus — contre l'alternative « le
+> classeur du foyer », qui était la recommandation. Les trois coûts sont nommés
+> dans la doc produit : changement d'ordre de grandeur du volume, quota qui devient
+> une contrainte réelle, comparaison frontale avec la pellicule du téléphone.
+>
+> Ordre : **1** (dettes : pagination curseur + `size_bytes` en colonne — prérequis
+> dur de tous les autres) → **2** (l'intention et la file « À trier », qui résout
+> la friction sans dépendre de l'infrastructure) → **3** (stockage objet) et
+> **4** (tâches de fond), indépendants entre eux mais prérequis du **6** (import
+> massif) → **5** (quota, dès que 1 est livré) → **7** (synchro iPhone).
+>
+> **⚠️ Ce cadrage ne tranche pas la priorité relative avec le parcours 28.** Les
+> lots 0 et 4 de celui-ci corrigent des écarts *ouverts aujourd'hui* (runner
+> exposé, dépôt public sans licence) et restent hors séquence, avant tout le reste.
+>
+> - Doc produit : [`PARCOURS_29_ALBUM_DU_FOYER.md`](./parcours/PARCOURS_29_ALBUM_DU_FOYER.md)
+> - Backlog : [`PARCOURS_29_BACKLOG_TECHNIQUE.md`](./parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md)
+> - Fiche concept : [`PIPELINE_MEDIA.md`](./fiches/PIPELINE_MEDIA.md)
+> - Journal : [`2026-08-03_parcours-29_cadrage_initial.md`](./journal/2026-08-03_parcours-29_cadrage_initial.md)
+
+---
+
 > **Priorité au 2026-07-31 — Parcours 28 : ouvrir Maisonnée (open source,
 > auto-hébergeable).** Chantier cadré ce jour (doc produit, fiche concept, backlog
 > en 8 lots, issues #485 → #493) ; aucun lot démarré.

--- a/docs/fiches/PIPELINE_MEDIA.md
+++ b/docs/fiches/PIPELINE_MEDIA.md
@@ -1,0 +1,197 @@
+# Pipeline média — où vivent les octets, qui les sert, quand ils sont transformés
+
+> Fiche liée au [parcours 29](../parcours/PARCOURS_29_ALBUM_DU_FOYER.md).
+> Voir aussi [AUTO_HEBERGEMENT.md](AUTO_HEBERGEMENT.md) pour la notion de
+> capacité optionnelle, dont ce chantier fait un usage central.
+
+## 1. Le problème
+
+Un fichier n'est pas une ligne de base de données. Il est gros, il coûte cher à
+déplacer, et il a **trois vies distinctes** : il arrive, il est transformé, il est
+servi. Tant qu'un foyer en a deux cents, la solution la plus simple gagne à tous
+les coups — on écrit sur le disque, on transforme dans la requête, on sert avec le
+serveur web. C'est ce que fait House aujourd'hui, et c'était le bon choix.
+
+À dix mille photos, chacun de ces trois raccourcis se paie, et ils se paient
+séparément :
+
+- **écrire sur le disque du serveur** finit par saturer un volume qu'on ne peut
+  agrandir qu'en redémarrant la machine ;
+- **transformer dans la requête** transforme un import de deux cents photos en
+  deux cents requêtes longues, chacune occupant un worker gunicorn pendant que le
+  processeur ré-encode un HEIC ;
+- **servir depuis le serveur** met toute la bande passante des images sur le lien
+  d'une seule machine.
+
+Le piège, c'est que ces trois problèmes *ressemblent* à un seul (« il faudrait
+passer au cloud »). Les traiter comme un seul produit une réécriture qu'on ne
+peut plus livrer par morceaux.
+
+## 2. Le concept en deux phrases
+
+Un pipeline média répond à **trois questions indépendantes** : où vivent les
+octets, qui les envoie au navigateur, et à quel moment ils sont transformés.
+Chacune se tranche séparément, et une architecture saine est celle où changer la
+réponse à l'une ne force pas à changer les deux autres.
+
+## 3. Comment on l'applique dans house
+
+### Où vivent les octets
+
+Deux emplacements possibles, derrière la même abstraction Django
+(`default_storage`) :
+
+- **le disque du serveur** — le défaut, et le seul mode de l'auto-hébergement ;
+- **un stockage objet S3-compatible** — déclaré par configuration, jamais deviné.
+
+La bascule est un **réglage explicite**, pas une déduction depuis `DEBUG` ou
+depuis la présence d'une variable. C'est la leçon déjà payée par
+`PROTECTED_MEDIA_ACCEL` : un mécanisme de transport qui se déduit d'un réglage de
+confidentialité produit, le jour où on sort des deux déploiements connus, une
+image cassée sans une ligne d'erreur.
+
+### Qui envoie les octets
+
+Trois modes, et c'est ici que se joue le contrôle d'accès :
+
+| Mode | Qui sert | Où l'accès est vérifié |
+|---|---|---|
+| Django | gunicorn | dans la vue, avant de lire le fichier |
+| `X-Accel-Redirect` | Nginx | dans la vue, qui répond un en-tête |
+| URL présignée | le stockage objet | dans la vue **qui fabrique l'URL** |
+
+Les deux premiers gardent Django sur le chemin des octets. Le troisième l'en
+sort — et c'est **le vrai coût de l'option**, qu'il faut nommer précisément.
+
+`apps/core/views_media.py` est la seule porte du foyer qui ne passe ni par un
+viewset ni par un queryset : elle reçoit un chemin et rend des octets. Elle porte
+trois règles gagnées au prix de vrais incidents, dont un où 177 documents sur 202
+sont devenus invisibles en production (issue #517). La troisième dit l'essentiel :
+**un fichier se rattache à un foyer en base, pas par la forme de son chemin.**
+
+Une URL présignée ne connaît pas cette règle. Elle est un **secret porteur** :
+qui l'a, l'ouvre. La sécurité repose donc entièrement sur le fait qu'elle est
+courte à vivre et qu'elle ne s'obtient qu'en demandant à Django, qui, lui, fait
+toujours le contrôle du foyer et de `is_private`. D'où trois contraintes non
+négociables :
+
+1. **durée de validité courte** (quelques minutes), suffisante pour afficher une
+   page, insuffisante pour partager un lien ;
+2. **jamais persistée** — ni dans un JSON stocké, ni dans un index de recherche,
+   ni dans une notification ;
+3. **jamais fabriquée en masse à l'avance** : une galerie signe les vignettes de
+   la page affichée, pas celles des dix mille photos du foyer.
+
+### Quand ils sont transformés
+
+Aujourd'hui : dans la requête. Lecture EXIF, ré-encodage, redimensionnement,
+vignettes, OCR — tout se passe pendant que le navigateur attend.
+
+Demain : **l'upload écrit, le worker transforme.** La requête d'upload fait le
+strict minimum — vérifier le quota, poser le fichier, créer la ligne — et rend la
+main. Le reste est une tâche de fond, et le document porte un
+`processing_state`.
+
+Le détail qui décide de la qualité perçue : **une photo dont la vignette n'est
+pas encore générée est un état, pas une erreur.** Si la galerie ne sait pas
+distinguer les deux, un import de deux cents photos affiche deux cents cases
+cassées, et l'utilisateur conclut que l'import a échoué alors qu'il se déroule
+parfaitement. C'est la même famille de bug que « un compteur à zéro a deux
+sens » : l'absence d'information et l'information « rien » ne se disent jamais
+pareil.
+
+## 4. Pourquoi cette implémentation
+
+### Une file adossée à Postgres, pas Celery + Redis
+
+La pile de production n'a **pas de Redis** ; elle a `db`, `web`, deux conteneurs
+`scheduler` et `nginx`. Le projet sait donc déjà faire tourner un processus de
+fond — ce qu'il ne sait pas faire tourner, c'est un *broker*.
+
+Introduire Redis, c'est un service de plus à sauvegarder, à surveiller, à mettre
+à jour — et surtout à **imposer à l'auto-hébergeur**, dont la pile tient
+aujourd'hui en trois conteneurs. Une file dont le broker est la base Postgres
+déjà présente ne coûte qu'un conteneur worker, sur le modèle exact des
+`scheduler` existants.
+
+La contrepartie est réelle et doit être écrite : un broker ORM interroge la base
+en boucle, et ça ne passe pas à l'échelle d'un SaaS multi-milliers de foyers.
+C'est un **choix daté**, juste au volume d'un foyer et à rejuger si l'échelle
+change — pas une position de principe.
+
+### L'upload direct au stockage, et son corollaire de sécurité
+
+Deux cents photos à 4 Mo, c'est 800 Mo qui traversent gunicorn puis Nginx pour
+finir dans un bucket. Faire signer au serveur une autorisation d'écriture, et
+laisser le navigateur envoyer directement, retire complètement Django du chemin
+des octets.
+
+Le corollaire n'est pas optionnel : **le serveur ne voit plus le contenu au
+moment de l'upload.** Or `validate_upload` vérifie les *magic bytes* et ignore
+délibérément le `Content-Type` annoncé par le client. Cette vérification ne peut
+donc plus vivre là où elle est. Elle se déplace dans le worker, et le document
+reste en **quarantaine** — `processing_state` non résolu, jamais servi, jamais
+listé — tant qu'elle n'a pas réussi. Sans ce déplacement, l'upload direct
+revient à accepter n'importe quel fichier dans le bucket sur la seule parole du
+client.
+
+### Un curseur, pas un offset
+
+Une galerie paginée par `?page=2` suppose que la liste ne bouge pas entre deux
+pages. Pendant un import, elle bouge par le haut : chaque photo qui arrive
+décale tout, et l'utilisateur qui fait défiler voit des doublons et rate des
+photos — sans qu'aucune requête soit fausse.
+
+La pagination par curseur ancre la page suivante sur **la dernière ligne lue**,
+pas sur un rang. Elle exige en revanche un ordre **total et stable** : la galerie
+trie par `effective_date` (un `COALESCE(taken_at, created_at)` annoté), qui n'est
+pas unique — deux photos d'une même rafale partagent la seconde. Le tri doit donc
+être complété par un départage stable, sinon le curseur saute des lignes.
+
+### Compter les octets sur le disque, pas l'original
+
+Un fichier importé produit plusieurs objets : l'original, la version normalisée
+(ré-encodée, redimensionnée), et les vignettes. Un quota qui ne compte que
+l'original annonce à l'utilisateur 20 à 40 % de moins que ce qu'il occupe
+réellement — et c'est l'hébergeur qui paie la différence. Le compteur mesure ce
+qui est stocké.
+
+Et il ne se dénormalise pas : c'est un `Sum` sur une colonne indexée, recalculable
+à tout moment — même règle que le solde bancaire et que le « dépensé » d'un
+budget. Un total dénormalisé qui dérive est pire que pas de total, parce que
+personne ne peut plus dire lequel des deux chiffres est faux.
+
+## 5. Ce qu'on a écarté et pourquoi
+
+- **Celery + Redis.** Le standard de l'écosystème, et le bon choix dès qu'il y a
+  plusieurs machines. Ici il ajoute un service à opérer et une dépendance à
+  imposer à l'auto-hébergement, pour une charge qui tient largement dans un
+  worker.
+- **Un `PAGE_SIZE` global dans `REST_FRAMEWORK`.** Ça paginerait *toutes* les
+  réponses de l'API d'un coup, donc changerait leur forme pour cinquante-sept
+  viewsets et casserait tous les clients qui lisent un tableau. La pagination se
+  pose viewset par viewset, en commençant par celui qui en souffre.
+- **Redimensionner l'image dans le navigateur avant l'envoi.** Ça diviserait la
+  bande passante par dix — et ça détruirait l'EXIF, donc la date de prise de vue,
+  donc le tri de la galerie. Le piège est déjà documenté et a déjà mordu une fois
+  côté serveur (`read_taken_at` doit précéder `normalize_image`). L'original part
+  tel quel ; c'est le worker qui allège.
+- **Rendre le stockage objet obligatoire.** Ce serait imposer un compte chez un
+  fournisseur à qui veut héberger House chez lui — l'inverse exact de ce que le
+  parcours 28 a construit.
+- **Des URLs non devinables sur un stockage public.** Un UUID dans un chemin
+  public n'est pas un contrôle d'accès : il fuit par le presse-papier, l'historique
+  du navigateur, le référent HTTP. Une photo d'intérieur mérite un contrôle réel,
+  pas une adresse difficile à taper.
+
+## 6. Pour aller plus loin
+
+- [django-storages](https://django-storages.readthedocs.io/) — backends de
+  stockage Django, dont S3
+- [Amazon S3 — presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/using-presigned-url.html)
+  — le mécanisme, valable pour tous les fournisseurs S3-compatibles
+- [DRF — Cursor pagination](https://www.django-rest-framework.org/api-guide/pagination/#cursorpagination)
+  — et la contrainte d'ordre total qu'elle impose
+- [django-q2](https://django-q2.readthedocs.io/) — file de tâches à broker ORM
+- [Apple Shortcuts — Find Photos](https://support.apple.com/guide/shortcuts/) —
+  filtrage par date et par lieu côté téléphone

--- a/docs/fiches/README.md
+++ b/docs/fiches/README.md
@@ -25,6 +25,7 @@ Chaque fiche suit le même squelette :
 - [CARTOGRAPHIE_DEPENSES.md](CARTOGRAPHIE_DEPENSES.md) — Cartographie du mécanisme de dépenses : tous les points d'écriture et de lecture, et la dette résorbée (parcours 08 + 21)
 - [IMPORT_ET_RAPPROCHEMENT.md](IMPORT_ET_RAPPROCHEMENT.md) — Import idempotent & rapprochement flou : dédupliquer un relevé bancaire sans identifiant natif, et apparier une ligne à un achat déjà saisi (parcours 25)
 - [SNAPSHOT_ET_RECIT.md](SNAPSHOT_ET_RECIT.md) — Instantané figé & récit tardif : garder la mémoire d'une période close sans réécrire l'histoire, et la raconter dans la langue du lecteur (parcours 21 + 27)
+- [PIPELINE_MEDIA.md](PIPELINE_MEDIA.md) — Pipeline média : où vivent les octets, qui les sert, quand ils sont transformés (stockage objet optionnel, URL présignée et contrôle d'accès, file de tâches adossée à Postgres) (parcours 29)
 - [AUTO_HEBERGEMENT.md](AUTO_HEBERGEMENT.md) — D'un déploiement à un produit installable : ce que change le passage à l'auto-hébergement (modèle de menace, capacités optionnelles, licence copyleft réseau, sauvegarde comme fonctionnalité) (parcours 28)
 
 ## Quand créer une fiche ?

--- a/docs/journal/2026-08-03_parcours-29_cadrage_initial.md
+++ b/docs/journal/2026-08-03_parcours-29_cadrage_initial.md
@@ -1,0 +1,93 @@
+# 2026-08-03 — Parcours 29 cadrage initial
+
+## Contexte
+
+Session de cadrage du vingt-neuvième chantier : **l'album du foyer** — faire des
+photos le point d'entrée de House.
+
+Déclencheur immédiat : la livraison le matin même du téléversement multiple
+(#524 / PR #525), qui a fait apparaître la friction suivante dès la première
+utilisation réelle. Dit par l'utilisateur :
+
+> « Les photos techniques sont mélangées avec les photos souvenirs, les photos
+> observation. »
+
+Le but explicite de la session : **produire uniquement de la documentation, des
+specs et les issues GitHub** — aucun code.
+
+## Ce que le cadrage a trouvé
+
+Quatre manques, vérifiés dans le code pendant la séance, qui expliquent l'ordre
+des lots :
+
+1. `DocumentViewSet` n'a **aucune pagination**, et il n'y a pas de `PAGE_SIZE`
+   global : la galerie charge la totalité du foyer dans une réponse. Déjà signalé
+   dans `docs/MODULES/documents.md`, jamais traité.
+2. La taille d'un fichier vit dans `metadata` — donc inagrégeable sans cast JSON,
+   exactement la dette résorbée côté argent avec `amount` / `kind` / `supplier`.
+3. **Aucune infrastructure de tâches de fond** : ni Celery, ni django-q, ni Redis.
+   La pile a en revanche déjà deux conteneurs `scheduler` — le projet sait faire
+   tourner un processus de fond, pas un broker.
+4. `Household` porte **déjà** `latitude` / `longitude`, posées pour la météo : le
+   géofence de la synchro iPhone a son ancre sans rien ajouter.
+
+## L'arbitrage central
+
+Deux ambitions étaient sur la table.
+
+- **Le classeur du foyer** — technique + observation + un album curaté ; les
+  souvenirs restent dans la pellicule. Volume faible, quota bon marché,
+  et une catégorie que personne ne sert. **Recommandé par l'assistant.**
+- **L'album complet** — House remplace la pellicule comme point d'entrée photo.
+  **Retenu par l'utilisateur.**
+
+L'argument opposé à l'album complet était sa collision avec la deuxième demande
+de la même session (un quota de stockage par foyer) : les souvenirs sont la
+catégorie la plus lourde en octets et la moins spécifique à House, donc celle qui
+décide du coût par foyer. L'arbitrage a été maintenu ; il est écrit tel quel dans
+la doc produit, avec ses trois coûts nommés, parce que la suite du backlog n'a de
+sens qu'à cette lumière.
+
+Conséquence directe : le stockage objet cesse d'être une option lointaine et
+entre dans le chantier (lot 3), avant le gros volume — migrer après coûte
+beaucoup plus cher.
+
+## Le concept retenu
+
+Une photo porte trois axes (zone = *où*, entité = *sur quoi*, phase = *quand dans
+le chantier*). Il en manquait un : **l'intention** — `technical`, `observation`,
+`memory`, et le vide.
+
+Le point structurant : **le vide n'est pas « souvenir »**. Vide signifie que
+personne n'a trié, c'est un écart, et il alimente une file « À trier ». C'est la
+transposition littérale de `inflow_nature == ""` n'est pas `"other"`, et du
+principe du parcours 26 (« toute entité est soit résolue, soit flaggée avec un
+motif »).
+
+Décision qui en découle et qui a été discutée : **aucun backfill**. Marquer
+`technical` toute photo déjà liée à un projet serait écrire une devinette en base,
+où elle deviendrait indistinguable d'un choix — ce que `banking.rules` interdit.
+Tout l'existant part dans « À trier », et c'est le tri **par grappe de session**
+qui rend la contrepartie tenable.
+
+## Contrainte conservée
+
+House est auto-hébergeable depuis le parcours 28, en trois conteneurs. Le stockage
+objet et le traitement asynchrone sont donc des **capacités déclarées et
+optionnelles**, sur le modèle de `PROTECTED_MEDIA_ACCEL` — jamais des prérequis.
+C'est la contrainte qui a écarté Celery + Redis.
+
+## Livrables
+
+- Doc produit : [`PARCOURS_29_ALBUM_DU_FOYER.md`](../parcours/PARCOURS_29_ALBUM_DU_FOYER.md)
+- Fiche concept : [`PIPELINE_MEDIA.md`](../fiches/PIPELINE_MEDIA.md)
+- Backlog : [`PARCOURS_29_BACKLOG_TECHNIQUE.md`](../parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md)
+- Issues : parente #526, lots #527 → #533, annexe V2 #534
+
+## Ce qui reste à arbitrer
+
+**Ce chantier ne dit pas ce qu'il advient du parcours 28.** Les lots 0 et 4 de
+celui-ci corrigent des écarts *ouverts aujourd'hui* (runner exposé, absence de
+licence sur un dépôt public) et restent hors séquence. La priorité relative entre
+le reste du parcours 28 et le parcours 29 n'a pas été tranchée pendant cette
+séance.

--- a/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
+++ b/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
@@ -129,7 +129,7 @@ photos portent déjà une intention ne se réassigne pas en bloc sans le dire.
 | « Qu'est-ce qui traîne sans être rangé ? » | Rien ne le dit | La file « À trier », avec son compte |
 | « J'ai 200 photos à importer » | Dix ouvertures d'un dialogue, une modale bloquée 40 min | Une page d'import, une file qui survit à la navigation |
 | « Combien de place j'occupe ? » | Rien ne le dit | Un compteur, visible avant de mordre |
-| « Je viens de rentrer, j'ai pris 15 photos » | On les retrouve, on les sélectionne, on les envoie | Un raccourci iOS les propose déjà |
+| « Je viens de rentrer, j'ai pris 15 photos » | On ouvre House, on retrouve les fichiers, on les envoie | Feuille de partage du téléphone, puis une automatisation qui ne propose que ce qui vient de la maison |
 
 ## Ce qu'on ne fait pas en V1
 

--- a/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
+++ b/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
@@ -1,0 +1,186 @@
+# Parcours 29 — L'album du foyer
+
+Ce document cadre le vingt-neuvième chantier de House. Il fait des photos le
+**point d'entrée** de l'application, et non plus une vue secondaire du module
+Documents.
+
+- Fiche concept : [PIPELINE_MEDIA.md](../fiches/PIPELINE_MEDIA.md)
+- Backlog technique : [PARCOURS_29_BACKLOG_TECHNIQUE.md](./PARCOURS_29_BACKLOG_TECHNIQUE.md)
+- Module concerné : [documents](../MODULES/documents.md)
+
+## Résumé
+
+Le problème, dit par l'utilisateur :
+
+> « Je photographie le numéro de série d'une chaudière, une fissure qui
+> m'inquiète, et l'anniversaire de ma fille. Les trois finissent au même endroit,
+> dans le même ordre. »
+
+Une photo dans House porte aujourd'hui trois axes : la **zone** dit *où*,
+l'**entité** liée (projet, équipement, tâche) dit *sur quoi*, la **phase**
+avant/pendant/après dit *quand dans le chantier*. Aucun des trois ne dit
+**pourquoi cette photo existe** — et c'est précisément la question qui sépare une
+preuve technique d'un souvenir.
+
+Ce parcours ajoute ce quatrième axe, l'**intention**, et en fait la première
+chose que la galerie demande. Il assume dans la foulée la conséquence de
+l'ambition retenue — House devient l'endroit où l'on range *toutes* ses photos,
+souvenirs compris —, ce qui fait entrer le foyer dans un ordre de grandeur que le
+module ne sait pas encore encaisser.
+
+C'est le même raisonnement que « le budget est la catégorie » côté argent : un
+projet et une zone disent sur quoi et où porte un euro, jamais de quelle nature
+il est. Un euro sans budget est un écart ; une photo sans intention aussi.
+
+## Positionnement produit
+
+Les parcours 02 à 05 ont construit la mémoire du foyer, le parcours 20 a donné
+aux projets leurs photos avant/après, et le parcours 21 a rendu la galerie
+triable par date de prise de vue. Toutes ces briques traitent la photo comme
+**une pièce jointe à autre chose**.
+
+Le parcours 29 renverse la relation : la photo devient une entrée à part entière,
+qu'on ouvre pour elle-même, et la première question posée n'est plus « à quoi
+est-elle rattachée » mais « à quoi sert-elle ». C'est aussi le premier chantier
+qui vise explicitement l'**ouverture quotidienne** de l'application : une galerie
+qu'on consulte, et pas seulement un classeur qu'on alimente.
+
+## Le pari, et ce qu'il coûte
+
+Deux ambitions étaient sur la table le 2026-08-03.
+
+**Le classeur du foyer** — House prend le technique, l'observation, et un album
+*du foyer* curaté ; les souvenirs personnels restent dans la pellicule du
+téléphone. Volume faible, quota bon marché, forfait gratuit crédible, et une
+catégorie que personne ne sert bien.
+
+**L'album complet** — House vise à remplacer la pellicule comme point d'entrée
+photo, souvenirs inclus. **C'est celle qui a été retenue.**
+
+Il faut écrire ici ce qu'elle coûte, parce que la suite du backlog n'a de sens
+qu'à cette lumière :
+
+- **Le volume change d'ordre de grandeur.** Un foyer « classeur » stocke quelques
+  centaines de photos ; un foyer « album » en stocke des dizaines de milliers.
+  Trois mécanismes qui tenaient très bien jusqu'ici cessent de tenir : la galerie
+  charge tout d'un coup, les fichiers vivent sur le disque d'un VPS, et le
+  traitement d'une image occupe le thread de la requête.
+- **Le quota devient une contrainte réelle, pas une précaution.** Les souvenirs
+  sont la catégorie la plus lourde en octets et la moins spécifique à House :
+  c'est elle qui décidera du coût par foyer.
+- **La comparaison devient frontale.** Un utilisateur qui range ses souvenirs
+  dans House les compare à ce que fait son téléphone — sauvegarde automatique,
+  recherche par visage, retouche. House ne gagnera pas sur ce terrain, et ne doit
+  pas essayer : ce qu'il apporte, c'est le **contexte du foyer** que la pellicule
+  n'aura jamais (cette photo est la chaudière, elle est dans la buanderie, elle
+  date du chantier de 2024).
+
+Le pari est donc : *l'intention et le contexte valent plus que les visages et les
+filtres.* Il est assumé, et il oriente tout le reste — notamment le fait qu'on ne
+construira **jamais** de reconnaissance de visages ni d'éditeur d'image.
+
+## Le concept : l'intention d'une photo
+
+Une nouvelle valeur portée par le document lui-même, et non par un de ses liens :
+
+| Intention | Ce que c'est | Exemple |
+|---|---|---|
+| `technical` | Une **preuve**. On la reprendra pour lire quelque chose dessus. | Numéro de série, index de compteur, plan, plaque signalétique |
+| `observation` | Un **fait daté** qu'on remarque, et qui appellera peut-être une action. | Une fissure, une fuite, la pousse d'un semis, une poule qui boite |
+| `memory` | Un **souvenir** du foyer. | Un repas, un anniversaire, le jardin sous la neige |
+| *(vide)* | **Personne n'a encore trié.** | Ce qui vient d'être importé |
+
+Le point qui structure tout le reste : **le vide n'est pas « souvenir ».** Vide
+signifie que personne n'a regardé — c'est un écart, et il alimente une file
+« À trier ». `memory` signifie qu'on a choisi. Confondre les deux rendrait la
+file aveugle et l'utilisateur croirait avoir rangé.
+
+C'est exactement la règle établie côté banque (`inflow_nature == ""` n'est pas
+`"other"`), et la déclinaison du principe du parcours 26 : *toute entité est soit
+résolue, soit flaggée avec un motif ; rien ne reste dans un entre-deux
+silencieux.*
+
+Conséquence directe sur l'écran : **la galerie ne s'ouvre plus sur tout.** Elle
+s'ouvre sur une intention. Le mélange dont se plaint l'utilisateur n'est pas un
+problème d'affichage, c'est une donnée absente ; l'ajouter suffit à le résoudre,
+et aucun filtre n'y suffirait sans elle.
+
+## Le tri se fait par groupe, jamais photo par photo
+
+Trente photos rapportées d'un week-end forment **une session**, pas trente
+décisions. Le tri se présente donc par grappes — des photos prises dans le même
+créneau —, et une intention s'attribue à la grappe entière.
+
+Ce n'est pas un confort : c'est la condition de survie de la fonctionnalité. Une
+file qui demande trente gestes pour trente photos ne se vide jamais, et une file
+qu'on ne vide jamais cesse d'être lue au bout d'une semaine — exactement ce qui
+est arrivé aux compteurs du Contrôle avant qu'ils ne soient bornés.
+
+Avec la garde-fou que l'application connaît déjà côté argent : **une action de
+lot ne doit jamais écraser un travail déjà fait.** Une grappe dont certaines
+photos portent déjà une intention ne se réassigne pas en bloc sans le dire.
+
+## Ce que l'utilisateur gagne
+
+| Question | Aujourd'hui | Après |
+|---|---|---|
+| « Montre-moi les photos du chantier » | Elles sont mêlées aux repas de famille | La galerie s'ouvre sur une intention |
+| « Où est la photo du numéro de série ? » | On fait défiler par mois | Intention `technical` + la zone ou l'équipement |
+| « Qu'est-ce qui traîne sans être rangé ? » | Rien ne le dit | La file « À trier », avec son compte |
+| « J'ai 200 photos à importer » | Dix ouvertures d'un dialogue, une modale bloquée 40 min | Une page d'import, une file qui survit à la navigation |
+| « Combien de place j'occupe ? » | Rien ne le dit | Un compteur, visible avant de mordre |
+| « Je viens de rentrer, j'ai pris 15 photos » | On les retrouve, on les sélectionne, on les envoie | Un raccourci iOS les propose déjà |
+
+## Ce qu'on ne fait pas en V1
+
+Explicitement différé, et pour la plupart **définitivement écarté** :
+
+- **Les forfaits payants.** Le compteur de stockage est construit ; la
+  facturation (paiement, TVA, factures, remboursements) est un chantier entier,
+  et invendable tant que la rétention n'est pas prouvée. On ne vend pas un quota
+  qu'on n'a jamais mesuré — mais on ne mesure pas pour vendre demain.
+- **La reconnaissance de visages.** Écartée durablement : coût, dépendance à un
+  fournisseur, et un risque disproportionné sur des photos d'enfants.
+- **L'édition d'image** (recadrage, filtres, retouche). Le téléphone le fait
+  mieux, et House n'a aucune raison de rentrer là.
+- **Le partage hors du foyer** (lien public, album invité).
+- **La déduplication perceptuelle** — repérer deux photos quasi identiques. Utile
+  à gros volume, mais ça suppose des empreintes d'image et une file de calcul
+  qu'on n'aura qu'après le lot 3.
+- **Une application iOS native.** La synchronisation passe par un raccourci
+  Shortcuts, qui couvre le besoin sans rien publier sur l'App Store.
+- **La déduction de la zone depuis le GPS.** Le positionnement ne descend jamais
+  au niveau de la pièce, et encore moins en intérieur. La zone restera un geste.
+
+## Les quatre choses qui n'existent pas encore
+
+Le chantier bute sur quatre manques réels, vérifiés dans le code au cadrage. Ils
+expliquent l'ordre des lots :
+
+1. **La galerie n'est pas paginée.** `DocumentViewSet` n'a pas de
+   `pagination_class`, et il n'y a pas de `PAGE_SIZE` global : la liste complète
+   du foyer part dans une seule réponse. C'est déjà signalé dans la fiche du
+   module, et c'est le blocage n°1 — aucune feature d'import massif n'a de sens
+   avant.
+2. **La taille d'un fichier vit dans `metadata`.** Un quota est une agrégation ;
+   `metadata` doit rester affiché, jamais requêté ni contraint. Il faut promouvoir
+   `size_bytes` en colonne, comme `amount` / `kind` / `supplier` l'ont été sur
+   `Interaction`.
+3. **Il n'y a aucune infrastructure de tâches de fond.** Ni Celery, ni django-q,
+   ni Redis. OCR, normalisation et vignettes tournent dans le thread de la requête
+   HTTP — une « décision assumée en phase solo » que ce parcours révise.
+4. **Les fichiers vivent sur le disque du serveur.** Servis par
+   `X-Accel-Redirect` en production, par Django en auto-hébergement. Un album
+   complet ne tient pas sur un volume de VPS, et migrer *après* le gros volume
+   coûte beaucoup plus cher que de le décider avant.
+
+## Une contrainte que ce chantier ne doit pas casser
+
+House est auto-hébergeable depuis le parcours 28, et sa pile
+`docker compose up` tient en trois conteneurs, sans Nginx et sans stockage
+externe. Le stockage objet et la file de tâches doivent donc être des
+**capacités déclarées et optionnelles**, sur le modèle de `PROTECTED_MEDIA_ACCEL`
+— jamais des prérequis. Un foyer auto-hébergé qui range ses photos sur son propre
+disque doit continuer de fonctionner sans compte S3 et sans conteneur
+supplémentaire, avec pour seule contrepartie un traitement synchrone et un quota
+adossé à son disque.

--- a/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
+++ b/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
@@ -131,6 +131,35 @@ photos portent déjà une intention ne se réassigne pas en bloc sans le dire.
 | « Combien de place j'occupe ? » | Rien ne le dit | Un compteur, visible avant de mordre |
 | « Je viens de rentrer, j'ai pris 15 photos » | On ouvre House, on retrouve les fichiers, on les envoie | Feuille de partage du téléphone, puis une automatisation qui ne propose que ce qui vient de la maison |
 
+## Envoyer depuis son téléphone, sans ouvrir House
+
+Le geste le plus fréquent n'est pas « j'ouvre House pour importer », c'est « je viens
+de photographier quelque chose ». Il doit donc partir de l'app Photos, pas de House :
+on sélectionne, on partage, c'est fini. Ce chemin ne dépend d'aucun lot de ce
+parcours et se livre à part (#535 pour iOS, #537 pour Android).
+
+Il faut assumer que **les deux plateformes ne coûtent pas la même chose à
+l'utilisateur** :
+
+- **Android** — il installe House sur son écran d'accueil, et « Maisonnée » apparaît
+  dans le menu de partage du système. Rien d'autre à faire, jamais.
+- **iOS** — il importe un raccourci et y colle un jeton, une fois. Deux minutes.
+
+L'écart ne vient pas de House : Safari ne permet pas à une application web de
+recevoir du contenu partagé, là où Android le permet. Le raccourci est le
+contournement, et il n'y en a pas d'autre sans publier une application native — ce
+qu'on ne fera pas.
+
+Deux conséquences produit à tenir :
+
+- **Le raccourci se distribue déjà construit.** Le monter à la main demande une
+  quarantaine de minutes et se trompe cinq fois ; personne ne le fera. L'utilisateur
+  ouvre un lien, répond à deux questions posées par le raccourci lui-même, et c'est
+  tout.
+- **Ce qui part du téléphone n'est jamais classé au départ.** Le raccourci envoie,
+  House range. Mettre l'intelligence dans le téléphone la met dans un endroit qu'on
+  ne peut ni corriger ni tester sans la réinstaller chez chaque membre du foyer.
+
 ## Ce qu'on ne fait pas en V1
 
 Explicitement différé, et pour la plupart **définitivement écarté** :

--- a/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
@@ -1,0 +1,341 @@
+# Parcours 29 — Backlog technique
+
+> Cadrage réalisé le 2026-08-03. Aucun code n'a été écrit à ce stade.
+
+## Tableau de bord
+
+| Lot | Sujet | Statut | Issue |
+|---|---|---|---|
+| 1 | Les dettes qui bloquent le volume — pagination curseur + `size_bytes` en colonne | ⬜ À faire | #527 |
+| 2 | L'intention (`purpose`) et la file « À trier » | ⬜ À faire | #528 |
+| 3 | Le stockage objet, optionnel | ⬜ À faire | #529 |
+| 4 | Le traitement en tâche de fond | ⬜ À faire | #530 |
+| 5 | Le quota de stockage du foyer | ⬜ À faire | #531 |
+| 6 | L'import massif | ⬜ À faire | #532 |
+| 7 | La synchro iPhone — raccourci + géofence | ⬜ À faire | #533 |
+
+**Issue parente** : #526 · **Issue annexe (V2 différés)** : #534
+
+## Doc associée
+
+- Doc produit : [PARCOURS_29_ALBUM_DU_FOYER.md](./PARCOURS_29_ALBUM_DU_FOYER.md)
+- Fiche concept : [PIPELINE_MEDIA.md](../fiches/PIPELINE_MEDIA.md)
+- Fiche module : [docs/MODULES/documents.md](../MODULES/documents.md)
+- Fiche connexe : [AUTO_HEBERGEMENT.md](../fiches/AUTO_HEBERGEMENT.md) — la notion
+  de capacité optionnelle, dont les lots 3 et 4 dépendent entièrement
+- CLAUDE.md, sections « Fraîcheur des données », « Pattern standard — Feature
+  page », « Notifications »
+- Précédents à répliquer : promotion de colonnes depuis `metadata`
+  (`Interaction.amount` / `kind` / `supplier`, `docs/fiches/CARTOGRAPHIE_DEPENSES.md`),
+  file « À ranger » de l'argent (`banking.queries`), détecteurs du parcours 26
+
+## Flow cible
+
+1. l'utilisateur ouvre `/app/photos` — la galerie s'ouvre **sur une intention**,
+   pas sur tout, et affiche le compte de ce qui reste à trier ;
+2. il importe deux cents photos depuis une page d'import dédiée ; la file survit
+   à la navigation et se reprend après interruption ;
+3. chaque photo est écrite immédiatement, puis traitée en tâche de fond
+   (validation, EXIF, normalisation, vignettes, OCR) ; son état est visible ;
+4. les nouvelles photos arrivent dans « À trier », regroupées par **session** ;
+   une intention s'attribue à la grappe entière ;
+5. le compteur de stockage du foyer se met à jour, visible avant de mordre ;
+6. depuis l'iPhone, un raccourci propose les photos du jour prises à la maison.
+
+## Décisions de cadrage
+
+- **Pagination viewset par viewset, jamais globale.** Poser un `PAGE_SIZE` dans
+  `REST_FRAMEWORK` changerait la forme des réponses de cinquante-sept viewsets
+  d'un coup. Seul `DocumentViewSet` est paginé, et par **curseur** — un import en
+  cours décale une pagination par offset et fait sauter des lignes.
+- **`size_bytes` est promu en colonne, `metadata['size']` reste écrit.** Un quota
+  est une agrégation, et `metadata` doit rester affiché, jamais requêté. La clé
+  JSON n'est pas supprimée dans le même lot : une migration destructive se livre
+  en deux fois, l'ancien code voyant le nouveau schéma le temps du basculement.
+- **Aucun backfill de `purpose`.** Il serait tentant de marquer `technical` toute
+  photo déjà liée à un projet ou à un équipement. Ce serait écrire une devinette
+  en base, où elle deviendrait indistinguable d'un choix de l'utilisateur —
+  exactement ce que `banking.rules` interdit (« des valeurs de départ, jamais des
+  vérités »). Tout l'existant part donc dans « À trier ». La contrepartie est
+  assumée et rendue tenable par le tri **par grappe** : quelques centaines de
+  photos représentent quelques dizaines de gestes, pas quelques centaines.
+- **Le stockage objet et le traitement asynchrone sont des capacités déclarées,
+  jamais des prérequis.** `MEDIA_BACKEND` et `ASYNC_PROCESSING` se déclarent, sur
+  le modèle de `PROTECTED_MEDIA_ACCEL`, et ne se déduisent ni de `DEBUG` ni de la
+  présence d'une variable. Une instance auto-hébergée doit continuer de tourner
+  en trois conteneurs, sans compte S3 et sans worker.
+- **La file de tâches est adossée à Postgres, pas à Redis.** La pile n'a pas de
+  Redis et a déjà deux conteneurs `scheduler` : le projet sait faire tourner un
+  processus de fond, pas un broker. Choix daté, juste au volume d'un foyer, à
+  rejuger si l'échelle change (voir la fiche).
+- **L'upload direct déplace la validation, il ne la supprime pas.** Dès que le
+  navigateur écrit directement dans le stockage, le serveur ne voit plus les
+  octets : `validate_upload` (magic bytes) migre dans le worker, et le document
+  reste en **quarantaine** — jamais servi, jamais listé — tant qu'elle n'a pas
+  réussi.
+- **Le tri se fait par grappe de session**, calculée à la lecture depuis
+  `taken_at` (aucune colonne de groupe en base : un regroupement stocké devrait
+  être recalculé à chaque correction de date).
+- **Le géofence vit sur le téléphone.** Filtrer côté serveur suppose d'avoir déjà
+  téléversé — donc payé le stockage et la bande passante pour jeter, et fait
+  entrer dans House la position de photos qui ne la concernent pas.
+
+## Lot 1 — Les dettes qui bloquent le volume (#527)
+
+### But
+
+Rendre la galerie et le compteur d'octets tenables **avant** d'ajouter quoi que
+ce soit. Aucun changement visible pour l'utilisateur hormis un défilement infini.
+
+### Fichiers
+
+- `apps/documents/pagination.py` *(nouveau)* — `PhotoCursorPagination` : curseur
+  sur l'ordre d'affichage de la galerie, `page_size` par défaut et borné.
+- `apps/documents/views.py` — `pagination_class` sur `DocumentViewSet`
+  **uniquement**.
+- `apps/documents/models.py` — `Document.size_bytes`, entier non signé, indexé.
+- `apps/documents/migrations/` — deux migrations : le champ, puis le backfill
+  idempotent depuis `metadata['size']`.
+- `apps/documents/views.py::upload` — renseigne `size_bytes` à la création.
+- `ui/src/lib/api/documents.ts` — `fetchPhotoDocuments` / `fetchDocuments`
+  consomment le curseur.
+- `ui/src/features/photos/hooks.ts`, `PhotosPage.tsx` — `useInfiniteQuery` et
+  défilement.
+
+### Critères
+
+1. La galerie d'un foyer à 5 000 photos s'ouvre sans charger les 5 000 lignes.
+2. Pendant un import concurrent, le défilement ne duplique ni ne saute de photo
+   — **test de régression nommé** : l'ordre du curseur est total.
+3. `Sum('size_bytes')` par foyer, sans cast JSON.
+4. Le backfill est rejouable et n'écrase pas une valeur déjà juste.
+5. Aucun autre viewset ne change de forme de réponse.
+
+## Lot 2 — L'intention (`purpose`) et la file « À trier » (#528)
+
+### But
+
+Donner à une photo la raison de son existence, et rendre visible ce que personne
+n'a encore rangé. **C'est le lot qui résout la friction de l'utilisateur.**
+
+### Fichiers
+
+- `apps/documents/models.py` — `Document.purpose` : `technical` / `observation` /
+  `memory`, vide autorisé, indexé. Constante `PHOTO_PURPOSES`.
+- `apps/documents/migrations/` — le champ, **sans backfill** (voir décisions).
+- `apps/documents/serializers.py` — `purpose` en lecture et écriture.
+- `apps/documents/views.py` — filtre `?purpose=`, dont un marqueur explicite pour
+  « non trié » (ne jamais laisser un paramètre vide signifier « tous »).
+- `apps/documents/queries.py` *(nouveau)* — `untriaged(household)` et
+  `cluster_sessions(photos, gap)` : regroupement par rafale, calculé à la lecture.
+- `apps/documents/views.py` — action de lot `set_purpose` : liste d'identifiants
+  + intention, qui **n'écrase jamais** une intention déjà posée sans demande
+  explicite.
+- `ui/src/features/photos/PhotosPage.tsx` — pastilles d'intention, la galerie
+  s'ouvre sur l'une d'elles.
+- `ui/src/features/photos/TriagePanel.tsx` *(nouveau)* — la file, par grappes.
+- `ui/src/features/photos/hooks.ts` — mutation de lot + invalidation.
+- `ui/src/locales/{fr,en,de,es}/translation.json` — `photos.purpose.*`.
+- Tutoriels (`/tutorials`) : le guide Photos change de parcours.
+
+### Critères
+
+1. Une photo importée sans intention apparaît dans « À trier », avec son compte.
+2. La galerie s'ouvre sur une intention, jamais sur l'ensemble.
+3. Trier une grappe de trente photos est **un** geste.
+4. Une grappe contenant déjà des intentions le signale et ne les écrase pas —
+   **test de régression nommé**.
+5. Vide et `memory` ne se confondent nulle part : ni dans un filtre, ni dans un
+   compteur, ni à l'écran — **test de régression nommé**.
+6. Les quatre catalogues i18n sont à parité (`keys.test.ts` vert).
+
+## Lot 3 — Le stockage objet, optionnel (#529)
+
+### But
+
+Pouvoir ranger les octets ailleurs que sur le disque du serveur, **sans
+l'imposer** à qui héberge House chez lui.
+
+### Fichiers
+
+- `requirements/base.txt` — backend de stockage S3-compatible.
+- `config/settings/base.py` — `STORAGES` + réglage `MEDIA_BACKEND` déclaré.
+- `apps/core/media_urls.py` *(nouveau)* — `media_url(document, variant)` : chemin
+  protégé (modes actuels) ou URL présignée courte.
+- `apps/core/views_media.py` — un quatrième mode ; **ses trois règles restent
+  intactes**.
+- `apps/documents/serializers.py` — `file_url` / `thumbnail_url` / `medium_url`
+  passent tous par `media_url`.
+- `apps/documents/management/commands/migrate_media_storage.py` *(nouveau)* —
+  `--dry-run`, idempotente, vérifie taille et empreinte, ne supprime la source
+  qu'explicitement.
+- `docs/self-hosting/` *(anglais)* — le réglage et son caractère optionnel.
+
+### Critères
+
+1. `MEDIA_BACKEND=local` : comportement strictement identique à aujourd'hui,
+   `X-Accel-Redirect` compris.
+2. `MEDIA_BACKEND=s3` : les URLs expirent, et un document d'un autre foyer reste
+   refusé — **test de régression nommé**.
+3. Aucune URL présignée dans un payload persisté, un index de recherche ou une
+   notification — **test de régression nommé**.
+4. La commande de migration est rejouable et vérifie ce qu'elle a copié.
+
+## Lot 4 — Le traitement en tâche de fond (#530)
+
+### But
+
+Sortir de la requête HTTP tout ce qui n'a pas besoin d'y être.
+
+### Fichiers
+
+- `requirements/base.txt` — file de tâches à broker ORM.
+- `config/settings/base.py` — configuration de la file + réglage
+  `ASYNC_PROCESSING` déclaré.
+- `docker-compose.prod.yml` — conteneur `worker`, sur le modèle des `scheduler`.
+- `apps/documents/models.py` — `processing_state` (`pending` / `ready` /
+  `failed`) et `processing_error`.
+- `apps/documents/tasks.py` *(nouveau)* — `process_document` : validation des
+  magic bytes, EXIF (**avant** normalisation), normalisation, vignettes, OCR.
+- `apps/documents/views.py::upload` — écrit puis enfile ; **exécute en direct**
+  quand `ASYNC_PROCESSING` est faux.
+- `ui/src/features/photos/PhotoThumb.tsx` — l'état d'attente, distinct d'une
+  erreur.
+
+### Critères
+
+1. En mode asynchrone, l'upload d'une photo de 5 Mo répond sans attendre le
+   traitement.
+2. Une photo en attente affiche un **état**, jamais une image cassée — **test de
+   régression nommé**.
+3. Un traitement en échec est visible, nommé, et rejouable.
+4. `ASYNC_PROCESSING=False` : comportement d'aujourd'hui, aucun conteneur
+   supplémentaire requis.
+5. La lecture EXIF précède toujours la normalisation (le test existant de
+   `taken_at` doit rester vert après le déplacement).
+
+## Lot 5 — Le quota de stockage du foyer (#531)
+
+### But
+
+Mesurer, montrer, **puis** borner. Aucune facturation.
+
+### Fichiers
+
+- `apps/households/models.py` — le forfait porté par le foyer.
+- `apps/households/plans.py` *(nouveau)* — la table des limites, un défaut
+  généreux.
+- `apps/core/storage_quota.py` *(nouveau)* — `used_bytes(household)` et
+  `assert_fits(household, incoming)` : **point d'application unique**, sur le
+  modèle de `banking.validators.assert_allocation_fits`.
+- `apps/documents/views.py` — l'appel, à l'upload et à l'ingestion.
+- `apps/households/views.py` — lecture du compteur.
+- `ui/src/features/settings/StorageSection.tsx` *(nouveau)*.
+- i18n 4 langues.
+
+### Critères
+
+1. Le compteur mesure l'original **et** la version normalisée **et** les
+   vignettes.
+2. « Rien mesuré » et « rien envoyé » ne se disent pas pareil — **test de
+   régression nommé** (voir « un compteur à zéro a deux sens »).
+3. Le dépassement rend un 400 nommé, jamais un 500.
+4. Aucun total dénormalisé en base.
+5. Aucun code de facturation, d'abonnement ou de paiement.
+
+## Lot 6 — L'import massif (#532)
+
+### But
+
+Deux cents photos en un geste, sans modale, sans perdre le travail en route.
+
+### Fichiers
+
+- `ui/src/features/photos/ImportPage.tsx` *(nouveau)* + route `/app/photos/import`.
+- `ui/src/features/photos/importQueue.ts` *(nouveau)* — file persistée côté
+  navigateur, reprise après interruption, parallélisme borné.
+- `apps/documents/views.py` — `presign_upload` (dépend du lot 3) et
+  `complete_upload` (crée la ligne, enfile le traitement).
+- `ui/src/features/documents/DocumentUploadDialog.tsx` — reste le chemin des
+  petits lots ; renvoie vers la page d'import au-delà d'un seuil.
+
+### Critères
+
+1. Deux cents photos, changement d'onglet au milieu : l'import continue et se
+   reprend — **preuve E2E**, ce comportement ne s'atteste pas en jsdom.
+2. Un fichier refusé est nommé ; les autres continuent.
+3. Le quota est vérifié **avant** de signer, jamais après l'envoi.
+4. Le dialogue existant garde son comportement pour un petit lot (tests du
+   lot livré en #525 toujours verts).
+
+## Lot 7 — La synchro iPhone : raccourci + géofence (#533)
+
+### But
+
+Enlever le geste d'import pour les photos prises à la maison.
+
+### Fichiers
+
+- `apps/accounts/models.py` — jeton d'appareil, révocable, distinct du JWT de
+  session.
+- `apps/documents/views.py` — ingestion authentifiée par ce jeton.
+- `apps/documents/exif.py` — lecture des coordonnées **avant** normalisation,
+  jamais réécrites dans le fichier stocké.
+- `apps/documents/models.py` — `taken_at_home` : booléen **nullable** (inconnu
+  n'est pas « non »).
+- Documentation du raccourci iOS *(anglais)*.
+
+### Critères
+
+1. Le géofence **pré-sélectionne**, il ne classe jamais : une photo prise
+   ailleurs reste importable, une photo prise à la maison n'est pas `technical`
+   pour autant.
+2. Les coordonnées ne sont jamais réécrites dans le fichier stocké.
+3. Un jeton se révoque, et l'ingestion s'arrête aussitôt.
+4. `taken_at_home` distingue les trois états inconnu / oui / non.
+
+## Ordre recommandé
+
+`1 → 2 → 3 → 4 → 5 → 6 → 7`
+
+Le lot 1 est un prérequis dur de tous les autres. Le lot 2 apporte la valeur
+utilisateur immédiatement après, sans dépendre de l'infrastructure — c'est le
+choix de l'utilisateur au cadrage, et il est bon : il résout la friction réelle
+avant d'engager le chantier lourd. Les lots 3 et 4 sont indépendants l'un de
+l'autre mais tous deux prérequis du lot 6. Le lot 5 peut se glisser dès que le
+lot 1 est livré.
+
+## Points de vigilance
+
+- **L'ordre du curseur doit être total.** `effective_date` est un
+  `COALESCE(taken_at, created_at)` annoté, pas une valeur unique : deux photos
+  d'une même rafale partagent la seconde. Sans départage stable, le curseur saute
+  des lignes.
+- **Les trois règles de `views_media.py` ne se négocient pas.** Elles ont été
+  gagnées sur des incidents de production (dont 177 documents devenus invisibles,
+  issue #517). Un quatrième mode s'ajoute à côté ; il n'en réécrit aucune.
+- **`read_taken_at` précède `normalize_image`, toujours.** Déplacer ce couple
+  dans un worker est exactement l'occasion d'inverser les deux lignes sans que
+  rien ne le signale, sauf le test de régression existant.
+- **Le front doit déclarer sa fraîcheur.** Toute nouvelle racine de cache passe
+  par `DERIVED_FROM` dans `ui/src/lib/invalidate.ts`, et les mutations vivent dans
+  le `hooks.ts` de leur feature (`invalidate.test.ts` refuse le reste).
+- **La fiche `docs/MODULES/documents.md` porte déjà l'audit du module** ; chaque
+  lot doit la mettre à jour, pas la doubler.
+- **Le lot 6 rend caduque une partie du dialogue livré en #525** ; ne pas le
+  supprimer, il reste le bon chemin pour dix photos.
+
+## Définition de done technique
+
+Pour chaque lot :
+
+1. `pytest` vert, y compris les tests de régression **nommés** dans les critères.
+2. `npm run lint` sans erreur et `npx tsc -b ui/tsconfig.json` propre.
+3. i18n : les quatre catalogues à parité, aucun `defaultValue` (`keys.test.ts`).
+4. `docs/MODULES/documents.md` (et `households.md` pour le lot 5) à jour — pas un
+   doublon de ce backlog, l'état du module.
+5. Tutoriels mis à jour dès que le parcours utilisateur change (lots 2 et 6 au
+   minimum).
+6. Le tableau de bord ci-dessus mis à jour (statut + numéro de PR).
+7. Pour les lots 3 et 4 : la pile auto-hébergée (`docker compose up`, trois
+   conteneurs) démarre et fonctionne **sans** la capacité activée.

--- a/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
@@ -12,7 +12,7 @@
 | 4 | Le traitement en tâche de fond | ⬜ À faire | #530 |
 | 5 | Le quota de stockage du foyer | ⬜ À faire | #531 |
 | 6 | L'import massif | ⬜ À faire | #532 |
-| 7 | La synchro iPhone — raccourci + géofence | ⬜ À faire | #533 |
+| 7 | Le géofence — n'envoyer que ce qui a été pris à la maison | ⬜ À faire | #533 |
 
 **Issue parente** : #526 · **Issue annexe (V2 différés)** : #534
 
@@ -40,7 +40,8 @@
 4. les nouvelles photos arrivent dans « À trier », regroupées par **session** ;
    une intention s'attribue à la grappe entière ;
 5. le compteur de stockage du foyer se met à jour, visible avant de mordre ;
-6. depuis l'iPhone, un raccourci propose les photos du jour prises à la maison.
+6. depuis le téléphone, la feuille de partage envoie une sélection à House ; une
+   automatisation ne propose que ce qui a été pris à la maison.
 
 ## Décisions de cadrage
 
@@ -268,22 +269,31 @@ Deux cents photos en un geste, sans modale, sans perdre le travail en route.
 4. Le dialogue existant garde son comportement pour un petit lot (tests du
    lot livré en #525 toujours verts).
 
-## Lot 7 — La synchro iPhone : raccourci + géofence (#533)
+## Lot 7 — Le géofence : n'envoyer que ce qui a été pris à la maison (#533)
+
+> **Le partage depuis le téléphone a été sorti de ce parcours** le 2026-08-03, pour
+> être livré tout de suite sur le mécanisme d'upload existant. Raison : il ne
+> dépend d'aucun des lots 1 à 6, et il tient déjà debout — `ActiveHouseholdMiddleware`
+> résout le foyer depuis `user.active_household_id` et non depuis un en-tête, donc
+> un client authentifié n'a rien d'autre à fournir que son jeton. Ce qui reste ici
+> est le seul morceau qui a besoin du reste du parcours : **filtrer ce qu'on
+> envoie**, et savoir à l'arrivée si une photo a été prise à la maison.
 
 ### But
 
-Enlever le geste d'import pour les photos prises à la maison.
+Enlever le tri manuel des photos rapportées d'ailleurs, sans jamais décider à la
+place de l'utilisateur.
 
 ### Fichiers
 
-- `apps/accounts/models.py` — jeton d'appareil, révocable, distinct du JWT de
-  session.
-- `apps/documents/views.py` — ingestion authentifiée par ce jeton.
 - `apps/documents/exif.py` — lecture des coordonnées **avant** normalisation,
   jamais réécrites dans le fichier stocké.
 - `apps/documents/models.py` — `taken_at_home` : booléen **nullable** (inconnu
   n'est pas « non »).
-- Documentation du raccourci iOS *(anglais)*.
+- `apps/documents/queries.py` — le filtre correspondant dans la file « À trier ».
+- Documentation de l'automatisation iOS *(anglais)* : *Rechercher des photos* où
+  le lieu est proche du domicile, déclenchée à l'arrivée, avec un album iOS dédié
+  pour la déduplication.
 
 ### Critères
 
@@ -291,8 +301,12 @@ Enlever le geste d'import pour les photos prises à la maison.
    ailleurs reste importable, une photo prise à la maison n'est pas `technical`
    pour autant.
 2. Les coordonnées ne sont jamais réécrites dans le fichier stocké.
-3. Un jeton se révoque, et l'ingestion s'arrête aussitôt.
-4. `taken_at_home` distingue les trois états inconnu / oui / non.
+3. `taken_at_home` distingue les trois états inconnu / oui / non — **test de
+   régression nommé** (une capture d'écran n'a pas de lieu, et ça n'est pas
+   « pas à la maison »).
+4. Le filtre du géofence est vérifié sur un vrai iPhone : le comportement des
+   Raccourcis sur l'EXIF n'est pas supposé, il est constaté (voir le piège déjà
+   payé sur `taken_at`).
 
 ## Ordre recommandé
 

--- a/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
@@ -15,7 +15,12 @@
 | 7 | Le géofence — n'envoyer que ce qui a été pris à la maison | ⬜ À faire | #533 |
 
 **Issue parente** : #526 · **Issue annexe (V2 différés)** : #534
-**Extraits du parcours** (ne dépendent d'aucun lot) : #535 (partage iOS) · #537 (partage Android)
+**⚠️ Prérequis, livré AVANT ce parcours** : #535 (partage iOS + jeton d'appareil) ·
+#537 (partage Android). Arbitré le 2026-08-03 : le mécanisme d'envoi depuis le
+téléphone est construit **complètement et mis en prod d'abord**, les lots ci-dessous
+viennent s'y greffer ensuite. Raison : c'est le geste le plus fréquent, il ne dépend
+d'aucun lot, et il alimente en photos réelles la file « À trier » que le lot 2
+construira.
 
 ## Doc associée
 

--- a/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
@@ -15,6 +15,7 @@
 | 7 | Le géofence — n'envoyer que ce qui a été pris à la maison | ⬜ À faire | #533 |
 
 **Issue parente** : #526 · **Issue annexe (V2 différés)** : #534
+**Extraits du parcours** (ne dépendent d'aucun lot) : #535 (partage iOS) · #537 (partage Android)
 
 ## Doc associée
 
@@ -307,6 +308,70 @@ place de l'utilisateur.
 4. Le filtre du géofence est vérifié sur un vrai iPhone : le comportement des
    Raccourcis sur l'EXIF n'est pas supposé, il est constaté (voir le piège déjà
    payé sur `taken_at`).
+
+## Envoyer depuis le téléphone — extrait du parcours, et l'asymétrie à assumer
+
+Le geste « je viens de prendre des photos, je les envoie à House » a été **sorti des
+lots** le 2026-08-03 : il ne dépend d'aucun des lots 1 à 6, et il tient déjà debout
+sur l'API existante. Il est documenté ici parce que c'est le parcours qui en porte
+le raisonnement — le travail, lui, vit dans #535 et #537.
+
+Le socle qui le rend possible sans rien ajouter : **`ActiveHouseholdMiddleware`
+résout le foyer depuis `user.active_household_id`, jamais depuis un en-tête.** Un
+client authentifié n'a donc rien d'autre à fournir que son jeton pour que
+`POST /upload/` sache dans quel foyer écrire.
+
+### Les deux plateformes ne coûtent pas la même chose
+
+| | iOS (#535) | Android (#537) |
+|---|---|---|
+| Mécanisme | Raccourci Shortcuts | `share_target` de la PWA |
+| Authentification | **Jeton d'appareil** à construire | La session existante |
+| Installation par l'utilisateur | Importer un raccourci, coller un jeton | Installer la PWA, rien d'autre |
+| Serveur | Modèle, classe d'authentification, **middleware** | **Aucune modification** |
+
+**L'asymétrie vient de Safari, qui ne prend pas en charge le *Web Share Target*** —
+pas de House. Une PWA installée sur iPhone ne peut pas recevoir de contenu partagé,
+et c'est structurel. D'où le détour par un raccourci, et par un jeton, puisqu'un
+raccourci ne peut pas emprunter la session du navigateur.
+
+### Trois pièges constatés en montant le raccourci à la main
+
+Le montage a été fait de bout en bout le 2026-08-03, contre la prod. Il **marche** —
+et il a confirmé le seul point qu'aucun test serveur ne pouvait trancher : **l'app
+Raccourcis préserve l'EXIF**, `taken_at` arrive renseigné sur une vraie photo
+iPhone. Ce qu'il a aussi montré :
+
+- **Une URL réduite à son domaine ne rend pas une erreur, elle rend le front.**
+  `https://<domaine>` sert la page HTML de l'application ; Shortcuts l'appelle
+  « Rich Text » et échoue à en extraire un dictionnaire. Le message d'erreur
+  désigne alors l'action de parsing, jamais l'URL — trois quarts d'heure de
+  recherche au mauvais endroit.
+- **Oublier `type=photo` n'est pas cosmétique** : le fichier atterrit en `document`,
+  donc le serveur prend la branche OCR au lieu des vignettes et **envoie la photo à
+  un modèle de vision**. Un appel payant pour décrire une image sans texte, et rien
+  dans la galerie. Sur un lot de deux cents, deux cents appels pour rien.
+- **La réponse d'upload embarque `recent_interaction_candidates`** — les cinq
+  dernières entrées du journal du foyer, sujets compris. C'est voulu pour
+  l'interface web (parcours 02), mais un raccourci qui envoie une photo reçoit en
+  retour les libellés des dernières dépenses bancaires. Pas une fuite, mais ça
+  précise le périmètre d'un jeton : « ne donner accès qu'à l'envoi » doit porter sur
+  **ce qui revient** autant que sur ce qu'on peut appeler.
+
+### Le piège d'Android, symétrique et tout aussi peu évident
+
+**Un service worker ne peut pas lire `localStorage`**, où vit le jeton du SPA. Il ne
+peut donc pas fabriquer l'en-tête `Authorization`, et ne doit **pas** tenter l'envoi
+lui-même. Il intercepte le POST de partage, met les fichiers de côté, redirige vers
+une route de l'application — et c'est **la page** qui téléverse.
+
+### Ce qui reste irréductible
+
+Sur iOS : importer un raccourci et coller un jeton, une fois. Deux minutes. C'est le
+prix d'entrée sans application native, et il est acceptable — **à condition que le
+raccourci soit distribué déjà construit**, avec ses *Import Questions* pour
+l'adresse de l'instance et le jeton. Le monter à la main, comme il a fallu le faire
+pour le valider, prend quarante minutes et cinq erreurs : personne ne le refera.
 
 ## Ordre recommandé
 


### PR DESCRIPTION
Cadrage complet du parcours 29, **aucun code**.

## Quoi

Déclencheur : la friction apparue à la première utilisation réelle du téléversement multiple livré le matin même (#525) — « les photos techniques sont mélangées avec les photos souvenirs, les photos observation ».

Une photo porte trois axes — la **zone** dit *où*, l'**entité** liée dit *sur quoi*, la **phase** avant/pendant/après dit *quand dans le chantier*. Aucun ne dit **pourquoi elle existe**. Le parcours ajoute ce quatrième axe, l'**intention** (`technical` / `observation` / `memory`), et le vide, qui n'est pas « souvenir » mais « personne n'a trié » — même règle que `inflow_nature == ""` n'est pas `"other"`.

## Contenu

| Fichier | |
|---|---|
| `docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md` | Doc produit — l'arbitrage « album complet » retenu contre la recommandation « classeur du foyer », avec ses trois coûts nommés |
| `docs/fiches/PIPELINE_MEDIA.md` | Fiche concept — où vivent les octets, qui les sert, quand ils sont transformés |
| `docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md` | 7 lots, chacun avec Fichiers + Critères, décisions de cadrage, vigilances |
| `docs/journal/2026-08-03_parcours-29_cadrage_initial.md` | Entrée de journal datée |
| `docs/MODULES/documents.md` | L'envoi de photos depuis un iPhone, et le piège du middleware |
| `docs/NEXT_STEPS.md`, `docs/fiches/README.md` | Bloc de priorité + index |

## Quatre manques vérifiés dans le code au cadrage

Ils expliquent l'ordre des lots :

1. `DocumentViewSet` n'a **aucune pagination**, et il n'y a pas de `PAGE_SIZE` global
2. La taille d'un fichier vit dans `metadata` — inagrégeable sans cast JSON
3. **Aucune infrastructure de tâches de fond** (ni Celery, ni django-q, ni Redis)
4. Les fichiers vivent sur le disque du serveur, servis par `X-Accel-Redirect`

## Issues

Parente #526 · lots #527 → #533 · annexe V2 #534.

**Prérequis sorti du parcours et livré avant** : #535 (partage iOS + jeton d'appareil) et #537 (partage Android). Le raccourci iOS a été monté et validé contre la prod pendant le cadrage — il marche, et il a confirmé que **l'app Raccourcis préserve l'EXIF**.

## Ce que ce cadrage ne tranche pas

La priorité relative avec le parcours 28. Ses lots 0 et 4 corrigent des écarts ouverts aujourd'hui (runner exposé, dépôt public sans licence) et restent hors séquence. C'est écrit tel quel dans `NEXT_STEPS.md`.