### PR TITLE
Parcours 28 — Lot 5 : sauvegarde, restauration testée, doc d'exploitation (#491)

### DIFF
--- a/.github/workflows/backup-restore.yml
+++ b/.github/workflows/backup-restore.yml
@@ -1,0 +1,74 @@
+# Sauvegarde → base neuve → restauration → assertions.
+#
+# Workflow **appelé**, jamais déclenché seul : `ci.yml` le lance sur chaque PR
+# (informatif — il ne garde pas le deploy), et `release.yml` le lance avant de
+# publier une image (bloquant — une version qu'on distribue doit savoir se
+# restaurer).
+#
+# Un seul texte pour les deux appelants, exprès. Copié dans chaque workflow, il
+# aurait dérivé au premier changement de format de dump, et c'est précisément le
+# changement que ce job existe pour attraper.
+name: Backup & restore
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  round-trip:
+    name: Sauvegarde et restauration
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        # La même image que la pile auto-hébergée. Sur un `postgres:16` nu, la
+        # restauration échoue sur `CREATE EXTENSION vector` — c'est justement le
+        # scénario que `restore_db.sh` refuse d'entamer, et qu'on ne veut pas
+        # découvrir chez quelqu'un.
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: maisonnee
+          POSTGRES_PASSWORD: test_password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Une base de maintenance : le script crée puis supprime les deux siennes.
+      DATABASE_URL: postgres://maisonnee:test_password@localhost:5432/postgres
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/base.txt
+
+      # `base.txt` suffit : le script migre et dumpe, il ne lance aucun test.
+      - name: Install dependencies
+        run: pip install -r requirements/base.txt
+
+      # Le client Postgres du runner doit être au moins aussi récent que le
+      # serveur : `pg_dump` refuse de dumper une base plus récente que lui, et
+      # l'image du service suit les mises à jour de pgvector sans nous prévenir.
+      - name: Install the PostgreSQL 16 client
+        run: |
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+          curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+            | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/postgresql.gpg
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client-16
+          pg_dump --version
+
+      - name: Round-trip
+        run: ./scripts/test-backup-restore.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,18 @@ jobs:
       - name: Test de résilience nginx
         run: ./nginx/test-resilience.sh
 
+  # Une sauvegarde jamais restaurée n'est pas une sauvegarde. Ce job rejoue le
+  # cycle complet sur une base neuve à chaque PR — voir `backup-restore.yml`.
+  #
+  # ⚠️ Il ne garde PAS le deploy, et c'est délibéré : la prod de l'auteur a ses
+  # sauvegardes et son historique, et bloquer une correction urgente sur un round
+  # trip de restauration ferait payer à la production un risque qui pèse sur les
+  # instances tierces. C'est `release.yml` qui le rend bloquant, là où il compte
+  # — au moment où on distribue une image que des inconnus installeront.
+  backup:
+    name: Backup & restore
+    uses: ./.github/workflows/backup-restore.yml
+
   deploy:
     name: Deploy to Production
     # ⚠️ SEUL job de ce dépôt PUBIC à tourner sur le runner self-hosted, donc sur

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,17 @@ permissions:
   contents: read
 
 jobs:
+  # Bloquant ici, informatif dans `ci.yml`. Une image qu'on publie sera installée
+  # par des gens qui y mettront leurs relevés bancaires : leur distribuer une
+  # version dont on n'a pas vérifié qu'elle sait se restaurer, c'est leur
+  # promettre une sauvegarde qui n'en est pas une.
+  backup:
+    name: Backup & restore
+    uses: ./.github/workflows/backup-restore.yml
+
   image:
     name: Publier l'image multi-architecture
+    needs: [backup]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1216,6 +1216,45 @@ globale ».
 
 ---
 
+## Sauvegarde — ce qui n'a jamais été restauré n'est pas sauvegardé
+
+Doc : `docs/self-hosting/backup-restore.md`. Régression :
+`scripts/test-backup-restore.sh`, rejoué par la CI sur chaque PR et **bloquant
+pour une release** (`.github/workflows/backup-restore.yml`, appelé par `ci.yml`
+et `release.yml` — un seul texte pour les deux).
+
+- **Une sauvegarde, c'est une paire.** La base **et** le répertoire d'état, qui
+  porte la clé secrète et les fichiers téléversés. Les deux archives partagent un
+  **horodatage**, et c'est fonctionnel : `restore_db.sh` retrouve la seconde
+  toute seule et **refuse** une restauration à moitié tant qu'on n'a pas dit
+  `--db-only`. Une base restaurée seule donne une instance dont chaque document
+  est référencé et absent, et dont la clé neuve déconnecte tout le monde — le
+  tout avec un tableau de bord parfaitement normal.
+- **`ON_ERROR_STOP=1` sur tout `psql` de restauration.** Sans lui, `psql`
+  continue après une erreur et **sort 0** : une restauration qui se déclare
+  réussie en ayant perdu une table est le seul résultat pire qu'un échec.
+- **Un refus vaut mieux qu'une restauration partielle.** Le dump contient
+  `CREATE EXTENSION vector` ; sur un Postgres nu il échoue à mi-parcours en
+  laissant une base à moitié peuplée. `restore_db.sh` vérifie
+  `pg_available_extensions` **avant** de vider quoi que ce soit.
+- **Le test tient le format, pas la prose.** Une procédure de restauration écrite
+  est vraie le jour où on l'écrit ; ce qui la périme (une extension ajoutée au
+  schéma, une option de `pg_dump` qui change de sens) ne se voit dans aucune
+  relecture. Le test migre un schéma **réel**, sauvegarde, restaure sur une base
+  **neuve**, et vérifie le compte de tables, une ligne témoin, l'extension, la
+  clé et un fichier. La ligne témoin vit dans une table à elle : l'accrocher à un
+  modèle métier ferait rougir le test le jour où ce modèle gagne une colonne
+  obligatoire — un rouge qui n'apprendrait rien sur la restauration.
+- **Non bloquant pour le deploy, bloquant pour la release.** La prod de l'auteur
+  a ses sauvegardes ; bloquer un correctif urgent sur un round-trip ferait payer
+  à la production un risque qui pèse sur les instances tierces. Au moment de
+  distribuer une image, l'arbitrage s'inverse.
+- **Une migration destructive se livre en deux fois** — règle interne du deploy,
+  devenue **promesse publique** dès qu'on distribue une image : plus personne ne
+  contrôle quand les instances mettent à jour.
+
+---
+
 ## Capacités optionnelles — une absence se déclare, elle ne se devine pas
 
 Un foyer qui s'auto-héberge n'a ni clé Anthropic, ni Voyage, ni SMTP, ni VAPID,

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,4 +1,21 @@
-# Déploiement — House App
+# Déploiement — **le déploiement de l'auteur**
+
+> ⚠️ **Ce document décrit une installation précise : celle de l'auteur.** Un VPS,
+> Traefik en frontal, un runner de CI auto-hébergé, une image construite sur la
+> machine, un domaine. Il suppose tout ça et ne s'en excuse pas.
+>
+> **Pour héberger Maisonnée chez vous, ce n'est pas ici** : c'est
+> [`docs/self-hosting/`](docs/self-hosting/README.md) — trois lignes, une image
+> déjà construite, aucune de ces hypothèses.
+>
+> Ce fichier reste pour deux raisons. Il porte les **invariants du §3.4**
+> (résolveur nginx, montage par répertoire, `--no-deps`, migrer avant de
+> basculer), que la pile auto-hébergée hérite ou contourne explicitement — et
+> `nginx/test-resilience.sh` les tient. Et il documente le seul déploiement qui
+> tourne réellement en production aujourd'hui.
+>
+> Les deux piles partagent le même code et la même image ; elles ne partagent
+> pas leurs hypothèses, et c'est pour ça qu'elles restent deux fichiers.
 
 ## Table des matières
 
@@ -497,6 +514,17 @@ docker compose -f docker-compose.prod.yml down -v
 ---
 
 ## 8. Backups
+
+> ⚠️ **Ce qui suit sauvegarde la base, et rien d'autre.** Les fichiers téléversés
+> et la clé secrète vivent à côté ; une base restaurée seule donne une instance
+> dont chaque document est référencé et absent. Le raisonnement complet et la
+> **procédure de restauration** — la partie que personne ne répète avant d'en
+> avoir besoin — sont dans
+> [`docs/self-hosting/backup-restore.md`](docs/self-hosting/backup-restore.md).
+>
+> `backup_db.sh` prend désormais `--state-dir`, et `restore_db.sh` est son
+> pendant en lecture. Le cycle complet est rejoué par la CI
+> (`scripts/test-backup-restore.sh`) sur une base neuve à chaque PR.
 
 ### Backup de la base de données
 

--- a/backup_db.sh
+++ b/backup_db.sh
@@ -1,24 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create a compressed PostgreSQL backup from DATABASE_URL and rotate old backups.
+# Sauvegarde d'une instance : la base, et — si on le lui demande — le répertoire
+# d'état qui porte la clé secrète et les fichiers du foyer.
+#
+# ⚠️ Une sauvegarde de la base seule n'est pas une sauvegarde de l'instance.
+# Restaurer la base sans les fichiers laisse chaque document référencé et absent,
+# et perdre la clé secrète déconnecte tout le monde, base intacte. Les deux
+# archives portent donc le **même horodatage** : c'est ce qui permet à
+# `restore_db.sh` de retrouver la seconde toute seule, et de refuser en silence
+# une restauration à moitié.
+#
 # Usage: ./backup_db.sh [--keep N] [--out-dir DIR] [--db-url URL] [--prefix NAME]
+#                       [--state-dir DIR]
 
 KEEP="10"
 OUT_DIR="backups"
 PREFIX="house_db"
 DB_URL="${DATABASE_URL:-}"
+STATE_DIR=""
 
 usage() {
   cat <<'EOF'
 Usage: ./backup_db.sh [options]
 
 Options:
-  --keep N         Keep only the N most recent backup files (default: 10)
+  --keep N         Keep only the N most recent backups (default: 10)
   --out-dir DIR    Backup output directory (default: backups)
   --db-url URL     PostgreSQL connection URL (default: DATABASE_URL env var or .env.local)
   --prefix NAME    Backup filename prefix (default: house_db)
+  --state-dir DIR  Also archive this directory (secret key + uploaded files).
+                   Self-hosted stacks: the `maisonnee-state` volume, mounted at /data.
   -h, --help       Show this help
+
+Produces:
+  DIR/PREFIX_<timestamp>.sql.gz          the database
+  DIR/PREFIX_<timestamp>_state.tar.gz    the state directory, when --state-dir is given
+
+Both share one timestamp on purpose — restore_db.sh pairs them by it.
 EOF
 }
 
@@ -38,6 +57,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --prefix)
       PREFIX="$2"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="$2"
       shift 2
       ;;
     -h|--help)
@@ -71,6 +94,11 @@ if ! command -v pg_dump >/dev/null 2>&1; then
   exit 1
 fi
 
+if [[ -n "$STATE_DIR" ]] && [[ ! -d "$STATE_DIR" ]]; then
+  echo "Error: --state-dir '$STATE_DIR' is not a directory" >&2
+  exit 1
+fi
+
 mkdir -p "$OUT_DIR"
 ts="$(date +%Y%m%d_%H%M%S)"
 out_file="$OUT_DIR/${PREFIX}_${ts}.sql.gz"
@@ -80,7 +108,18 @@ pg_dump "$DB_URL" --no-owner --no-privileges | gzip > "$out_file"
 # Verify archive integrity right away.
 gzip -t "$out_file"
 
-# Rotate old backups (newest first, delete files after KEEP).
+state_file=""
+if [[ -n "$STATE_DIR" ]]; then
+  state_file="$OUT_DIR/${PREFIX}_${ts}_state.tar.gz"
+  # `-C` so paths inside the archive are relative: restoring must not depend on
+  # where the directory happened to live on the machine that made the backup.
+  tar -czf "$state_file" -C "$STATE_DIR" .
+  gzip -t "$state_file"
+fi
+
+# Rotate old backups (newest first, delete files after KEEP). The state archive
+# of a rotated-out backup goes with it — keeping an orphan state archive next to
+# no database is how a backup directory starts lying about what it can restore.
 if [[ "$KEEP" -ge 0 ]]; then
   files=()
   while IFS= read -r line; do
@@ -91,6 +130,7 @@ if [[ "$KEEP" -ge 0 ]]; then
     i="$KEEP"
     while [[ "$i" -lt "${#files[@]}" ]]; do
       rm -f "${files[$i]}"
+      rm -f "${files[$i]%.sql.gz}_state.tar.gz"
       i=$((i + 1))
     done
   fi
@@ -98,3 +138,10 @@ fi
 
 echo "Backup created: $out_file"
 shasum -a 256 "$out_file"
+if [[ -n "$state_file" ]]; then
+  echo "State archived:  $state_file"
+  shasum -a 256 "$state_file"
+else
+  echo "Note: no --state-dir given — this backup restores the database only," >&2
+  echo "      not the uploaded files nor the instance secret key." >&2
+fi

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -19,7 +19,8 @@ enough to be worth the detour — this repository documents *why* far more than
 | **`docs/parcours/`** | One set of documents per body of work ("parcours"): a product document (what problem, for whom, what is deliberately excluded) and a technical backlog split into independently shippable lots. | What is planned, what is out of scope on purpose, and where the current work sits. |
 | **`docs/MODULES/`** | Status of each Django app: what to fix, what to build, what to improve. | Where to start on a given module. |
 | **`docs/journal/`** | Dated notes from working sessions — decisions as they were made, including the ones that were later reversed. | Archaeology: why a given choice was made on a given day. |
-| **`DEPLOYMENT.md`** (root) | The maintainer's own VPS deployment, including a networking primer. | The only deployment guide that exists today. A self-hosting guide in English (`docs/self-hosting/`) is being written; until then, this is it — and it is written for one specific server, so read it as an example rather than as instructions. |
+| **`docs/self-hosting/`** | **In English.** The operator's manual: install, optional keys, backup **and restore**, upgrades, releases, troubleshooting. | Start here if you want to run Maisonnée. It assumes Docker and nothing else. |
+| **`DEPLOYMENT.md`** (root) | The maintainer's own VPS deployment, including a networking primer. | Not an install guide — it assumes one specific server, Traefik, and a self-hosted CI runner. Worth reading for the deploy invariants it documents (why the proxy doesn't fall with the app, why migrations run before traffic switches). |
 | **Commit messages & issues** | French, conventional commits (`type(scope): description`). | The changelog is generated from them. |
 
 ## What is already in English

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,9 +46,10 @@ Parcours 01→06 livrés. Voir `JOURNAL_PRODUIT.md` pour le détail.
   auto-hébergeable (AGPL-3.0, `docker compose up`, foyers pilotes)
 - `./fiches/AUTO_HEBERGEMENT.md` — le cours : d'un déploiement à un produit
   installable (modèle de menace, capacités optionnelles, licence, sauvegarde)
-- `./self-hosting/` — *(à créer, lot 5)* installation, sauvegarde/restauration,
-  mises à jour et dépannage pour une machine quelconque. `../DEPLOYMENT.md` reste
-  le déploiement de l'auteur.
+- `./self-hosting/` — **en anglais**, le manuel de l'exploitant : installation,
+  clés optionnelles, sauvegarde **et restauration**, mises à jour, releases,
+  dépannage. `../DEPLOYMENT.md` reste le déploiement de l'auteur et le dit
+  désormais dès sa première ligne.
 
 ## RFC et notes thématiques
 

--- a/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_28_BACKLOG_TECHNIQUE.md
@@ -21,7 +21,7 @@ Issue ombrelle : **#485**
 | 2 | `docker compose up` — première installation en une commande | ✅ Livré | #488 |
 | 3 | Dégradation propre sans service tiers (IA, SMTP, push, Telegram) | ✅ Livré | #489 |
 | 4 | LICENSE AGPL-3.0 + gouvernance (CONTRIBUTING, SECURITY, DCO, templates) | ✅ Livré (PR #496) | #490 |
-| 5 | Exploitation par un tiers : sauvegarde, restauration testée, mises à jour, releases | ⬜ À faire | #491 |
+| 5 | Exploitation par un tiers : sauvegarde, restauration testée, mises à jour, releases | 🔄 Partiel — doc, scripts et CI livrés ; **reste le premier tag** | #491 |
 | 6 | Façade Maisonnée : README bilingue, captures, GIF, identité | ⬜ À faire | #492 |
 | 7 | Recette pilote (5-10 foyers) puis annonce et mesure de la rétention | ⬜ À faire | #493 |
 | 8 | Identité visuelle : logo, palette de marque, icônes, aperçu social | ⬜ À faire | #494 |
@@ -567,6 +567,36 @@ une sauvegarde.
 > `ghcr` naît **privé**, même sur un dépôt public : sans un passage manuel en
 > public, le `docker compose up` d'un inconnu échoue sur `denied` — ce qui
 > ressemble à un bug et n'en est pas un.
+
+> **Partiellement livré — tout sauf le tag.**
+>
+> **Livré** : `docs/self-hosting/` (README, install, backup-restore, upgrade,
+> releases, troubleshooting — en anglais, sans OVH ni domaine ni chemin
+> personnel) ; `backup_db.sh --state-dir` ; `restore_db.sh` ;
+> `scripts/test-backup-restore.sh` **exécuté pour de vrai** (89 tables, ligne
+> témoin, extension `vector`, clé secrète et fichier téléversé restaurés sur une
+> base neuve) ; workflow réutilisable `backup-restore.yml` appelé par `ci.yml`
+> (informatif) **et** `release.yml` (bloquant, `image` en `needs`) ;
+> `DEPLOYMENT.md` annonce en première ligne qu'il décrit le déploiement de
+> l'auteur et renvoie vers `docs/self-hosting/`.
+>
+> **Reste, et ce sont deux décisions, pas du code** : supprimer `v1.0.0` et
+> poser `v0.1.0` (critère 3), puis basculer le paquet `ghcr` en public. Le
+> premier tag prouve ou casse le build arm64 — critère 4 du lot 2, en attente
+> depuis le lot 2.
+>
+> **Trois écarts au plan.** ① `backup_db.sh` **n'archive pas** `media/` en
+> propre : il archive le **répertoire d'état**, qui porte les fichiers *et* la
+> clé secrète. Le volume `maisonnee-state` les réunit exprès (lot 2) — ce qu'une
+> sauvegarde doit prendre en plus de la base est ainsi un nom à retenir, pas deux
+> à oublier. ② Le job de CI est un **workflow réutilisable**, pas un job copié
+> dans `ci.yml` et `release.yml` : deux copies auraient divergé au premier
+> changement de format de dump, c'est-à-dire exactement ce que ce job existe pour
+> attraper. ③ La doc donne des commandes **`docker compose` autonomes** plutôt
+> que d'exiger un clone du dépôt : un auto-hébergeur a téléchargé un fichier, pas
+> une arborescence. Les scripts restent l'implémentation testée de la même
+> procédure, pour l'auteur et pour la CI ; la convention d'horodatage est
+> commune aux deux chemins.
 
 **Critères**
 

--- a/docs/self-hosting/README.md
+++ b/docs/self-hosting/README.md
@@ -1,0 +1,55 @@
+# Self-hosting Maisonnée
+
+Maisonnée is a household app you run yourself: documents, money, tasks, projects,
+zones and equipment, for one family, on one machine you control. No account, no
+telemetry, no hosted tier.
+
+These pages are the operator's manual. They assume Docker and nothing else.
+
+| Page | What it answers |
+|---|---|
+| [install.md](install.md) | Getting it running, and putting it behind a domain if you want one |
+| [ai-providers.md](ai-providers.md) | The optional keys — assistant, semantic search, email, push, Telegram — what each costs and what the app does without it |
+| [backup-restore.md](backup-restore.md) | Backing up, and — the part that matters — **restoring** |
+| [upgrade.md](upgrade.md) | Updating, and the compatibility promise that comes with it |
+| [releases.md](releases.md) | What a version number means here, and how to pin one |
+| [troubleshooting.md](troubleshooting.md) | It doesn't start / it's slow / I can't log in |
+
+## Start here
+
+```bash
+curl -O https://raw.githubusercontent.com/jammindev/house/main/docker-compose.yml
+docker compose up
+```
+
+Then open <http://localhost:8000>. The first account's credentials are printed in
+the output, in a box. Nothing to edit, no key to sign up for.
+
+To look around a filled-in household before typing anything of your own:
+
+```bash
+docker compose --profile demo up
+```
+
+## The two things to know before you trust it with your data
+
+**Two volumes, and you need both.** `postgres-data` holds the database;
+`maisonnee-state` holds the instance secret key *and* every file anyone
+uploaded. Backing up only the first gives you a restore where every document is
+referenced and missing, and where everyone is logged out. [backup-restore.md](backup-restore.md)
+treats them as one thing on purpose.
+
+**A destructive change ships in two steps.** Once other people run this, we no
+longer control when they update — so a column is never dropped and renamed in the
+same version. See the compatibility section of [upgrade.md](upgrade.md).
+
+## Where the rest of the documentation is
+
+The project's internal documentation is in French, and it is where the reasoning
+lives — every rule tied to a bug that actually happened. [`docs/README.en.md`](../README.en.md)
+is an English index of it: what each folder holds and why it might be worth
+reading.
+
+`DEPLOYMENT.md` at the repository root is **the author's own deployment** — one
+VPS, Traefik, a self-hosted CI runner. It is kept because it documents invariants
+this stack inherits, not because you should follow it.

--- a/docs/self-hosting/backup-restore.md
+++ b/docs/self-hosting/backup-restore.md
@@ -1,0 +1,160 @@
+# Backup and restore
+
+A backup you have never restored is not a backup — it is a file you have hopes
+about. This page is written in that order on purpose: restoring first, because
+that is the part nobody rehearses.
+
+## What has to be saved
+
+Two volumes, and you need **both**:
+
+| Volume | Holds | If you lose it |
+|---|---|---|
+| `postgres-data` | The database | Everything |
+| `maisonnee-state` | The instance secret key **and** every uploaded file | Every document is referenced and missing, and everyone is logged out — with the database perfectly intact |
+
+That second row is the one that catches people. A database-only backup restores
+an instance that looks fine on the dashboard and is hollow the moment anyone
+opens a document.
+
+So a backup here is **a pair of files sharing one timestamp**:
+
+```
+maisonnee_20260803_020000.sql.gz          the database
+maisonnee_20260803_020000_state.tar.gz    the secret key + the files
+```
+
+The shared timestamp is not cosmetic: it is what lets a restore find the second
+file on its own, and refuse to half-restore when it is missing.
+
+## Backing up
+
+Find your volume names first — Compose prefixes them with the directory name:
+
+```bash
+docker volume ls | grep maisonnee
+# e.g. maisonnee_maisonnee-state
+```
+
+Then, from the directory holding your `docker-compose.yml`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+STAMP="$(date +%Y%m%d_%H%M%S)"
+OUT="$HOME/maisonnee-backups"
+STATE_VOLUME="maisonnee_maisonnee-state"   # from `docker volume ls`
+mkdir -p "$OUT"
+
+# 1. The database
+docker compose exec -T db \
+  pg_dump -U maisonnee maisonnee --no-owner --no-privileges \
+  | gzip > "$OUT/maisonnee_${STAMP}.sql.gz"
+
+# 2. The secret key and the files, same timestamp
+docker run --rm \
+  -v "${STATE_VOLUME}:/data:ro" \
+  -v "$OUT:/backup" \
+  alpine tar -czf "/backup/maisonnee_${STAMP}_state.tar.gz" -C /data .
+
+gzip -t "$OUT/maisonnee_${STAMP}.sql.gz"
+gzip -t "$OUT/maisonnee_${STAMP}_state.tar.gz"
+echo "Backup: $OUT/maisonnee_${STAMP}.*"
+```
+
+You can run this while the app is up: `pg_dump` takes a consistent snapshot, and
+the files only ever get added to.
+
+Put it in `cron` and **copy the result off the machine**. A backup that lives on
+the disk it protects covers you against a mistake, not against the disk.
+
+```
+0 2 * * * /home/you/maisonnee-backup.sh >> /home/you/backup.log 2>&1
+```
+
+## Restoring
+
+> Stop the application first. Restoring into a database something is writing to
+> gives you a result nobody can characterise.
+
+```bash
+docker compose stop web scheduler scheduler-briefings
+
+STAMP=20260803_020000
+OUT="$HOME/maisonnee-backups"
+STATE_VOLUME="maisonnee_maisonnee-state"
+
+# 1. Replace the schema, then load the dump.
+#    ON_ERROR_STOP matters: without it psql keeps going after a failure and
+#    exits 0 — a restore that reports success having lost a table is the only
+#    outcome worse than a failure.
+docker compose exec -T db psql -U maisonnee -d maisonnee -v ON_ERROR_STOP=1 \
+  -c 'DROP SCHEMA IF EXISTS public CASCADE;' -c 'CREATE SCHEMA public;'
+
+gunzip -c "$OUT/maisonnee_${STAMP}.sql.gz" \
+  | docker compose exec -T db psql -U maisonnee -d maisonnee -v ON_ERROR_STOP=1 -q
+
+# 2. Replace the state volume — emptied first, so files from the instance you
+#    are replacing cannot survive alongside the ones you are restoring.
+docker run --rm \
+  -v "${STATE_VOLUME}:/data" \
+  -v "$OUT:/backup:ro" \
+  alpine sh -c 'rm -rf /data/* /data/..?* /data/.[!.]* 2>/dev/null; \
+                tar -xzf /backup/maisonnee_'"${STAMP}"'_state.tar.gz -C /data'
+
+docker compose up -d
+```
+
+Then — and this is the actual test — **log in and open a document**. A restore
+that has not been looked at is a restore that has not happened.
+
+### Restoring onto a different machine
+
+Same commands. Two things to get right:
+
+- **Use the same database image**, `pgvector/pgvector:pg16`. The dump contains
+  `CREATE EXTENSION vector`; a bare `postgres:16` fails on that line, halfway
+  through, leaving a partial database.
+- **Restore the state volume too.** A new machine generates a fresh secret key
+  if the volume is empty, which logs everybody out — and the documents simply
+  aren't there.
+
+### Restoring the database only
+
+Sometimes that is genuinely what you want (you are recovering a bad import and
+the files never changed). Do it knowingly: skip step 2, and expect uploaded
+documents to be whatever the current volume holds.
+
+## The scripts in the repository
+
+If you have `psql` on the host — the author's deployment does, and CI does —
+`backup_db.sh` and `restore_db.sh` at the repository root are the same procedure
+with the sharp edges filed off:
+
+```bash
+./backup_db.sh  --db-url "$DATABASE_URL" --out-dir backups --state-dir /var/lib/maisonnee
+./restore_db.sh --from backups/house_db_20260803_020000.sql.gz --state-dir /var/lib/maisonnee
+```
+
+`restore_db.sh` refuses three things, each of which has a reason:
+
+1. **It refuses to run without confirmation.** You retype the database name, or
+   pass `--yes`. A `--force` you type by reflex protects nobody.
+2. **It refuses to silently restore the database alone.** No matching
+   `*_state.tar.gz`? Say `--db-only` and mean it.
+3. **It refuses to start when the `vector` extension is unavailable** on the
+   target, rather than failing halfway and leaving a partial database.
+
+## How we know the format still round-trips
+
+`scripts/test-backup-restore.sh` runs on every pull request and blocks every
+release: it migrates a real schema, backs it up, restores it into a **fresh**
+database, and asserts the table count, a marker row, the `vector` extension, the
+secret key and an uploaded file all survived.
+
+That test exists because a written restore procedure is true on the day it is
+written. What makes it stop being true — an extension added to the schema, a
+`pg_dump` option that changes meaning, a `psql` that exits 0 after failing —
+never shows up in a re-reading. On the day it matters, you don't discover those
+things: you suffer them.

--- a/docs/self-hosting/install.md
+++ b/docs/self-hosting/install.md
@@ -1,0 +1,132 @@
+# Install
+
+## Requirements
+
+Docker with the Compose plugin (`docker compose version` should print v2 or
+later). Roughly 2 GB of RAM and 5 GB of disk to start. `amd64` and `arm64` are
+both published, so a Raspberry Pi 4/5, an N100 box, or a Synology all work.
+
+Nothing else. No Python, no Node, no `git clone`.
+
+## Three lines
+
+```bash
+curl -O https://raw.githubusercontent.com/jammindev/house/main/docker-compose.yml
+docker compose up
+open http://localhost:8000
+```
+
+The first start pulls the image, creates the database, applies the schema, and
+creates the first account — whose email and password are printed in a box in the
+output. **Copy the password**: it is generated once and never shown again.
+
+Run it in the background once you're satisfied it starts:
+
+```bash
+docker compose up -d
+```
+
+## What is running
+
+| Service | Role |
+|---|---|
+| `db` | PostgreSQL 16 with the `vector` extension. Not published outside the compose network. |
+| `init` | Runs once per start: waits for the database, migrates, creates the first account, exits. `web` waits for it to succeed. |
+| `web` | The application, on port 8000. Serves its own static files and its own protected media — there is no Nginx in this stack. |
+| `scheduler`, `scheduler-briefings` | Proactive reminders and briefings. Idle until someone schedules something. |
+
+Two named volumes hold everything that matters: `postgres-data` and
+`maisonnee-state`. See [backup-restore.md](backup-restore.md) before you have
+anything worth losing.
+
+## Optional settings
+
+All have a working default. Put them in a `.env` file next to
+`docker-compose.yml`:
+
+| Variable | Default | What it does |
+|---|---|---|
+| `MAISONNEE_PORT` | `8000` | Port published on the host |
+| `MAISONNEE_PUBLIC_URL` | — | The public address, if the instance has one. See below. |
+| `MAISONNEE_ADMIN_EMAIL` | `admin@maisonnee.local` | First account's login |
+| `MAISONNEE_ADMIN_PASSWORD` | generated | First account's password |
+| `MAISONNEE_HOUSEHOLD_NAME` | — | Name of the household created on first start |
+| `MAISONNEE_IMAGE` | `ghcr.io/jammindev/maisonnee:latest` | Pin a version — see [releases.md](releases.md) |
+| `POSTGRES_PASSWORD` | `maisonnee` | Database password. Set it **before** the first start. |
+| `GUNICORN_WORKERS` | `2` | Raise it on a machine that isn't a Pi |
+
+The optional third-party keys — assistant, semantic search, email, push,
+Telegram — live in the same file and have their own page:
+[ai-providers.md](ai-providers.md).
+
+## Putting it on the network
+
+The stack serves **plain HTTP** on the published port, deliberately. TLS
+terminates in whatever reverse proxy you already run.
+
+### On your LAN only
+
+Nothing to do. Reach it at `http://<machine>:8000`. Leave `MAISONNEE_PUBLIC_URL`
+unset: the host list stays permissive, because a machine on a LAN is reached by
+IP, by `.local` name, and by VPN name, and none of those are known in advance.
+
+A VPN (Tailscale, WireGuard) is the cheapest way to reach your household from
+outside without exposing anything.
+
+### Behind a domain
+
+Set `MAISONNEE_PUBLIC_URL` **and** point a reverse proxy at the published port.
+
+```bash
+# .env
+MAISONNEE_PUBLIC_URL=https://maison.example.org
+```
+
+Declaring it does three things at once: cookies become `Secure`, HSTS switches
+on, and the allowed-host list narrows to that single name. **The host list closes
+at the exact moment the exposure widens** — which is the point, because nobody
+remembers to tighten it afterwards.
+
+Caddy, which gets you a certificate with no further configuration:
+
+```
+maison.example.org {
+    reverse_proxy localhost:8000
+}
+```
+
+Traefik, nginx or any other proxy work the same way. Two requirements:
+
+- **Forward `X-Forwarded-Proto`.** Without it Django believes the request came in
+  over plain HTTP. The stack deliberately does *not* redirect to HTTPS itself —
+  your proxy already does, and a second redirect on a proxy that drops that header
+  is an infinite loop. It is the classic self-hosting trap and it only shows up on
+  the machine that hosts.
+- **Don't buffer** if you use the assistant: its answers stream.
+
+### Exposing it at all
+
+Think about it before you do. This app holds bank statements and insurance
+contracts. A VPN is not much less convenient than a public domain and removes
+the whole question. If you do expose it, set `MAISONNEE_PUBLIC_URL`, keep the
+image updated, and read [backup-restore.md](backup-restore.md) first rather than
+after.
+
+## Adding the rest of the household
+
+Settings → *Households* → invite. This produces a **link you copy** — Maisonnée
+sends no email unless you configured SMTP, and you do not need SMTP for this.
+Whoever opens the link picks a password and lands in the household, with no
+prior account. The link is valid for a week and can be revoked.
+
+## Checking it is alive
+
+```bash
+curl -f http://localhost:8000/health/     # 200, no database query
+docker compose ps                          # every service Up, db healthy
+docker compose logs -f web
+```
+
+`/health/` is a proof of life, not of health: it deliberately touches no
+database, so a database hiccup doesn't make the container report sick while it is
+merely waiting.

--- a/docs/self-hosting/releases.md
+++ b/docs/self-hosting/releases.md
@@ -1,0 +1,58 @@
+# Releases
+
+## Versioning
+
+Semantic versioning, with the meaning that matters to someone running this:
+
+| Part | Changes when |
+|---|---|
+| `MAJOR` | Something you have to act on — a manual step, a dropped setting, a database major bump |
+| `MINOR` | Features, and additive migrations. `pull && up -d`. |
+| `PATCH` | Fixes only |
+
+**The project is `0.x`, and that is a statement, not a placeholder.** It has run
+one real household for a year; it has not yet run yours. `0.x` says the shape of
+things can still move between minors, and that the release notes are worth
+reading rather than skimming.
+
+## What a tag produces
+
+Pushing a `v*` tag runs `.github/workflows/release.yml`, which:
+
+1. runs the backup-and-restore round trip — **blocking**: a version people will
+   install must be one we have seen restore itself;
+2. builds `linux/amd64` **and** `linux/arm64` (a Pi or a NAS is half the
+   self-hosting audience, and an amd64-only image answers them `exec format
+   error`, which teaches nobody anything);
+3. pushes to `ghcr.io/jammindev/maisonnee` as `X.Y.Z`, `X.Y` and — unless it is a
+   pre-release — `latest`;
+4. starts the image once and runs `manage.py check --deploy` on it. An image
+   nobody started is not a published image, it is a published hope.
+
+## Pinning a version
+
+`latest` is the default and follows every release. To decide for yourself when to
+move:
+
+```bash
+# .env
+MAISONNEE_IMAGE=ghcr.io/jammindev/maisonnee:0.1.0
+```
+
+`0.1` (no patch) tracks fixes within a minor without ever changing features —
+usually the setting you want on a machine you don't want to think about.
+
+## Release notes
+
+Each tag carries notes derived from the commit history: what changed, and
+whether the release contains a migration. Commits follow
+`type(scope): description`, and only `feat`, `fix` and `perf` reach the notes —
+refactors and chores stay internal.
+
+## If `docker compose up` says `denied`
+
+The GitHub package is public, but a **newly created** `ghcr.io` package is
+private by default even on a public repository, and the first pull by a stranger
+then fails with `denied` — which looks like a bug and is not one. If you hit
+that, the package visibility has not been flipped yet; open an issue and it will
+be. Nothing on your side needs changing.

--- a/docs/self-hosting/troubleshooting.md
+++ b/docs/self-hosting/troubleshooting.md
@@ -1,0 +1,100 @@
+# Troubleshooting
+
+Start here, always:
+
+```bash
+docker compose ps            # which service is not Up
+docker compose logs --tail=100 init
+docker compose logs --tail=100 web
+```
+
+`init` runs first and `web` waits for it. If something is wrong at startup, the
+answer is almost always in `init`'s log, not `web`'s.
+
+---
+
+## It doesn't start
+
+**`web` never comes up, `init` exited non-zero.** Read `docker compose logs
+init`. The usual causes: the database volume belongs to a different PostgreSQL
+major (see [upgrade.md](upgrade.md)), the disk is full, or a migration failed. A
+failed migration leaves `web` on the previous container rather than serving a
+half-migrated schema — that is the intended behaviour, not a deadlock.
+
+**`db` restarts in a loop.** Almost always a `POSTGRES_PASSWORD` changed *after*
+the first start. The password is baked into the data directory at
+initialisation; changing the variable afterwards doesn't change it, it just stops
+matching. Either put the original value back, or start over from a backup.
+
+**`exec format error`.** You are on `arm64` and pulled an `amd64`-only image.
+Every release publishes both — `docker compose pull` again, and check
+`MAISONNEE_IMAGE` isn't pinned to something old.
+
+**`denied` when pulling.** See the last section of [releases.md](releases.md);
+it is a package-visibility issue, not something on your side.
+
+---
+
+## I can't reach it
+
+**Nothing on `:8000`.** `docker compose ps` — is `web` actually up? Is
+`MAISONNEE_PORT` set to something else? Is another process already on that port?
+
+**`DisallowedHost` / 400 with a domain.** You set `MAISONNEE_PUBLIC_URL` and are
+reaching the instance by a *different* name (its IP, its `.local` name). That is
+the setting working as intended: declaring a public URL narrows the allowed hosts
+to that name. Reach it by that name, or unset the variable if the instance is not
+actually public.
+
+**Redirect loop over HTTPS.** Your reverse proxy is not forwarding
+`X-Forwarded-Proto`. Django then believes the request arrived in plain HTTP.
+Fix the proxy — the stack deliberately does not redirect to HTTPS itself
+precisely so that this loop cannot be created from two sides at once.
+
+**Logged out at every restart.** The `maisonnee-state` volume is not persisting,
+so a new secret key is generated each time. Check `docker volume ls` and that
+you have not been running with `--rm` or recreating the volume.
+
+---
+
+## It behaves oddly
+
+**The assistant answers "not configured".** It is not broken; the instance has
+no provider key. Settings → *What this instance can do* lists every optional
+capability and links to [ai-providers.md](ai-providers.md).
+
+**Search finds nothing by meaning.** Same thing: semantic search is off unless
+both a key and `AGENT_HYBRID_RETRIEVAL_ENABLED` are set — and the flag should
+only go on after `backfill_embeddings` has run. A half-filled index searches,
+finds nothing, and never says it only looked at part of your household.
+
+**A document 404s.** The `maisonnee-state` volume and the database disagree:
+usually a database restored without its matching state archive. That is the
+failure [backup-restore.md](backup-restore.md) exists to prevent, and the way out
+is to restore the matching `*_state.tar.gz`.
+
+**Invitations go nowhere.** Expected without SMTP. Invitations produce a **link
+you copy** — the email is a convenience, never the only route in.
+
+---
+
+## It's slow
+
+**On a Pi.** `GUNICORN_WORKERS=2` is the default because this stack has to fit on
+one. On anything larger, raise it. Uploading and OCR are the heavy paths.
+
+**Everything is slow at once.** Check disk space (`df -h`) and the database
+volume's size. PostgreSQL degrades sharply on a full disk.
+
+---
+
+## Getting the logs someone can read
+
+```bash
+docker compose logs --tail=200 > maisonnee-logs.txt
+docker compose ps >> maisonnee-logs.txt
+docker version >> maisonnee-logs.txt
+```
+
+Then open an issue. **Read the file before attaching it** — logs from your own
+instance can contain household names, email addresses and file names.

--- a/docs/self-hosting/upgrade.md
+++ b/docs/self-hosting/upgrade.md
@@ -1,0 +1,75 @@
+# Upgrading
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+That is the whole procedure. The `init` service runs before `web` is allowed to
+start: it applies the migrations, and `web` waits for it to succeed. The server
+therefore never serves on a schema it has not migrated — which is what makes
+`pull && up -d` safe rather than hopeful.
+
+**Back up first.** Not because upgrades usually go wrong, but because a
+migration is the one operation that changes your data in a way you cannot undo by
+restarting. See [backup-restore.md](backup-restore.md).
+
+## Watching it land
+
+```bash
+docker compose logs -f init     # migrations
+docker compose ps               # web healthy again
+curl -f http://localhost:8000/health/
+```
+
+If `init` fails, `web` does not start — you keep the previous container until you
+fix it. That is deliberate: a half-migrated instance that serves is worse than an
+instance that doesn't.
+
+## The compatibility promise
+
+Once other people run this, nobody controls when they update. So:
+
+> **A destructive schema change ships in two releases.** A column is never
+> dropped or renamed in the same version that stops using it.
+
+Release *n* stops writing the column and starts writing its replacement; release
+*n+1*, at the earliest, drops it. The reason is mechanical: during any upgrade
+there is a moment where the **old code sees the new schema**, and a column that
+vanished in that moment is a 500 for everyone who was mid-request.
+
+This started as an internal deploy rule — the author's production migrates on a
+disposable container before switching traffic. Distributing an image promotes it
+to a public promise, because the window is no longer minutes on one machine but
+however long strangers take to run `pull`.
+
+Practically, for you: **skipping versions is safe**, and going backwards is not.
+
+## Rolling back
+
+The image is versioned; your data is not. Pin the previous image and restart:
+
+```bash
+# .env
+MAISONNEE_IMAGE=ghcr.io/jammindev/maisonnee:0.1.0
+```
+
+```bash
+docker compose up -d
+```
+
+This works when the release you are leaving applied no migration, or an additive
+one. It does **not** work across a destructive one: the older code will meet
+tables it does not know how to read. In that case, restore the backup you took
+before upgrading — which is the second reason to take it.
+
+Release notes say when a version contains a migration. See [releases.md](releases.md).
+
+## Upgrading PostgreSQL
+
+The database image is pinned to `pgvector/pgvector:pg16`. Don't bump the major
+version by editing the tag: PostgreSQL does not read a newer major's data
+directory, and the container will refuse to start on a directory it considers
+foreign. The migration path is dump → new volume → restore, and it is exactly the
+procedure in [backup-restore.md](backup-restore.md). When a major bump becomes
+worthwhile it will come with its own release note.

--- a/restore_db.sh
+++ b/restore_db.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Le pendant en lecture de `backup_db.sh`.
+#
+# Une sauvegarde jamais restaurée n'est pas une sauvegarde : c'est un fichier
+# dont on espère quelque chose. Ce script existe pour que la restauration soit un
+# geste **connu**, exécuté au moins une fois avant le jour où elle compte — et
+# `scripts/test-backup-restore.sh` le rejoue à chaque CI, sur une base neuve.
+#
+# Trois refus délibérés :
+#
+#   1. **Il écrase.** Restaurer, c'est remplacer le contenu de la base cible —
+#      d'où la confirmation explicite : il faut retaper le nom de la base, ou
+#      passer --yes. Un `--force` qu'on tape par habitude ne protège personne.
+#   2. **Il ne restaure pas la base sans les fichiers en silence.** Si l'archive
+#      d'état jumelle manque, il le dit et demande --db-only. Une base restaurée
+#      seule référence des documents qui n'existent plus.
+#   3. **Il refuse une extension absente.** Le dump contient `CREATE EXTENSION
+#      vector` : restaurer sur un Postgres nu échoue à mi-parcours, en laissant
+#      une base à moitié peuplée. Mieux vaut ne pas commencer.
+#
+# Usage: ./restore_db.sh --from FILE.sql.gz [--db-url URL] [--state-dir DIR]
+#                        [--db-only] [--yes]
+
+DUMP=""
+DB_URL="${DATABASE_URL:-}"
+STATE_DIR=""
+DB_ONLY="0"
+ASSUME_YES="0"
+
+usage() {
+  cat <<'EOF'
+Usage: ./restore_db.sh --from FILE.sql.gz [options]
+
+Options:
+  --from FILE      The .sql.gz produced by backup_db.sh (required)
+  --db-url URL     Target PostgreSQL URL (default: DATABASE_URL env var or .env.local)
+  --state-dir DIR  Where to restore the state archive (secret key + uploaded files).
+                   Its contents are replaced.
+  --db-only        Restore the database only, and say so. Required when the
+                   matching *_state.tar.gz is missing.
+  --yes            Skip the interactive confirmation (for scripts and CI)
+  -h, --help       Show this help
+
+This REPLACES the target database. Stop the application first.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --from)
+      DUMP="$2"
+      shift 2
+      ;;
+    --db-url)
+      DB_URL="$2"
+      shift 2
+      ;;
+    --state-dir)
+      STATE_DIR="$2"
+      shift 2
+      ;;
+    --db-only)
+      DB_ONLY="1"
+      shift
+      ;;
+    --yes)
+      ASSUME_YES="1"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$DUMP" ]]; then
+  echo "Error: --from is required" >&2
+  usage
+  exit 1
+fi
+
+if [[ ! -f "$DUMP" ]]; then
+  echo "Error: no such file: $DUMP" >&2
+  exit 1
+fi
+
+if [[ -z "$DB_URL" ]] && [[ -f ".env.local" ]]; then
+  DB_URL="$(grep '^DATABASE_URL=' .env.local | head -n 1 | cut -d'=' -f2-)"
+fi
+
+if [[ -z "$DB_URL" ]]; then
+  echo "Error: DATABASE_URL is not set and .env.local has no DATABASE_URL" >&2
+  exit 1
+fi
+
+for binary in psql gunzip; do
+  if ! command -v "$binary" >/dev/null 2>&1; then
+    echo "Error: $binary is not installed or not in PATH" >&2
+    exit 1
+  fi
+done
+
+# L'archive est-elle lisible ? Le savoir maintenant, pas au milieu du `psql`.
+gzip -t "$DUMP"
+
+# ── L'archive d'état jumelle ────────────────────────────────────────────────
+#
+# Appariée par l'horodatage, pas par une convention que l'utilisateur devrait
+# retenir : `..._20260803_101500.sql.gz` ↔ `..._20260803_101500_state.tar.gz`.
+STATE_ARCHIVE="${DUMP%.sql.gz}_state.tar.gz"
+if [[ ! -f "$STATE_ARCHIVE" ]]; then
+  STATE_ARCHIVE=""
+fi
+
+if [[ -z "$STATE_ARCHIVE" ]] && [[ "$DB_ONLY" != "1" ]]; then
+  cat >&2 <<EOF
+Error: no state archive next to this dump.
+
+  expected: ${DUMP%.sql.gz}_state.tar.gz
+
+The database alone restores an instance whose documents are all referenced and
+missing, and whose secret key is new (everyone is logged out). If that is really
+what you want, say so: re-run with --db-only.
+EOF
+  exit 1
+fi
+
+if [[ -n "$STATE_ARCHIVE" ]] && [[ "$DB_ONLY" != "1" ]] && [[ -z "$STATE_DIR" ]]; then
+  echo "Error: this backup carries a state archive — pass --state-dir DIR to restore it," >&2
+  echo "       or --db-only to deliberately leave it out." >&2
+  exit 1
+fi
+
+# Le nom de la base, pour la confirmation et pour le message final. Extrait de
+# l'URL sans en afficher le mot de passe.
+DB_NAME="$(printf '%s' "$DB_URL" | sed -E 's#^[^/]*//[^/]*/##; s#\?.*$##')"
+DB_HOST="$(printf '%s' "$DB_URL" | sed -E 's#^[^/]*//##; s#^[^@]*@##; s#/.*$##')"
+
+echo "About to REPLACE the contents of:"
+echo "  database   $DB_NAME  (on $DB_HOST)"
+if [[ -n "$STATE_ARCHIVE" ]] && [[ "$DB_ONLY" != "1" ]]; then
+  echo "  state dir  $STATE_DIR  (replaced by $STATE_ARCHIVE)"
+else
+  echo "  state dir  — not restored (--db-only)"
+fi
+echo
+
+if [[ "$ASSUME_YES" != "1" ]]; then
+  # Retaper le nom : la seule confirmation qu'on ne donne pas par réflexe.
+  printf "Type the database name to confirm: "
+  read -r typed
+  if [[ "$typed" != "$DB_NAME" ]]; then
+    echo "Aborted — '$typed' does not match '$DB_NAME'." >&2
+    exit 1
+  fi
+fi
+
+# ── L'extension attendue est-elle disponible ? ──────────────────────────────
+#
+# Le dump porte `CREATE EXTENSION vector`. Sur un Postgres nu, `psql` échoue à
+# cette ligne — après avoir déjà créé la moitié des tables. On regarde avant.
+if gunzip -c "$DUMP" | grep -qi 'CREATE EXTENSION.*vector'; then
+  available="$(psql "$DB_URL" -tAc \
+    "SELECT 1 FROM pg_available_extensions WHERE name = 'vector'" 2>/dev/null || true)"
+  if [[ "$available" != "1" ]]; then
+    cat >&2 <<'EOF'
+Error: this dump needs the `vector` extension, and the target server does not
+have it available.
+
+Use the same image the stack ships with (pgvector/pgvector:pg16). Restoring
+onto a bare postgres image fails halfway through and leaves a partial database.
+EOF
+    exit 1
+  fi
+fi
+
+echo "→ Dropping the current schema"
+# `DROP SCHEMA public CASCADE` plutôt que `DROP DATABASE` : le script n'a pas
+# besoin des droits de création de base, et la cible peut être gérée par un
+# hébergeur qui ne les donne pas. Le dump recrée tout ce qu'il contient.
+psql "$DB_URL" -v ON_ERROR_STOP=1 -q -c 'DROP SCHEMA IF EXISTS public CASCADE;' \
+                                   -c 'CREATE SCHEMA public;'
+
+echo "→ Restoring the database"
+# ON_ERROR_STOP : sans lui, `psql` continue après une erreur et sort 0. Une
+# restauration qui se déclare réussie en ayant perdu une table est le seul
+# résultat pire qu'un échec.
+gunzip -c "$DUMP" | psql "$DB_URL" -v ON_ERROR_STOP=1 -q
+
+if [[ -n "$STATE_ARCHIVE" ]] && [[ "$DB_ONLY" != "1" ]]; then
+  echo "→ Restoring the state directory"
+  gzip -t "$STATE_ARCHIVE"
+  mkdir -p "$STATE_DIR"
+  # Vider d'abord : un `tar -x` par-dessus laisserait cohabiter les fichiers de
+  # l'instance précédente avec ceux de la sauvegarde, et personne ne saurait
+  # dire lesquels font foi.
+  find "$STATE_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
+  tar -xzf "$STATE_ARCHIVE" -C "$STATE_DIR"
+fi
+
+echo
+echo "✓ Restored into $DB_NAME"
+if [[ "$DB_ONLY" == "1" ]]; then
+  echo "  Database only — uploaded files and secret key were NOT restored."
+fi
+echo "  Start the application and check that you can log in and open a document."

--- a/scripts/test-backup-restore.sh
+++ b/scripts/test-backup-restore.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sauvegarde → base neuve → restauration → assertions. Exécuté, pas décrit.
+#
+# Pourquoi un test et pas un paragraphe de doc : une procédure de restauration
+# écrite est vraie le jour où on l'écrit. Ce qui la périme ne se voit jamais dans
+# une relecture — une extension ajoutée au schéma (`vector`, `unaccent`), une
+# option de `pg_dump` qui change de sens, un `psql` qui sort 0 après avoir
+# échoué. Le jour où ça compte, on ne découvre pas ces choses-là : on les subit.
+#
+# Ce que le test tient exactement :
+#
+#   1. Le dump d'un schéma **réel** (migrations Django complètes, extensions
+#      comprises) se recharge sur une base vide sans erreur.
+#   2. Les données sont là après coup — pas seulement les tables.
+#   3. Le répertoire d'état (clé secrète + fichiers) fait l'aller-retour.
+#   4. `restore_db.sh` **refuse** une restauration à moitié : sans archive
+#      d'état, il faut le dire.
+#
+# Usage : DATABASE_URL=postgres://user:pass@host:5432/postgres ./scripts/test-backup-restore.sh
+#
+# `DATABASE_URL` désigne une base sur laquelle on a le droit de faire
+# `CREATE DATABASE` : le script crée les deux siennes, et les supprime en
+# sortant, quelle qu'en soit la raison.
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "Error: DATABASE_URL must point at a PostgreSQL server (any database)." >&2
+  exit 1
+fi
+
+for binary in psql pg_dump python; do
+  if ! command -v "$binary" >/dev/null 2>&1; then
+    echo "Error: $binary is not installed or not in PATH" >&2
+    exit 1
+  fi
+done
+
+STAMP="$(date +%s)_$$"
+SOURCE_DB="maisonnee_backup_src_${STAMP}"
+TARGET_DB="maisonnee_backup_dst_${STAMP}"
+WORK_DIR="$(mktemp -d)"
+
+# L'URL du serveur, sans la base : on y raccroche les noms qu'on crée.
+SERVER_URL="${DATABASE_URL%/*}"
+ADMIN_URL="$DATABASE_URL"
+SOURCE_URL="$SERVER_URL/$SOURCE_DB"
+TARGET_URL="$SERVER_URL/$TARGET_DB"
+
+cleanup() {
+  # Toujours, même sur échec : un test qui laisse deux bases derrière lui rend
+  # le suivant rouge pour une raison qui n'a rien à voir.
+  psql "$ADMIN_URL" -q -c "DROP DATABASE IF EXISTS $SOURCE_DB WITH (FORCE)" >/dev/null 2>&1 || true
+  psql "$ADMIN_URL" -q -c "DROP DATABASE IF EXISTS $TARGET_DB WITH (FORCE)" >/dev/null 2>&1 || true
+  rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "✗ $1" >&2
+  exit 1
+}
+
+echo "→ 1/6  Deux bases neuves"
+psql "$ADMIN_URL" -v ON_ERROR_STOP=1 -q -c "CREATE DATABASE $SOURCE_DB"
+psql "$ADMIN_URL" -v ON_ERROR_STOP=1 -q -c "CREATE DATABASE $TARGET_DB"
+
+echo "→ 2/6  Le schéma réel, migrations comprises"
+# Le schéma réel et pas une table jouet : c'est lui qui porte les extensions et
+# les types dont la restauration peut échouer.
+DATABASE_URL="$SOURCE_URL" \
+DJANGO_SETTINGS_MODULE=config.settings.test \
+  python manage.py migrate --noinput >/dev/null
+
+# Une ligne qu'on saura reconnaître de l'autre côté, dans une table à nous.
+#
+# Pas une table métier, exprès : ce test regarde le **format du dump**, et
+# l'accrocher aux colonnes de `households` le ferait rougir le jour où ce modèle
+# gagne un champ obligatoire — un rouge qui n'apprendrait rien sur la
+# restauration. Le schéma réel reste intégralement sauvegardé et restauré ; c'est
+# le compte de tables et l'extension, plus bas, qui l'attestent.
+MARKER="maisonnée-restauration-${STAMP}"
+psql "$SOURCE_URL" -v ON_ERROR_STOP=1 -q \
+  -c "CREATE TABLE restore_marker (id serial PRIMARY KEY, label text NOT NULL)" \
+  -c "INSERT INTO restore_marker (label) VALUES ('$MARKER')"
+
+SOURCE_TABLES="$(psql "$SOURCE_URL" -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'")"
+[[ "$SOURCE_TABLES" -gt 20 ]] || fail "schéma source suspect : $SOURCE_TABLES tables"
+
+echo "→ 3/6  Un répertoire d'état, comme celui du volume"
+STATE_SRC="$WORK_DIR/state"
+mkdir -p "$STATE_SRC/media/documents"
+echo "clé-secrète-$STAMP" > "$STATE_SRC/secret_key"
+echo "contenu-document-$STAMP" > "$STATE_SRC/media/documents/facture.txt"
+
+echo "→ 4/6  Sauvegarde"
+./backup_db.sh \
+  --db-url "$SOURCE_URL" \
+  --out-dir "$WORK_DIR/backups" \
+  --prefix maisonnee \
+  --state-dir "$STATE_SRC" >/dev/null
+
+DUMP="$(ls -1t "$WORK_DIR"/backups/maisonnee_*.sql.gz | head -n 1)"
+[[ -f "$DUMP" ]] || fail "aucun dump produit"
+[[ -f "${DUMP%.sql.gz}_state.tar.gz" ]] || fail "aucune archive d'état produite"
+
+echo "→ 5/6  Le refus d'une restauration à moitié"
+# Le garde-fou compte autant que la restauration : on le vérifie sur une copie
+# du dump privée de son archive jumelle.
+LONELY="$WORK_DIR/lonely_20200101_000000.sql.gz"
+cp "$DUMP" "$LONELY"
+if ./restore_db.sh --from "$LONELY" --db-url "$TARGET_URL" --yes >/dev/null 2>&1; then
+  fail "restore_db.sh a restauré sans archive d'état, sans --db-only"
+fi
+
+echo "→ 6/6  Restauration sur la base neuve"
+STATE_DST="$WORK_DIR/state-restored"
+./restore_db.sh \
+  --from "$DUMP" \
+  --db-url "$TARGET_URL" \
+  --state-dir "$STATE_DST" \
+  --yes >/dev/null
+
+# ── Assertions ───────────────────────────────────────────────────────────────
+
+TARGET_TABLES="$(psql "$TARGET_URL" -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public'")"
+[[ "$TARGET_TABLES" == "$SOURCE_TABLES" ]] \
+  || fail "tables restaurées : $TARGET_TABLES, attendu $SOURCE_TABLES"
+
+RESTORED="$(psql "$TARGET_URL" -tAc \
+  "SELECT count(*) FROM restore_marker WHERE label = '$MARKER'")"
+[[ "$RESTORED" == "1" ]] || fail "la ligne témoin n'a pas survécu au voyage"
+
+# L'extension du schéma est bien là — c'est elle qui casse une restauration sur
+# une image Postgres nue, et le mode d'échec est silencieux jusqu'à la première
+# recherche sémantique.
+HAS_VECTOR="$(psql "$TARGET_URL" -tAc \
+  "SELECT count(*) FROM pg_extension WHERE extname = 'vector'")"
+[[ "$HAS_VECTOR" == "1" ]] || fail "l'extension vector n'a pas été restaurée"
+
+[[ "$(cat "$STATE_DST/secret_key")" == "clé-secrète-$STAMP" ]] \
+  || fail "la clé secrète n'a pas été restaurée"
+[[ "$(cat "$STATE_DST/media/documents/facture.txt")" == "contenu-document-$STAMP" ]] \
+  || fail "les fichiers du foyer n'ont pas été restaurés"
+
+echo
+echo "✓ Sauvegarde et restauration vérifiées de bout en bout"
+echo "  $SOURCE_TABLES tables, la ligne témoin, l'extension vector, la clé et les fichiers."


### PR DESCRIPTION
Avance le **lot 5 du parcours 28** (#491). Suite des lots 0, 1, 2, 3 et 4.

> **Partiel, et volontairement.** Tout est livré **sauf le tag** : supprimer `v1.0.0` et poser `v0.1.0` sont des gestes publics, ils t'appartiennent. L'issue #491 reste donc ouverte.

## Le problème

`DEPLOYMENT.md` est excellent et écrit pour *un* VPS, avec son auteur dans la boucle. Il n'y avait aucune procédure de **restauration** — et une sauvegarde jamais restaurée n'est pas une sauvegarde.

## Une sauvegarde est une paire

La base **et** le répertoire d'état, qui porte la clé secrète et les fichiers téléversés. Les deux archives partagent un horodatage, et c'est fonctionnel : `restore_db.sh` retrouve la seconde tout seul et **refuse** une restauration à moitié tant qu'on n'a pas dit `--db-only`.

Une base restaurée seule donne une instance dont chaque document est référencé et absent, et dont la clé neuve déconnecte tout le monde — le tout avec un tableau de bord parfaitement normal. C'est le mode d'échec que ce lot existe pour rendre impossible par distraction.

## `restore_db.sh` refuse trois choses

1. **De s'exécuter sans confirmation** — retaper le nom de la base, ou `--yes`. Un `--force` qu'on tape par habitude ne protège personne.
2. **De restaurer la base seule en silence** — sans archive jumelle, il faut dire `--db-only`.
3. **De commencer quand `vector` manque sur la cible** — sinon `psql` échoue à mi-parcours et laisse une base à moitié peuplée.

`ON_ERROR_STOP=1` sur tous les `psql` : sans lui, `psql` continue après une erreur et **sort 0**. Une restauration qui se déclare réussie en ayant perdu une table est le seul résultat pire qu'un échec.

## Le test, exécuté

`scripts/test-backup-restore.sh` : schéma **réel** migré → sauvegarde → base **neuve** → restauration → assertions sur le compte de tables, une ligne témoin, l'extension `vector`, la clé secrète et un fichier téléversé. Lancé en local avant d'ouvrir cette PR : **89 tables, tout survit**.

Workflow **réutilisable** (`backup-restore.yml`), appelé par les deux :

- `ci.yml` — **informatif**, ne garde pas le deploy : bloquer un correctif urgent ferait payer à la production un risque qui pèse sur les instances tierces ;
- `release.yml` — **bloquant** (`image` en `needs`) : une image que des inconnus installeront doit savoir se restaurer.

Un job copié dans les deux fichiers aurait divergé au premier changement de format de dump — exactement ce que ce job existe pour attraper.

## La doc

`docs/self-hosting/` en anglais : README, install, backup-restore, upgrade, releases, troubleshooting. Ni OVH, ni domaine, ni chemin personnel (critère 4). Les commandes sont **autonomes en `docker compose`** : un auto-hébergeur a téléchargé un fichier, pas une arborescence. Les scripts restent l'implémentation testée de la même procédure, et la convention d'horodatage est commune aux deux chemins.

`DEPLOYMENT.md` annonce dès sa première ligne qu'il décrit **le déploiement de l'auteur** et renvoie vers `docs/self-hosting/` ; les deux hubs de doc (`docs/README.md`, `docs/README.en.md`) sont à jour.

## Compatibilité

`backup_db.sh` sans `--state-dir` fait exactement ce qu'il faisait — ta crontab n'a rien à changer — et le dit sur stderr.

## Ce qui reste

Deux décisions, pas du code :

1. **`v1.0.0`** — posé à la main en 2025 sur un commit de config TypeScript sans rapport, lu par rien. Préférence écrite au cadrage : le supprimer et partir de `v0.1.0`.
2. **Le paquet `ghcr` naît privé**, même sur un dépôt public — un clic, sans lequel le `docker compose up` d'un inconnu échoue sur `denied`.

Le premier tag lèvera aussi le **critère 4 du lot 2** : `release.yml` n'a jamais été exécuté, puisqu'il ne se déclenche que sur un tag.
