### PR TITLE
feat(documents): expliquer dans l'app comment envoyer depuis son téléphone

### DIFF
--- a/docs/MODULES/documents.md
+++ b/docs/MODULES/documents.md
@@ -189,6 +189,25 @@ Le cache de partage est **consommé** à la lecture (`features/photos/sharedFile
 sans ça un simple rechargement renverrait le même lot, en doublons. Régression :
 `sharedFiles.test.ts`.
 
+#### L'aide vit dans l'app, pas seulement dans le dépôt
+
+L'écran *Réglages → Appareils* explique la marche à suivre **selon l'appareil qui le
+lit** (`devicePlatform()`), et le guide Photos des tutoriels porte la même étape.
+
+Sans ça, l'écran livrait un jeton sans dire quoi en faire, et la seule explication
+vivait dans `docs/` — que personne d'autre que nous n'ouvre. La fonctionnalité
+existait sans être trouvable. Trois publics, trois réponses différentes, et aucun
+moyen pour l'utilisateur de deviner laquelle est la sienne :
+
+| Lecteur | Ce qu'on lui dit |
+|---|---|
+| Android | Rien à configurer — installer l'app suffit, le jeton ne le concerne pas |
+| iOS | Les trois étapes, et les deux pièges (corps `Form`, champ `type`) |
+| Ordinateur | Cet écran sert à connecter un téléphone, ouvrez-le depuis le vôtre |
+
+Afficher les trois reviendrait à n'en afficher aucune. Régression :
+`ui/src/features/settings/components/DevicesSection.test.tsx`.
+
 #### Le raccourci iOS, avec un jeton
 
 Deux actions, contre quatre avec l'authentification par mot de passe — et surtout

--- a/ui/src/features/settings/components/DevicesSection.test.tsx
+++ b/ui/src/features/settings/components/DevicesSection.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { DevicesSection } from './DevicesSection';
+
+/**
+ * Ce que ces tests tiennent :
+ *
+ * **Chacun lit les instructions de son propre téléphone, et seulement les siennes.**
+ * L'écran livrait un jeton sans dire quoi en faire — or la réponse n'est pas la même
+ * partout et l'utilisateur n'a aucun moyen de la deviner : sur Android le jeton ne
+ * sert à rien, sur iOS il ne sert que dans un raccourci, sur un ordinateur la
+ * question ne se pose pas. Afficher les trois revient à n'en afficher aucune.
+ *
+ * C'est la règle « ne jamais demander une information que House peut calculer »
+ * appliquée à l'aide : la plateforme se lit, elle ne se demande pas.
+ */
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../hooks', () => ({
+  useDeviceTokens: () => ({ data: [], isLoading: false }),
+  useCreateDeviceToken: () => ({ mutate: vi.fn(), isPending: false }),
+  useRevokeDeviceToken: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/lib/toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+function pretendUserAgent(value: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value,
+    configurable: true,
+  });
+}
+
+const UA = {
+  ios: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15',
+  android: 'Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36',
+  desktop: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+};
+
+describe("l'écran Appareils parle à l'appareil qui le lit", () => {
+  const original = window.navigator.userAgent;
+
+  beforeEach(() => {
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    pretendUserAgent(original);
+  });
+
+  it('sur Android, dit qu’il n’y a rien à configurer', () => {
+    pretendUserAgent(UA.android);
+    render(<DevicesSection />);
+
+    expect(screen.getByText('settings.devices.android.title')).toBeInTheDocument();
+    expect(screen.queryByText('settings.devices.ios.title')).not.toBeInTheDocument();
+    expect(screen.queryByText('settings.devices.desktop.hint')).not.toBeInTheDocument();
+  });
+
+  it('sur iPhone, donne les trois étapes et les deux pièges', () => {
+    pretendUserAgent(UA.ios);
+    render(<DevicesSection />);
+
+    expect(screen.getByText('settings.devices.ios.title')).toBeInTheDocument();
+    expect(screen.getByText('settings.devices.ios.step1')).toBeInTheDocument();
+    expect(screen.getByText('settings.devices.ios.warning')).toBeInTheDocument();
+    expect(screen.queryByText('settings.devices.android.title')).not.toBeInTheDocument();
+  });
+
+  it('sur un ordinateur, renvoie vers le téléphone au lieu de faire semblant', () => {
+    pretendUserAgent(UA.desktop);
+    render(<DevicesSection />);
+
+    expect(screen.getByText('settings.devices.desktop.hint')).toBeInTheDocument();
+    expect(screen.queryByText('settings.devices.ios.title')).not.toBeInTheDocument();
+    expect(screen.queryByText('settings.devices.android.title')).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/features/settings/components/DevicesSection.tsx
+++ b/ui/src/features/settings/components/DevicesSection.tsx
@@ -6,8 +6,57 @@ import { Button } from '@/design-system/button';
 import { Input } from '@/design-system/input';
 import { formatDateTime } from '@/lib/format';
 import { useToast } from '@/lib/toast';
+import { devicePlatform, isStandalone } from '@/lib/pwa/platform';
 import { useCreateDeviceToken, useDeviceTokens, useRevokeDeviceToken } from '../hooks';
 import { SettingsSection } from './SettingsSection';
+
+/**
+ * Ce que l'écran explique dépend de **l'appareil qui le lit**, et l'utilisateur n'a
+ * aucun moyen de le deviner : sur Android le jeton ne sert à rien (le partage
+ * système suffit), sur iOS il ne sert que dans un raccourci qu'il faut construire,
+ * et sur un ordinateur la question ne se pose pas.
+ *
+ * Sans ça, l'écran livrait une chaîne de caractères sans dire quoi en faire — la
+ * fonctionnalité existait sans être trouvable, et seule la documentation du dépôt
+ * la rendait utilisable. Un utilisateur hébergé ne lit jamais le dépôt.
+ */
+function PlatformHint() {
+  const { t } = useTranslation();
+  const platform = devicePlatform();
+
+  if (platform === 'android') {
+    return (
+      <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">{t('settings.devices.android.title')}</p>
+        <p className="mt-1">
+          {isStandalone()
+            ? t('settings.devices.android.installed')
+            : t('settings.devices.android.toInstall')}
+        </p>
+      </div>
+    );
+  }
+
+  if (platform === 'ios') {
+    return (
+      <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+        <p className="font-medium text-foreground">{t('settings.devices.ios.title')}</p>
+        <ol className="mt-1 list-decimal space-y-1 pl-4">
+          <li>{t('settings.devices.ios.step1')}</li>
+          <li>{t('settings.devices.ios.step2')}</li>
+          <li>{t('settings.devices.ios.step3')}</li>
+        </ol>
+        <p className="mt-2">{t('settings.devices.ios.warning')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg bg-muted p-3 text-sm text-muted-foreground">
+      {t('settings.devices.desktop.hint')}
+    </div>
+  );
+}
 
 /**
  * Les appareils autorisés à envoyer des photos sans mot de passe.
@@ -55,6 +104,8 @@ export function DevicesSection() {
   return (
     <SettingsSection title={t('settings.devices.title')} description={t('settings.devices.subtitle')}>
       <div className="space-y-4">
+        <PlatformHint />
+
         {issued ? (
           <div className="space-y-2 rounded-lg border border-primary/30 bg-primary/10 p-3">
             <p className="text-sm font-medium text-foreground">

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -91,7 +91,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'sheet', 'analysis', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance', 'sheet'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },
-  { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add', 'file'] },
+  { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add', 'phone', 'file'] },
   { key: 'directory', moduleKey: 'directory', to: '/app/directory', stepIds: ['contacts', 'structures'] },
   { key: 'alerts', Icon: AlertCircle, to: '/app/alerts', stepIds: ['review', 'act'] },
   { key: 'settings', Icon: User, to: '/app/settings', stepIds: ['profile', 'household', 'invite', 'modules'] },

--- a/ui/src/lib/pwa/platform.ts
+++ b/ui/src/lib/pwa/platform.ts
@@ -5,6 +5,28 @@ export function isIos(): boolean {
   return /iphone|ipad|ipod/i.test(navigator.userAgent);
 }
 
+export function isAndroid(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /android/i.test(navigator.userAgent);
+}
+
+/**
+ * La plateforme, du point de vue de **ce qu'on peut y faire** — pas de la marque.
+ *
+ * L'envoi de photos depuis un téléphone n'a pas le même parcours partout, et
+ * l'utilisateur n'a aucun moyen de le deviner : Android reçoit le partage système
+ * sans rien configurer, iOS impose un raccourci et un jeton, et sur un ordinateur
+ * la question ne se pose pas. Un écran qui ne fait pas cette distinction affiche à
+ * chacun les instructions des deux autres.
+ */
+export type DevicePlatform = 'ios' | 'android' | 'desktop';
+
+export function devicePlatform(): DevicePlatform {
+  if (isIos()) return 'ios';
+  if (isAndroid()) return 'android';
+  return 'desktop';
+}
+
 /** True quand l'app tourne installée (écran d'accueil / fenêtre standalone). */
 export function isStandalone(): boolean {
   if (typeof window === 'undefined') return false;

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1152,7 +1152,22 @@
       "issuedTitle": "Dein Token",
       "issuedOnce": "Kopiere ihn jetzt – er wird nicht erneut angezeigt. Wir speichern nur einen Fingerabdruck, er lässt sich also nicht wiederherstellen.",
       "copy": "Kopieren",
-      "copied": "Token kopiert."
+      "copied": "Token kopiert.",
+      "android": {
+        "title": "Unter Android nichts einzurichten",
+        "installed": "Wähle in deiner Galerie Fotos aus, tippe auf Teilen und wähle Maisonnée. Das Token unten wird nur für ein iPhone gebraucht.",
+        "toInstall": "Installiere Maisonnée zuerst auf deinem Startbildschirm: « Maisonnée » erscheint dann im Teilen-Menü deiner Galerie. Das Token unten wird nur für ein iPhone gebraucht."
+      },
+      "ios": {
+        "title": "Auf dem iPhone in drei Schritten",
+        "step1": "Erstelle unten ein Token und kopiere es.",
+        "step2": "Erstelle in der Kurzbefehle-App einen Kurzbefehl, der im Teilen-Menü erscheint und Bilder annimmt.",
+        "step3": "Füge « Für jedes Objekt wiederholen » über die Kurzbefehl-Eingabe hinzu und darin « Inhalte von URL laden » auf deine Instanz, Methode POST, mit dem Authorization-Header « Device » gefolgt von deinem Token, einem Formular-Body, einem Feld file vom Typ Datei mit dem wiederholten Objekt und einem Feld type mit dem Wert photo.",
+        "warning": "Zwei Fallen: Der Body muss Formular sein und nicht JSON, und das Feld type muss photo lauten – sonst landet das Foto nicht in der Galerie."
+      },
+      "desktop": {
+        "hint": "Dieser Bildschirm dient dazu, ein Telefon zu verbinden. Öffne Maisonnée von deinem aus, um die Anleitung zu sehen."
+      }
     }
   },
   "tutorials": {
@@ -1603,6 +1618,10 @@
           "file": {
             "title": "Ein Foto einem Bereich zuordnen",
             "body": "Die Markierung „Ohne Bereich“ zeigt ein Foto, das nirgends einsortiert ist; der gleichnamige Filter sammelt sie alle. Weisen Sie einen Bereich zu, ohne die Galerie zu verlassen: über das ⋯-Menü der Miniatur oder im Block Bereiche des geöffneten Fotos. Für mehrere auf einmal: „Auswählen“ und ankreuzen — die gewählten Bereiche kommen zu den vorhandenen hinzu."
+          },
+          "phone": {
+            "title": "Vom Telefon aus senden",
+            "body": "Der häufigste Handgriff ist nicht, Maisonnée zum Importieren zu öffnen, sondern gerade etwas fotografiert zu haben. Unter Android installierst du die App auf dem Startbildschirm, und « Maisonnée » erscheint im Teilen-Menü – mehr nicht. Auf dem iPhone erstellst du unter Einstellungen → Geräte ein Token und dann einen Kurzbefehl, der die Fotos sendet – die Anleitung steht auf diesem Bildschirm, wenn du ihn vom Telefon aus öffnest."
           }
         }
       },

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1152,7 +1152,22 @@
       "issuedTitle": "Your token",
       "issuedOnce": "Copy it now — it will not be shown again. We only keep a fingerprint of it, so it cannot be recovered.",
       "copy": "Copy",
-      "copied": "Token copied."
+      "copied": "Token copied.",
+      "android": {
+        "title": "On Android, nothing to configure",
+        "installed": "In your gallery, select photos, tap Share, then choose Maisonnée. The token below is only useful for an iPhone.",
+        "toInstall": "First install Maisonnée on your home screen: « Maisonnée » will then appear in your gallery’s Share menu. The token below is only useful for an iPhone."
+      },
+      "ios": {
+        "title": "On iPhone, in three steps",
+        "step1": "Create a token below and copy it.",
+        "step2": "In the Shortcuts app, create a shortcut shown in the share sheet, accepting images.",
+        "step3": "Add « Repeat with Each » over the shortcut input, and inside it « Get Contents of URL » pointing at your instance, method POST, with the Authorization header set to « Device » followed by your token, a Form request body, a file field of type File set to the repeat item, and a type field set to photo.",
+        "warning": "Two pitfalls: the request body must be Form and not JSON, and the type field must be photo — without it the picture never reaches the gallery."
+      },
+      "desktop": {
+        "hint": "This screen is for connecting a phone. Open Maisonnée from yours to see how."
+      }
     }
   },
   "tutorials": {
@@ -1603,6 +1618,10 @@
           "file": {
             "title": "File a photo into a zone",
             "body": "The “No zone” badge flags a photo filed nowhere, and the filter of the same name gathers them all. Assign a zone without leaving the gallery: from the ⋯ menu on the thumbnail, or in the Zones block of the open photo. To file several at once, hit “Select” and tick them: the zones you pick are added to those already set."
+          },
+          "phone": {
+            "title": "Send from your phone",
+            "body": "The most common move is not opening Maisonnée to import, it is having just taken a picture. On Android, install the app on your home screen and « Maisonnée » appears in the Share menu: nothing else to do. On iPhone, create a token under Settings → Devices, then a shortcut that sends the photos — the steps are shown on that screen when you open it from your phone."
           }
         }
       },

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1152,7 +1152,22 @@
       "issuedTitle": "Tu token",
       "issuedOnce": "Cópialo ahora: no se volverá a mostrar. Solo guardamos una huella, así que no se puede recuperar.",
       "copy": "Copiar",
-      "copied": "Token copiado."
+      "copied": "Token copiado.",
+      "android": {
+        "title": "En Android no hay nada que configurar",
+        "installed": "En tu galería, selecciona fotos, toca Compartir y elige Maisonnée. El token de abajo solo sirve para un iPhone.",
+        "toInstall": "Instala primero Maisonnée en tu pantalla de inicio: « Maisonnée » aparecerá entonces en el menú Compartir de tu galería. El token de abajo solo sirve para un iPhone."
+      },
+      "ios": {
+        "title": "En iPhone, en tres pasos",
+        "step1": "Crea un token abajo y cópialo.",
+        "step2": "En la app Atajos, crea un atajo que aparezca en la hoja de compartir y acepte imágenes.",
+        "step3": "Añade « Repetir con cada » sobre la entrada del atajo y, dentro, « Obtener contenido de URL » apuntando a tu instancia, método POST, con la cabecera Authorization « Device » seguida de tu token, un cuerpo de tipo Formulario, un campo file de tipo Archivo con el elemento repetido y un campo type con el valor photo.",
+        "warning": "Dos trampas: el cuerpo debe ser Formulario y no JSON, y el campo type debe valer photo — sin él la foto no llega a la galería."
+      },
+      "desktop": {
+        "hint": "Esta pantalla sirve para conectar un teléfono. Abre Maisonnée desde el tuyo para ver cómo hacerlo."
+      }
     }
   },
   "tutorials": {
@@ -1603,6 +1618,10 @@
           "file": {
             "title": "Clasificar una foto en una zona",
             "body": "La etiqueta «Sin zona» señala una foto que no está clasificada en ninguna parte, y el filtro del mismo nombre las reúne. Asígnale una zona sin salir de la galería: desde el menú ⋯ de la miniatura o en el bloque Zonas de la foto abierta. Para clasificar varias a la vez, pulsa «Seleccionar» y márcalas: las zonas elegidas se añaden a las ya presentes."
+          },
+          "phone": {
+            "title": "Enviar desde tu teléfono",
+            "body": "El gesto más frecuente no es abrir Maisonnée para importar, sino acabar de fotografiar algo. En Android, instala la app en tu pantalla de inicio y « Maisonnée » aparece en el menú Compartir: nada más que hacer. En iPhone, crea un token en Ajustes → Dispositivos y luego un atajo que envíe las fotos — los pasos se muestran en esa pantalla cuando la abres desde tu teléfono."
           }
         }
       },

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1152,7 +1152,22 @@
       "issuedTitle": "Votre jeton",
       "issuedOnce": "Copiez-le maintenant : il ne s'affichera plus. Nous n'en gardons qu'une empreinte, il est donc impossible de le retrouver.",
       "copy": "Copier",
-      "copied": "Jeton copié."
+      "copied": "Jeton copié.",
+      "android": {
+        "title": "Sur Android, rien à configurer",
+        "installed": "Dans votre galerie, sélectionnez des photos, touchez Partager, puis choisissez Maisonnée. Le jeton ci-dessous n'est utile que pour un iPhone.",
+        "toInstall": "Installez d'abord Maisonnée sur votre écran d'accueil : « Maisonnée » apparaîtra alors dans le menu Partager de votre galerie. Le jeton ci-dessous n'est utile que pour un iPhone."
+      },
+      "ios": {
+        "title": "Sur iPhone, en trois étapes",
+        "step1": "Créez un jeton ci-dessous et copiez-le.",
+        "step2": "Dans l'app Raccourcis, créez un raccourci affiché dans la feuille de partage, qui accepte les images.",
+        "step3": "Ajoutez « Répéter pour chaque » sur l'entrée du raccourci, et dedans « Obtenir le contenu de » votre instance, en POST, avec l'en-tête Authorization « Device » suivi de votre jeton, un corps de type Formulaire, un champ file de type Fichier valant l'élément répété, et un champ type valant photo.",
+        "warning": "Deux pièges : le corps doit être Formulaire et non JSON, et le champ type doit valoir photo — sans lui la photo n'arrive pas dans la galerie."
+      },
+      "desktop": {
+        "hint": "Cet écran sert à connecter un téléphone. Ouvrez Maisonnée depuis le vôtre pour voir la marche à suivre."
+      }
     }
   },
   "tutorials": {
@@ -1603,6 +1618,10 @@
           "file": {
             "title": "Ranger une photo dans une zone",
             "body": "La pastille « Sans zone » signale une photo rangée nulle part, et le filtre du même nom les regroupe. Attribuez-lui une zone sans quitter la galerie : par le menu ⋯ de la vignette, ou dans le bloc Zones de la photo ouverte. Pour en ranger plusieurs d'un coup, « Sélectionner » puis cochez : les zones choisies s'ajoutent à celles déjà présentes."
+          },
+          "phone": {
+            "title": "Envoyer depuis votre téléphone",
+            "body": "Le geste le plus fréquent n'est pas d'ouvrir Maisonnée pour importer, c'est de venir de photographier quelque chose. Sur Android, installez l'app sur votre écran d'accueil et « Maisonnée » apparaît dans le menu Partager : rien d'autre à faire. Sur iPhone, créez un jeton dans Réglages → Appareils, puis un raccourci qui l'envoie — la marche à suivre s'affiche sur cet écran depuis votre téléphone."
           }
         }
       },


### PR DESCRIPTION
Suite de #539. Ferme le trou trouvé à la recette : **le mécanisme existait sans être trouvable**.

## Le problème

L'écran *Réglages → Appareils* créait un jeton et affichait une chaîne de caractères, sans dire quoi en faire. La seule explication vivait dans `docs/self-hosting/` et `docs/MODULES/` — que personne d'autre que nous n'ouvre. Un utilisateur hébergé n'a jamais accès au dépôt.

Et la réponse n'est pas la même selon l'appareil, sans qu'il ait le moyen de la deviner :

| Lecteur | Ce qu'on lui dit maintenant |
|---|---|
| Android | Rien à configurer — installer l'app suffit, le jeton ne le concerne pas |
| iOS | Les trois étapes, et les deux pièges (corps `Form`, champ `type=photo`) |
| Ordinateur | Cet écran sert à connecter un téléphone, ouvrez-le depuis le vôtre |

Afficher les trois reviendrait à n'en afficher aucune.

## Ce que ça change

- **`devicePlatform()`** dans `lib/pwa/platform.ts` — la plateforme se lit, elle ne se demande pas. C'est « ne jamais demander une information que House peut calculer » appliqué à l'aide.
- **L'écran Appareils** porte l'aide contextuelle, et cite explicitement les deux erreurs qui ont coûté le plus cher au montage manuel : `Request Body` resté sur JSON, et le champ `type` oublié — qui envoie la photo à l'OCR de vision au lieu de la mettre dans la galerie.
- **Les tutoriels** gagnent l'étape « Envoyer depuis votre téléphone » dans le guide Photos. La PR #539 avait sauté cette règle du CLAUDE.md (« toute feature qui change le parcours utilisateur met à jour les tutoriels dans la même PR ») ; c'est réparé ici.
- 4 langues.

## Tests

- **247 front** (31 fichiers), dont 3 nouveaux qui vérifient que chaque plateforme ne voit **que** ses propres instructions
- `keys.test.ts` vert, `tsc -b` propre, lint 0 erreur
- Aucun changement backend

## Ce qui reste hors dépôt

Le lien iCloud du raccourci iOS distribuable, qui se crée depuis un iPhone. Tant qu'il n'existe pas, chaque utilisateur iOS construit son raccourci — et c'est désormais l'app qui lui explique comment, plutôt que la documentation du dépôt.