### PR TITLE
Parcours 28 — Lot 3 : dégradation propre sans service tiers (#489)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ scripts/sync_from_prod.sh
 # déjà couverts plus haut.)
 coverage.json
 issues/
+# Cache incrémental de `tsc -b` — le seul mode qui voit les erreurs du tsconfig
+# solution, donc celui qu'on lance pour typer le front.
+*.tsbuildinfo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1216,6 +1216,54 @@ globale ».
 
 ---
 
+## Capacités optionnelles — une absence se déclare, elle ne se devine pas
+
+Un foyer qui s'auto-héberge n'a ni clé Anthropic, ni Voyage, ni SMTP, ni VAPID,
+ni bot Telegram. Rien ne plantait pour autant — l'agent répondait « je ne sais
+pas », la jambe sémantique renvoyait `[]`, l'e-mail partait dans les logs. Le
+défaut était ailleurs : **l'interface promettait quand même**, et l'utilisateur
+en concluait que le produit était mauvais plutôt qu'il lui manquait une clé.
+D'où le registre `app_settings.capabilities`. Doc : `docs/MODULES/app_settings.md`
++ `docs/self-hosting/ai-providers.md`.
+
+- **Ajouter une capacité optionnelle = une entrée au registre + ses clés i18n**,
+  aucune modification d'écran. Le `CapabilitySpec` s'enregistre depuis
+  l'`apps.py::ready()` de **l'app qui possède le réglage** — même modèle que
+  `agent.searchables` et `banking.compliance.REGISTRY`.
+- **`available` est un callable, jamais une valeur figée à l'import.** Un
+  booléen calculé au chargement gèlerait l'état du premier démarrage, et aucun
+  test ne pourrait le simuler par `override_settings`.
+- **L'inconnu vaut indisponible** (fournisseur non implémenté, moitié d'une paire
+  de clés) — même défaut sûr que `guess_internal`. Une devinette optimiste fait
+  promettre à l'écran ce que le premier clic dément.
+- **Chaque capacité porte l'ancre d'une section existante** de
+  `docs/self-hosting/ai-providers.md`, vérifiée par test : sans ce contrôle le
+  lien meurt le jour où il est écrit, et « nécessite une clé Anthropic »
+  redevient le mur qu'on voulait supprimer. Le libellé, lui, vit dans le
+  namespace i18n `capabilities` du **front** — ajouter une capacité ne doit pas
+  imposer un passage dans quatre `.po`. Sa couverture est vérifiée **depuis
+  Python**, seul côté qui connaît la liste.
+- **Les clés se posent par instance, jamais par foyer** : le `.env` *est* le BYOK
+  de l'auto-hébergeur, et l'endpoint `/api/capabilities/` est donc **global**.
+  Une saisie de clé dans l'interface ferait de `get_llm_client()` une décision
+  d'appelant, ce que `apps/agent/llm.py` interdit. Le payload ne transporte
+  jamais une valeur, seulement le nom de la variable.
+- **Refuser se dit en 503 nommé** (`capabilities.require`), posé **avant tout
+  effet de bord** : un abonnement push ou un tour de conversation que rien ne
+  pourra honorer coûte plus cher qu'un refus immédiat. La garde est dans la
+  **vue**, pas dans le service — `service.ask` doit continuer à répondre « je ne
+  sais pas » à ses appelants non-HTTP (digest, pings), mais servi à travers
+  l'API ce même « je ne sais pas » est un mensonge.
+- **Une capacité n'a qu'une définition.** Telegram avait déjà son 503 écrit à la
+  main, et le front du push déduisait la configuration d'une clé publique vide :
+  deux définitions du même test finissent par diverger, et c'est l'utilisateur
+  qui arbitre. Tout passe par le registre.
+
+Régressions : `apps/app_settings/tests/test_capabilities.py`,
+`agent/tests/test_views.py::TestAnUnconfiguredInstanceSaysSo`.
+
+---
+
 ## Notifications — prévenir un foyer passe par `notify_household`
 
 Toute notification de la famille « **un membre a fait quelque chose** » (tâche

--- a/apps/accounts/apps.py
+++ b/apps/accounts/apps.py
@@ -4,3 +4,15 @@ from django.apps import AppConfig
 class AccountsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "accounts"
+
+    def ready(self):
+        from app_settings.capabilities import CapabilitySpec, register
+
+        from .capabilities import email_available
+
+        register(CapabilitySpec(
+            key="email",
+            available=email_available,
+            doc_anchor="email-smtp",
+            env_vars=("EMAIL_HOST", "EMAIL_HOST_USER", "EMAIL_HOST_PASSWORD"),
+        ))

--- a/apps/accounts/capabilities.py
+++ b/apps/accounts/capabilities.py
@@ -1,0 +1,37 @@
+"""L'e-mail sortant — réinitialisation de mot de passe, invitation adressée.
+
+Ce que cette capacité **ne** conditionne **pas**, et c'est le point : inviter un
+second membre. Le lien ``/join/<token>`` se copie à la main et suffit à faire
+entrer quelqu'un dans le foyer. L'e-mail est un confort, jamais le véhicule
+unique — sans quoi un foyer auto-hébergé resterait à une personne, ce qui vide
+de son sens un produit dont l'unité est le foyer.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+# Backends qui n'envoient rien vers l'extérieur. `console` et `locmem` sont des
+# défauts de développement et de test ; `dummy` avale tout. Les traiter comme
+# « disponible » ferait annoncer « e-mail envoyé » à un utilisateur qui
+# n'attendrait plus rien d'autre.
+_NON_DELIVERING_BACKENDS = (
+    "django.core.mail.backends.console.EmailBackend",
+    "django.core.mail.backends.locmem.EmailBackend",
+    "django.core.mail.backends.dummy.EmailBackend",
+)
+
+
+def email_available() -> bool:
+    """Un e-mail part-il vraiment d'ici ?
+
+    Le backend SMTP sans ``EMAIL_HOST`` compte pour indisponible : Django tente
+    alors ``localhost:587``, et l'échec arrive au moment de l'envoi, loin de
+    l'écran qui l'a promis.
+    """
+    backend = getattr(settings, "EMAIL_BACKEND", "") or ""
+    if not backend or backend in _NON_DELIVERING_BACKENDS:
+        return False
+    if backend == "django.core.mail.backends.smtp.EmailBackend":
+        return bool(getattr(settings, "EMAIL_HOST", "") or "")
+    # Backend tiers (Anymail, SES…) : celui qui l'installe l'a configuré.
+    return True

--- a/apps/agent/apps.py
+++ b/apps/agent/apps.py
@@ -50,3 +50,23 @@ class AgentConfig(AppConfig):
         # post_save/post_delete receivers; they self-gate on
         # settings.EMBEDDING_INDEXING_ENABLED (off by default).
         from . import signals  # noqa: F401
+
+        # Capacités optionnelles (parcours 28, lot 3) — ce que l'instance sait
+        # faire selon les clés dont elle dispose. L'écran lit le registre, il ne
+        # relit pas les settings.
+        from app_settings.capabilities import CapabilitySpec, register as register_capability
+
+        from .capabilities import assistant_available, semantic_search_available
+
+        register_capability(CapabilitySpec(
+            key="assistant",
+            available=assistant_available,
+            doc_anchor="assistant-anthropic",
+            env_vars=("ANTHROPIC_API_KEY",),
+        ))
+        register_capability(CapabilitySpec(
+            key="semantic_search",
+            available=semantic_search_available,
+            doc_anchor="semantic-search-embeddings",
+            env_vars=("VOYAGE_API_KEY", "AGENT_HYBRID_RETRIEVAL_ENABLED"),
+        ))

--- a/apps/agent/capabilities.py
+++ b/apps/agent/capabilities.py
@@ -1,0 +1,49 @@
+"""Ce que l'agent sait faire sur cette instance — et ce qui lui manque.
+
+Deux capacités distinctes, et il faut résister à l'envie de les fondre : elles
+tiennent à des fournisseurs différents et l'une marche très bien sans l'autre.
+L'assistant répond sans embeddings (recherche lexicale seule) ; la recherche
+sémantique est un **second étage** de la barre du haut, qui n'a pas besoin de
+l'assistant. Les afficher ensemble ferait dire à un écran qu'il manque une clé
+qu'il n'utilise pas.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def assistant_available() -> bool:
+    """L'agent conversationnel peut-il appeler un modèle ?
+
+    Le fournisseur inconnu vaut **indisponible**, pas disponible : c'est
+    ``get_llm_client`` qui décide, et il lève ``LLMError`` sur tout ce qu'il ne
+    connaît pas. Même défaut sûr que ``banking.rules.guess_internal`` — une
+    devinette optimiste ferait promettre à l'écran ce que le premier message
+    démentirait.
+    """
+    provider = (getattr(settings, "LLM_PROVIDER", "anthropic") or "").lower()
+    if provider == "anthropic":
+        return bool(getattr(settings, "ANTHROPIC_API_KEY", "") or "")
+    return False
+
+
+def semantic_search_available() -> bool:
+    """La deuxième jambe de la recherche peut-elle tourner ?
+
+    Deux conditions, et les deux comptent. L'interrupteur
+    ``AGENT_HYBRID_RETRIEVAL_ENABLED`` est délibérément séparé de la clé : il ne
+    s'allume qu'une fois l'index peuplé (``backfill_embeddings``), parce qu'un
+    index à moitié rempli rend la recherche silencieusement fausse — elle ne
+    trouve pas, sans jamais dire qu'elle n'a pas cherché.
+    """
+    if not getattr(settings, "AGENT_HYBRID_RETRIEVAL_ENABLED", False):
+        return False
+    provider = (getattr(settings, "EMBEDDING_PROVIDER", "voyage") or "").lower()
+    if provider == "voyage":
+        return bool(getattr(settings, "VOYAGE_API_KEY", "") or "")
+    if provider == "openai":
+        return bool(getattr(settings, "OPENAI_API_KEY", "") or "")
+    if provider == "ollama":
+        # Pas de clé : un endpoint local suffit, et il a un défaut.
+        return bool(getattr(settings, "EMBEDDING_BASE_URL", "") or "")
+    return False

--- a/apps/agent/tests/test_views.py
+++ b/apps/agent/tests/test_views.py
@@ -54,6 +54,42 @@ class TestAuth:
         assert resp.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
 
 
+class TestAnUnconfiguredInstanceSaysSo:
+    """Sans clé, l'endpoint refuse en 503 nommé — il n'invente pas une réponse.
+
+    `service.ask` renvoie proprement « je ne sais pas » quand la clé manque, et
+    c'est le bon comportement pour ses appelants non-HTTP (le digest, les
+    pings). Servi à travers l'API, ce même « je ne sais pas » est un mensonge
+    utile à personne : l'utilisateur en conclut que l'assistant est mauvais
+    plutôt qu'il manque une clé à l'instance. D'où la garde dans la vue, et pas
+    dans le service. Parcours 28, lot 3.
+    """
+
+    def test_ask_refuses_and_names_the_way_out(self, owner_client, household, settings):
+        settings.ANTHROPIC_API_KEY = ""
+
+        resp = owner_client.post(URL, {"question": "engie?"}, format="json")
+
+        assert resp.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        body = resp.json()
+        assert body["code"] == "capability_unavailable"
+        assert body["capability"] == "assistant"
+        assert "ANTHROPIC_API_KEY" in body["env_vars"]
+        assert body["docs_url"].endswith("ai-providers.md#assistant-anthropic")
+
+    def test_nothing_is_persisted_by_a_refused_turn(
+        self, owner_client, household, settings, monkeypatch
+    ):
+        """La garde passe **avant** l'effet de bord : un tour refusé ne laisse
+        ni conversation, ni message, ni appel au fournisseur."""
+        settings.ANTHROPIC_API_KEY = ""
+        ask = _patch_ask(monkeypatch)
+
+        owner_client.post(URL, {"question": "engie?"}, format="json")
+
+        assert ask.call_count == 0
+
+
 class TestValidation:
     def test_empty_body_rejected(self, owner_client, household):
         resp = owner_client.post(URL, {}, format="json")

--- a/apps/agent/views.py
+++ b/apps/agent/views.py
@@ -14,6 +14,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from app_settings.capabilities import require as require_capability
 from core.permissions import IsHouseholdMember, resolve_request_household
 
 from . import memory as memory_service
@@ -69,6 +70,8 @@ class AskView(APIView):
     throttle_classes = [AgentBurstRateThrottle, AgentSustainedRateThrottle]
 
     def post(self, request):
+        require_capability("assistant")
+
         request_serializer = AskRequestSerializer(data=request.data)
         request_serializer.is_valid(raise_exception=True)
         question = request_serializer.validated_data["question"]
@@ -181,6 +184,7 @@ class ConversationViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"], url_path="messages")
     def messages(self, request, pk=None):
+        require_capability("assistant")
         conversation = self.get_object()
 
         request_serializer = PostMessageSerializer(data=request.data)
@@ -231,6 +235,10 @@ class ConversationViewSet(viewsets.ModelViewSet):
         payload the non-streaming endpoint returns) or ``error``. Persistence is
         identical: both turns are written only once the answer exists.
         """
+        # Avant d'ouvrir le flux : une fois les en-têtes SSE partis, il n'y a
+        # plus de code de statut à envoyer — le refus deviendrait un événement
+        # `error` que le client doit savoir lire.
+        require_capability("assistant")
         conversation = self.get_object()
 
         request_serializer = PostMessageSerializer(data=request.data)

--- a/apps/app_settings/capabilities.py
+++ b/apps/app_settings/capabilities.py
@@ -1,0 +1,159 @@
+"""
+Registre des capacités optionnelles — ce que l'instance sait faire, et ce qui
+lui manque pour faire le reste.
+
+Un foyer qui s'auto-héberge n'a ni clé Anthropic, ni Voyage, ni SMTP, ni VAPID,
+ni bot Telegram. Rien ne plante pour autant — ``agent.service.ask`` répond
+proprement « je ne sais pas », ``retrieval.semantic_only`` renvoie ``[]``. Le
+défaut n'est pas là : **l'interface promet quand même** ce qu'elle ne peut pas
+tenir, et l'utilisateur en conclut que le produit est mauvais plutôt qu'il lui
+manque une clé.
+
+Une capacité absente doit donc se **déclarer** : dire qu'elle manque, pourquoi,
+et comment l'activer. C'est le même mouvement que ``coverage.window_status()``
+pour la conformité de l'argent — **un compteur à zéro a deux sens**, « rien à
+signaler » et « rien d'évaluable », et les confondre produit un silence qui
+ressemble à une réponse.
+
+Trois règles tenues par ``apps/app_settings/tests/test_capabilities.py`` :
+
+1. **La disponibilité est un callable, jamais une valeur figée à l'import.**
+   Un booléen calculé au chargement du module gèlerait l'état du premier
+   démarrage : ajouter une clé et redémarrer ne changerait rien tant que le
+   process vit, et aucun test ne pourrait la simuler par ``override_settings``.
+2. **Chaque capacité porte l'ancre d'une section existante** de
+   ``docs/self-hosting/ai-providers.md``. Sans ce contrôle, le lien meurt le
+   jour où il est écrit et « nécessite une clé Anthropic » redevient exactement
+   le mur qu'on voulait supprimer — même raison que la parité des catalogues
+   i18n : deux textes qui divergent font perdre leur crédit aux deux.
+3. **Chaque capacité déclare les variables qui la portent.** C'est la seule
+   chose que l'écran peut afficher sans mentir, et elle vit ici parce que
+   l'appelant ne doit pas avoir à connaître le nom d'un réglage pour dire ce
+   qui manque.
+
+Le **libellé** utilisateur, lui, n'est pas ici : il vit dans le namespace i18n
+``capabilities`` du front (4 catalogues), comme les libellés de ``kind`` du
+module Argent. Ajouter une capacité ne doit pas imposer un passage dans quatre
+``.po`` puis un ``compilemessages``.
+
+Alimenté depuis les ``apps.py::ready()`` des apps concernées — même modèle que
+``agent.searchables`` et ``banking.compliance.REGISTRY``. L'app qui possède le
+réglage possède son détecteur ; ``app_settings`` ne connaît pas la liste.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+# Base publique de la documentation d'exploitation. Une instance auto-hébergée
+# n'embarque pas les sources : le lien pointe le dépôt, seul endroit où la page
+# est lisible sans avoir cloné.
+DOCS_BASE_URL = "https://github.com/jammindev/house/blob/main/docs/self-hosting"
+DOCS_PAGE = "ai-providers.md"
+
+
+@dataclass(frozen=True)
+class CapabilitySpec:
+    """Une capacité que l'instance a, ou n'a pas."""
+
+    key: str
+    """Identifiant stable — sert de clé i18n côté front (``capabilities.<key>.*``)."""
+
+    available: Callable[[], bool]
+    """Prédicat évalué **à chaque lecture**, jamais à l'import (voir l'en-tête)."""
+
+    doc_anchor: str
+    """Ancre de la section de ``ai-providers.md`` qui explique comment l'activer."""
+
+    env_vars: tuple[str, ...] = ()
+    """Variables d'environnement qui portent la capacité, dans l'ordre où on les pose."""
+
+    @property
+    def docs_url(self) -> str:
+        return f"{DOCS_BASE_URL}/{DOCS_PAGE}#{self.doc_anchor}"
+
+
+REGISTRY: list[CapabilitySpec] = []
+
+
+def register(spec: CapabilitySpec) -> None:
+    """Enregistrer une capacité. Idempotent sur la clé — ``ready()`` peut être
+    appelé deux fois (autoreload du runserver), et un doublon ferait compter
+    deux fois la même capacité dans le payload."""
+    for index, existing in enumerate(REGISTRY):
+        if existing.key == spec.key:
+            REGISTRY[index] = spec
+            return
+    REGISTRY.append(spec)
+
+
+def get(key: str) -> CapabilitySpec | None:
+    """La capacité enregistrée sous cette clé, ou ``None``."""
+    for spec in REGISTRY:
+        if spec.key == key:
+            return spec
+    return None
+
+
+def is_available(key: str) -> bool:
+    """Vrai si la capacité est enregistrée **et** configurée.
+
+    Une clé inconnue vaut « indisponible » : un appelant qui se trompe de clé
+    doit dégrader, pas promettre.
+    """
+    spec = get(key)
+    return bool(spec and spec.available())
+
+
+class CapabilityUnavailable(APIException):
+    """503 nommé — l'instance n'a pas ce qu'il faut pour répondre.
+
+    Masquer un bouton côté client ne suffit pas : un onglet resté ouvert, un
+    raccourci, un client tiers atteignent l'endpoint quand même. Ce qu'ils
+    doivent recevoir, c'est la même phrase que l'écran — pas un 500, et surtout
+    pas un 200 qui invente une réponse. Un assistant sans clé qui répondrait
+    « je ne sais pas » ferait croire à un produit médiocre au lieu d'une
+    configuration incomplète, et c'est précisément le malentendu que ce lot
+    existe pour supprimer.
+
+    ``detail`` reste une **string** : l'intercepteur axios du front la lit telle
+    quelle. Le reste du contexte (clé, variables, lien) voyage à côté.
+    """
+
+    status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+    default_code = "capability_unavailable"
+
+    def __init__(self, key: str):
+        spec = get(key)
+        super().__init__({
+            "detail": f"Capability '{key}' is not configured on this instance.",
+            "code": self.default_code,
+            "capability": key,
+            "env_vars": list(spec.env_vars) if spec else [],
+            "docs_url": spec.docs_url if spec else None,
+        })
+
+
+def require(key: str) -> None:
+    """Lever ``CapabilityUnavailable`` si la capacité manque. À appeler **avant**
+    tout effet de bord — persister un tour de conversation ou un abonnement push
+    que rien ne pourra honorer coûte plus cher que de refuser tout de suite."""
+    if not is_available(key):
+        raise CapabilityUnavailable(key)
+
+
+def snapshot() -> list[dict]:
+    """L'état de toutes les capacités, prêt à sérialiser — trié par clé pour que
+    le payload soit stable d'un appel à l'autre (le front en fait une liste)."""
+    return [
+        {
+            "key": spec.key,
+            "available": bool(spec.available()),
+            "env_vars": list(spec.env_vars),
+            "docs_url": spec.docs_url,
+        }
+        for spec in sorted(REGISTRY, key=lambda s: s.key)
+    ]

--- a/apps/app_settings/tests/test_capabilities.py
+++ b/apps/app_settings/tests/test_capabilities.py
@@ -1,0 +1,200 @@
+"""Le registre des capacités optionnelles — et les trois dérives qu'il empêche.
+
+Une capacité absente ne casse rien : l'assistant répondait « je ne sais pas »,
+la jambe sémantique renvoyait `[]`, l'e-mail partait dans les logs. Le défaut
+était ailleurs — **l'interface promettait quand même**, et l'utilisateur en
+concluait que le produit était mauvais plutôt qu'il lui manquait une clé.
+
+Ces tests tiennent ce que le registre promet en retour : que l'état soit lu à
+chaque appel et non figé à l'import, que le lien « comment l'activer » atteigne
+une section qui existe, et que le libellé existe dans les quatre langues. Les
+trois se cassent en silence — c'est ce qui les rend testables et pas relisables.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from django.test import override_settings
+
+from app_settings.capabilities import (
+    REGISTRY,
+    CapabilityUnavailable,
+    is_available,
+    require,
+    snapshot,
+)
+
+from .factories import UserFactory
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOCS_PAGE = REPO_ROOT / "docs/self-hosting/ai-providers.md"
+LOCALES = REPO_ROOT / "ui/src/locales"
+LANGUAGES = ("en", "fr", "de", "es")
+
+CAPABILITIES_URL = "/api/capabilities/"
+
+
+def _github_slug(heading: str) -> str:
+    """L'ancre que GitHub fabrique pour un titre.
+
+    Minuscules, ponctuation retirée, espaces en tirets. C'est cette règle-là qui
+    décide si le lien du registre atterrit quelque part — pas une ancre explicite
+    ``{#…}``, que GitHub n'interprète pas et affiche telle quelle.
+    """
+    slug = heading.strip().lower()
+    slug = re.sub(r"[^\w\s-]", "", slug)
+    return re.sub(r"\s+", "-", slug)
+
+
+def _doc_anchors() -> set[str]:
+    text = DOCS_PAGE.read_text(encoding="utf-8")
+    return {_github_slug(m) for m in re.findall(r"^#{1,6}\s+(.+)$", text, re.MULTILINE)}
+
+
+class TestTheStateIsReadNotFrozen:
+    """Un booléen calculé à l'import gèlerait l'état du premier démarrage.
+
+    Ajouter une clé et redémarrer ne changerait rien tant que le process vit, et
+    aucun test ne pourrait simuler l'absence de clé. D'où le callable — vérifié
+    ici en le faisant répondre deux choses différentes dans la même session.
+    """
+
+    @override_settings(ANTHROPIC_API_KEY="", LLM_PROVIDER="anthropic")
+    def test_no_key_means_unavailable(self):
+        assert is_available("assistant") is False
+
+    @override_settings(ANTHROPIC_API_KEY="sk-ant-test", LLM_PROVIDER="anthropic")
+    def test_a_key_flips_it_without_a_restart(self):
+        assert is_available("assistant") is True
+
+    @override_settings(ANTHROPIC_API_KEY="sk-ant-test", LLM_PROVIDER="ollama")
+    def test_an_unknown_provider_is_unavailable_not_optimistic(self):
+        """`get_llm_client` lève sur ce qu'il ne connaît pas : promettre ici
+        ferait démentir l'écran par le premier message."""
+        assert is_available("assistant") is False
+
+    def test_an_unknown_key_is_unavailable(self):
+        """Un appelant qui se trompe de clé doit dégrader, pas promettre."""
+        assert is_available("does_not_exist") is False
+
+
+class TestEachCapabilityIsAnchoredInTheDocs:
+    """Le lien « comment l'activer » doit atteindre une section qui existe.
+
+    Sans ce contrôle il meurt le jour où il est écrit, et « nécessite une clé
+    Anthropic » redevient exactement le mur qu'on voulait supprimer. Même raison
+    que la parité des catalogues i18n : deux textes qui divergent font perdre
+    leur crédit aux deux.
+    """
+
+    def test_the_page_exists(self):
+        assert DOCS_PAGE.exists(), f"{DOCS_PAGE} manquante — le registre y renvoie"
+
+    def test_every_anchor_reaches_a_heading(self):
+        anchors = _doc_anchors()
+        missing = {
+            spec.key: spec.doc_anchor for spec in REGISTRY if spec.doc_anchor not in anchors
+        }
+        assert not missing, (
+            f"capacités dont le lien de doc ne mène nulle part : {missing} — "
+            f"ancres disponibles : {sorted(anchors)}"
+        )
+
+    def test_a_wrong_anchor_would_be_caught(self):
+        """Sabotage : la première version d'un test de ce genre passait à vide."""
+        assert "capacite-inventee" not in _doc_anchors()
+
+
+class TestEachCapabilityIsNamedInTheFourCatalogues:
+    """Ajouter une capacité = une entrée au registre + ses clés i18n.
+
+    Vérifié depuis Python, seul côté qui connaît la liste des capacités — miroir
+    de `test_global_search.py::TestThePaletteCoversTheRegistry`. Une clé
+    construite (`t(\\`capabilities.${key}.name\\`)`) échappe par construction au
+    contrôle statique de `keys.test.ts` : la contrepartie est que le catalogue
+    doit couvrir **toutes** les valeurs de l'énumération.
+    """
+
+    REQUIRED_SUBKEYS = ("name", "unavailable", "without", "enabled")
+
+    @staticmethod
+    def _catalogue(lang: str) -> dict:
+        path = LOCALES / lang / "translation.json"
+        return json.loads(path.read_text(encoding="utf-8")).get("capabilities", {})
+
+    @pytest.mark.parametrize("lang", LANGUAGES)
+    def test_every_capability_has_its_labels(self, lang):
+        catalogue = self._catalogue(lang)
+        missing = [
+            f"capabilities.{spec.key}.{sub}"
+            for spec in REGISTRY
+            for sub in self.REQUIRED_SUBKEYS
+            if not catalogue.get(spec.key, {}).get(sub)
+        ]
+        assert not missing, f"clés absentes du catalogue {lang} : {missing}"
+
+    @pytest.mark.parametrize("lang", LANGUAGES)
+    def test_the_shared_labels_exist(self, lang):
+        catalogue = self._catalogue(lang)
+        for key in ("title", "description", "envVars", "howToEnable"):
+            assert catalogue.get(key), f"capabilities.{key} absente du catalogue {lang}"
+
+
+class TestTheSnapshotNeverLeaksAValue:
+    """La liste dit quels réglages manquent, jamais ce qu'ils contiennent."""
+
+    @override_settings(ANTHROPIC_API_KEY="sk-ant-super-secret")
+    def test_only_the_variable_names_travel(self):
+        payload = json.dumps(snapshot())
+        assert "sk-ant-super-secret" not in payload
+        assert "ANTHROPIC_API_KEY" in payload
+
+    def test_the_payload_is_stable(self):
+        keys = [row["key"] for row in snapshot()]
+        assert keys == sorted(keys)
+        assert set(keys) == {spec.key for spec in REGISTRY}
+
+
+class TestTheEndpoint:
+    @pytest.mark.django_db
+    def test_it_answers_the_registry(self, client):
+        client.force_login(UserFactory())
+
+        response = client.get(CAPABILITIES_URL)
+
+        assert response.status_code == 200
+        rows = response.json()["capabilities"]
+        assert {row["key"] for row in rows} == {spec.key for spec in REGISTRY}
+        for row in rows:
+            assert set(row) == {"key", "available", "env_vars", "docs_url"}
+
+    @pytest.mark.django_db
+    def test_it_requires_a_logged_in_user(self, client):
+        """La liste des réglages manquants est une cartographie utile à qui
+        cherche une porte — elle ne se sert pas à un anonyme."""
+        response = client.get(CAPABILITIES_URL)
+
+        assert response.status_code in (401, 403)
+
+
+class TestARefusalIsNamed:
+    """« Indisponible » se dit en 503 nommé, jamais en 500 ni en 200 inventé."""
+
+    @override_settings(ANTHROPIC_API_KEY="")
+    def test_require_raises_a_503_carrying_the_way_out(self):
+        with pytest.raises(CapabilityUnavailable) as excinfo:
+            require("assistant")
+
+        detail = excinfo.value.detail
+        assert excinfo.value.status_code == 503
+        assert detail["capability"] == "assistant"
+        assert detail["code"] == "capability_unavailable"
+        assert "ANTHROPIC_API_KEY" in detail["env_vars"]
+        assert "ai-providers.md#assistant-anthropic" in detail["docs_url"]
+
+    @override_settings(ANTHROPIC_API_KEY="sk-ant-test", LLM_PROVIDER="anthropic")
+    def test_it_stays_silent_when_the_capability_is_there(self):
+        require("assistant")  # ne lève pas

--- a/apps/app_settings/urls.py
+++ b/apps/app_settings/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from .views import CapabilitiesView
+
+urlpatterns = [
+    path("", CapabilitiesView.as_view(), name="capabilities"),
+]

--- a/apps/app_settings/views.py
+++ b/apps/app_settings/views.py
@@ -1,0 +1,29 @@
+"""Ce que l'instance sait faire — lu par le front avant d'afficher une promesse."""
+from __future__ import annotations
+
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .capabilities import snapshot
+
+
+class CapabilitiesView(APIView):
+    """``GET /api/capabilities/`` — l'état des capacités optionnelles.
+
+    **Pas household-scopé, et c'est structurant** : les clés se configurent par
+    instance (le ``.env`` *est* le BYOK du self-hoster), jamais par foyer. Une
+    saisie de clé par foyer ferait de ``get_llm_client()`` une décision
+    d'appelant — ce que ``apps/agent/llm.py`` interdit explicitement — et n'aurait
+    de sens que le jour où quelqu'un héberge des foyers tiers.
+
+    Authentifié quand même : la liste dit quels réglages manquent, ce qui est une
+    cartographie utile à qui cherche une porte. Elle n'expose **jamais** la
+    valeur d'une clé, seulement son nom et le fait qu'elle soit posée.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response({"capabilities": snapshot()}, status=status.HTTP_200_OK)

--- a/apps/recap/apps.py
+++ b/apps/recap/apps.py
@@ -20,6 +20,19 @@ class RecapConfig(AppConfig):
             default_send_at=time(9, 0),
         ))
 
+        # Capacité optionnelle (parcours 28, lot 3) : sans clé le récap sort
+        # quand même, avec ses gabarits.
+        from app_settings.capabilities import CapabilitySpec, register as register_capability
+
+        from .capabilities import recap_polish_available
+
+        register_capability(CapabilitySpec(
+            key="recap_ai",
+            available=recap_polish_available,
+            doc_anchor="recap-wording-anthropic",
+            env_vars=("ANTHROPIC_API_KEY", "RECAP_AI_POLISH_ENABLED"),
+        ))
+
 
 def _build_monthly_recap_message(household, user, *, today):
     """Ping body: last month's recap teaser on the 1st (None otherwise/too thin)."""

--- a/apps/recap/capabilities.py
+++ b/apps/recap/capabilities.py
@@ -1,0 +1,22 @@
+"""Le récap mensuel se lit-il avec des phrases écrites par un modèle ?
+
+Sans clé, le récap **existe toujours** : les gabarits de ``report/render.py``
+donnent des légendes justes, simplement plus sèches. C'est une capacité de
+confort, et c'est exactement pour ça qu'elle doit se déclarer plutôt que se
+deviner — un écran qui ne promet rien ne déçoit pas.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def recap_polish_available() -> bool:
+    """L'interrupteur **et** la clé, parce que ``polish_captions`` exige les deux.
+
+    Renvoyer ``True`` sur la seule présence de la clé ferait afficher « activé »
+    à un récap qui rend ses gabarits — le compteur vert d'un contrôle qui n'a
+    rien vérifié.
+    """
+    if not getattr(settings, "RECAP_AI_POLISH_ENABLED", False):
+        return False
+    return bool(getattr(settings, "ANTHROPIC_API_KEY", "") or "")

--- a/apps/telegram/apps.py
+++ b/apps/telegram/apps.py
@@ -5,3 +5,15 @@ class TelegramConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "telegram"
     verbose_name = "Telegram"
+
+    def ready(self):
+        from app_settings.capabilities import CapabilitySpec, register
+
+        from .capabilities import telegram_available
+
+        register(CapabilitySpec(
+            key="telegram",
+            available=telegram_available,
+            doc_anchor="telegram-bot",
+            env_vars=("TELEGRAM_BOT_TOKEN", "TELEGRAM_BOT_USERNAME"),
+        ))

--- a/apps/telegram/capabilities.py
+++ b/apps/telegram/capabilities.py
@@ -1,0 +1,17 @@
+"""Le canal Telegram — pings proactifs, digest quotidien, conversation.
+
+Deux réglages, deux rôles : le **token** parle à l'API de Telegram, le
+**username** construit le lien ``t.me`` que l'utilisateur ouvre pour lier son
+compte. Sans le second, l'écran de liaison affiche un bouton qui ne mène nulle
+part : une capacité à moitié configurée est une capacité indisponible.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def telegram_available() -> bool:
+    return bool(
+        (getattr(settings, "TELEGRAM_BOT_TOKEN", "") or "")
+        and (getattr(settings, "TELEGRAM_BOT_USERNAME", "") or "")
+    )

--- a/apps/telegram/views.py
+++ b/apps/telegram/views.py
@@ -11,6 +11,9 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from app_settings.capabilities import is_available as capability_available
+from app_settings.capabilities import require as require_capability
+
 from . import service
 from .linking import make_link_token
 from .models import TelegramAccount
@@ -50,11 +53,11 @@ class LinkTokenView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
-        if not settings.TELEGRAM_BOT_TOKEN or not settings.TELEGRAM_BOT_USERNAME:
-            return Response(
-                {"detail": "Telegram channel is not enabled."},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+        # Le 503 était déjà là, écrit à la main. Il passe par le registre pour
+        # que « le canal est-il configuré ? » n'ait qu'une seule définition —
+        # celle que l'écran lit aussi. Deux formulations du même test finissent
+        # par diverger, et c'est l'utilisateur qui arbitre.
+        require_capability("telegram")
         token = make_link_token(request.user)
         return Response(
             {
@@ -77,9 +80,7 @@ class TelegramAccountView(APIView):
         account = TelegramAccount.objects.filter(user=request.user).first()
         return Response(
             {
-                "enabled": bool(
-                    settings.TELEGRAM_BOT_TOKEN and settings.TELEGRAM_BOT_USERNAME
-                ),
+                "enabled": capability_available("telegram"),
                 "linked": account is not None,
                 "username": account.username if account else "",
                 "linked_at": account.linked_at if account else None,

--- a/apps/webpush/apps.py
+++ b/apps/webpush/apps.py
@@ -5,3 +5,15 @@ class WebpushConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "webpush"
     verbose_name = "Web Push"
+
+    def ready(self):
+        from app_settings.capabilities import CapabilitySpec, register
+
+        from .capabilities import push_available
+
+        register(CapabilitySpec(
+            key="push",
+            available=push_available,
+            doc_anchor="push-notifications-vapid",
+            env_vars=("VAPID_PUBLIC_KEY", "VAPID_PRIVATE_KEY", "VAPID_ADMIN_EMAIL"),
+        ))

--- a/apps/webpush/capabilities.py
+++ b/apps/webpush/capabilities.py
@@ -1,0 +1,24 @@
+"""Les notifications push du navigateur — sans VAPID, l'abonnement ne peut pas
+même être créé.
+
+Cas particulier à ne pas rater : ``VapidPublicKeyView`` renvoie aujourd'hui une
+clé **vide** avec un 200. Le navigateur accepte la réponse, puis
+``pushManager.subscribe()`` échoue sur un ``InvalidAccessError`` illisible. La
+capacité doit donc se dire *avant* le clic, pas après.
+"""
+from __future__ import annotations
+
+from django.conf import settings
+
+
+def push_available() -> bool:
+    """Les deux moitiés de la paire, jamais une seule.
+
+    La publique part au navigateur, la privée signe l'envoi : avec l'une sans
+    l'autre l'abonnement se crée et aucun message n'arrive — la panne la plus
+    silencieuse de la famille.
+    """
+    return bool(
+        (getattr(settings, "VAPID_PUBLIC_KEY", "") or "")
+        and (getattr(settings, "VAPID_PRIVATE_KEY", "") or "")
+    )

--- a/apps/webpush/tests/test_webpush.py
+++ b/apps/webpush/tests/test_webpush.py
@@ -43,11 +43,43 @@ def _sub_payload(endpoint="https://push.example.com/abc"):
     return {"endpoint": endpoint, "keys": {"p256dh": "p256dh-key", "auth": "auth-key"}}
 
 
+# --- instance sans VAPID ----------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_subscribe_refuses_when_the_instance_has_no_vapid_pair(user, auth_client, settings):
+    """Un abonnement que rien ne pourra honorer est pire qu'un refus.
+
+    Il s'enregistrait, l'écran disait « activé », et aucune notification
+    n'arrivait — la panne la plus silencieuse de la famille. Parcours 28, lot 3.
+    """
+    settings.VAPID_PUBLIC_KEY = ""
+    settings.VAPID_PRIVATE_KEY = ""
+
+    response = auth_client.post("/api/webpush/subscribe/", _sub_payload(), format="json")
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+    assert response.json()["capability"] == "push"
+    assert not WebPushSubscription.objects.filter(user=user).exists()
+
+
+@pytest.mark.django_db
+def test_half_a_pair_is_not_a_configured_instance(user, auth_client, settings):
+    """Avec la publique seule, le navigateur accepte l'abonnement et rien
+    n'arrive jamais."""
+    settings.VAPID_PUBLIC_KEY = "test-public-key"
+    settings.VAPID_PRIVATE_KEY = ""
+
+    response = auth_client.post("/api/webpush/subscribe/", _sub_payload(), format="json")
+
+    assert response.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
 # --- subscribe / unsubscribe ------------------------------------------------
 
 
 @pytest.mark.django_db
-def test_subscribe_creates_subscription(user, auth_client):
+def test_subscribe_creates_subscription(user, auth_client, vapid):
     response = auth_client.post("/api/webpush/subscribe/", _sub_payload(), format="json")
 
     assert response.status_code == status.HTTP_201_CREATED
@@ -58,7 +90,7 @@ def test_subscribe_creates_subscription(user, auth_client):
 
 
 @pytest.mark.django_db
-def test_subscribe_is_idempotent_by_endpoint(user, auth_client):
+def test_subscribe_is_idempotent_by_endpoint(user, auth_client, vapid):
     auth_client.post("/api/webpush/subscribe/", _sub_payload(), format="json")
     payload = _sub_payload()
     payload["keys"]["p256dh"] = "rotated-key"

--- a/apps/webpush/views.py
+++ b/apps/webpush/views.py
@@ -4,6 +4,8 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from app_settings.capabilities import require as require_capability
+
 from .models import WebPushSubscription
 from .serializers import SubscribeSerializer, UnsubscribeSerializer
 from .service import send_web_push
@@ -15,6 +17,10 @@ class VapidPublicKeyView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
+        # Sans paire VAPID, renvoyer 200 + une clé vide faisait échouer
+        # `pushManager.subscribe()` sur un `InvalidAccessError` illisible, une
+        # fois le clic donné. Le refus se dit ici, où il reste explicable.
+        require_capability("push")
         return Response({"publicKey": getattr(settings, "VAPID_PUBLIC_KEY", "")})
 
 
@@ -22,6 +28,9 @@ class SubscribeView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
+        # Un abonnement que rien ne pourra honorer est pire qu'un refus : il
+        # s'enregistre, l'écran dit « activé », et aucune notification n'arrive.
+        require_capability("push")
         serializer = SubscribeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         endpoint = serializer.validated_data["endpoint"]
@@ -61,6 +70,7 @@ class TestPushView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
+        require_capability("push")
         sent = send_web_push(
             request.user,
             "House",

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -232,6 +232,15 @@ CORS_ALLOW_CREDENTIALS = True
 FRONTEND_URL = "http://localhost:5174"
 DEFAULT_FROM_EMAIL = "noreply@house.local"
 
+# Un e-mail part dans les logs par défaut, pas vers un SMTP. Le défaut de Django
+# est `smtp.EmailBackend` sur `localhost:25` : sur une instance sans serveur mail
+# — le cas d'un foyer auto-hébergé — chaque envoi partait en timeout au moment de
+# l'envoi, loin de l'écran qui l'avait promis. Chaque environnement pose le sien
+# (production lit `EMAIL_BACKEND`, les tests `locmem`) ; celui-ci est le filet.
+# La capacité `email` du registre (`app_settings.capabilities`) sait que ce
+# backend ne délivre rien et le **dit** à l'interface, au lieu de le taire.
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
 # Anthropic API key for the AI layer (Claude Vision OCR, agent, ...).
 # Empty string by default — extraction degrades to a no-op when unset.
 # Overridden per environment in local.py / production.py.

--- a/config/settings/selfhost.py
+++ b/config/settings/selfhost.py
@@ -135,7 +135,8 @@ _DEFAULTS = {
     "SECURE_HSTS_INCLUDE_SUBDOMAINS": str(_is_public_https),
     "SECURE_HSTS_PRELOAD": "False",
     # Sans clé SMTP, un e-mail part dans les logs du conteneur plutôt que nulle
-    # part. Le lot 3 rendra cette dégradation visible dans l'interface.
+    # part — et la capacité `email` du registre le déclare à l'interface, qui
+    # propose alors le lien d'invitation à copier au lieu d'un envoi muet.
     "EMAIL_BACKEND": "django.core.mail.backends.console.EmailBackend",
 }
 if PUBLIC_URL:

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -52,6 +52,21 @@ SECURE_PROXY_SSL_HEADER = None
 # Email backend for tests
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
+# La suite tourne sur une instance **configurée** : les endpoints de l'agent
+# refusent désormais en 503 nommé quand la capacité `assistant` manque
+# (parcours 28, lot 3), et sans cette clé chaque test de vue mesurerait ce refus
+# au lieu du comportement qu'il vient vérifier.
+#
+# La valeur est volontairement inutilisable : aucun test n'appelle le
+# fournisseur pour de vrai — ils passent tous un client de test à `service.ask`
+# ou remplacent la fonction. Un test qui atteindrait le réseau échouerait
+# bruyamment sur l'authentification, jamais en silence.
+#
+# L'absence de clé reste testée, explicitement, là où c'est le sujet :
+# `app_settings/tests/test_capabilities.py` et
+# `agent/tests/test_service.py::test_missing_api_key_returns_idk_...`.
+ANTHROPIC_API_KEY = "sk-ant-test-not-a-real-key"
+
 # Password hashers (faster for tests)
 PASSWORD_HASHERS = [
     "django.contrib.auth.hashers.MD5PasswordHasher",

--- a/config/urls.py
+++ b/config/urls.py
@@ -53,6 +53,9 @@ urlpatterns = [
     path("api/shopping/", include("shopping.urls")),
     path("api/briefings/", include("briefings.urls")),
     path("api/webpush/", include("webpush.urls")),
+    # Capacités optionnelles de l'instance (parcours 28, lot 3) — pas de
+    # household dans l'URL : les clés se posent par instance, jamais par foyer.
+    path("api/capabilities/", include("app_settings.urls")),
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 

--- a/docs/MODULES/app_settings.md
+++ b/docs/MODULES/app_settings.md
@@ -1,20 +1,87 @@
 # Module — app_settings
 
-> Audit : 2026-04-28. Rôle : namespace UI pour les paramètres utilisateur (profil, thème, mot de passe, gestion du foyer).
+> Audit : 2026-08-03. Rôle : namespace UI pour les paramètres utilisateur (profil, thème, mot de passe, gestion du foyer) **et** registre des capacités optionnelles de l'instance.
 
 ## État synthétique
 
-- **Backend** : Absent (pas de modèle propre — l'app Django ne contient que `apps.py`, `templates/` legacy et un test `test_switch_household.py`)
-- **Frontend** : Complet dans `ui/src/features/settings/` (`SettingsPage`, components `ProfileSection`, `ThemeSection`, `ChangePasswordSection`, `AvatarSection`, `HouseholdManagement`, `PendingInvitations`)
-- **Locales (en/fr/de/es)** : ok (namespace `settings` présent dans les 4 locales)
-- **Tests** : oui — 1 fichier (`test_switch_household.py`)
+- **Backend** : pas de modèle, mais un registre (`capabilities.py`) et un endpoint (`views.py`, `urls.py`)
+- **Frontend** : Complet dans `ui/src/features/settings/` (`SettingsPage`, components `ProfileSection`, `ThemeSection`, `ChangePasswordSection`, `AvatarSection`, `HouseholdManagement`, `PendingInvitations`, `CapabilitiesSection`)
+- **Locales (en/fr/de/es)** : ok (namespaces `settings` et `capabilities` présents dans les 4 locales)
+- **Tests** : 2 fichiers (`test_switch_household.py`, `test_capabilities.py`)
 - **Migrations** : 0
 
 ## Modèles & API
 
 - Modèles principaux : aucun — toutes les données sont stockées dans `accounts` (User, profil) et `households` (membership, invitations)
-- Endpoints exposés : aucun propre — la page consomme `/api/accounts/` (user + change password + avatar) et `/api/households/switch/` — *source : `ui/src/features/settings/SettingsPage.tsx:33`*
+- Endpoints exposés : `GET /api/capabilities/` (`CapabilitiesView`, `IsAuthenticated`, **non household-scopé**) ; la page consomme aussi `/api/accounts/` (user + change password + avatar) et `/api/households/switch/`
 - Permissions : héritées des apps consommées
+
+## Capacités optionnelles — le registre (parcours 28, lot 3)
+
+Doc utilisateur : `docs/self-hosting/ai-providers.md`. Règle structurante :
+
+> Une capacité absente doit se **déclarer** — dire qu'elle manque, pourquoi, et
+> comment l'activer. Jamais un écran vide, jamais une erreur technique, jamais
+> une réponse inventée.
+
+Sans clé, rien ne plantait déjà : l'agent répondait « je ne sais pas », la jambe
+sémantique renvoyait `[]`, l'e-mail partait dans les logs. Le défaut était que
+**l'interface promettait quand même**, et l'utilisateur en concluait que le
+produit était mauvais plutôt qu'il lui manquait une clé.
+
+- **Ajouter une capacité optionnelle = une entrée au registre + ses clés i18n**,
+  aucune modification d'écran. Le `CapabilitySpec` s'enregistre depuis
+  l'`apps.py::ready()` de **l'app qui possède le réglage** — même modèle que
+  `agent.searchables` et `banking.compliance.REGISTRY`. `app_settings` ne
+  connaît pas la liste. Six capacités aujourd'hui : `assistant` et
+  `semantic_search` (agent), `recap_ai` (recap), `email` (accounts), `push`
+  (webpush), `telegram` (telegram).
+- **`available` est un callable, jamais une valeur figée à l'import.** Un
+  booléen calculé au chargement gèlerait l'état du premier démarrage : ajouter
+  une clé et redémarrer ne changerait rien tant que le process vit, et aucun
+  test ne pourrait le simuler par `override_settings`.
+- **Le prédicat renvoie `False` sur l'inconnu** (fournisseur non implémenté,
+  clé absente d'une paire) — même défaut sûr que `banking.rules.guess_internal`.
+  Une devinette optimiste fait promettre à l'écran ce que le premier clic
+  dément.
+- **Chaque capacité porte l'ancre d'une section existante** de
+  `ai-providers.md`, vérifiée par test. Sans ce contrôle le lien meurt le jour
+  où il est écrit, et « nécessite une clé Anthropic » redevient le mur qu'on
+  voulait supprimer — même raison que la parité des catalogues i18n.
+- **Le libellé vit côté front** (namespace i18n `capabilities`), pas en
+  `gettext` : ajouter une capacité ne doit pas imposer un passage dans quatre
+  `.po` puis un `compilemessages`. La couverture des quatre catalogues est
+  vérifiée **depuis Python**, seul côté qui connaît la liste des capacités.
+- **Les clés se posent par instance, jamais par foyer.** Le `.env` *est* le BYOK
+  de l'auto-hébergeur. Une saisie de clé dans l'interface ferait de
+  `get_llm_client()` une décision d'appelant — ce que `apps/agent/llm.py`
+  interdit — et n'aurait de sens que le jour où quelqu'un héberge des foyers
+  tiers. D'où un endpoint **global**, hors du scoping foyer.
+- **Le payload ne transporte jamais une valeur de clé**, seulement son nom et le
+  fait qu'elle soit posée.
+
+### Refuser se dit en 503 nommé
+
+`capabilities.require(key)` lève `CapabilityUnavailable` (503, `detail` string
+pour l'intercepteur axios, plus `capability` / `env_vars` / `docs_url` à côté).
+Posé **avant tout effet de bord** : persister un tour de conversation ou un
+abonnement push que rien ne pourra honorer coûte plus cher que de refuser tout
+de suite.
+
+- **La garde est dans la vue, pas dans le service.** `agent.service.ask` doit
+  continuer à renvoyer « je ne sais pas » pour ses appelants non-HTTP (digest,
+  pings) ; servi à travers l'API, ce même « je ne sais pas » est un mensonge.
+- **`telegram` avait déjà son 503, écrit à la main** : il passe par le registre
+  pour que « le canal est-il configuré ? » n'ait qu'une seule définition — celle
+  que l'écran lit aussi. Idem pour le front du push, qui déduisait la
+  configuration d'une clé publique vide.
+- La suite de tests tourne sur une instance **configurée**
+  (`config/settings/test.py` pose `ANTHROPIC_API_KEY`) ; l'absence de clé est
+  testée là où c'est le sujet.
+
+Régressions : `apps/app_settings/tests/test_capabilities.py`,
+`agent/tests/test_views.py::TestAnUnconfiguredInstanceSaysSo`,
+`webpush/tests/test_webpush.py::test_subscribe_refuses_when_the_instance_has_no_vapid_pair`.
 
 ## Notes
 

--- a/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
@@ -1,6 +1,6 @@
 # Parcours 28 — Backlog technique : ouvrir Maisonnée
 
-> **État au 2026-07-31** — lots 0, 1, 2 et 4 livrés ; lot 1bis partiel.
+> **État au 2026-08-03** — lots 0, 1, 2, 3 et 4 livrés ; lot 1bis partiel.
 > Chantier technique transverse : rendre le projet publiable, installable par un
 > tiers et défendable une fois exposé. Aucune feature métier.
 
@@ -19,7 +19,7 @@ Issue ombrelle : **#485**
 | 1 | Durcissement multi-tenant + test générique d'isolation (**bloquant**) | ✅ Livré (PR #497) | #487 |
 | 1bis | Isolation **en écriture** : FK de serializer ✅ (PR #499) ; actions custom + 26 `APIView` restants | 🔄 Partiel | #498 |
 | 2 | `docker compose up` — première installation en une commande | ✅ Livré | #488 |
-| 3 | Dégradation propre sans service tiers (IA, SMTP, push, Telegram) | ⬜ À faire | #489 |
+| 3 | Dégradation propre sans service tiers (IA, SMTP, push, Telegram) | ✅ Livré | #489 |
 | 4 | LICENSE AGPL-3.0 + gouvernance (CONTRIBUTING, SECURITY, DCO, templates) | ✅ Livré (PR #496) | #490 |
 | 5 | Exploitation par un tiers : sauvegarde, restauration testée, mises à jour, releases | ⬜ À faire | #491 |
 | 6 | Façade Maisonnée : README bilingue, captures, GIF, identité | ⬜ À faire | #492 |
@@ -388,6 +388,35 @@ produit dont l'unité est le foyer.
 > **est** le BYOK du self-hoster. Une saisie de clé dans l'interface ferait de
 > `get_llm_client()` une décision d'appelant — ce que `apps/agent/llm.py` interdit
 > explicitement — et n'a de sens que le jour où quelqu'un héberge des foyers tiers.
+
+> **Livré — trois écarts au plan, tous assumés.**
+>
+> **① Le point bloquant du lot n'existait déjà plus.** « Sans SMTP, inviter un
+> second membre part dans le vide » a été corrigé le 2026-07-29 par le fix #461 :
+> `create_invitation` produit un `/join/<token>` que `InvitePanel` copie, et
+> `join_with_new_account` fait entrer quelqu'un qui n'a pas de compte. Le lot ne
+> l'a donc pas refait — il l'a **documenté** comme la voie normale
+> (`ai-providers.md`, section e-mail), parce qu'un chemin qui existe mais que
+> personne ne connaît ne rattrape rien.
+>
+> **② Le récap n'est pas gaté, et c'est le sujet du lot.** Le plan listait
+> `features/recap/` parmi les écrans à masquer ; sans clé le récap **sort quand
+> même**, avec ses gabarits. Y poser un bandeau « nécessite une clé » aurait
+> annoncé cassé ce qui marche — exactement le malentendu qu'on supprime. La
+> capacité `recap_ai` se déclare dans la liste des Réglages, là où elle répond à
+> la vraie question (« qu'est-ce qui dort ici ? ») sans en inventer une fausse.
+>
+> **③ Deux définitions trouvées en chemin, ramenées à une.** Telegram avait déjà
+> son 503 « channel is not enabled » écrit à la main, et le front du push
+> déduisait la configuration d'une **clé publique vide** — un 200 portant une
+> réponse que le serveur connaissait déjà, suivi d'un `InvalidAccessError`
+> illisible après le clic. Les deux passent par le registre : un état de
+> configuration ne peut pas avoir deux définitions.
+>
+> Défaut réparé au passage : `EMAIL_BACKEND` n'était posé nulle part dans
+> `base.py`, donc le défaut de Django (`smtp` sur `localhost:25`) s'appliquait à
+> tout module de réglages qui ne le surchargeait pas — un échec au moment de
+> l'envoi, loin de l'écran qui l'avait promis.
 
 **Critères**
 

--- a/docs/self-hosting/ai-providers.md
+++ b/docs/self-hosting/ai-providers.md
@@ -1,0 +1,253 @@
+# Optional services
+
+Maisonnée runs without a single API key. Nothing crashes, nothing hangs, and no
+screen is left blank — but six capabilities stay switched off until you give the
+instance what they need.
+
+This page is the reference behind every "not available on this instance" message
+in the app. Each section below is one capability: what it does, what it costs,
+what the app does **without** it, and the exact variables to set.
+
+## How keys are configured
+
+**Keys are per instance, never per household.** They live in the `.env` file
+next to your `docker-compose.yml` — that file *is* the bring-your-own-key
+surface. There is no key field anywhere in the interface, and that is
+deliberate: which provider answers a question is a deployment decision, not a
+per-user one.
+
+After editing `.env`:
+
+```bash
+docker compose up -d
+```
+
+The app reads the new values at startup. You can confirm what the instance
+believes it can do at `GET /api/capabilities/`, which is also what the interface
+reads before promising anything.
+
+**Every capability below is optional.** Skipping all of them leaves a complete
+household app — documents, money, tasks, budgets, the monthly recap. What you
+lose is the assistant, semantic search, warmer recap wording, outgoing email,
+push notifications, and Telegram.
+
+---
+
+## Assistant (Anthropic)
+
+The conversational assistant: ask a question in plain language, get an answer
+grounded in your household's own documents, expenses and tasks, with citations
+back to the source. It also powers OCR on uploaded documents.
+
+**Without it.** The Assistant tab says it needs a key and links here. Every other
+screen is untouched — and, importantly, the search box at the top still works
+(see the next section: keyword search needs no key at all).
+
+**Get a key.** Create one at [console.anthropic.com](https://console.anthropic.com/)
+→ *API keys*. It starts with `sk-ant-`.
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Optional, with sensible defaults already set:
+
+```bash
+LLM_PROVIDER=anthropic                       # the only provider implemented today
+LLM_TEXT_MODEL=claude-haiku-4-5-20251001     # chat and recap wording
+LLM_VISION_MODEL=claude-haiku-4-5-20251001   # OCR on document uploads
+```
+
+**Cost.** Claude Haiku 4.5 is billed per million tokens — $1.00 in, $5.00 out at
+the time of writing ([current pricing](https://claude.com/pricing)). A household
+asking a few questions a day and uploading a handful of documents a week lands in
+the low single digits of dollars per month. The app records every call in its
+own usage log (`/app/admin/ai-usage`), so you can watch the real number rather
+than trust this estimate.
+
+---
+
+## Semantic search (embeddings)
+
+The search box has two stages. The first is **keyword search** — a few indexed
+SQL queries, answered in milliseconds, and it needs no key whatsoever. The second
+stage finds what the words missed: "the paper about the boiler" matching a PDF
+titled *Chaudière — contrat d'entretien*.
+
+**Without it.** The first stage still answers. You simply never see the extra
+group of results the second stage would have added. Nothing is slower, nothing
+errors — the second stage returns an empty list and the interface says so rather
+than pretending it searched everything.
+
+**Two settings, and you need both.** The key alone is not enough:
+
+```bash
+VOYAGE_API_KEY=pa-...
+AGENT_HYBRID_RETRIEVAL_ENABLED=True
+```
+
+Get a key at [dash.voyageai.com](https://dash.voyageai.com/). Embeddings are
+billed per million tokens; the one-off cost of indexing an existing household is
+larger than the ongoing cost of queries, which is a few cents a month. Check
+[Voyage's pricing page](https://www.voyageai.com/pricing) for current rates.
+
+**Turn the flag on only after the index is built.** Sequence:
+
+```bash
+docker compose exec web python manage.py backfill_embeddings
+# then set AGENT_HYBRID_RETRIEVAL_ENABLED=True and restart
+```
+
+A half-filled index is worse than no index: the search runs, finds nothing, and
+never tells you it only looked at part of your household.
+
+**Other providers.** `EMBEDDING_PROVIDER` accepts `voyage` (default), `openai`
+(`OPENAI_API_KEY`), or `ollama` (no key, `EMBEDDING_BASE_URL` pointing at your
+local instance — it needs about 8 GB of RAM).
+
+> ⚠️ **Changing `EMBEDDING_PROVIDER` or `EMBEDDING_MODEL` after you have indexed
+> means re-running `backfill_embeddings` on everything.** The vector column is
+> fixed at `EMBEDDING_DIMENSIONS`, and an index holding vectors from two
+> different models returns silently wrong results. The startup check catches a
+> change of *width*; it cannot catch a change of *model* at the same width.
+
+---
+
+## Recap wording (Anthropic)
+
+Each month Maisonnée assembles a recap of the household — what was spent, what
+was fixed, what was photographed. With a key, an LLM rewrites the captions into
+warmer prose in the reader's own language.
+
+**Without it.** The recap still exists, still shows every figure, and is still
+translated into all four interface languages. The sentences are simply the
+built-in templates: accurate, a little drier.
+
+Two settings, both required:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...     # the same key as the assistant
+RECAP_AI_POLISH_ENABLED=True
+```
+
+**Cost.** One call per household per month, a few hundred tokens. Negligible
+next to the assistant.
+
+---
+
+## Email (SMTP)
+
+Outgoing transactional email: password reset, and the notification sent to
+someone you invite who already has an account.
+
+**Without it — and this is the important part — you can still add people to your
+household.** Every invitation produces a `/join/<token>` link you copy and send
+yourself, by whatever means you already use. Email is a convenience here, never
+the only route in. Password reset is the one thing that genuinely needs a
+mailbox; without SMTP you reset a password from the admin instead.
+
+By default emails are written to the container log (`docker compose logs web`),
+which is useful for testing and honest about delivering nothing.
+
+To send for real, point the instance at any SMTP server — your own, or a
+transactional provider:
+
+```bash
+EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+EMAIL_HOST=smtp.example.com
+EMAIL_PORT=587
+EMAIL_HOST_USER=maisonnee@example.com
+EMAIL_HOST_PASSWORD=...
+EMAIL_USE_TLS=True
+DEFAULT_FROM_EMAIL=maisonnee@example.com
+```
+
+**Cost.** Free on most providers at household volume — a handful of messages a
+month.
+
+---
+
+## Push notifications (VAPID)
+
+Browser push, so a phone with Maisonnée installed as a web app is notified when
+a task is completed or a threshold is crossed, without the app being open.
+
+**Without it.** In-app notifications still work, and so does the bell in the
+header. The push toggle in Settings says what it needs. Nothing is sent into a
+void.
+
+VAPID keys are self-generated — there is no account to create, nothing to pay:
+
+```bash
+docker compose exec web python manage.py generate_vapid_keys
+```
+
+Copy the two values it prints into `.env`:
+
+```bash
+VAPID_PUBLIC_KEY=...
+VAPID_PRIVATE_KEY=...
+VAPID_ADMIN_EMAIL=you@example.com    # push services use this to reach you
+```
+
+**Both halves matter.** With the public key alone, the browser accepts the
+subscription and no message ever arrives — the quietest failure in the set,
+which is why the app refuses to create the subscription at all until it has the
+pair.
+
+> Push requires HTTPS (except on `localhost`). Set `MAISONNEE_PUBLIC_URL` so the
+> instance serves secure cookies to match.
+
+---
+
+## Telegram bot
+
+A second door into the household: ask the assistant a question from Telegram,
+receive the daily digest and proactive reminders there.
+
+**Without it.** The Telegram card in Settings is hidden. Notifications still
+reach the app itself.
+
+Create a bot by messaging [@BotFather](https://t.me/BotFather) on Telegram
+(`/newbot`). You get a token; the username is the one you chose:
+
+```bash
+TELEGRAM_BOT_TOKEN=123456:ABC-...
+TELEGRAM_BOT_USERNAME=my_household_bot     # without the @
+TELEGRAM_WEBHOOK_SECRET=<a long random string you invent>
+```
+
+Then register the webhook so Telegram knows where to reach your instance:
+
+```bash
+docker compose exec web python manage.py telegram_set_webhook
+```
+
+**Both the token and the username are required.** The token talks to Telegram;
+the username builds the `t.me` link a member opens to link their account. With
+only the token, the linking screen shows a button that leads nowhere.
+
+**Cost.** Free. Note that the assistant answering over Telegram uses your
+Anthropic key like any other question.
+
+---
+
+## Checking what is on
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" http://localhost:8000/api/capabilities/
+```
+
+```json
+{
+  "capabilities": [
+    {"key": "assistant", "available": false,
+     "env_vars": ["ANTHROPIC_API_KEY"],
+     "docs_url": "https://github.com/jammindev/house/blob/main/docs/self-hosting/ai-providers.md#assistant-anthropic"}
+  ]
+}
+```
+
+`available: false` is never an error state. It means the instance knows exactly
+what it cannot do and says so — to you here, and to every screen that would
+otherwise have promised it.

--- a/ui/src/components/CapabilityNotice.tsx
+++ b/ui/src/components/CapabilityNotice.tsx
@@ -1,0 +1,67 @@
+import { ExternalLink } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { Card } from '@/design-system/card';
+import { useCapability } from '@/lib/capabilities';
+import { cn } from '@/lib/utils';
+
+interface Props {
+  /** Clé du registre (`assistant`, `semantic_search`, `email`, `push`, …). */
+  capability: string;
+  className?: string;
+}
+
+/**
+ * « Cette instance ne peut pas encore faire ça — et voici comment l'activer. »
+ *
+ * Le seul texte autorisé à la place d'une capacité absente. Un écran vide, un
+ * spinner sans fin ou une erreur technique disent tous la même chose à
+ * l'utilisateur : le produit est cassé. Or il ne l'est pas — il lui manque une
+ * clé, et **quelqu'un peut la poser**. C'est la différence entre un défaut et
+ * une configuration, et elle ne se voit que si on l'écrit.
+ *
+ * Le composant ne connaît aucune capacité en particulier : le libellé vient du
+ * catalogue i18n (`capabilities.<key>.*`), les variables et le lien viennent du
+ * serveur. Ajouter une capacité n'y touche pas.
+ */
+export default function CapabilityNotice({ capability, className }: Props) {
+  const { t } = useTranslation();
+  const { capability: spec } = useCapability(capability);
+
+  return (
+    <Card className={cn('space-y-3 p-4', className)}>
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-foreground">
+          {t(`capabilities.${capability}.unavailable`)}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {t(`capabilities.${capability}.without`)}
+        </p>
+      </div>
+
+      {spec && spec.env_vars.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {t('capabilities.envVars')}{' '}
+          {spec.env_vars.map((name, index) => (
+            <span key={name}>
+              {index > 0 && ', '}
+              <code className="rounded bg-muted px-1 py-0.5 font-mono">{name}</code>
+            </span>
+          ))}
+        </p>
+      )}
+
+      {spec && (
+        <a
+          href={spec.docs_url}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+        >
+          {t('capabilities.howToEnable')}
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        </a>
+      )}
+    </Card>
+  );
+}

--- a/ui/src/features/agent/AgentLauncher.test.tsx
+++ b/ui/src/features/agent/AgentLauncher.test.tsx
@@ -15,6 +15,13 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
+// La bulle n'existe que sur une instance qui a l'assistant (parcours 28, lot 3).
+// Ce fichier teste la fermeture du panneau, pas la dégradation : on se place sur
+// une instance configurée, sans monter le client react-query pour autant.
+vi.mock('@/lib/capabilities', () => ({
+  useCapability: () => ({ available: true, isLoading: false, capability: undefined }),
+}));
+
 function CurrentPath() {
   const location = useLocation();
   return <span data-testid="path">{location.pathname}</span>;

--- a/ui/src/features/agent/AgentLauncher.tsx
+++ b/ui/src/features/agent/AgentLauncher.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
 import { SheetDialog } from '@/design-system/sheet-dialog';
+import { useCapability } from '@/lib/capabilities';
 import { cn } from '@/lib/utils';
 import EntityAssistant from './EntityAssistant';
 import HouseholdChat from './HouseholdChat';
@@ -22,6 +23,7 @@ import { resolveEntityContext, type EntityContext } from './entityRoute';
 export default function AgentLauncher() {
   const { t } = useTranslation();
   const location = useLocation();
+  const { available: assistantAvailable } = useCapability('assistant');
 
   const [open, setOpen] = React.useState(false);
   // The entity context, snapshotted when the panel opens. null = household mode.
@@ -53,6 +55,12 @@ export default function AgentLauncher() {
   }, [open, location.key]);
 
   if (onAgentPage) return null;
+
+  // Une bulle flottante sur toutes les pages pour une capacité que l'instance
+  // n'a pas est une promesse permanente qu'on ne tient pas. L'explication
+  // existe, elle vit au bout de l'entrée « Assistant » de la barre latérale et
+  // dans les Réglages — pas en surimpression de chaque écran.
+  if (!assistantAvailable) return null;
 
   return (
     <>

--- a/ui/src/features/agent/ChatPanel.tsx
+++ b/ui/src/features/agent/ChatPanel.tsx
@@ -3,7 +3,9 @@ import { Send, Sparkles, AlertTriangle, RotateCcw, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/design-system/button';
 import { Textarea } from '@/design-system/textarea';
+import CapabilityNotice from '@/components/CapabilityNotice';
 import { useCurrentUser } from '@/features/settings/hooks';
+import { useCapability } from '@/lib/capabilities';
 import { cn } from '@/lib/utils';
 import ChatBubble from './ChatBubble';
 import PrivacyNotice from './PrivacyNotice';
@@ -125,6 +127,9 @@ export default function ChatPanel({
   // web search (implies a Sonnet 4.6+ model) — never an inert control otherwise.
   const { data: currentUser } = useCurrentUser();
   const webSearchAvailable = Boolean(currentUser?.agent_web_search_available);
+  // L'assistant lui-même est une capacité de l'instance (clé du fournisseur).
+  const { available: assistantAvailable, isLoading: assistantLoading } =
+    useCapability('assistant');
 
   const [messages, setMessages] = React.useState<Message[]>([]);
   const [draft, setDraft] = React.useState('');
@@ -272,6 +277,22 @@ export default function ChatPanel({
 
   const isEmpty = messages.length === 0 && !isBusy;
   const disabled = needsPrivacy || isBusy || (!conversationId && !ensureConversation);
+
+  // Sans clé, le serveur refuse en 503 nommé plutôt que d'inventer un « je ne
+  // sais pas » — inutile d'offrir un champ de saisie qui ne peut que décevoir.
+  // Le gate est **ici**, dans le panneau partagé : la page, le tiroir flottant
+  // et l'onglet d'une entité passent tous les trois par lui.
+  //
+  // `assistantLoading` n'est pas `false` : afficher « il manque une clé » à un
+  // foyer qui en a une, le temps d'un aller-retour, est le même mensonge dans
+  // l'autre sens.
+  if (!assistantLoading && !assistantAvailable) {
+    return (
+      <div className={cn('flex min-h-0 flex-col gap-4', className)}>
+        <CapabilityNotice capability="assistant" />
+      </div>
+    );
+  }
 
   return (
     <div className={cn('flex min-h-0 flex-col gap-4', className)}>

--- a/ui/src/features/settings/SettingsPage.tsx
+++ b/ui/src/features/settings/SettingsPage.tsx
@@ -15,6 +15,7 @@ import { HouseholdManagement } from './components/HouseholdManagement';
 import { ModulesSection } from './components/ModulesSection';
 import { PendingInvitations } from './components/PendingInvitations';
 import { AboutSection } from './components/AboutSection';
+import { CapabilitiesSection } from './components/CapabilitiesSection';
 
 export default function SettingsPage() {
   const { t } = useTranslation();
@@ -51,6 +52,7 @@ export default function SettingsPage() {
       <ThemeSection />
       <AgentMemorySection />
       <ChangePasswordSection />
+      <CapabilitiesSection />
       <AboutSection />
     </div>
   );

--- a/ui/src/features/settings/components/CapabilitiesSection.tsx
+++ b/ui/src/features/settings/components/CapabilitiesSection.tsx
@@ -1,0 +1,99 @@
+import { Check, ExternalLink, Minus } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { useCapabilities } from '@/lib/capabilities';
+import { SettingsSection } from './SettingsSection';
+
+/**
+ * Ce que cette instance sait faire — et ce qui lui manque pour le reste.
+ *
+ * Les six capacités optionnelles au même endroit, avec pour chacune ce qu'on
+ * perd sans elle et le lien qui explique comment la poser. Les écrans concernés
+ * le disent déjà là où l'utilisateur bute (`CapabilityNotice`) ; cette section
+ * répond à l'autre question, celle de celui qui installe : **qu'est-ce qui
+ * dort ici ?**
+ *
+ * Une capacité absente n'est pas une erreur et ne se peint pas en rouge : un
+ * foyer qui n'a pas de bot Telegram n'a rien de cassé. D'où le gris.
+ */
+export function CapabilitiesSection() {
+  const { t } = useTranslation();
+  const { data, isLoading } = useCapabilities();
+
+  if (isLoading) {
+    return (
+      <SettingsSection
+        title={t('capabilities.title')}
+        description={t('capabilities.description')}
+      >
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-12 animate-pulse rounded-lg bg-muted" />
+          ))}
+        </div>
+      </SettingsSection>
+    );
+  }
+
+  if (!data || data.length === 0) return null;
+
+  return (
+    <SettingsSection
+      title={t('capabilities.title')}
+      description={t('capabilities.description')}
+    >
+      <ul className="divide-y divide-border">
+        {data.map((capability) => (
+          <li key={capability.key} className="flex items-start gap-3 py-3 first:pt-0 last:pb-0">
+            <span
+              className={
+                capability.available
+                  ? 'mt-0.5 text-primary'
+                  : 'mt-0.5 text-muted-foreground'
+              }
+              aria-hidden="true"
+            >
+              {capability.available ? (
+                <Check className="h-4 w-4" />
+              ) : (
+                <Minus className="h-4 w-4" />
+              )}
+            </span>
+
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground">
+                {t(`capabilities.${capability.key}.name`)}
+              </p>
+              <p className="text-sm text-muted-foreground">
+                {capability.available
+                  ? t(`capabilities.${capability.key}.enabled`)
+                  : t(`capabilities.${capability.key}.without`)}
+              </p>
+
+              {!capability.available && (
+                <p className="mt-1.5 text-xs text-muted-foreground">
+                  {capability.env_vars.map((name, index) => (
+                    <span key={name}>
+                      {index > 0 && ', '}
+                      <code className="rounded bg-muted px-1 py-0.5 font-mono">{name}</code>
+                    </span>
+                  ))}
+                  {capability.env_vars.length > 0 && ' — '}
+                  <a
+                    href={capability.docs_url}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    className="inline-flex items-center gap-1 text-primary hover:underline"
+                  >
+                    {t('capabilities.howToEnable')}
+                    <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                  </a>
+                </p>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </SettingsSection>
+  );
+}

--- a/ui/src/features/settings/components/WebPushSection.tsx
+++ b/ui/src/features/settings/components/WebPushSection.tsx
@@ -10,6 +10,7 @@ import {
   subscribeWebPush,
   unsubscribeWebPush,
 } from '@/lib/api/webpush';
+import { useCapability } from '@/lib/capabilities';
 import { isIos, isPushSupported, isStandalone, urlBase64ToUint8Array } from '@/lib/pwa/platform';
 import { SettingsSection } from './SettingsSection';
 
@@ -114,11 +115,17 @@ function useWebPush(vapidKey: string | undefined) {
  */
 export function WebPushSection() {
   const { t } = useTranslation();
+  // « Le push est-il configuré ? » a désormais **une** définition : le registre
+  // de capacités. La déduire d'une clé publique vide en était une seconde, et
+  // c'est elle qui laissait le serveur répondre 200 à une question dont il
+  // connaissait déjà la réponse. La requête n'est même pas lancée sans la
+  // capacité — sinon chaque visite des Réglages rejouait trois fois un 503.
+  const { available: pushAvailable } = useCapability('push');
   const { data: vapidKey, isLoading } = useQuery({
     queryKey: ['settings', 'webpush', 'vapid'],
     queryFn: fetchVapidPublicKey,
     staleTime: Infinity,
-    enabled: isPushSupported(),
+    enabled: isPushSupported() && pushAvailable,
   });
 
   const configured = Boolean(vapidKey);

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -94,7 +94,7 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add', 'phone', 'file'] },
   { key: 'directory', moduleKey: 'directory', to: '/app/directory', stepIds: ['contacts', 'structures'] },
   { key: 'alerts', Icon: AlertCircle, to: '/app/alerts', stepIds: ['review', 'act'] },
-  { key: 'settings', Icon: User, to: '/app/settings', stepIds: ['profile', 'household', 'invite', 'modules'] },
+  { key: 'settings', Icon: User, to: '/app/settings', stepIds: ['profile', 'household', 'invite', 'modules', 'capabilities'] },
 ];
 
 /** Clé de progression d'un guide, telle que stockée sur l'utilisateur. */

--- a/ui/src/lib/api/capabilities.ts
+++ b/ui/src/lib/api/capabilities.ts
@@ -1,0 +1,20 @@
+import { api } from '@/lib/axios';
+
+/**
+ * Une capacité optionnelle de l'instance — ce que ce serveur sait faire selon
+ * les clés dont il dispose. Voir `apps/app_settings/capabilities.py`.
+ */
+export interface Capability {
+  /** Identifiant stable ; sert aussi de clé i18n (`capabilities.<key>.*`). */
+  key: string;
+  available: boolean;
+  /** Variables d'environnement qui portent la capacité, dans l'ordre à poser. */
+  env_vars: string[];
+  /** Section de `docs/self-hosting/ai-providers.md` qui explique comment l'activer. */
+  docs_url: string;
+}
+
+export async function fetchCapabilities(): Promise<Capability[]> {
+  const { data } = await api.get<{ capabilities: Capability[] }>('/capabilities/');
+  return data.capabilities;
+}

--- a/ui/src/lib/capabilities.ts
+++ b/ui/src/lib/capabilities.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCapabilities, type Capability } from '@/lib/api/capabilities';
+
+/**
+ * Ce que l'instance sait faire — lu avant d'afficher une promesse.
+ *
+ * Une capacité absente (pas de clé Anthropic, pas de SMTP, pas de VAPID) ne
+ * casse rien côté serveur : l'assistant répond « je ne sais pas », la jambe
+ * sémantique renvoie `[]`, l'e-mail part dans les logs. Le défaut est ailleurs —
+ * **l'interface promet quand même**, et l'utilisateur en conclut que le produit
+ * est mauvais plutôt qu'il lui manque une clé.
+ *
+ * Ce hook est la contrepartie front du registre `app_settings.capabilities` :
+ * il ne relit jamais un réglage, il lit le verdict du serveur. Ajouter une
+ * capacité = une entrée dans le registre + les clés `capabilities.<key>.*` dans
+ * les quatre catalogues, aucune modification d'écran.
+ *
+ * Ce n'est pas une donnée de foyer : les clés se posent par instance (le `.env`
+ * **est** le BYOK de l'auto-hébergeur), donc rien ici n'entre dans le graphe
+ * d'invalidation de `lib/invalidate.ts` — aucune écriture de l'app ne peut la
+ * changer.
+ */
+
+export const capabilityKeys = {
+  all: ['capabilities'] as const,
+};
+
+/**
+ * `staleTime` long, mais **pas** `Infinity` : ajouter une clé et redémarrer le
+ * conteneur ne recharge pas l'onglet ouvert du foyer. Trente minutes bornent
+ * l'attente sans transformer chaque montage d'écran gaté en requête.
+ */
+const CAPABILITIES_STALE_TIME = 30 * 60 * 1000;
+
+export function useCapabilities() {
+  return useQuery({
+    queryKey: capabilityKeys.all,
+    queryFn: fetchCapabilities,
+    staleTime: CAPABILITIES_STALE_TIME,
+  });
+}
+
+/**
+ * L'état d'**une** capacité.
+ *
+ * `available` reste `false` tant que la liste n'est pas chargée, et
+ * `isLoading` dit pourquoi. Les confondre afficherait « nécessite une clé »
+ * pendant le chargement, à un foyer qui en a une — la version écran du compteur
+ * à zéro qui a deux sens.
+ */
+export function useCapability(key: string): {
+  available: boolean;
+  isLoading: boolean;
+  capability: Capability | undefined;
+} {
+  const { data, isLoading } = useCapabilities();
+  const capability = data?.find((c) => c.key === key);
+  return { available: Boolean(capability?.available), isLoading, capability };
+}

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1672,6 +1672,10 @@
           "modules": {
             "title": "Die richtigen Module aktivieren",
             "body": "Deaktivieren Sie unnötige Module (Hühnerstall, Versicherung…), um die Navigation zu entlasten."
+          },
+          "capabilities": {
+            "title": "Sehen, was diese Instanz kann",
+            "body": "Assistent, semantische Suche, E-Mail, Push-Benachrichtigungen, Telegram: Diese Funktionen hängen von Schlüsseln ab, die bei der Installation hinterlegt wurden, nicht von einer Haushaltseinstellung. Die Liste zeigt, was aktiv ist, was ohne die übrigen fehlt, und verweist auf die Anleitung zur Aktivierung."
           }
         }
       },
@@ -4296,5 +4300,47 @@
     "empty": "Noch kein Lieferant erfasst",
     "willBeAdded": "Neuer Lieferant — wird hinzugefügt",
     "fromLabel": "Aus der Bezeichnung des Vorgangs"
+  },
+  "capabilities": {
+    "title": "Was diese Instanz kann",
+    "description": "Was dieser Server leisten kann, abhängig von den hinterlegten Schlüsseln.",
+    "envVars": "Zu setzende Variablen:",
+    "howToEnable": "So wird es aktiviert",
+    "assistant": {
+      "name": "Assistent",
+      "unavailable": "Der Assistent ist auf dieser Instanz nicht eingerichtet.",
+      "without": "Ohne Anbieterschlüssel kann der Assistent nicht antworten. Alles andere in Maisonnée funktioniert, einschließlich der Stichwortsuche.",
+      "enabled": "Der Assistent beantwortet Fragen zum Haushalt."
+    },
+    "semantic_search": {
+      "name": "Semantische Suche",
+      "unavailable": "Die semantische Suche ist auf dieser Instanz nicht eingerichtet.",
+      "without": "Die Stichwortsuche antwortet weiterhin; es fehlen nur die sinngemäß gefundenen Treffer.",
+      "enabled": "Die Suche findet auch dem Sinn nach, nicht nur nach exakten Wörtern."
+    },
+    "recap_ai": {
+      "name": "Rückblick-Formulierung",
+      "unavailable": "Das Umformulieren des Rückblicks ist auf dieser Instanz nicht eingerichtet.",
+      "without": "Der Monatsrückblick erscheint trotzdem, mit seinen Standardtexten.",
+      "enabled": "Die Bildunterschriften des Monatsrückblicks werden in Alltagssprache umgeschrieben."
+    },
+    "email": {
+      "name": "Ausgehende E-Mail",
+      "unavailable": "Auf dieser Instanz ist kein Mailserver eingerichtet.",
+      "without": "E-Mails werden ins Serverprotokoll geschrieben. Mitglieder lassen sich trotzdem hinzufügen: Der Einladungslink wird von Hand kopiert.",
+      "enabled": "Diese Instanz versendet E-Mails."
+    },
+    "push": {
+      "name": "Push-Benachrichtigungen",
+      "unavailable": "Push-Benachrichtigungen sind auf dieser Instanz nicht eingerichtet.",
+      "without": "Benachrichtigungen bleiben in der App; bei geschlossener App erreicht nichts das Telefon.",
+      "enabled": "Benachrichtigungen erreichen die angemeldeten Geräte."
+    },
+    "telegram": {
+      "name": "Telegram",
+      "unavailable": "Der Telegram-Kanal ist auf dieser Instanz nicht eingerichtet.",
+      "without": "Der Telegram-Kanal ist aus. Benachrichtigungen bleiben in der App.",
+      "enabled": "Der Haushalt kann über Telegram mit dem Assistenten sprechen."
+    }
   }
 }

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1672,6 +1672,10 @@
           "modules": {
             "title": "Enable the right modules",
             "body": "Disable modules you don't need (chicken coop, insurance…) to lighten the navigation."
+          },
+          "capabilities": {
+            "title": "See what this instance can do",
+            "body": "Assistant, semantic search, email, push notifications, Telegram: these depend on keys set when the app was installed, not on a household setting. The list shows which ones are on, what you lose without the others, and links to how each is enabled."
           }
         }
       },
@@ -4296,5 +4300,47 @@
     "empty": "No supplier recorded yet",
     "willBeAdded": "New supplier — it will be added",
     "fromLabel": "From the operation label"
+  },
+  "capabilities": {
+    "title": "What this instance can do",
+    "description": "The capabilities this server has, based on the keys it was given.",
+    "envVars": "Variables to set:",
+    "howToEnable": "How to enable it",
+    "assistant": {
+      "name": "Assistant",
+      "unavailable": "The assistant is not configured on this instance.",
+      "without": "Without a provider key the assistant cannot answer. Everything else in Maisonnée works, including keyword search.",
+      "enabled": "The assistant answers questions about your household."
+    },
+    "semantic_search": {
+      "name": "Semantic search",
+      "unavailable": "Semantic search is not configured on this instance.",
+      "without": "Keyword search still answers; only the results found by meaning are missing.",
+      "enabled": "Search also finds things by meaning, not just exact words."
+    },
+    "recap_ai": {
+      "name": "Recap wording",
+      "unavailable": "Recap rewriting is not configured on this instance.",
+      "without": "The monthly recap is still produced, with its built-in wording.",
+      "enabled": "The monthly recap captions are rewritten in everyday language."
+    },
+    "email": {
+      "name": "Outgoing email",
+      "unavailable": "No mail server is configured on this instance.",
+      "without": "Emails are written to the server log. You can still add members: the invitation link is copied by hand.",
+      "enabled": "This instance sends email."
+    },
+    "push": {
+      "name": "Push notifications",
+      "unavailable": "Push notifications are not configured on this instance.",
+      "without": "Notifications stay inside the app; nothing reaches a phone while it is closed.",
+      "enabled": "Notifications reach subscribed devices."
+    },
+    "telegram": {
+      "name": "Telegram",
+      "unavailable": "The Telegram channel is not configured on this instance.",
+      "without": "The Telegram channel is off. Notifications stay inside the app.",
+      "enabled": "Your household can talk to the assistant from Telegram."
+    }
   }
 }

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1672,6 +1672,10 @@
           "modules": {
             "title": "Activar los módulos adecuados",
             "body": "Desactiva los módulos que no uses (gallinero, seguros…) para aligerar la navegación."
+          },
+          "capabilities": {
+            "title": "Saber qué puede hacer esta instancia",
+            "body": "Asistente, búsqueda semántica, correo, notificaciones push, Telegram: dependen de claves definidas al instalar la aplicación, no de un ajuste del hogar. La lista indica cuáles están activas, qué se pierde sin las demás y enlaza con cómo activarlas."
           }
         }
       },
@@ -4296,5 +4300,47 @@
     "empty": "Ningún proveedor registrado",
     "willBeAdded": "Nuevo proveedor — se añadirá",
     "fromLabel": "Según el concepto de la operación"
+  },
+  "capabilities": {
+    "title": "Lo que puede hacer esta instancia",
+    "description": "Lo que este servidor sabe hacer, según las claves de que dispone.",
+    "envVars": "Variables que hay que definir:",
+    "howToEnable": "Cómo activarlo",
+    "assistant": {
+      "name": "Asistente",
+      "unavailable": "El asistente no está configurado en esta instancia.",
+      "without": "Sin una clave de proveedor el asistente no puede responder. Todo lo demás de Maisonnée funciona, incluida la búsqueda por palabras clave.",
+      "enabled": "El asistente responde a las preguntas del hogar."
+    },
+    "semantic_search": {
+      "name": "Búsqueda semántica",
+      "unavailable": "La búsqueda semántica no está configurada en esta instancia.",
+      "without": "La búsqueda por palabras clave sigue respondiendo; solo faltan los resultados encontrados por sentido.",
+      "enabled": "La búsqueda también encuentra por sentido, no solo por palabras exactas."
+    },
+    "recap_ai": {
+      "name": "Redacción del resumen",
+      "unavailable": "La reescritura del resumen no está configurada en esta instancia.",
+      "without": "El resumen mensual se publica igualmente, con sus textos por defecto.",
+      "enabled": "Los pies de foto del resumen mensual se reescriben en lenguaje cotidiano."
+    },
+    "email": {
+      "name": "Correo saliente",
+      "unavailable": "No hay ningún servidor de correo configurado en esta instancia.",
+      "without": "Los correos se escriben en el registro del servidor. Aun así puedes añadir miembros: el enlace de invitación se copia a mano.",
+      "enabled": "Esta instancia envía correos."
+    },
+    "push": {
+      "name": "Notificaciones push",
+      "unavailable": "Las notificaciones push no están configuradas en esta instancia.",
+      "without": "Las notificaciones se quedan en la aplicación; nada llega al teléfono cuando está cerrada.",
+      "enabled": "Las notificaciones llegan a los dispositivos suscritos."
+    },
+    "telegram": {
+      "name": "Telegram",
+      "unavailable": "El canal de Telegram no está configurado en esta instancia.",
+      "without": "El canal de Telegram está apagado. Las notificaciones se quedan en la aplicación.",
+      "enabled": "El hogar puede hablar con el asistente desde Telegram."
+    }
   }
 }

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1672,6 +1672,10 @@
           "modules": {
             "title": "Activer les bons modules",
             "body": "Désactivez les modules inutiles (poulailler, assurance…) pour alléger la navigation."
+          },
+          "capabilities": {
+            "title": "Savoir ce que cette instance sait faire",
+            "body": "Assistant, recherche sémantique, e-mail, notifications push, Telegram : ces capacités dépendent de clés posées à l'installation, pas d'un réglage du foyer. La liste dit lesquelles sont actives, ce qu'on perd sans les autres, et renvoie à la marche à suivre pour les activer."
           }
         }
       },
@@ -4296,5 +4300,47 @@
     "empty": "Aucun fournisseur enregistré",
     "willBeAdded": "Nouveau fournisseur — il sera ajouté",
     "fromLabel": "D'après le libellé de l'opération"
+  },
+  "capabilities": {
+    "title": "Capacités de cette instance",
+    "description": "Ce que ce serveur sait faire, selon les clés dont il dispose.",
+    "envVars": "Variables à poser :",
+    "howToEnable": "Comment l'activer",
+    "assistant": {
+      "name": "Assistant",
+      "unavailable": "L'assistant n'est pas configuré sur cette instance.",
+      "without": "Sans clé de fournisseur, l'assistant ne peut pas répondre. Tout le reste de Maisonnée fonctionne, y compris la recherche par mots-clés.",
+      "enabled": "L'assistant répond aux questions du foyer."
+    },
+    "semantic_search": {
+      "name": "Recherche sémantique",
+      "unavailable": "La recherche sémantique n'est pas configurée sur cette instance.",
+      "without": "La recherche par mots-clés répond toujours ; seuls les résultats trouvés par le sens manquent.",
+      "enabled": "La recherche trouve aussi par le sens, pas seulement par les mots exacts."
+    },
+    "recap_ai": {
+      "name": "Récap raconté",
+      "unavailable": "La réécriture du récap n'est pas configurée sur cette instance.",
+      "without": "Le récap mensuel sort quand même, avec ses phrases par défaut.",
+      "enabled": "Les légendes du récap mensuel sont réécrites en langage courant."
+    },
+    "email": {
+      "name": "E-mail sortant",
+      "unavailable": "Aucun serveur d'envoi n'est configuré sur cette instance.",
+      "without": "Les e-mails s'écrivent dans les journaux du serveur. Inviter un membre reste possible : le lien d'invitation se copie à la main.",
+      "enabled": "Cette instance envoie des e-mails."
+    },
+    "push": {
+      "name": "Notifications push",
+      "unavailable": "Les notifications push ne sont pas configurées sur cette instance.",
+      "without": "Les notifications restent dans l'application ; rien n'arrive sur le téléphone quand elle est fermée.",
+      "enabled": "Les notifications arrivent sur les appareils abonnés."
+    },
+    "telegram": {
+      "name": "Telegram",
+      "unavailable": "Le canal Telegram n'est pas configuré sur cette instance.",
+      "without": "Le canal Telegram est éteint. Les notifications restent dans l'application.",
+      "enabled": "Le foyer peut parler à l'assistant depuis Telegram."
+    }
   }
 }


### PR DESCRIPTION
Ferme le **lot 3 du parcours 28** (#489). Suite des lots 0 (#495), 1 (#497), 2 (#500) et 4 (#496).

## Le problème

Sans clé, rien ne plantait déjà : `service.ask` renvoyait proprement « je ne sais pas », `retrieval.semantic_only` renvoyait `[]`, l'e-mail partait dans les logs. Le défaut était ailleurs — **l'interface promettait quand même**, et l'utilisateur en concluait que le produit était mauvais plutôt qu'il lui manquait une clé.

## Ce que ça livre

- **Registre `app_settings.capabilities`** — six capacités (`assistant`, `semantic_search`, `recap_ai`, `email`, `push`, `telegram`), chacune enregistrée depuis l'`apps.py::ready()` de l'app qui possède le réglage. Même modèle que `agent.searchables` : `app_settings` ne connaît pas la liste.
- **`GET /api/capabilities/`** — non household-scopé, parce que les clés se posent par instance (le `.env` *est* le BYOK de l'auto-hébergeur). Le payload ne transporte jamais une valeur, seulement le nom de la variable.
- **`docs/self-hosting/ai-providers.md`** (anglais) — une section par capacité : où obtenir la clé, quelle variable la porte, **ce que l'app fait sans elle**, l'ordre de grandeur du coût.
- **Front** — `CapabilityNotice` (le seul texte autorisé à la place d'une capacité absente), section « Capacités de cette instance » dans les Réglages, gating de `ChatPanel` et de la bulle flottante, clés `capabilities.*` dans les 4 catalogues, étape de tutoriel.
- **503 nommé** (`capabilities.require`) posé **avant tout effet de bord**, sur `ask` / `messages` / `messages/stream` / `webpush.subscribe` / `webpush.test` / `telegram.link-token`.

## Trois écarts au plan, assumés

1. **Le point bloquant du lot n'existait déjà plus.** « Sans SMTP, inviter part dans le vide » a été corrigé le 29 juillet par le fix #461 (`/join/<token>` + `InvitePanel`). Le lot ne l'a pas refait, il l'a **documenté** comme la voie normale : un chemin que personne ne connaît ne rattrape rien.
2. **Le récap n'est pas gaté.** Sans clé il sort quand même, avec ses gabarits. Un bandeau « nécessite une clé » y aurait annoncé cassé ce qui marche — exactement le malentendu qu'on supprime.
3. **Deux définitions ramenées à une.** Telegram avait son 503 écrit à la main ; le front du push déduisait la configuration d'une clé publique vide (200, puis `InvalidAccessError` illisible après le clic).

Défaut réparé en chemin : `EMAIL_BACKEND` n'était posé nulle part dans `base.py`, donc le défaut de Django (`smtp` sur `localhost:25`) s'appliquait à tout module de réglages qui ne le surchargeait pas.

## Régressions

- `apps/app_settings/tests/test_capabilities.py` — l'état est lu et non figé, chaque ancre de doc atteint un titre existant, chaque capacité est nommée dans les 4 catalogues (vérifié depuis Python, seul côté qui connaît la liste), le payload ne fuit aucune valeur.
- `agent/tests/test_views.py::TestAnUnconfiguredInstanceSaysSo` — 503 nommé, et rien de persisté.
- `webpush/tests/test_webpush.py` — la moitié d'une paire VAPID n'est pas une instance configurée.

`config/settings/test.py` pose désormais `ANTHROPIC_API_KEY` : la suite tourne sur une instance **configurée**, et l'absence de clé est testée là où c'est le sujet.

## Vérifications

- `pytest` : **4237 passés**, 2 skipped
- `vitest` : **251 passés**
- `tsc -b` : aucune erreur nouvelle (baseline identique)
- `npm run lint` : 0 erreur — `npm run build` : ok
