### PR TITLE
feat(documents): une photo dit pourquoi elle existe, et ce qui n'est pas trié se voit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1341,6 +1341,37 @@ qu'il dit, pas comment il le diffuse. Doc : `docs/MODULES/notifications.md`.
 
 ---
 
+## Photos — l'intention est un axe, et le vide n'en est pas une valeur
+
+`Document.purpose` (`technical` / `observation` / `memory`, vide = **non trié**) dit
+**pourquoi une photo existe**. Les trois autres axes disent autre chose : la zone dit
+*où*, le lien d'entité *sur quoi*, `DocumentLink.phase` *quand dans le chantier* — et
+c'est l'intention qui sépare une preuve d'un souvenir. Doc :
+`docs/MODULES/documents.md` § « L'intention d'une photo ».
+
+- **⚠️ Le vide n'est pas `memory`.** Vide = personne n'a regardé (un écart, qui alimente
+  la file « À trier ») ; `memory` = quelqu'un a choisi. Troisième occurrence du même
+  principe après `inflow_nature == ""` ≠ `"other"` et le parcours 26 : *toute entité est
+  soit résolue, soit flaggée ; rien ne reste dans un entre-deux silencieux.* Un compteur
+  qui les confond annonce « rien à trier » en montrant une photothèque en vrac.
+- **Un marqueur s'écrit** : `?purpose=untriaged`. Un `?purpose=` vide répond **400**,
+  comme une valeur inconnue — jamais « toutes ». Un paramètre oublié ne doit pas pouvoir
+  se lire comme un filtre.
+- **Aucun backfill sur un axe que l'utilisateur pose.** Marquer `technical` ce qui est
+  lié à un projet écrirait une devinette indistinguable d'un choix (`banking.rules` :
+  « des valeurs de départ, jamais des vérités »).
+- **Un lot n'écrase jamais un choix déjà posé** : `set_purpose` renvoie `{updated,
+  skipped}`, et écraser demande `overwrite: true`. Le tri se fait **par grappe de
+  session** calculée à la lecture — une file qui demande trente gestes pour trente
+  photos ne se vide jamais, et une file qu'on ne vide jamais cesse d'être lue.
+- **Une file bornée le dit** : `total` (ce qui reste) **et** ce que l'écran montre,
+  jamais l'un pour l'autre.
+
+Régressions : `documents/tests/test_photo_purpose.py::TestEmptyIsNotAMemory` et
+`::TestABatchNeverOverwritesAChoice`, `test_triage_clusters.py`.
+
+---
+
 ## Page Tutoriel (`ui/src/features/tutorials/`)
 
 Page `/app/tutorial` (sidebar, section Compte) : checklist « Bien démarrer » +

--- a/apps/documents/migrations/0009_document_purpose.py
+++ b/apps/documents/migrations/0009_document_purpose.py
@@ -1,0 +1,36 @@
+"""L'intention d'une photo — le champ seul, **sans backfill**.
+
+Il serait tentant de marquer `technical` toute photo déjà liée à un projet ou à un
+équipement. Ce serait écrire une devinette en base, où elle deviendrait
+indistinguable d'un choix de l'utilisateur — exactement ce que `banking.rules`
+interdit (« des valeurs de départ, jamais des vérités »).
+
+Tout l'existant part donc dans « À trier ». La contrepartie est assumée, et rendue
+tenable par le tri **par grappe** : quelques centaines de photos représentent
+quelques dizaines de gestes, pas quelques centaines.
+"""
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('documents', '0008_document_taken_at'),
+        ('households', '0012_invitation_shareable_link'),
+        ('interactions', '0030_backfill_suppliers'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='document',
+            name='purpose',
+            field=models.CharField(blank=True, choices=[('technical', 'Technical'), ('observation', 'Observation'), ('memory', 'Memory')], default='', help_text='Why this photo exists. Empty = nobody sorted it yet, never a fallback.', max_length=16),
+        ),
+        migrations.AddIndex(
+            model_name='document',
+            index=models.Index(fields=['household', 'purpose'], name='idx_docs_hh_purpose'),
+        ),
+    ]

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -74,7 +74,36 @@ class Document(HouseholdScopedModel):
         db_index=True,
         help_text="Capture date read from EXIF. NULL = unknown, never a fallback.",
     )
-    
+
+    class Purpose(models.TextChoices):
+        TECHNICAL = 'technical', _('Technical')
+        OBSERVATION = 'observation', _('Observation')
+        MEMORY = 'memory', _('Memory')
+
+    # L'intention d'une photo : **pourquoi elle existe**.
+    #
+    # La zone dit *où*, le lien d'entité dit *sur quoi*, `DocumentLink.phase` dit
+    # *quand dans le chantier* — aucun des trois ne sépare la preuve du souvenir.
+    # C'est le même mouvement que « le budget est la catégorie » côté argent : un
+    # projet et une zone disent sur quoi porte un euro, jamais de quelle nature il est.
+    #
+    # ⚠️ **Le vide n'est pas `memory`.** Vide signifie que personne n'a encore trié —
+    # c'est un écart, et il alimente la file « À trier » ; `memory` signifie qu'on a
+    # choisi. Les confondre rendrait la file aveugle et l'utilisateur croirait avoir
+    # rangé. Même règle que `inflow_nature == ""` qui n'est pas `"other"`, et même
+    # principe qu'au parcours 26 : toute entité est soit résolue, soit flaggée.
+    #
+    # Conséquence : rien n'écrit jamais de repli ici, et aucun backfill n'a été fait à
+    # l'introduction du champ — marquer `technical` ce qui est lié à un projet aurait
+    # écrit une devinette en base, indistinguable d'un choix de l'utilisateur.
+    purpose = models.CharField(
+        max_length=16,
+        choices=Purpose.choices,
+        blank=True,
+        default='',
+        help_text="Why this photo exists. Empty = nobody sorted it yet, never a fallback.",
+    )
+
     # Privacy
     is_private = models.BooleanField(
         default=False,
@@ -101,6 +130,9 @@ class Document(HouseholdScopedModel):
         ordering = ['-created_at']
         indexes = [
             models.Index(fields=['household', 'type'], name='idx_docs_hh_type'),
+            # Le compteur « À trier » est un `COUNT(*)` indexé, jamais une
+            # matérialisation en Python — même exigence que les badges du Contrôle.
+            models.Index(fields=['household', 'purpose'], name='idx_docs_hh_purpose'),
             models.Index(fields=['interaction'], name='idx_docs_interaction'),
             models.Index(fields=['created_by'], name='idx_docs_creator'),
         ]

--- a/apps/documents/queries.py
+++ b/apps/documents/queries.py
@@ -1,0 +1,120 @@
+"""Lectures de la galerie photo : ce qui reste à trier, et par quelles grappes.
+
+Un seul endroit calcule « non trié » et « une session », parce que deux écrans le
+lisent — la pastille de la galerie et le panneau de tri. Le marqueur et le compteur
+doivent sortir de la même fonction, sinon ils finissent par se contredire sur la même
+donnée (même règle que `banking.queries.allocation_state` face au Contrôle).
+"""
+
+from datetime import timedelta
+
+from django.db.models import Count
+
+from .models import Document
+
+#: Au-delà de ce silence entre deux prises de vue, on change de session.
+#:
+#: Deux heures est un réglage, pas une vérité : il sépare l'après-midi de bricolage du
+#: dîner du soir, et garde ensemble les trente photos d'une même balade.
+SESSION_GAP = timedelta(hours=2)
+
+#: Combien de photos on lit au plus pour bâtir les grappes d'un écran.
+#:
+#: `DocumentViewSet` n'est pas encore paginé (lot 1 du parcours 29) : sans cette borne
+#: le panneau de tri serait une **seconde** liste chargeant tout le foyer, et il
+#: arriverait sur une photothèque entière puisque rien n'a été backfillé.
+TRIAGE_WINDOW = 500
+
+#: Combien de grappes un écran de tri montre au plus.
+TRIAGE_CLUSTERS = 20
+
+#: Le marqueur qui désigne « personne n'a trié » dans un filtre et dans un compteur.
+#:
+#: Il porte un nom parce qu'il doit s'écrire : `?purpose=` vide serait indistinguable
+#: d'un paramètre oublié, et un paramètre oublié veut dire « toutes ».
+UNTRIAGED = 'untriaged'
+
+
+def untriaged(queryset):
+    """Les photos que personne n'a encore rangées.
+
+    ⚠️ `purpose=''` et `purpose='memory'` ne se confondent nulle part : le vide dit que
+    personne n'a regardé, `memory` dit qu'on a choisi. Filtrer sur « pas technique ni
+    observation » attraperait les deux et rendrait la file aveugle.
+
+    Restreint aux `type='photo'` : l'intention est propre aux photos, une facture n'a
+    pas à peupler la file.
+    """
+    return queryset.filter(type='photo', purpose='')
+
+
+def cluster_sessions(photos, *, gap=SESSION_GAP, limit=None, window_was_full=False):
+    """Regroupe des photos **déjà triées par date décroissante** en sessions.
+
+    Calculé à la lecture, sans aucune colonne de groupe : un regroupement stocké
+    devrait être recalculé à chaque correction de date de prise de vue, et la date
+    d'une photo se corrige.
+
+    La date qui sert est `effective_date` (`COALESCE(taken_at, created_at)`), pas la
+    date d'ajout : quinze photos envoyées d'un coup depuis la feuille de partage du
+    téléphone contiennent aussi bien la chaudière de mardi que l'anniversaire de
+    samedi. Les grouper par envoi reformerait exactement le mélange qu'on défait.
+
+    `window_was_full` dit que l'appelant a lu une fenêtre bornée et qu'il pourrait donc
+    y avoir d'autres photos juste après la dernière : la grappe de queue est alors
+    peut-être coupée, et on la laisse pour le prochain écran plutôt que d'en annoncer
+    un compte faux.
+    """
+    clusters = []
+    for photo in photos:
+        moment = _effective_date(photo)
+        if clusters and _within(clusters[-1]['oldest'], moment, gap):
+            clusters[-1]['photos'].append(photo)
+            clusters[-1]['oldest'] = moment
+        else:
+            # `newest` / `oldest` plutôt que début / fin : la liste arrive du plus
+            # récent au plus ancien, et deux bornes nommées par l'ordre de lecture se
+            # liraient à l'envers de ce que l'écran affiche.
+            clusters.append({'newest': moment, 'oldest': moment, 'photos': [photo]})
+
+    if window_was_full and len(clusters) > 1:
+        clusters.pop()
+
+    if limit is not None:
+        clusters = clusters[:limit]
+    return clusters
+
+
+def _effective_date(photo):
+    """Le pendant Python de l'annotation SQL — et le même repli, au même endroit."""
+    return getattr(photo, 'effective_date', None) or photo.taken_at or photo.created_at
+
+
+def _within(previous, current, gap):
+    """Vrai si deux prises de vue appartiennent au même créneau.
+
+    L'écart se prend en valeur absolue : l'appelant garantit l'ordre décroissant, mais
+    deux photos d'une même rafale peuvent porter la même seconde, et un ordre qui
+    s'inverse ne doit pas ouvrir une session par photo.
+    """
+    return abs((previous - current).total_seconds()) <= gap.total_seconds()
+
+
+def purpose_counts(queryset):
+    """Combien de photos par intention, dont le vide — en une requête, sans Python.
+
+    Le vide compte comme une valeur : c'est lui qui alimente « À trier », et un
+    compteur absent se lirait comme un zéro, c'est-à-dire comme « rien à signaler ».
+    """
+    rows = (
+        queryset.filter(type='photo')
+        .values('purpose')
+        .order_by('purpose')
+        .annotate(total=Count('id'))
+    )
+    counts = {value: 0 for value, _label in Document.Purpose.choices}
+    counts[UNTRIAGED] = 0
+    for row in rows:
+        key = row['purpose'] or UNTRIAGED
+        counts[key] = row['total']
+    return counts

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -217,21 +217,33 @@ class DocumentSerializer(serializers.ModelSerializer):
         return None
 
     def validate(self, attrs):
-        """Une intention ne se pose que sur une photo.
+        """Une intention ne se pose que sur une photo — **et n'y survit pas** au reclassement.
 
         Contrairement à `taken_at`, `purpose` est **saisi** : il est donc ouvert en
         écriture. Mais le champ est propre aux photos — accepter une intention sur une
         facture peuplerait la file « À trier » de choses qu'elle ne sait pas montrer,
         et personne ne verrait d'où elles viennent.
+
+        Les deux chemins ne se traitent pas pareil, et c'est délibéré :
+
+        - **poser** une intention sur autre chose qu'une photo est une erreur du client,
+          donc un 400 ;
+        - **reclasser** en facture une photo qui en portait une est un geste légitime :
+          on efface l'intention devenue sans objet plutôt que de bloquer. Sans ça, une
+          facture gardait `purpose='technical'` pour toujours — invisible partout
+          (`untriaged()` et `purpose_counts` filtrent `type='photo'`), donc jamais
+          corrigeable. C'est la règle du parcours 26 appliquée ici : reclasser un
+          remboursement en salaire efface son budget avec lui.
         """
         attrs = super().validate(attrs)
-        purpose = attrs.get('purpose')
-        if purpose:
-            doc_type = attrs.get('type') or getattr(self.instance, 'type', None)
-            if doc_type != 'photo':
+        doc_type = attrs.get('type') or getattr(self.instance, 'type', None)
+        purpose = attrs.get('purpose', getattr(self.instance, 'purpose', ''))
+        if purpose and doc_type != 'photo':
+            if 'purpose' in attrs:
                 raise serializers.ValidationError(
                     {'purpose': 'Only a photo can carry a purpose.'}
                 )
+            attrs['purpose'] = ''
         return attrs
 
 

--- a/apps/documents/serializers.py
+++ b/apps/documents/serializers.py
@@ -73,7 +73,7 @@ class DocumentSerializer(serializers.ModelSerializer):
             'file_url', 'thumbnail_url', 'medium_url',
             'qualification', 'linked_interactions',
             'legacy_interaction', 'legacy_interaction_subject',
-            'phase', 'taken_at', 'zone_links', 'entity_links',
+            'phase', 'taken_at', 'purpose', 'zone_links', 'entity_links',
         ]
         # `taken_at` est lu dans l'EXIF, jamais saisi : l'exposer en écriture
         # permettrait de le contredire par un PATCH, et le tri de la galerie
@@ -215,6 +215,24 @@ class DocumentSerializer(serializers.ModelSerializer):
             if str(link.object_id) == str(entity_id):
                 return link.phase or ''
         return None
+
+    def validate(self, attrs):
+        """Une intention ne se pose que sur une photo.
+
+        Contrairement à `taken_at`, `purpose` est **saisi** : il est donc ouvert en
+        écriture. Mais le champ est propre aux photos — accepter une intention sur une
+        facture peuplerait la file « À trier » de choses qu'elle ne sait pas montrer,
+        et personne ne verrait d'où elles viennent.
+        """
+        attrs = super().validate(attrs)
+        purpose = attrs.get('purpose')
+        if purpose:
+            doc_type = attrs.get('type') or getattr(self.instance, 'type', None)
+            if doc_type != 'photo':
+                raise serializers.ValidationError(
+                    {'purpose': 'Only a photo can carry a purpose.'}
+                )
+        return attrs
 
 
 class DocumentDetailSerializer(DocumentSerializer):

--- a/apps/documents/tests/test_photo_purpose.py
+++ b/apps/documents/tests/test_photo_purpose.py
@@ -280,6 +280,43 @@ class TestOnlyAPhotoCarriesAPurpose:
         photo.refresh_from_db()
         assert photo.purpose == "technical"
 
+    def test_reclassifying_a_photo_drops_the_purpose_it_carried(
+        self, client, household, owner
+    ):
+        """Reclasser est légitime — mais l'intention ne survit pas au reclassement.
+
+        Sans cet effacement, la facture gardait `purpose='technical'` pour toujours :
+        invisible partout (la file et les compteurs filtrent `type='photo'`), donc
+        jamais corrigeable. Un état qu'aucun écran ne montre est celui qu'on ne
+        rattrape jamais. Même règle que le budget d'un remboursement reclassé en
+        salaire.
+        """
+        photo = _photo(household, owner, "Chaudiere", purpose="technical")
+
+        response = client.patch(
+            f"{LIST_URL}{photo.id}/", {"type": "invoice"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        photo.refresh_from_db()
+        assert photo.type == "invoice"
+        assert photo.purpose == ""
+
+    def test_reclassifying_into_a_photo_keeps_the_purpose_asked_for(
+        self, client, household, owner
+    ):
+        invoice = _photo(household, owner, "Facture", doc_type="invoice")
+
+        response = client.patch(
+            f"{LIST_URL}{invoice.id}/",
+            {"type": "photo", "purpose": "technical"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        invoice.refresh_from_db()
+        assert invoice.purpose == "technical"
+
     def test_untriaged_ignores_documents_that_are_not_photos(
         self, client, household, owner
     ):

--- a/apps/documents/tests/test_photo_purpose.py
+++ b/apps/documents/tests/test_photo_purpose.py
@@ -1,0 +1,290 @@
+"""L'intention d'une photo — `Document.purpose`, son filtre et son lot.
+
+Une photo porte déjà trois axes : la zone dit *où*, le lien d'entité dit *sur quoi*,
+`DocumentLink.phase` dit *quand dans le chantier*. Aucun ne dit **pourquoi elle
+existe** — et c'est la question qui sépare une preuve technique d'un souvenir.
+
+Les deux invariants tenus ici, et qui ne se voient dans aucune relecture de diff :
+
+1. **le vide n'est pas `memory`** — vide dit que personne n'a regardé (un écart),
+   `memory` dit qu'on a choisi. Les confondre rend la file « À trier » aveugle et
+   l'utilisateur croit avoir rangé ;
+2. **un lot n'écrase jamais un choix déjà posé** — une grappe dont quelques photos
+   sont déjà rangées est le cas normal, pas l'exception.
+"""
+import pytest
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from documents.models import Document
+from households.models import Household, HouseholdMember
+
+LIST_URL = "/api/documents/documents/"
+SET_PURPOSE_URL = "/api/documents/documents/set_purpose/"
+COUNTS_URL = "/api/documents/documents/purpose_counts/"
+
+
+def _photo(household, user, name="Photo", purpose="", doc_type="photo") -> Document:
+    return Document.objects.create(
+        household=household,
+        created_by=user,
+        file_path=f"documents/{name.lower()}.jpg",
+        name=name,
+        mime_type="image/jpeg",
+        type=doc_type,
+        purpose=purpose,
+    )
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="purpose@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = Household.objects.create(name="Purpose House")
+    HouseholdMember.objects.create(
+        user=owner, household=hh, role=HouseholdMember.Role.OWNER
+    )
+    owner.active_household = hh
+    owner.save(update_fields=["active_household"])
+    return hh
+
+
+@pytest.fixture
+def client(owner, household):
+    api = APIClient()
+    api.force_authenticate(user=owner)
+    api.credentials(HTTP_X_HOUSEHOLD_ID=str(household.id))
+    return api
+
+
+def _names(response) -> set[str]:
+    payload = response.json()
+    rows = payload["results"] if isinstance(payload, dict) else payload
+    return {row["name"] for row in rows}
+
+
+@pytest.mark.django_db
+class TestEmptyIsNotAMemory:
+    """Le test de régression du parcours 29 : deux états, jamais un seul.
+
+    C'est la déclinaison photo de `inflow_nature == ""` qui n'est pas `"other"`. Le
+    défaut qu'il attrape est silencieux des deux côtés : une file qui se croit vide, et
+    un souvenir qu'on redemande de trier.
+    """
+
+    def test_an_untriaged_photo_is_not_returned_as_a_memory(
+        self, client, household, owner
+    ):
+        _photo(household, owner, name="Pas triee")
+        _photo(household, owner, name="Anniversaire", purpose="memory")
+
+        response = client.get(LIST_URL, {"purpose": "memory"})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _names(response) == {"Anniversaire"}
+
+    def test_a_memory_is_not_returned_as_untriaged(self, client, household, owner):
+        _photo(household, owner, name="Pas triee")
+        _photo(household, owner, name="Anniversaire", purpose="memory")
+
+        response = client.get(LIST_URL, {"purpose": "untriaged"})
+
+        assert _names(response) == {"Pas triee"}
+
+    def test_the_counter_tells_them_apart(self, client, household, owner):
+        _photo(household, owner, name="Chaudiere", purpose="technical")
+        _photo(household, owner, name="Anniversaire", purpose="memory")
+        _photo(household, owner, name="Pas triee")
+        _photo(household, owner, name="Pas triee non plus")
+
+        counts = client.get(COUNTS_URL).json()
+
+        assert counts["memory"] == 1
+        assert counts["technical"] == 1
+        assert counts["observation"] == 0
+        assert counts["untriaged"] == 2
+
+    def test_the_triage_queue_only_holds_what_nobody_sorted(
+        self, client, household, owner
+    ):
+        _photo(household, owner, name="Anniversaire", purpose="memory")
+        _photo(household, owner, name="Pas triee")
+
+        payload = client.get("/api/documents/documents/triage/").json()
+
+        assert payload["total"] == 1
+        assert [photo["name"] for cluster in payload["clusters"] for photo in cluster["photos"]] == [
+            "Pas triee"
+        ]
+
+    def test_an_empty_parameter_never_means_all(self, client, household, owner):
+        """`?purpose=` vide est refusé, jamais dégradé en « toutes ».
+
+        Dégrader ferait afficher la galerie entière sous une pastille « À trier », et
+        le compteur d'à côté dirait autre chose que la liste.
+        """
+        _photo(household, owner, name="Anniversaire", purpose="memory")
+
+        response = client.get(LIST_URL, {"purpose": ""})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_an_unknown_purpose_is_refused(self, client, household, owner):
+        response = client.get(LIST_URL, {"purpose": "souvenir"})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+
+@pytest.mark.django_db
+class TestABatchNeverOverwritesAChoice:
+    """Trier une grappe ne défait pas le travail déjà fait.
+
+    Même règle que l'éditeur de ventilation, qui ne détache jamais par effet de bord :
+    ce qu'on n'a pas regardé une par une ne se réécrit pas en silence.
+    """
+
+    def test_it_sorts_a_whole_cluster_in_one_call(self, client, household, owner):
+        photos = [_photo(household, owner, f"P{index}") for index in range(3)]
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [p.id for p in photos], "purpose": "memory"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"updated": 3, "skipped": 0}
+        for photo in photos:
+            photo.refresh_from_db()
+            assert photo.purpose == "memory"
+
+    def test_it_leaves_an_already_sorted_photo_alone_and_says_so(
+        self, client, household, owner
+    ):
+        already = _photo(household, owner, "Chaudiere", purpose="technical")
+        untouched = _photo(household, owner, "Gateau")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [already.id, untouched.id], "purpose": "memory"},
+            format="json",
+        )
+
+        assert response.json() == {"updated": 1, "skipped": 1}
+        already.refresh_from_db()
+        untouched.refresh_from_db()
+        assert already.purpose == "technical"
+        assert untouched.purpose == "memory"
+
+    def test_overwriting_is_possible_but_asked_for(self, client, household, owner):
+        already = _photo(household, owner, "Chaudiere", purpose="technical")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [already.id], "purpose": "memory", "overwrite": True},
+            format="json",
+        )
+
+        assert response.json() == {"updated": 1, "skipped": 0}
+        already.refresh_from_db()
+        assert already.purpose == "memory"
+
+    def test_reapplying_the_same_purpose_is_not_a_conflict(
+        self, client, household, owner
+    ):
+        """Un lot idempotent ne doit pas se dire à moitié appliqué."""
+        photo = _photo(household, owner, "Chaudiere", purpose="technical")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [photo.id], "purpose": "technical"},
+            format="json",
+        )
+
+        assert response.json() == {"updated": 1, "skipped": 0}
+
+    def test_an_empty_purpose_is_refused(self, client, household, owner):
+        """« Détrier » un lot serait une destruction de masse déguisée en raccourci."""
+        photo = _photo(household, owner, "Chaudiere", purpose="technical")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [photo.id], "purpose": ""},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        photo.refresh_from_db()
+        assert photo.purpose == "technical"
+
+    def test_a_photo_from_another_household_refuses_the_whole_batch(
+        self, client, household, owner
+    ):
+        mine = _photo(household, owner, "Chez moi")
+        stranger = UserFactory(email="stranger-purpose@example.com")
+        other_household = Household.objects.create(name="Ailleurs")
+        HouseholdMember.objects.create(
+            user=stranger, household=other_household, role=HouseholdMember.Role.OWNER
+        )
+        theirs = _photo(other_household, stranger, "Chez eux")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [mine.id, theirs.id], "purpose": "memory"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mine.refresh_from_db()
+        theirs.refresh_from_db()
+        assert mine.purpose == ""
+        assert theirs.purpose == ""
+
+
+@pytest.mark.django_db
+class TestOnlyAPhotoCarriesAPurpose:
+    """L'intention est propre aux photos — une facture n'a pas à peupler la file."""
+
+    def test_the_batch_refuses_a_non_photo(self, client, household, owner):
+        invoice = _photo(household, owner, "Facture", doc_type="invoice")
+
+        response = client.post(
+            SET_PURPOSE_URL,
+            {"document_ids": [invoice.id], "purpose": "technical"},
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_a_patch_refuses_a_non_photo(self, client, household, owner):
+        invoice = _photo(household, owner, "Facture", doc_type="invoice")
+
+        response = client.patch(
+            f"{LIST_URL}{invoice.id}/", {"purpose": "technical"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_a_patch_sorts_a_single_photo(self, client, household, owner):
+        photo = _photo(household, owner, "Chaudiere")
+
+        response = client.patch(
+            f"{LIST_URL}{photo.id}/", {"purpose": "technical"}, format="json"
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        photo.refresh_from_db()
+        assert photo.purpose == "technical"
+
+    def test_untriaged_ignores_documents_that_are_not_photos(
+        self, client, household, owner
+    ):
+        _photo(household, owner, "Facture", doc_type="invoice")
+
+        payload = client.get("/api/documents/documents/triage/").json()
+
+        assert payload["total"] == 0

--- a/apps/documents/tests/test_triage_clusters.py
+++ b/apps/documents/tests/test_triage_clusters.py
@@ -1,0 +1,208 @@
+"""Le tri se fait par grappe de session, jamais photo par photo.
+
+Trente photos rapportées d'un week-end forment **une** décision. Ce n'est pas un
+confort : une file qui demande trente gestes ne se vide jamais, et une file qu'on ne
+vide jamais cesse d'être lue au bout d'une semaine.
+
+La grappe se calcule sur `effective_date` (`COALESCE(taken_at, created_at)`), et non
+sur la date d'ajout : quinze photos envoyées d'un coup depuis la feuille de partage du
+téléphone contiennent aussi bien la chaudière de mardi que l'anniversaire de samedi.
+Les grouper par envoi reformerait exactement le mélange qu'on défait.
+"""
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+
+from accounts.tests.factories import UserFactory
+from documents.models import Document
+from documents.queries import SESSION_GAP, cluster_sessions
+from households.models import Household, HouseholdMember
+
+TRIAGE_URL = "/api/documents/documents/triage/"
+
+
+@pytest.fixture
+def owner(db):
+    return UserFactory(email="clusters@example.com")
+
+
+@pytest.fixture
+def household(db, owner):
+    hh = Household.objects.create(name="Clusters House")
+    HouseholdMember.objects.create(
+        user=owner, household=hh, role=HouseholdMember.Role.OWNER
+    )
+    owner.active_household = hh
+    owner.save(update_fields=["active_household"])
+    return hh
+
+
+@pytest.fixture
+def client(owner, household):
+    api = APIClient()
+    api.force_authenticate(user=owner)
+    api.credentials(HTTP_X_HOUSEHOLD_ID=str(household.id))
+    return api
+
+
+def _photo(household, user, name, taken_at=None) -> Document:
+    return Document.objects.create(
+        household=household,
+        created_by=user,
+        file_path=f"documents/{name.lower()}.jpg",
+        name=name,
+        mime_type="image/jpeg",
+        type="photo",
+        taken_at=taken_at,
+    )
+
+
+class _FakePhoto:
+    """Un porteur de date — `cluster_sessions` ne demande rien d'autre."""
+
+    def __init__(self, effective_date):
+        self.effective_date = effective_date
+        self.taken_at = effective_date
+        self.created_at = effective_date
+
+
+def _at(hours_ago):
+    return timezone.now() - timedelta(hours=hours_ago)
+
+
+class TestClusterSessions:
+    def test_photos_taken_close_together_form_one_cluster(self):
+        photos = [_FakePhoto(_at(hours)) for hours in (0, 0.5, 1)]
+
+        clusters = cluster_sessions(photos)
+
+        assert len(clusters) == 1
+        assert len(clusters[0]["photos"]) == 3
+
+    def test_a_silence_longer_than_the_gap_opens_a_new_session(self):
+        photos = [_FakePhoto(_at(hours)) for hours in (0, 1, 30, 31)]
+
+        clusters = cluster_sessions(photos)
+
+        assert [len(cluster["photos"]) for cluster in clusters] == [2, 2]
+
+    def test_the_gap_is_measured_between_neighbours_not_from_the_start(self):
+        """Une journée de photos toutes les heures reste **une** session.
+
+        Mesurer depuis la première photo découperait un après-midi continu en tranches
+        de deux heures, et rendrait la file plus longue que ce qu'elle range.
+        """
+        photos = [_FakePhoto(_at(hours)) for hours in range(0, 8)]
+
+        clusters = cluster_sessions(photos)
+
+        assert len(clusters) == 1
+
+    def test_a_burst_sharing_one_second_stays_one_session(self):
+        moment = timezone.now()
+        photos = [_FakePhoto(moment) for _ in range(5)]
+
+        assert len(cluster_sessions(photos)) == 1
+
+    def test_it_returns_at_most_the_asked_number_of_clusters(self):
+        photos = [_FakePhoto(_at(hours * 24)) for hours in range(10)]
+
+        clusters = cluster_sessions(photos, limit=3)
+
+        assert len(clusters) == 3
+
+    def test_a_full_window_drops_its_tail_cluster(self):
+        """La dernière grappe d'une fenêtre pleine est peut-être coupée.
+
+        L'annoncer avec son compte dirait « 3 photos » là où il y en a peut-être
+        trente — un compte faux vaut moins que rien.
+        """
+        photos = [_FakePhoto(_at(hours * 24)) for hours in range(4)]
+
+        clusters = cluster_sessions(photos, window_was_full=True)
+
+        assert len(clusters) == 3
+
+    def test_a_full_window_of_one_cluster_keeps_it(self):
+        """Sinon un foyer dont tout tient dans une session verrait une file vide."""
+        photos = [_FakePhoto(_at(minutes / 60)) for minutes in range(5)]
+
+        clusters = cluster_sessions(photos, window_was_full=True)
+
+        assert len(clusters) == 1
+
+    def test_the_default_gap_is_the_one_the_module_declares(self):
+        photos = [
+            _FakePhoto(timezone.now()),
+            _FakePhoto(timezone.now() - SESSION_GAP - timedelta(minutes=1)),
+        ]
+
+        assert len(cluster_sessions(photos)) == 2
+
+
+@pytest.mark.django_db
+class TestTheTriageEndpointGroupsByCapture:
+    def test_photos_uploaded_together_but_taken_apart_are_two_sessions(
+        self, client, household, owner
+    ):
+        """Le cas de la feuille de partage : un envoi, deux moments.
+
+        C'est exactement le mélange dont se plaint l'utilisateur — la chaudière et
+        l'anniversaire dans le même lot. Grouper par date d'ajout le reformerait.
+        """
+        _photo(household, owner, "Chaudiere", taken_at=_at(72))
+        _photo(household, owner, "Gateau", taken_at=_at(2))
+        _photo(household, owner, "Bougies", taken_at=_at(1.5))
+
+        payload = client.get(TRIAGE_URL).json()
+
+        assert payload["total"] == 3
+        assert [cluster["count"] for cluster in payload["clusters"]] == [2, 1]
+
+    def test_a_photo_without_capture_date_falls_back_to_its_upload(
+        self, client, household, owner
+    ):
+        """`taken_at` est `NULL` pour une capture d'écran ou un EXIF strippé.
+
+        Le repli se fait à la lecture, jamais en base — la photo doit quand même
+        apparaître dans la file, sinon elle n'en sortirait plus jamais.
+        """
+        _photo(household, owner, "Capture", taken_at=None)
+
+        payload = client.get(TRIAGE_URL).json()
+
+        assert payload["total"] == 1
+        assert payload["clusters"][0]["photos"][0]["name"] == "Capture"
+
+    def test_the_newest_session_comes_first(self, client, household, owner):
+        _photo(household, owner, "Vieille", taken_at=_at(72))
+        _photo(household, owner, "Recente", taken_at=_at(1))
+
+        payload = client.get(TRIAGE_URL).json()
+
+        assert payload["clusters"][0]["photos"][0]["name"] == "Recente"
+
+    def test_a_cluster_carries_a_stable_key(self, client, household, owner):
+        _photo(household, owner, "Gateau", taken_at=_at(2))
+
+        first = client.get(TRIAGE_URL).json()["clusters"][0]["key"]
+        second = client.get(TRIAGE_URL).json()["clusters"][0]["key"]
+
+        assert first == second
+
+    def test_a_photo_from_another_household_never_shows_up(
+        self, client, household, owner
+    ):
+        stranger = UserFactory(email="stranger-clusters@example.com")
+        other = Household.objects.create(name="Ailleurs")
+        HouseholdMember.objects.create(
+            user=stranger, household=other, role=HouseholdMember.Role.OWNER
+        )
+        _photo(other, stranger, "Chez eux", taken_at=_at(1))
+
+        payload = client.get(TRIAGE_URL).json()
+
+        assert payload["total"] == 0
+        assert payload["clusters"] == []

--- a/apps/documents/views.py
+++ b/apps/documents/views.py
@@ -22,6 +22,14 @@ from .extraction import extract_text
 from .exif import read_taken_at
 from .image_processing import normalize_image
 from .models import Document, DocumentLink
+from .queries import (
+    TRIAGE_CLUSTERS,
+    TRIAGE_WINDOW,
+    UNTRIAGED,
+    cluster_sessions,
+    untriaged,
+)
+from .queries import purpose_counts as compute_purpose_counts
 from .serializers import (
     DocumentSerializer,
     DocumentDetailSerializer,
@@ -100,6 +108,24 @@ def get_documents_queryset_for_request(request):
     if without_zone in {'1', 'true', 'yes'}:
         zone_ct = ContentType.objects.get_for_model(Zone)
         queryset = queryset.exclude(links__content_type=zone_ct)
+
+    # L'intention d'une photo. `untriaged` est un **marqueur explicite** : un paramètre
+    # vide ou inconnu est refusé, jamais dégradé en « toutes ». Laisser un vide vouloir
+    # dire « tous » est ce qui rend un compteur aveugle — l'écran annoncerait « rien à
+    # trier » en montrant la galerie entière.
+    if 'purpose' in query_params:
+        purpose = (query_params.get('purpose') or '').strip()
+        if purpose == UNTRIAGED:
+            queryset = untriaged(queryset)
+        elif purpose in {value for value, _label in Document.Purpose.choices}:
+            queryset = queryset.filter(purpose=purpose)
+        else:
+            raise ValidationError({
+                'purpose': (
+                    f'Unknown purpose: {purpose!r}. '
+                    f'Expected one of technical, observation, memory, {UNTRIAGED}.'
+                )
+            })
 
     # Legacy per-entity params (?zone= / ?project= / ?equipment=) + generic
     # ?linked_to=<entity_type>:<uuid> all resolve to a DocumentLink filter.
@@ -471,6 +497,135 @@ class DocumentViewSet(viewsets.ModelViewSet):
             )
 
         return Response({'updated': updated}, status=status.HTTP_200_OK)
+
+    @action(detail=False, methods=['get'], url_path='purpose_counts')
+    def purpose_counts(self, request):
+        """Combien de photos par intention, dont « à trier ».
+
+        Un endpoint à part, et pas un bloc de la réponse de `triage/` : la galerie
+        affiche ces compteurs en permanence, et les obtenir en chargeant une fenêtre de
+        photos ferait payer un écran de lecture au prix d'un écran de tri. C'est la
+        même exigence que les badges du Contrôle — un compteur reste un `COUNT(*)`.
+        """
+        return Response(
+            compute_purpose_counts(self.get_queryset()), status=status.HTTP_200_OK
+        )
+
+    @action(detail=False, methods=['get'])
+    def triage(self, request):
+        """Les photos que personne n'a rangées, **par grappes de session**.
+
+        Trente photos rapportées d'un week-end forment une session, pas trente
+        décisions : une file qui demande trente gestes ne se vide jamais, et une file
+        qu'on ne vide jamais cesse d'être lue au bout d'une semaine.
+
+        La fenêtre est bornée (`TRIAGE_WINDOW`) parce que `DocumentViewSet` n'est pas
+        encore paginé : sans elle, ce panneau chargerait toute la photothèque du foyer
+        — l'intégralité, puisque l'introduction du champ n'a rien backfillé.
+        """
+        queryset = untriaged(self.get_queryset()).order_by('-effective_date', '-id')
+        total = queryset.count()
+
+        window = list(queryset[:TRIAGE_WINDOW])
+        clusters = cluster_sessions(
+            window,
+            limit=TRIAGE_CLUSTERS,
+            window_was_full=len(window) >= TRIAGE_WINDOW,
+        )
+
+        serializer_context = {'request': request}
+        return Response(
+            {
+                'total': total,
+                'clusters': [
+                    {
+                        # La photo la plus récente de la grappe : une clé stable d'un
+                        # rechargement à l'autre, qui disparaît avec la grappe.
+                        'key': str(cluster['photos'][0].id),
+                        'start': cluster['oldest'],
+                        'end': cluster['newest'],
+                        'count': len(cluster['photos']),
+                        'photos': DocumentSerializer(
+                            cluster['photos'], many=True, context=serializer_context
+                        ).data,
+                    }
+                    for cluster in clusters
+                ],
+            },
+            status=status.HTTP_200_OK,
+        )
+
+    @action(detail=False, methods=['post'], url_path='set_purpose')
+    def set_purpose(self, request):
+        """Pose une intention sur un lot de photos : `{document_ids, purpose, overwrite}`.
+
+        **Le lot n'écrase jamais un choix déjà fait.** Une grappe dont certaines photos
+        portent déjà une intention est le cas normal, pas l'exception : elle se range
+        sans toucher au travail déjà fait, et la réponse dit combien ont été laissées.
+        Écraser reste possible, mais c'est un geste explicite (`overwrite: true`) — même
+        règle que l'éditeur de ventilation, qui ne détache jamais par effet de bord.
+
+        Une intention vide est **refusée** : « détrier » trente photos d'un coup serait
+        une destruction de masse déguisée en raccourci, et le geste unitaire existe pour
+        ça (PATCH sur la photo).
+
+        **Tout ou rien** sur les identifiants, comme `bulk_add_zones` : en ranger la
+        moitié sans le dire laisserait l'utilisateur croire son tri fait.
+        """
+        raw_documents = request.data.get('document_ids', None)
+        if raw_documents is None:
+            raise ValidationError({'document_ids': 'document_ids is required.'})
+        if isinstance(raw_documents, str) or not isinstance(raw_documents, (list, tuple)):
+            raise ValidationError({'document_ids': 'document_ids must be a list.'})
+
+        purpose = (request.data.get('purpose') or '').strip()
+        if not purpose:
+            raise ValidationError({'purpose': 'purpose is required and cannot be empty.'})
+        if purpose not in {value for value, _label in Document.Purpose.choices}:
+            raise ValidationError({'purpose': f'Unknown purpose: {purpose!r}.'})
+
+        document_ids = []
+        for value in raw_documents:
+            text = str(value).strip()
+            if not text:
+                continue
+            if not text.isdigit():
+                raise ValidationError({'document_ids': f'Invalid document id: {text}'})
+            document_ids.append(int(text))
+        document_ids = list(dict.fromkeys(document_ids))
+        if not document_ids:
+            raise ValidationError({'document_ids': 'document_ids cannot be empty.'})
+
+        # `get_queryset()` porte déjà le scope foyer **et** la confidentialité : on ne
+        # refait pas ce filtrage ici, sous peine de le voir dériver.
+        documents = list(self.get_queryset().filter(pk__in=document_ids))
+        if len(documents) != len(document_ids):
+            raise ValidationError({'document_ids': 'Invalid document or access denied.'})
+
+        not_photos = [document for document in documents if document.type != 'photo']
+        if not_photos:
+            raise ValidationError({'document_ids': 'Only a photo can carry a purpose.'})
+
+        overwrite = bool(request.data.get('overwrite', False))
+        # Reposer la même intention n'est pas un conflit : c'est sans effet, et le dire
+        # « ignoré » ferait passer un lot idempotent pour un lot à moitié appliqué.
+        to_update = [
+            document for document in documents
+            if overwrite or not document.purpose or document.purpose == purpose
+        ]
+        skipped = len(documents) - len(to_update)
+
+        if to_update:
+            with transaction.atomic():
+                Document.objects.filter(pk__in=[d.pk for d in to_update]).update(
+                    purpose=purpose,
+                    updated_at=timezone.now(),
+                )
+
+        return Response(
+            {'updated': len(to_update), 'skipped': skipped},
+            status=status.HTTP_200_OK,
+        )
 
     @action(detail=True, methods=['post'])
     def reprocess_ocr(self, request, pk=None):

--- a/docs/MODULES/documents.md
+++ b/docs/MODULES/documents.md
@@ -185,6 +185,20 @@ nature il est.
   curseur du lot 1, pas encore livrée — à réviser quand elle le sera.
 - **Propre aux photos** : le serializer et le lot refusent un `purpose` sur un
   `type != 'photo'`, sinon la file se peuplerait de factures qu'elle ne sait pas montrer.
+  **Et l'intention ne survit pas au reclassement** : passer une photo en `invoice`
+  efface son `purpose` au lieu de bloquer. Les deux chemins diffèrent exprès — *poser*
+  une intention sur autre chose qu'une photo est une erreur du client (400), *reclasser*
+  est un geste légitime. Sans cet effacement, la facture gardait `purpose='technical'`
+  pour toujours : invisible partout (la file et les compteurs filtrent `type='photo'`),
+  donc jamais corrigeable — et un état qu'aucun écran ne montre est celui qu'on ne
+  rattrape jamais. Même règle que le budget d'un remboursement reclassé en salaire.
+  Régression : `test_photo_purpose.py::test_reclassifying_a_photo_drops_the_purpose_it_carried`.
+- **Le retrait optimiste d'une suppression porte sur le cache affiché.** La suppression
+  est différée de cinq secondes (le temps d'annuler) : en mode tri, ne retirer la photo
+  que de `photoKeys.list()` la laissait à l'écran pendant tout ce temps, et un second
+  clic partait supprimer un identifiant déjà condamné. `removeFromTriage` (dans
+  `hooks.ts`, testé à part) met à jour la file, y compris le `total` et la grappe qui se
+  vide.
 - Côté front, les trois intentions ont **une seule définition**
   (`ui/src/features/photos/purposes.ts`) : icône, libellé, phrase d'aide. « À trier » n'y
   est délibérément pas — ce n'est pas une quatrième intention, c'est l'absence de choix.

--- a/docs/MODULES/documents.md
+++ b/docs/MODULES/documents.md
@@ -25,10 +25,11 @@
 - `ocr_text` : texte extrait (vide si photo ou extraction échouée).
 - `metadata` : JSONField libre — contient `size`, `ocr_method`, `ocr_extracted_at`, `normalized`, `resized`, `dimensions`.
 - `taken_at` : `DateTimeField(null=True, db_index=True)` — date de **prise de vue**, lue dans l'EXIF à l'upload (`apps/documents/exif.py`). Voir « Date de prise de vue » plus bas.
+- `purpose` : `CharField` (`technical` / `observation` / `memory`, vide = **non trié**) — l'**intention** d'une photo. Voir « L'intention d'une photo » plus bas.
 - `is_private` : boolean — filtre appliqué dans le queryset (seul `created_by` voit ses propres privés).
 - `interaction` : FK nullable vers `Interaction` (`on_delete=CASCADE`). FK "legacy" conservée par rétro-compat. La relation principale passe désormais par `InteractionDocument` (M2M).
 - **Pas de soft-delete** — suppression physique + cascade complète.
-- Index : `idx_docs_hh_type` (household+type), `idx_docs_interaction` (interaction), `idx_docs_creator` (created_by).
+- Index : `idx_docs_hh_type` (household+type), `idx_docs_interaction` (interaction), `idx_docs_creator` (created_by), `idx_docs_hh_purpose` (household+purpose).
 
 ### Tables de liaison (autres apps)
 
@@ -52,6 +53,9 @@
 | DELETE | `documents/{id}/` | Suppression (déclenche signal → fichier physique + thumbnails) |
 | POST | `documents/upload/` | Upload multipart (magic bytes, normalization, OCR) |
 | GET | `documents/by_type/` | Comptage par type |
+| GET | `documents/purpose_counts/` | Compte des photos par intention, dont « à trier » |
+| GET | `documents/triage/` | Ce que personne n'a trié, **par grappes de session** |
+| POST | `documents/set_purpose/` | Pose une intention sur un lot ; n'écrase rien sans `overwrite` |
 | POST | `documents/{id}/reprocess_ocr/` | Relancer l'extraction OCR |
 
 Permissions : `IsHouseholdMember` partout. Seul le `created_by` peut changer `is_private` (`views.py:140-144`).
@@ -130,6 +134,60 @@ date du déclenchement, lue dans l'EXIF.
   `ordering=-effective_date`, et `grouping.ts::effectiveDate` applique la même règle
   pour les en-têtes de mois : s'ils divergeaient, une photo apparaîtrait sous un en-tête
   « juillet » entre deux photos de juin.
+
+### L'intention d'une photo (`Document.purpose`, parcours 29 lot 2)
+
+Une photo portait trois axes — la zone dit *où*, le lien d'entité dit *sur quoi*,
+`DocumentLink.phase` dit *quand dans le chantier*. Aucun ne disait **pourquoi elle
+existe**, et c'est la question qui sépare une preuve d'un souvenir : le numéro de série
+d'une chaudière, une fissure inquiétante et l'anniversaire d'une fille finissaient au
+même endroit, dans le même ordre. Même raisonnement que « le budget est la catégorie »
+côté argent : un projet et une zone disent sur quoi porte un euro, jamais de quelle
+nature il est.
+
+- **⚠️ Le vide n'est pas `memory`.** Vide = personne n'a regardé (un écart, qui alimente
+  la file « À trier ») ; `memory` = quelqu'un a choisi. Les confondre rendrait la file
+  aveugle et l'utilisateur croirait avoir rangé. C'est la déclinaison photo de
+  `inflow_nature == ""` qui n'est pas `"other"`, et du principe du parcours 26 : *toute
+  entité est soit résolue, soit flaggée ; rien ne reste dans un entre-deux silencieux*.
+  Régression : `test_photo_purpose.py::TestEmptyIsNotAMemory`.
+- **Le marqueur du filtre s'écrit** : `?purpose=untriaged`, jamais `?purpose=` vide, qui
+  répond **400** — comme une valeur inconnue. Un paramètre vide qui voudrait dire
+  « toutes » ferait afficher la galerie entière sous la pastille « À trier », et le
+  compteur d'à côté dirait autre chose que la liste.
+- **Aucun backfill, jamais.** Marquer `technical` ce qui est lié à un projet écrirait une
+  devinette en base, indistinguable d'un choix de l'utilisateur — ce que `banking.rules`
+  interdit (« des valeurs de départ, jamais des vérités »). Tout l'existant part donc
+  dans « À trier », et c'est le tri **par grappe** qui rend la contrepartie tenable.
+- **Le tri se fait par grappe de session, calculée à la lecture** (`queries.py::
+  cluster_sessions`, `SESSION_GAP = 2 h`). Aucune colonne de groupe : un regroupement
+  stocké devrait être recalculé à chaque correction de date, et une date de prise de vue
+  se corrige. La grappe se calcule sur `effective_date`, **pas** sur la date d'ajout :
+  quinze photos envoyées d'un coup depuis la feuille de partage contiennent la chaudière
+  de mardi *et* l'anniversaire de samedi — les grouper par envoi reformerait exactement
+  le mélange qu'on défait. Régression :
+  `test_triage_clusters.py::TestTheTriageEndpointGroupsByCapture`.
+- **Un lot n'écrase jamais un choix déjà posé.** `set_purpose` laisse intactes les photos
+  qui portent une autre intention et les renvoie dans `skipped` ; écraser est un geste
+  explicite (`overwrite: true`). Reposer la **même** intention n'est pas un conflit — un
+  lot idempotent ne doit pas se dire à moitié appliqué. Une intention **vide** est
+  refusée en lot (« détrier » trente photos serait une destruction de masse déguisée en
+  raccourci) mais admise sur une photo, par PATCH ou en recliquant la pastille dans la
+  visionneuse. Régression : `test_photo_purpose.py::TestABatchNeverOverwritesAChoice`.
+- **Le compteur est un `COUNT(*)`**, servi par `purpose_counts/` — un endpoint à part, et
+  non un bloc de la réponse de `triage/` : la galerie affiche ces compteurs en
+  permanence, et les obtenir en chargeant une fenêtre de photos ferait payer un écran de
+  lecture au prix d'un écran de tri (même exigence que les badges du Contrôle).
+- **La file est bornée, et le dit.** `TRIAGE_WINDOW = 500` photos lues, `TRIAGE_CLUSTERS
+  = 20` grappes rendues, la grappe de queue d'une fenêtre pleine étant abandonnée
+  (peut-être coupée). Le panneau affiche `total` **et** ce qu'il montre : annoncer le
+  compte de l'écran ferait croire la file finie. Cette borne remplace la pagination
+  curseur du lot 1, pas encore livrée — à réviser quand elle le sera.
+- **Propre aux photos** : le serializer et le lot refusent un `purpose` sur un
+  `type != 'photo'`, sinon la file se peuplerait de factures qu'elle ne sait pas montrer.
+- Côté front, les trois intentions ont **une seule définition**
+  (`ui/src/features/photos/purposes.ts`) : icône, libellé, phrase d'aide. « À trier » n'y
+  est délibérément pas — ce n'est pas une quatrième intention, c'est l'absence de choix.
 
 ### Pipeline OCR / extraction (`apps/documents/extraction.py`)
 

--- a/docs/NEXT_STEPS.md
+++ b/docs/NEXT_STEPS.md
@@ -1,8 +1,8 @@
 # Next steps
 
 > **Cadré au 2026-08-03 — Parcours 29 : l'album du foyer.** Chantier cadré ce
-> jour (doc produit, fiche concept, backlog en 7 lots, issues #526 → #534) ;
-> aucun lot démarré.
+> jour (doc produit, fiche concept, backlog en 7 lots, issues #526 → #534).
+> **Lot 2 livré le 2026-08-04** (#528) — les six autres restent à faire.
 >
 > Déclencheur : la livraison du téléversement multiple (#524) le matin même, et la
 > friction apparue à la première utilisation réelle — « les photos techniques sont
@@ -17,11 +17,17 @@
 > dans la doc produit : changement d'ordre de grandeur du volume, quota qui devient
 > une contrainte réelle, comparaison frontale avec la pellicule du téléphone.
 >
-> Ordre : **1** (dettes : pagination curseur + `size_bytes` en colonne — prérequis
-> dur de tous les autres) → **2** (l'intention et la file « À trier », qui résout
-> la friction sans dépendre de l'infrastructure) → **3** (stockage objet) et
-> **4** (tâches de fond), indépendants entre eux mais prérequis du **6** (import
+> Ordre initial : **1** (dettes : pagination curseur + `size_bytes` en colonne) →
+> **2** (l'intention et la file « À trier ») → **3** (stockage objet) et **4**
+> (tâches de fond), indépendants entre eux mais prérequis du **6** (import
 > massif) → **5** (quota, dès que 1 est livré) → **7** (synchro iPhone).
+>
+> **Réordonné le 2026-08-04 : le lot 2 est passé devant le lot 1, et il est livré.**
+> C'est le seul lot qui résout la friction réelle ; les six autres sont de
+> l'infrastructure pour un volume qui n'existe pas encore. Le lot 1 n'était pas un
+> prérequis *dur* du 2 — sa dette est contournée par une file bornée côté serveur
+> (`TRIAGE_WINDOW`), et la galerie à plat ne se charge pas en mode tri. Reste donc :
+> **1** (qui lèvera cette borne) → **3** et **4** → **6** → **5** → **7**.
 >
 > **⚠️ Ce cadrage ne tranche pas la priorité relative avec le parcours 28.** Les
 > lots 0 et 4 de celui-ci corrigent des écarts *ouverts aujourd'hui* (runner

--- a/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
+++ b/docs/parcours/PARCOURS_29_ALBUM_DU_FOYER.md
@@ -83,6 +83,11 @@ construira **jamais** de reconnaissance de visages ni d'éditeur d'image.
 
 Une nouvelle valeur portée par le document lui-même, et non par un de ses liens :
 
+> **Livré le 2026-08-04** (lot 2, #528) : le champ, le filtre, la file « À trier » par
+> grappes de session, le lot qui n'écrase rien. Le mot **« intention »** reste celui de
+> l'interface ; le champ s'appelle `purpose` dans le code, où les identifiants sont en
+> anglais. Détail d'implémentation : [documents.md](../MODULES/documents.md).
+
 | Intention | Ce que c'est | Exemple |
 |---|---|---|
 | `technical` | Une **preuve**. On la reprendra pour lire quelque chose dessus. | Numéro de série, index de compteur, plan, plaque signalétique |
@@ -105,6 +110,13 @@ s'ouvre sur une intention. Le mélange dont se plaint l'utilisateur n'est pas un
 problème d'affichage, c'est une donnée absente ; l'ajouter suffit à le résoudre,
 et aucun filtre n'y suffirait sans elle.
 
+> **Ce qui est livré, et ce qui attend.** La galerie porte ses pastilles d'intention et
+> son entrée « À trier », mais elle **s'ouvre encore sur tout**. La raison est la même
+> qui interdit le backfill : au premier matin, aucune photo ne porte d'intention, donc
+> s'ouvrir sur `technical` afficherait un écran vide sur une photothèque pleine. Un
+> défaut qui ment le premier jour coûte plus cher que le mélange qu'il corrige. La
+> bascule se fera quand la file aura été vidée une fois.
+
 ## Le tri se fait par groupe, jamais photo par photo
 
 Trente photos rapportées d'un week-end forment **une session**, pas trente
@@ -122,11 +134,14 @@ photos portent déjà une intention ne se réassigne pas en bloc sans le dire.
 
 ## Ce que l'utilisateur gagne
 
+Les trois premières lignes sont **livrées** (lot 2, 2026-08-04) ; les trois suivantes
+attendent leur lot.
+
 | Question | Aujourd'hui | Après |
 |---|---|---|
-| « Montre-moi les photos du chantier » | Elles sont mêlées aux repas de famille | La galerie s'ouvre sur une intention |
-| « Où est la photo du numéro de série ? » | On fait défiler par mois | Intention `technical` + la zone ou l'équipement |
-| « Qu'est-ce qui traîne sans être rangé ? » | Rien ne le dit | La file « À trier », avec son compte |
+| « Montre-moi les photos du chantier » | ~~Elles sont mêlées aux repas de famille~~ | ✅ Une pastille d'intention filtre la galerie |
+| « Où est la photo du numéro de série ? » | ~~On fait défiler par mois~~ | ✅ Intention `technical` + la zone ou l'équipement |
+| « Qu'est-ce qui traîne sans être rangé ? » | ~~Rien ne le dit~~ | ✅ La file « À trier », par grappes, avec son compte |
 | « J'ai 200 photos à importer » | Dix ouvertures d'un dialogue, une modale bloquée 40 min | Une page d'import, une file qui survit à la navigation |
 | « Combien de place j'occupe ? » | Rien ne le dit | Un compteur, visible avant de mordre |
 | « Je viens de rentrer, j'ai pris 15 photos » | On ouvre House, on retrouve les fichiers, on les envoie | Feuille de partage du téléphone, puis une automatisation qui ne propose que ce qui vient de la maison |

--- a/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
+++ b/docs/parcours/PARCOURS_29_BACKLOG_TECHNIQUE.md
@@ -1,18 +1,42 @@
 # Parcours 29 — Backlog technique
 
-> Cadrage réalisé le 2026-08-03. Aucun code n'a été écrit à ce stade.
+> Cadrage réalisé le 2026-08-03. **Lot 2 livré le 2026-08-04**, hors séquence — voir
+> « Le lot 2 a été livré seul » juste sous le tableau.
 
 ## Tableau de bord
 
 | Lot | Sujet | Statut | Issue |
 |---|---|---|---|
 | 1 | Les dettes qui bloquent le volume — pagination curseur + `size_bytes` en colonne | ⬜ À faire | #527 |
-| 2 | L'intention (`purpose`) et la file « À trier » | ⬜ À faire | #528 |
+| 2 | L'intention (`purpose`) et la file « À trier » | ✅ Livré (2026-08-04) | #528 |
 | 3 | Le stockage objet, optionnel | ⬜ À faire | #529 |
 | 4 | Le traitement en tâche de fond | ⬜ À faire | #530 |
 | 5 | Le quota de stockage du foyer | ⬜ À faire | #531 |
 | 6 | L'import massif | ⬜ À faire | #532 |
 | 7 | Le géofence — n'envoyer que ce qui a été pris à la maison | ⬜ À faire | #533 |
+
+## Le lot 2 a été livré seul, avant le lot 1
+
+Arbitré le 2026-08-04. Le lot 2 est le seul du parcours qui résout la friction réelle
+de l'utilisateur ; les six autres sont de l'infrastructure pour un volume qui n'existe
+pas encore. Attendre le stockage objet et la file de tâches pour dire *pourquoi une
+photo existe* aurait fait payer une gêne quotidienne au prix d'un chantier.
+
+Ce que ça coûte, écrit ici pour que le lot 1 sache ce qu'il vient lever :
+
+- **La file « À trier » est bornée côté serveur** (`TRIAGE_WINDOW = 500`,
+  `TRIAGE_CLUSTERS = 20`) au lieu d'être paginée. `DocumentViewSet` n'a toujours pas de
+  `pagination_class`, et comme la migration ne backfille rien, *toute* la photothèque
+  est « à trier » au premier jour : sans cette borne, le panneau aurait été une seconde
+  liste non paginée, pire que la première. La borne est honnête à l'écran — le panneau
+  affiche `total` (tout ce qui reste) **et** ce qu'il montre, jamais l'un pour l'autre.
+- **La galerie à plat ne se charge pas en mode tri** (`usePhotos(filters, !isTriage)`),
+  pour la même raison. À supprimer quand la pagination curseur existera.
+- **La galerie ne s'ouvre pas encore par défaut sur une intention** (critère 2 de
+  #528). Sans backfill, toutes les intentions sont vides le premier matin : ouvrir sur
+  `technical` afficherait un écran vide sur une photothèque pleine. Les pastilles et
+  l'entrée « À trier » sont livrées ; la bascule du défaut se fera quand la file aura
+  été vidée une fois.
 
 **Issue parente** : #526 · **Issue annexe (V2 différés)** : #534
 **⚠️ Prérequis, livré AVANT ce parcours** : #535 (partage iOS + jeton d'appareil) ·
@@ -118,7 +142,15 @@ ce soit. Aucun changement visible pour l'utilisateur hormis un défilement infin
 4. Le backfill est rejouable et n'écrase pas une valeur déjà juste.
 5. Aucun autre viewset ne change de forme de réponse.
 
-## Lot 2 — L'intention (`purpose`) et la file « À trier » (#528)
+## Lot 2 — L'intention (`purpose`) et la file « À trier » (#528) — ✅ livré
+
+> Livré le 2026-08-04. Écarts assumés par rapport au cadrage ci-dessous : la borne
+> `TRIAGE_WINDOW` remplace la pagination du lot 1, et l'ouverture par défaut de la
+> galerie sur une intention est différée (voir « Le lot 2 a été livré seul »). Trois
+> fichiers de plus que prévu : `queries.py` porte aussi `purpose_counts`, servi par un
+> endpoint à part pour que les pastilles restent un `COUNT(*)` ; `purposes.ts` tient
+> l'unique définition des trois intentions côté front ; `PhotoPurposeEditor.tsx` le
+> geste unitaire, seul endroit d'où l'on peut *détrier*.
 
 ### But
 

--- a/ui/src/features/photos/PhotoLightbox.tsx
+++ b/ui/src/features/photos/PhotoLightbox.tsx
@@ -36,6 +36,8 @@ interface Props {
    * `onRemove` et `removeLabel` de son appelant.
    */
   renderZones?: (photo: DocumentItem) => React.ReactNode;
+  /** Bloc « Intention » du panneau de métadonnées — injecté, comme `renderZones`. */
+  renderPurpose?: (photo: DocumentItem) => React.ReactNode;
 }
 
 /** Distance horizontale minimale, en px, pour qu'un glissement compte comme un swipe. */
@@ -84,6 +86,7 @@ export default function PhotoLightbox({
   removeLabel,
   phaseOf,
   renderZones,
+  renderPurpose,
 }: Props) {
   const { t } = useTranslation();
   const [failed, setFailed] = React.useState(false);
@@ -305,6 +308,8 @@ export default function PhotoLightbox({
                     {photo.notes}
                   </p>
                 ) : null}
+
+                {renderPurpose?.(photo)}
 
                 {renderZones?.(photo)}
 

--- a/ui/src/features/photos/PhotoPurposeEditor.tsx
+++ b/ui/src/features/photos/PhotoPurposeEditor.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next';
+import { FilterPill } from '@/design-system/filter-pill';
+import type { DocumentItem, PhotoPurpose } from '@/lib/api/documents';
+import { useSetPhotoPurpose } from './hooks';
+import { PURPOSES } from './purposes';
+
+/**
+ * Le choix d'intention d'**une** photo, dans le panneau de la visionneuse.
+ *
+ * Recliquer sur l'intention posée la retire : détrier une photo qu'on a sous les yeux
+ * est un geste unitaire légitime, contrairement au lot — qui, lui, refuse le vide,
+ * parce que « détrier trente photos » serait une destruction déguisée en raccourci.
+ */
+export default function PhotoPurposeEditor({ photo }: { photo: DocumentItem }) {
+  const { t } = useTranslation();
+  const setPurpose = useSetPhotoPurpose();
+
+  const current = photo.purpose || '';
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs font-medium text-muted-foreground">{t('photos.purpose.label')}</p>
+      <div className="flex flex-wrap gap-1.5">
+        {PURPOSES.map((spec) => {
+          const Icon = spec.icon;
+          const active = current === spec.key;
+          return (
+            <FilterPill
+              key={spec.key}
+              active={active}
+              disabled={setPurpose.isPending}
+              title={t(spec.hintKey)}
+              onClick={() =>
+                setPurpose.mutate({
+                  photoId: photo.id,
+                  purpose: (active ? '' : spec.key) as PhotoPurpose | '',
+                })
+              }
+            >
+              <Icon className="h-3 w-3" aria-hidden />
+              {t(spec.labelKey)}
+            </FilterPill>
+          );
+        })}
+      </div>
+      {/* Une photo non triée le dit. Sans cette ligne, « aucune pastille allumée » se
+          lirait comme un défaut d'affichage plutôt que comme un état — c'est la même
+          raison qui interdit d'afficher « conforme » sans avoir vérifié. */}
+      {current === '' ? (
+        <p className="text-xs text-muted-foreground">{t('photos.purpose.none')}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/src/features/photos/PhotosPage.tsx
+++ b/ui/src/features/photos/PhotosPage.tsx
@@ -28,13 +28,19 @@ import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useMultiSelect } from '@/lib/useMultiSelect';
 import { useSessionState } from '@/lib/useSessionState';
 import { formatMonthYear } from '@/lib/format';
-import { UNTRIAGED, type DocumentItem, type PhotoPurpose } from '@/lib/api/documents';
+import {
+  UNTRIAGED,
+  type DocumentItem,
+  type PhotoPurpose,
+  type TriageQueue,
+} from '@/lib/api/documents';
 import {
   usePhotos,
   useDeletePhoto,
   usePurposeCounts,
   useSetPhotosPurpose,
   useTriageQueue,
+  removeFromTriage,
   photoKeys,
 } from './hooks';
 import PhotoGrid, { PhotoGridSkeleton } from './PhotoGrid';
@@ -108,11 +114,24 @@ export default function PhotosPage() {
     (photo: DocumentItem) => {
       setOpenId(null);
       const listKey = photoKeys.list(filters);
+      // La suppression est **différée de cinq secondes** (le temps d'annuler) : seul le
+      // retrait optimiste fait disparaître la photo entre-temps. Il doit donc porter
+      // sur le cache réellement affiché — en mode tri, c'est celui de la file, pas
+      // celui de la galerie à plat. Ne retirer que de la liste laissait la photo à
+      // l'écran pendant cinq secondes, et un second clic partait supprimer un id déjà
+      // condamné.
+      const triageKey = photoKeys.triage();
       deleteWithUndo(photo.id, {
-        onRemove: () =>
-          qc.setQueryData<DocumentItem[]>(listKey, (old) => old?.filter((p) => p.id !== photo.id)),
-        onRestore: () =>
-          qc.setQueryData<DocumentItem[]>(listKey, (old) => (old ? [...old, photo] : [photo])),
+        onRemove: () => {
+          qc.setQueryData<DocumentItem[]>(listKey, (old) =>
+            old?.filter((p) => p.id !== photo.id),
+          );
+          qc.setQueryData<TriageQueue>(triageKey, (old) => removeFromTriage(old, photo.id));
+        },
+        onRestore: () => {
+          qc.setQueryData<DocumentItem[]>(listKey, (old) => (old ? [...old, photo] : [photo]));
+          void qc.invalidateQueries({ queryKey: triageKey });
+        },
       });
     },
     [deleteWithUndo, qc, filters],

--- a/ui/src/features/photos/PhotosPage.tsx
+++ b/ui/src/features/photos/PhotosPage.tsx
@@ -1,5 +1,14 @@
 import * as React from 'react';
-import { Camera, CheckSquare, MapPin, MapPinOff, SearchX, Trash2, Upload } from 'lucide-react';
+import {
+  Camera,
+  CheckSquare,
+  Inbox,
+  MapPin,
+  MapPinOff,
+  SearchX,
+  Trash2,
+  Upload,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useQueryClient } from '@tanstack/react-query';
 import ListPage from '@/components/ListPage';
@@ -19,13 +28,23 @@ import { useDeleteWithUndo } from '@/lib/useDeleteWithUndo';
 import { useMultiSelect } from '@/lib/useMultiSelect';
 import { useSessionState } from '@/lib/useSessionState';
 import { formatMonthYear } from '@/lib/format';
-import type { DocumentItem } from '@/lib/api/documents';
-import { usePhotos, useDeletePhoto, photoKeys } from './hooks';
+import { UNTRIAGED, type DocumentItem, type PhotoPurpose } from '@/lib/api/documents';
+import {
+  usePhotos,
+  useDeletePhoto,
+  usePurposeCounts,
+  useSetPhotosPurpose,
+  useTriageQueue,
+  photoKeys,
+} from './hooks';
 import PhotoGrid, { PhotoGridSkeleton } from './PhotoGrid';
 import PhotoLightbox from './PhotoLightbox';
 import PhotoZonesEditor from './PhotoZonesEditor';
 import PhotoZonesDialog from './PhotoZonesDialog';
 import PhotoZonesBulkDialog from './PhotoZonesBulkDialog';
+import PhotoPurposeEditor from './PhotoPurposeEditor';
+import TriagePanel from './TriagePanel';
+import { PURPOSES } from './purposes';
 import { groupPhotosByMonth } from './grouping';
 
 export default function PhotosPage() {
@@ -35,6 +54,10 @@ export default function PhotosPage() {
   const [search, setSearch] = React.useState('');
   const [zone, setZone] = useSessionState<string>('photos.zone', '');
   const [withoutZone, setWithoutZone] = useSessionState<boolean>('photos.withoutZone', false);
+  // '' = toutes les intentions. On **omet** la clé côté requête plutôt que d'envoyer
+  // un vide : le serveur refuse `?purpose=`, pour qu'un paramètre oublié ne puisse
+  // jamais se lire comme un filtre.
+  const [purpose, setPurpose] = useSessionState<string>('photos.purpose', '');
   const [openId, setOpenId] = React.useState<string | null>(null);
   const [uploadOpen, setUploadOpen] = React.useState(false);
   const [zonesFor, setZonesFor] = React.useState<DocumentItem | null>(null);
@@ -42,22 +65,37 @@ export default function PhotosPage() {
   // Une frappe ne vaut pas une requête : la recherche partait à chaque caractère.
   const debouncedSearch = useDebouncedValue(search.trim(), 300);
   const hasFilters = debouncedSearch !== '' || zone !== '' || withoutZone;
+  const isTriage = purpose === UNTRIAGED;
 
   const filters = React.useMemo(
     () => ({
       ...(debouncedSearch ? { search: debouncedSearch } : {}),
       ...(zone ? { zone } : {}),
       ...(withoutZone ? { without_zone: '1' } : {}),
+      ...(purpose ? { purpose } : {}),
     }),
-    [debouncedSearch, zone, withoutZone],
+    [debouncedSearch, zone, withoutZone, purpose],
   );
 
-  const { data: photos = [], isLoading, error } = usePhotos(filters);
+  // En mode tri, la galerie à plat ne se charge pas : elle ramènerait toute la
+  // photothèque (rien n'a été backfillé, donc tout est « à trier » au premier jour),
+  // et la file du serveur est déjà bornée.
+  const { data: photos = [], isLoading, error } = usePhotos(filters, !isTriage);
+  const { data: counts } = usePurposeCounts();
+  // Même clé que dans `TriagePanel` : react-query dédoublonne, la file n'est chargée
+  // qu'une fois. C'est elle qui donne au visualiseur de quoi naviguer.
+  const { data: triage } = useTriageQueue(isTriage);
   const deletePhotoMutation = useDeletePhoto();
+  const setPhotosPurpose = useSetPhotosPurpose();
+
+  const visiblePhotos = React.useMemo(
+    () => (isTriage ? (triage?.clusters.flatMap((cluster) => cluster.photos) ?? []) : photos),
+    [isTriage, triage, photos],
+  );
 
   // La portée de la sélection, ce sont les filtres : les changer vide les cases
   // cochées, sinon le lot suivant porterait sur des photos plus à l'écran.
-  const photoIds = React.useMemo(() => photos.map((p) => p.id), [photos]);
+  const photoIds = React.useMemo(() => visiblePhotos.map((p) => p.id), [visiblePhotos]);
   const selection = useMultiSelect(photoIds, { scopeKey: JSON.stringify(filters) });
   const [bulkZonesOpen, setBulkZonesOpen] = React.useState(false);
 
@@ -85,6 +123,16 @@ export default function PhotosPage() {
     setZone('');
     setWithoutZone(false);
   }, [setZone, setWithoutZone]);
+
+  // Changer d'intention change ce qu'on regarde : la sélection en cours ne porte plus
+  // sur rien de visible, et la garder ferait ranger des photos sorties de l'écran.
+  const handlePurposeChange = React.useCallback(
+    (next: string) => {
+      setPurpose(next === purpose ? '' : next);
+      selection.exit();
+    },
+    [purpose, setPurpose, selection],
+  );
 
   // « Dans le salon » et « dans aucune zone » ne peuvent pas être vrais ensemble :
   // les cumuler ne rendrait jamais qu'une liste vide, sans dire pourquoi.
@@ -123,14 +171,19 @@ export default function PhotosPage() {
   );
 
   const groups = React.useMemo(() => groupPhotosByMonth(photos), [photos]);
-  const showSkeleton = useDelayedLoading(isLoading);
+  const showSkeleton = useDelayedLoading(isLoading && !isTriage);
 
   // `ListPage` masque ses enfants quand la liste est vide — donc la barre de
   // filtres avec. On ne lui déclare « vide » que la galerie réellement vide :
   // sinon une recherche sans résultat effaçait le champ qui l'a produite, et il
   // devenait impossible de revenir en arrière.
-  const isTrulyEmpty = !isLoading && !error && photos.length === 0 && !hasFilters;
-  const isNoResults = !isLoading && !error && photos.length === 0 && hasFilters;
+  // En mode tri, le panneau porte son propre état vide (« tout est trié »), qui n'est
+  // pas le même message : une galerie vide et une file vide ne disent pas la même
+  // chose, et `ListPage` masquerait la barre d'intentions avec le reste.
+  const isTrulyEmpty =
+    !isTriage && !isLoading && !error && photos.length === 0 && !hasFilters && !purpose;
+  const isNoResults =
+    !isTriage && !isLoading && !error && photos.length === 0 && (hasFilters || Boolean(purpose));
 
   return (
     <>
@@ -145,8 +198,10 @@ export default function PhotosPage() {
         }}
         actions={
           <>
-            {/* Rien à cocher = pas de mode sélection à proposer. */}
-            {photos.length > 0 ? (
+            {/* Rien à cocher = pas de mode sélection à proposer. En mode tri, le
+                panneau range par grappe : une seconde sélection à la main ferait
+                deux gestes concurrents pour le même travail. */}
+            {!isTriage && photos.length > 0 ? (
               <Button
                 type="button"
                 variant="outline"
@@ -164,6 +219,45 @@ export default function PhotosPage() {
           </>
         }
       >
+        {/* L'intention d'abord : c'est elle qui sépare la preuve du souvenir, et le
+            reste des filtres (zone, recherche) ne dit que *où* et *quoi*. */}
+        <div className="mb-3 flex flex-wrap items-center gap-1.5">
+          <FilterPill active={purpose === ''} onClick={() => handlePurposeChange('')}>
+            {t('photos.purpose.all')}
+          </FilterPill>
+          {PURPOSES.map((spec) => {
+            const Icon = spec.icon;
+            return (
+              <FilterPill
+                key={spec.key}
+                active={purpose === spec.key}
+                onClick={() => handlePurposeChange(spec.key)}
+                title={t(spec.hintKey)}
+              >
+                <Icon className="h-3 w-3" aria-hidden />
+                {t(spec.labelKey)}
+                {counts ? <span className="tabular-nums">{counts[spec.key]}</span> : null}
+              </FilterPill>
+            );
+          })}
+          {/* « À trier » n'est pas une quatrième intention : c'est l'absence de choix.
+              Elle se montre à part, et son compteur se lit même à zéro — « rien à
+              trier » et « rien de trié » ne sont pas la même nouvelle. */}
+          <FilterPill
+            active={isTriage}
+            onClick={() => handlePurposeChange(UNTRIAGED)}
+            className={
+              !isTriage && counts?.untriaged
+                ? 'border-primary/40 text-foreground'
+                : undefined
+            }
+          >
+            <Inbox className="h-3 w-3" aria-hidden />
+            {t('photos.purpose.untriaged')}
+            {counts ? <span className="tabular-nums">{counts.untriaged}</span> : null}
+          </FilterPill>
+        </div>
+
         <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end">
           <div className="flex-1 space-y-1 sm:max-w-xs">
             <Label htmlFor="photos-search">{t('photos.search')}</Label>
@@ -198,7 +292,9 @@ export default function PhotosPage() {
           </div>
         </div>
 
-        {error ? (
+        {isTriage ? (
+          <TriagePanel onPhotoClick={(photo) => setOpenId(photo.id)} />
+        ) : error ? (
           <LoadError
             message={t('photos.loadFailed')}
             onRetry={() => void qc.invalidateQueries({ queryKey: photoKeys.all })}
@@ -253,6 +349,35 @@ export default function PhotosPage() {
                   <MapPin className="h-4 w-4" aria-hidden />
                   {t('photos.zones.assign')}
                 </Button>
+                {/* Poser une intention sur une sélection quelconque : le serveur
+                    laisse intactes celles qui en portaient déjà une, et le toast dit
+                    combien. Écraser reste possible, mais depuis la photo. */}
+                {PURPOSES.map((spec) => {
+                  const Icon = spec.icon;
+                  return (
+                    <Button
+                      key={spec.key}
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="gap-1.5"
+                      title={t(spec.hintKey)}
+                      disabled={selection.count === 0 || setPhotosPurpose.isPending}
+                      onClick={() =>
+                        setPhotosPurpose.mutate(
+                          {
+                            photoIds: selection.selectedIds,
+                            purpose: spec.key as PhotoPurpose,
+                          },
+                          { onSuccess: () => selection.exit() },
+                        )
+                      }
+                    >
+                      <Icon className="h-4 w-4" aria-hidden />
+                      {t(spec.labelKey)}
+                    </Button>
+                  );
+                })}
               </SelectionBar>
             ) : null}
           </div>
@@ -260,11 +385,12 @@ export default function PhotosPage() {
       </ListPage>
 
       <PhotoLightbox
-        photos={photos}
+        photos={visiblePhotos}
         openId={openId}
         onOpenChange={setOpenId}
         onRemove={handleDelete}
         removeLabel={t('common.delete')}
+        renderPurpose={(photo) => <PhotoPurposeEditor photo={photo} />}
         renderZones={(photo) => <PhotoZonesEditor photo={photo} />}
       />
 

--- a/ui/src/features/photos/TriagePanel.test.tsx
+++ b/ui/src/features/photos/TriagePanel.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TriagePanel from './TriagePanel';
+import PhotoPurposeEditor from './PhotoPurposeEditor';
+import type { DocumentItem, TriageQueue } from '@/lib/api/documents';
+
+vi.stubGlobal('matchMedia', (query: string) => ({
+  matches: false,
+  media: query,
+  onchange: null,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, vars?: Record<string, unknown>) =>
+      vars ? `${key}:${Object.values(vars).join(',')}` : key,
+  }),
+}));
+
+const sortCluster = vi.fn();
+const sortOne = vi.fn();
+let queue: TriageQueue | undefined;
+
+vi.mock('./hooks', async () => {
+  const actual = await vi.importActual<typeof import('./hooks')>('./hooks');
+  return {
+    ...actual,
+    useTriageQueue: () => ({ data: queue, isLoading: false, error: null, refetch: vi.fn() }),
+    useSetPhotosPurpose: () => ({ mutate: sortCluster, isPending: false }),
+    useSetPhotoPurpose: () => ({ mutate: sortOne, isPending: false }),
+  };
+});
+
+function photo(id: string): DocumentItem {
+  return {
+    id,
+    name: `photo ${id}`,
+    file_url: `/media/${id}.jpg`,
+    thumbnail_url: `/media/thumb/${id}.jpg`,
+    created_at: '2026-07-10T12:00:00Z',
+    metadata: {},
+    zone_links: [],
+  } as unknown as DocumentItem;
+}
+
+function cluster(key: string, ids: string[]) {
+  return {
+    key,
+    start: '2026-07-10T09:00:00Z',
+    end: '2026-07-10T11:00:00Z',
+    count: ids.length,
+    photos: ids.map(photo),
+  };
+}
+
+beforeEach(() => {
+  sortCluster.mockClear();
+  sortOne.mockClear();
+  queue = { total: 3, clusters: [cluster('c1', ['p1', 'p2', 'p3'])] };
+});
+
+/**
+ * Le tri se fait **par grappe**. Une file qui demande trente gestes pour trente photos
+ * ne se vide jamais, et une file qu'on ne vide jamais cesse d'être lue.
+ */
+describe('TriagePanel', () => {
+  it('range toute une grappe en un seul geste', () => {
+    render(<TriagePanel onPhotoClick={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /photos\.purpose\.memory/ }));
+
+    expect(sortCluster).toHaveBeenCalledTimes(1);
+    expect(sortCluster.mock.calls[0][0]).toEqual({
+      photoIds: ['p1', 'p2', 'p3'],
+      purpose: 'memory',
+    });
+  });
+
+  it('propose les trois intentions, et jamais « à trier » comme quatrième', () => {
+    render(<TriagePanel onPhotoClick={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /photos\.purpose\.technical/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /photos\.purpose\.observation/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /photos\.purpose\.memory/ })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /photos\.purpose\.untriaged/ })).toBeNull();
+  });
+
+  it('dit ce qui reste quand la file est plus longue que ce qu’elle montre', () => {
+    // Le serveur borne sa fenêtre : annoncer le compte de l'écran ferait croire la
+    // file finie alors que d'autres grappes attendent.
+    queue = { total: 120, clusters: [cluster('c1', ['p1', 'p2', 'p3'])] };
+
+    render(<TriagePanel onPhotoClick={vi.fn()} />);
+
+    expect(screen.getByText(/photos\.triage\.remainingPartial:120,3/)).toBeTruthy();
+  });
+
+  it('annonce une file vide, jamais une galerie vide', () => {
+    queue = { total: 0, clusters: [] };
+
+    render(<TriagePanel onPhotoClick={vi.fn()} />);
+
+    expect(screen.getByText('photos.triage.empty')).toBeTruthy();
+  });
+});
+
+/**
+ * ⚠️ Le vide n'est pas un souvenir. Une photo non triée doit le **dire** : « aucune
+ * pastille allumée » se lirait sinon comme un défaut d'affichage.
+ */
+describe('PhotoPurposeEditor', () => {
+  it('dit qu’une photo n’a pas encore été triée', () => {
+    render(<PhotoPurposeEditor photo={{ ...photo('p1'), purpose: '' }} />);
+
+    expect(screen.getByText('photos.purpose.none')).toBeTruthy();
+  });
+
+  it('ne dit pas « non triée » d’un souvenir', () => {
+    render(<PhotoPurposeEditor photo={{ ...photo('p1'), purpose: 'memory' }} />);
+
+    expect(screen.queryByText('photos.purpose.none')).toBeNull();
+  });
+
+  it('recliquer sur l’intention posée la retire', () => {
+    render(<PhotoPurposeEditor photo={{ ...photo('p1'), purpose: 'memory' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /photos\.purpose\.memory/ }));
+
+    expect(sortOne).toHaveBeenCalledWith({ photoId: 'p1', purpose: '' });
+  });
+
+  it('pose l’intention cliquée quand la photo n’en a pas', () => {
+    render(<PhotoPurposeEditor photo={{ ...photo('p1'), purpose: '' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /photos\.purpose\.technical/ }));
+
+    expect(sortOne).toHaveBeenCalledWith({ photoId: 'p1', purpose: 'technical' });
+  });
+});

--- a/ui/src/features/photos/TriagePanel.test.tsx
+++ b/ui/src/features/photos/TriagePanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import TriagePanel from './TriagePanel';
 import PhotoPurposeEditor from './PhotoPurposeEditor';
+import { removeFromTriage } from './hooks';
 import type { DocumentItem, TriageQueue } from '@/lib/api/documents';
 
 vi.stubGlobal('matchMedia', (query: string) => ({
@@ -106,6 +107,37 @@ describe('TriagePanel', () => {
     render(<TriagePanel onPhotoClick={vi.fn()} />);
 
     expect(screen.getByText('photos.triage.empty')).toBeTruthy();
+  });
+});
+
+/**
+ * Le retrait optimiste d'une suppression doit porter sur le cache **affiché**.
+ *
+ * La suppression est différée de cinq secondes (le temps d'annuler) : si la file n'est
+ * pas mise à jour, la photo reste à l'écran pendant tout ce temps, et un second clic
+ * part supprimer un identifiant déjà condamné.
+ */
+describe('removeFromTriage', () => {
+  it('retire la photo et décrémente ce qui reste', () => {
+    const queue: TriageQueue = { total: 9, clusters: [cluster('c1', ['p1', 'p2'])] };
+
+    const next = removeFromTriage(queue, 'p1');
+
+    expect(next?.total).toBe(8);
+    expect(next?.clusters[0].photos.map((p) => p.id)).toEqual(['p2']);
+    expect(next?.clusters[0].count).toBe(1);
+  });
+
+  it('fait disparaître une grappe qui se vide', () => {
+    const queue: TriageQueue = { total: 1, clusters: [cluster('c1', ['p1'])] };
+
+    expect(removeFromTriage(queue, 'p1')?.clusters).toEqual([]);
+  });
+
+  it('ne décompte pas une photo qui n’était pas dans la file', () => {
+    const queue: TriageQueue = { total: 4, clusters: [cluster('c1', ['p1'])] };
+
+    expect(removeFromTriage(queue, 'inconnue')?.total).toBe(4);
   });
 });
 

--- a/ui/src/features/photos/TriagePanel.tsx
+++ b/ui/src/features/photos/TriagePanel.tsx
@@ -1,0 +1,138 @@
+import { CheckCheck } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import EmptyState from '@/components/EmptyState';
+import LoadError from '@/components/LoadError';
+import { Button } from '@/design-system/button';
+import { Card } from '@/design-system/card';
+import { useDelayedLoading } from '@/lib/useDelayedLoading';
+import { formatDate } from '@/lib/format';
+import type { DocumentItem, PhotoPurpose, TriageCluster } from '@/lib/api/documents';
+import { useTriageQueue, useSetPhotosPurpose } from './hooks';
+import PhotoGrid, { PhotoGridSkeleton } from './PhotoGrid';
+import { PURPOSES } from './purposes';
+
+interface TriagePanelProps {
+  onPhotoClick: (photo: DocumentItem) => void;
+}
+
+/**
+ * La file « À trier » — ce que personne n'a encore rangé, **par grappes de session**.
+ *
+ * Trente photos rapportées d'un week-end forment une décision, pas trente. Ce n'est
+ * pas un confort : une file qui demande trente gestes ne se vide jamais, et une file
+ * qu'on ne vide jamais cesse d'être lue au bout d'une semaine — c'est ce qui est
+ * arrivé aux compteurs du Contrôle avant qu'ils ne soient bornés.
+ *
+ * Les grappes viennent du serveur : le compteur qu'affiche la pastille et le lot qu'on
+ * envoie doivent désigner exactement les mêmes photos.
+ */
+export default function TriagePanel({ onPhotoClick }: TriagePanelProps) {
+  const { t } = useTranslation();
+  const { data, isLoading, error, refetch } = useTriageQueue();
+  const setPurpose = useSetPhotosPurpose();
+  const showSkeleton = useDelayedLoading(isLoading);
+
+  if (error) {
+    return (
+      <LoadError
+        message={t('photos.loadFailed')}
+        onRetry={() => void refetch()}
+        retryLabel={t('common.retry')}
+      />
+    );
+  }
+
+  if (showSkeleton) return <PhotoGridSkeleton />;
+  if (!data) return null;
+
+  if (data.total === 0) {
+    return (
+      <EmptyState
+        icon={CheckCheck}
+        title={t('photos.triage.empty')}
+        description={t('photos.triage.empty_description')}
+      />
+    );
+  }
+
+  // `total` compte tout ce qui reste ; les grappes montrées sont bornées. Dire l'un
+  // en montrant l'autre est le seul moyen honnête de présenter une file tronquée —
+  // un compteur qui ne vaut que pour l'écran ferait croire la file finie.
+  const shown = data.clusters.reduce((sum, cluster) => sum + cluster.count, 0);
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        {shown < data.total
+          ? t('photos.triage.remainingPartial', { count: data.total, shown })
+          : t('photos.triage.remaining', { count: data.total })}
+      </p>
+
+      {data.clusters.map((cluster) => (
+        <ClusterCard
+          key={cluster.key}
+          cluster={cluster}
+          onPhotoClick={onPhotoClick}
+          onSort={(purpose) =>
+            setPurpose.mutate({
+              photoIds: cluster.photos.map((photo) => photo.id),
+              purpose,
+            })
+          }
+          isPending={setPurpose.isPending}
+        />
+      ))}
+    </div>
+  );
+}
+
+function ClusterCard({
+  cluster,
+  onPhotoClick,
+  onSort,
+  isPending,
+}: {
+  cluster: TriageCluster;
+  onPhotoClick: (photo: DocumentItem) => void;
+  onSort: (purpose: PhotoPurpose) => void;
+  isPending: boolean;
+}) {
+  const { t } = useTranslation();
+  const from = formatDate(cluster.start);
+  const to = formatDate(cluster.end);
+
+  return (
+    <Card className="space-y-3 p-3">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-sm font-medium text-foreground">
+          {from === to ? from : t('photos.triage.range', { from, to })}
+        </h3>
+        <span className="text-sm text-muted-foreground tabular-nums">
+          {t('photos.triage.count', { count: cluster.count })}
+        </span>
+      </div>
+
+      <PhotoGrid photos={cluster.photos} onPhotoClick={onPhotoClick} />
+
+      <div className="flex flex-wrap gap-2">
+        {PURPOSES.map((spec) => {
+          const Icon = spec.icon;
+          return (
+            <Button
+              key={spec.key}
+              type="button"
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              disabled={isPending}
+              onClick={() => onSort(spec.key)}
+            >
+              <Icon className="h-4 w-4" aria-hidden />
+              {t(spec.labelKey)}
+            </Button>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/ui/src/features/photos/hooks.ts
+++ b/ui/src/features/photos/hooks.ts
@@ -3,15 +3,21 @@ import { useTranslation } from 'react-i18next';
 import { useToast } from '@/lib/toast';
 import {
   fetchPhotoDocuments,
+  fetchPurposeCounts,
+  fetchTriageQueue,
   deleteDocument,
+  updateDocument,
   attachEntityDocument,
   detachEntityDocument,
   setDocumentPhase,
   setDocumentZones,
+  setPhotosPurpose,
   bulkAddDocumentZones,
   entityDetailQueryKey,
   type PhotoPhase,
+  type PhotoPurpose,
 } from '@/lib/api/documents';
+import { useInvalidate } from '@/lib/invalidate';
 import { documentKeys } from '@/features/documents/hooks';
 import { zoneKeys } from '@/features/zones/hooks';
 
@@ -20,21 +26,112 @@ export interface PhotoFilters {
   zone?: string;
   /** `'1'` = seulement les photos rangées dans aucune zone. */
   without_zone?: string;
+  /**
+   * `technical` | `observation` | `memory` | `untriaged`.
+   *
+   * ⚠️ Ne jamais envoyer la chaîne vide pour dire « toutes » : le serveur refuse en
+   * 400, précisément pour qu'un paramètre oublié ne se lise pas comme un filtre. Pour
+   * « toutes », on **omet** la clé.
+   */
+  purpose?: string;
   [key: string]: string | undefined;
 }
 
 export const photoKeys = {
   all: ['photos'] as const,
   list: (filters?: PhotoFilters) => [...photoKeys.all, 'list', filters ?? {}] as const,
+  /** La file « À trier », par grappes de session. */
+  triage: () => [...photoKeys.all, 'triage'] as const,
+  /** Les compteurs des pastilles d'intention. */
+  purposeCounts: () => [...photoKeys.all, 'purposeCounts'] as const,
   /** Photos linked to one entity (project, equipment…) — the detail Photos tab. */
   entity: (entityType: string, objectId: string) =>
     [...photoKeys.all, 'entity', entityType, objectId] as const,
 };
 
-export function usePhotos(filters?: PhotoFilters) {
+/**
+ * `enabled` sert à **ne pas** charger la galerie à plat quand l'écran affiche la file
+ * de tri : la liste n'est pas paginée, et « à trier » désigne au premier jour toute la
+ * photothèque (rien n'a été backfillé). La file, elle, est bornée par le serveur.
+ */
+export function usePhotos(filters?: PhotoFilters, enabled = true) {
   return useQuery({
     queryKey: photoKeys.list(filters),
     queryFn: () => fetchPhotoDocuments(filters),
+    enabled,
+  });
+}
+
+/**
+ * La file « À trier » — le serveur groupe les photos en sessions, pas le client.
+ *
+ * Le compteur de la pastille et le lot qu'on applique doivent sortir de la même
+ * fonction : une grappe recalculée ici finirait par ne plus désigner les mêmes
+ * photos que celle que le serveur a comptée.
+ */
+export function useTriageQueue(enabled = true) {
+  return useQuery({
+    queryKey: photoKeys.triage(),
+    queryFn: fetchTriageQueue,
+    enabled,
+  });
+}
+
+/** Les compteurs des pastilles — une requête à part, bon marché, toujours à jour. */
+export function usePurposeCounts() {
+  return useQuery({
+    queryKey: photoKeys.purposeCounts(),
+    queryFn: fetchPurposeCounts,
+  });
+}
+
+/**
+ * Range une grappe : pose une intention sur un lot de photos.
+ *
+ * Le toast dit combien de photos ont bougé **et** combien gardaient leur intention —
+ * sur un lot, « enregistré » sans nombre ne se vérifie pas, l'écran venant justement
+ * de vider ce qu'on regardait.
+ */
+export function useSetPhotosPurpose() {
+  const invalidate = useInvalidate();
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: ({
+      photoIds,
+      purpose,
+      overwrite,
+    }: {
+      photoIds: string[];
+      purpose: PhotoPurpose;
+      overwrite?: boolean;
+    }) => setPhotosPurpose(photoIds, purpose, { overwrite }),
+    onSuccess: ({ updated, skipped }) => {
+      invalidate('photos');
+      toast({
+        description: skipped
+          ? t('photos.purpose.savedWithSkipped', { count: updated, skipped })
+          : t('photos.purpose.saved', { count: updated }),
+        variant: 'success',
+      });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
+  });
+}
+
+/** Pose (ou retire) l'intention d'une seule photo. */
+export function useSetPhotoPurpose() {
+  const invalidate = useInvalidate();
+  const { t } = useTranslation();
+  const { toast } = useToast();
+  return useMutation({
+    mutationFn: ({ photoId, purpose }: { photoId: string; purpose: PhotoPurpose | '' }) =>
+      updateDocument(photoId, { purpose }),
+    onSuccess: () => {
+      invalidate('photos');
+      toast({ description: t('photos.purpose.savedOne'), variant: 'success' });
+    },
+    onError: () => toast({ description: t('common.saveFailed'), variant: 'destructive' }),
   });
 }
 

--- a/ui/src/features/photos/hooks.ts
+++ b/ui/src/features/photos/hooks.ts
@@ -16,6 +16,7 @@ import {
   entityDetailQueryKey,
   type PhotoPhase,
   type PhotoPurpose,
+  type TriageQueue,
 } from '@/lib/api/documents';
 import { useInvalidate } from '@/lib/invalidate';
 import { documentKeys } from '@/features/documents/hooks';
@@ -75,6 +76,32 @@ export function useTriageQueue(enabled = true) {
     queryFn: fetchTriageQueue,
     enabled,
   });
+}
+
+/**
+ * Retire une photo de la file en cache — le retrait optimiste d'une suppression.
+ *
+ * Une grappe qui se vide disparaît : garder un en-tête « 0 photo » ferait de la file
+ * une liste de fantômes, alors qu'elle est censée mesurer ce qui reste à faire. Et
+ * `total` compte tout ce qui reste, pas seulement l'affiché — il se décrémente donc
+ * uniquement si la photo y était vraiment.
+ */
+export function removeFromTriage(
+  queue: TriageQueue | undefined,
+  photoId: string,
+): TriageQueue | undefined {
+  if (!queue) return queue;
+  const wasThere = queue.clusters.some((cluster) =>
+    cluster.photos.some((photo) => photo.id === photoId),
+  );
+  if (!wasThere) return queue;
+  const clusters = queue.clusters
+    .map((cluster) => {
+      const photos = cluster.photos.filter((photo) => photo.id !== photoId);
+      return { ...cluster, photos, count: photos.length };
+    })
+    .filter((cluster) => cluster.photos.length > 0);
+  return { total: Math.max(0, queue.total - 1), clusters };
 }
 
 /** Les compteurs des pastilles — une requête à part, bon marché, toujours à jour. */

--- a/ui/src/features/photos/purposes.ts
+++ b/ui/src/features/photos/purposes.ts
@@ -1,0 +1,46 @@
+import { Eye, Heart, Wrench, type LucideIcon } from 'lucide-react';
+import type { PhotoPurpose } from '@/lib/api/documents';
+
+/**
+ * Les trois intentions, dans l'ordre où l'écran les propose — **une seule
+ * définition**, lue par les pastilles de la galerie, le panneau de tri et la
+ * lightbox. Trois listes séparées auraient dérivé à la première intention ajoutée,
+ * et un même mot serait apparu sous deux icônes.
+ *
+ * ⚠️ « À trier » n'est **pas** une quatrième intention : c'est l'absence de choix, et
+ * elle vit à part (`UNTRIAGED`) précisément pour qu'on ne puisse pas la ranger dans
+ * cette liste par commodité. Le vide n'est pas un souvenir.
+ */
+export interface PurposeSpec {
+  key: PhotoPurpose;
+  icon: LucideIcon;
+  /** Clé i18n du libellé — vérifiée par la couverture des quatre catalogues. */
+  labelKey: string;
+  /** Clé i18n de la phrase qui dit à quoi sert cette intention. */
+  hintKey: string;
+}
+
+export const PURPOSES: readonly PurposeSpec[] = [
+  {
+    key: 'technical',
+    icon: Wrench,
+    labelKey: 'photos.purpose.technical',
+    hintKey: 'photos.purpose.technicalHint',
+  },
+  {
+    key: 'observation',
+    icon: Eye,
+    labelKey: 'photos.purpose.observation',
+    hintKey: 'photos.purpose.observationHint',
+  },
+  {
+    key: 'memory',
+    icon: Heart,
+    labelKey: 'photos.purpose.memory',
+    hintKey: 'photos.purpose.memoryHint',
+  },
+];
+
+export function purposeSpec(purpose: string | null | undefined): PurposeSpec | undefined {
+  return PURPOSES.find((spec) => spec.key === purpose);
+}

--- a/ui/src/features/tutorials/content.ts
+++ b/ui/src/features/tutorials/content.ts
@@ -91,7 +91,9 @@ export const TUTORIAL_GUIDES: TutorialGuide[] = [
   { key: 'budget', moduleKey: 'money', Icon: PiggyBank, to: '/app/money?tab=budgets', stepIds: ['create', 'assign', 'track', 'sheet', 'analysis', 'recurring', 'report'] },
   { key: 'banking', moduleKey: 'money', Icon: Landmark, to: '/app/money?tab=accounts', stepIds: ['accounts', 'cash', 'openingBalance', 'import', 'journal', 'balance', 'sheet'] },
   { key: 'documents', moduleKey: 'documents', to: '/app/documents', stepIds: ['upload', 'link', 'find'] },
-  { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'add', 'phone', 'file'] },
+  // `sort` vient juste après `browse` : l'intention est la première question que
+  // pose désormais la galerie, avant même « où est rangée cette photo ».
+  { key: 'photos', moduleKey: 'photos', to: '/app/photos', stepIds: ['browse', 'sort', 'add', 'phone', 'file'] },
   { key: 'directory', moduleKey: 'directory', to: '/app/directory', stepIds: ['contacts', 'structures'] },
   { key: 'alerts', Icon: AlertCircle, to: '/app/alerts', stepIds: ['review', 'act'] },
   { key: 'settings', Icon: User, to: '/app/settings', stepIds: ['profile', 'household', 'invite', 'modules', 'capabilities'] },

--- a/ui/src/lib/api/documents.ts
+++ b/ui/src/lib/api/documents.ts
@@ -3,6 +3,40 @@ import { api } from '@/lib/axios';
 /** Renovation phase of a photo relative to a linked entity. Empty = unclassified. */
 export type PhotoPhase = 'before' | 'during' | 'after';
 
+/**
+ * L'intention d'une photo : **pourquoi elle existe**.
+ *
+ * ⚠️ `''` n'est pas `'memory'` : le vide dit que personne n'a trié, `'memory'` dit
+ * qu'on a choisi. Ne jamais traiter l'absence comme un souvenir, ni ici ni dans un
+ * compteur — c'est ce qui rendrait la file « À trier » aveugle.
+ */
+export type PhotoPurpose = 'technical' | 'observation' | 'memory';
+
+/** Le marqueur qui demande « ce que personne n'a trié ». Jamais un paramètre vide. */
+export const UNTRIAGED = 'untriaged';
+
+export interface PurposeCounts {
+  technical: number;
+  observation: number;
+  memory: number;
+  untriaged: number;
+}
+
+export interface TriageCluster {
+  /** Clé stable d'un rechargement à l'autre, servie par le serveur. */
+  key: string;
+  start: string;
+  end: string;
+  count: number;
+  photos: DocumentItem[];
+}
+
+export interface TriageQueue {
+  /** Tout ce qui reste à trier — pas seulement ce que les grappes montrent. */
+  total: number;
+  clusters: TriageCluster[];
+}
+
 export interface LinkedInteractionSummary {
   id: string;
   subject: string;
@@ -64,6 +98,11 @@ export interface DocumentItem {
    * dire « prise le » plutôt que « ajoutée le ».
    */
   taken_at?: string | null;
+  /**
+   * Pourquoi cette photo existe — preuve, observation ou souvenir. `''` = personne
+   * ne l'a encore triée, et c'est un état à part entière (voir `PhotoPurpose`).
+   */
+  purpose?: PhotoPurpose | '' | null;
   /**
    * Zones où la photo est rangée — servi **dès la liste**, pas seulement sur le
    * détail : c'est ce qui permet à la galerie de dire où est une photo et de
@@ -177,7 +216,9 @@ export async function uploadDocument(input: UploadDocumentInput): Promise<Docume
 
 export async function updateDocument(
   id: string,
-  payload: { name?: string; notes?: string; type?: string },
+  // `purpose: ''` est admis **ici seulement** : détrier une photo qu'on a regardée
+  // est un geste unitaire légitime. Le lot, lui, le refuse.
+  payload: { name?: string; notes?: string; type?: string; purpose?: PhotoPurpose | '' },
 ): Promise<DocumentItem> {
   const { data } = await api.patch(`/documents/documents/${id}/`, payload);
   return normalizeId(data as DocumentItem & { id: string | number });
@@ -214,6 +255,44 @@ export async function bulkAddDocumentZones(
     zone_ids: zoneIds,
   });
   return data as { updated: number };
+}
+
+/** Ce qui reste à trier, par grappes de session — le serveur groupe, pas le client. */
+export async function fetchTriageQueue(): Promise<TriageQueue> {
+  const { data } = await api.get('/documents/documents/triage/');
+  const payload = data as TriageQueue;
+  return {
+    ...payload,
+    clusters: payload.clusters.map((cluster) => ({
+      ...cluster,
+      photos: cluster.photos.map(normalizeId),
+    })),
+  };
+}
+
+/** Les compteurs des pastilles — un `COUNT(*)`, jamais une liste qu'on mesure. */
+export async function fetchPurposeCounts(): Promise<PurposeCounts> {
+  const { data } = await api.get('/documents/documents/purpose_counts/');
+  return data as PurposeCounts;
+}
+
+/**
+ * Pose une intention sur un lot de photos.
+ *
+ * `overwrite` est un geste explicite : sans lui, le serveur laisse intactes les
+ * photos qui portent déjà une autre intention et les compte dans `skipped`.
+ */
+export async function setPhotosPurpose(
+  documentIds: string[],
+  purpose: PhotoPurpose,
+  options: { overwrite?: boolean } = {},
+): Promise<{ updated: number; skipped: number }> {
+  const { data } = await api.post('/documents/documents/set_purpose/', {
+    document_ids: documentIds,
+    purpose,
+    ...(options.overwrite ? { overwrite: true } : {}),
+  });
+  return data as { updated: number; skipped: number };
 }
 
 /**

--- a/ui/src/locales/de/translation.json
+++ b/ui/src/locales/de/translation.json
@@ -1611,6 +1611,10 @@
             "title": "Galerie durchsehen",
             "body": "In Dokumente hochgeladene Bilder erscheinen hier, nach Monat gruppiert. Filtern Sie nach Bereich, um nur einen Raum zu sehen; bei geöffnetem Foto führen die Pfeile (oder ← →) zum nächsten, ohne zu schließen."
           },
+          "sort": {
+            "title": "Sagen, warum ein Foto existiert",
+            "body": "Ein Foto einer Seriennummer und ein Geburtstagsfoto gehören nicht an denselben Ort. Geben Sie jedem seinen Zweck: Technisch (ein Beleg, den man wieder liest), Beobachtung (eine datierte Feststellung — ein Riss, ein Leck) oder Erinnerung. Die Galerie filtert dann nach einem davon. Ein Foto, das niemand sortiert hat, bleibt unter « Zu sortieren » — das ist ein Zustand, keine Erinnerung als Standard."
+          },
           "add": {
             "title": "Fotos hinzufügen",
             "body": "Wähle gleich eine ganze Serie aus: Das Feld nimmt mehrere Fotos an, die nacheinander gesendet werden. Aus einem Projekt, einem Gerät oder einer Zone heraus sortiert der Reiter Fotos sie in Vorher / Während / Nachher und kann sie vergleichen."
@@ -1918,6 +1922,34 @@
       "seeGallery": "Galerie ansehen",
       "empty": "Nichts zu senden",
       "empty_hint": "Teile Fotos aus deiner Galerie, um sie hier wiederzufinden."
+    },
+    "purpose": {
+      "label": "Zweck",
+      "all": "Alle",
+      "none": "Dieses Foto hat noch niemand einsortiert.",
+      "untriaged": "Zu sortieren",
+      "technical": "Technisch",
+      "technicalHint": "Ein Beleg: Seriennummer, Zählerstand, Plan, Typenschild.",
+      "observation": "Beobachtung",
+      "observationHint": "Eine datierte Feststellung: ein Riss, ein Leck, ein keimender Setzling.",
+      "memory": "Erinnerung",
+      "memoryHint": "Eine Erinnerung des Haushalts: ein Essen, ein Geburtstag, der Garten im Schnee.",
+      "saved": "{{count}} Foto sortiert.",
+      "saved_other": "{{count}} Fotos sortiert.",
+      "savedWithSkipped": "{{count}} Foto sortiert; {{skipped}} behielt seinen Zweck.",
+      "savedWithSkipped_other": "{{count}} Fotos sortiert; {{skipped}} behielten ihren Zweck.",
+      "savedOne": "Zweck gespeichert."
+    },
+    "triage": {
+      "empty": "Alles ist sortiert",
+      "empty_description": "Jedes Foto sagt, warum es existiert. Neue erscheinen hier.",
+      "remaining": "{{count}} Foto zu sortieren.",
+      "remaining_other": "{{count}} Fotos zu sortieren.",
+      "remainingPartial": "{{count}} Foto zu sortieren, davon {{shown}} hier gezeigt.",
+      "remainingPartial_other": "{{count}} Fotos zu sortieren, davon {{shown}} hier gezeigt.",
+      "range": "Vom {{from}} bis {{to}}",
+      "count": "{{count}} Foto",
+      "count_other": "{{count}} Fotos"
     }
   },
   "directory": {

--- a/ui/src/locales/en/translation.json
+++ b/ui/src/locales/en/translation.json
@@ -1611,6 +1611,10 @@
             "title": "Browse the gallery",
             "body": "Images uploaded to Documents show up here, grouped by month. Filter by zone to focus on one room, and once a photo is open the arrows (or ← →) move to the next one without closing it."
           },
+          "sort": {
+            "title": "Say why a photo exists",
+            "body": "A serial-number photo and a birthday photo have no business sitting in the same place. Give each one its purpose: Technical (proof you will read again), Observation (a dated fact — a crack, a leak) or Memory. The gallery then filters on one of them. A photo nobody sorted stays in « To sort » — that is a state, not a memory by default."
+          },
           "add": {
             "title": "Add photos",
             "body": "Pick a whole series at once: the field accepts several photos, sent one after another. From a project, a piece of equipment or a zone, the Photos tab sorts them into Before / During / After and can compare them."
@@ -1918,6 +1922,34 @@
       "seeGallery": "View gallery",
       "empty": "Nothing to send",
       "empty_hint": "Share photos from your gallery to find them here."
+    },
+    "purpose": {
+      "label": "Purpose",
+      "all": "All",
+      "none": "Nobody has sorted this photo yet.",
+      "untriaged": "To sort",
+      "technical": "Technical",
+      "technicalHint": "Proof: a serial number, a meter reading, a plan, a rating plate.",
+      "observation": "Observation",
+      "observationHint": "A dated fact you noticed: a crack, a leak, a seedling coming up.",
+      "memory": "Memory",
+      "memoryHint": "A household memory: a meal, a birthday, the garden under snow.",
+      "saved": "{{count}} photo sorted.",
+      "saved_other": "{{count}} photos sorted.",
+      "savedWithSkipped": "{{count}} photo sorted; {{skipped}} kept its purpose.",
+      "savedWithSkipped_other": "{{count}} photos sorted; {{skipped}} kept their purpose.",
+      "savedOne": "Purpose saved."
+    },
+    "triage": {
+      "empty": "Everything is sorted",
+      "empty_description": "Every photo says why it exists. New ones will land here.",
+      "remaining": "{{count}} photo to sort.",
+      "remaining_other": "{{count}} photos to sort.",
+      "remainingPartial": "{{count}} photo to sort, {{shown}} shown here.",
+      "remainingPartial_other": "{{count}} photos to sort, {{shown}} shown here.",
+      "range": "{{from}} to {{to}}",
+      "count": "{{count}} photo",
+      "count_other": "{{count}} photos"
     }
   },
   "directory": {

--- a/ui/src/locales/es/translation.json
+++ b/ui/src/locales/es/translation.json
@@ -1611,6 +1611,10 @@
             "title": "Explorar la galería",
             "body": "Las imágenes subidas a Documentos aparecen aquí, agrupadas por mes. Filtra por zona para ver solo una habitación y, con una foto abierta, las flechas (o ← →) pasan a la siguiente sin cerrarla."
           },
+          "sort": {
+            "title": "Decir por qué existe una foto",
+            "body": "Una foto de un número de serie y una foto de cumpleaños no pintan nada en el mismo sitio. Dé a cada una su intención: Técnica (una prueba que se volverá a leer), Observación (un hecho fechado — una grieta, una fuga) o Recuerdo. La galería se filtra entonces por una de ellas. Una foto que nadie ha clasificado permanece en « Por clasificar » — es un estado, no un recuerdo por defecto."
+          },
           "add": {
             "title": "Añadir fotos",
             "body": "Selecciona toda una serie de una vez: el campo acepta varias fotos, enviadas una tras otra. Desde un proyecto, un equipo o una zona, la pestaña Fotos las clasifica en Antes / Durante / Después y sabe compararlas."
@@ -1918,6 +1922,34 @@
       "seeGallery": "Ver la galería",
       "empty": "Nada que enviar",
       "empty_hint": "Comparte fotos desde tu galería para encontrarlas aquí."
+    },
+    "purpose": {
+      "label": "Intención",
+      "all": "Todas",
+      "none": "Nadie ha clasificado aún esta foto.",
+      "untriaged": "Por clasificar",
+      "technical": "Técnica",
+      "technicalHint": "Una prueba: número de serie, lectura del contador, plano, placa de características.",
+      "observation": "Observación",
+      "observationHint": "Un hecho fechado que se nota: una grieta, una fuga, un brote que sale.",
+      "memory": "Recuerdo",
+      "memoryHint": "Un recuerdo del hogar: una comida, un cumpleaños, el jardín bajo la nieve.",
+      "saved": "{{count}} foto clasificada.",
+      "saved_other": "{{count}} fotos clasificadas.",
+      "savedWithSkipped": "{{count}} foto clasificada; {{skipped}} conservó su intención.",
+      "savedWithSkipped_other": "{{count}} fotos clasificadas; {{skipped}} conservaron su intención.",
+      "savedOne": "Intención guardada."
+    },
+    "triage": {
+      "empty": "Todo está clasificado",
+      "empty_description": "Cada foto dice por qué existe. Las nuevas llegarán aquí.",
+      "remaining": "{{count}} foto por clasificar.",
+      "remaining_other": "{{count}} fotos por clasificar.",
+      "remainingPartial": "{{count}} foto por clasificar, {{shown}} mostrada aquí.",
+      "remainingPartial_other": "{{count}} fotos por clasificar, {{shown}} mostradas aquí.",
+      "range": "Del {{from}} al {{to}}",
+      "count": "{{count}} foto",
+      "count_other": "{{count}} fotos"
     }
   },
   "directory": {

--- a/ui/src/locales/fr/translation.json
+++ b/ui/src/locales/fr/translation.json
@@ -1611,6 +1611,10 @@
             "title": "Parcourir la galerie",
             "body": "Les images déposées dans Documents apparaissent ici, regroupées par mois. Filtrez par zone pour ne voir qu'une pièce, et ouvrez une photo : les flèches (ou ← →) passent à la suivante sans refermer."
           },
+          "sort": {
+            "title": "Dire pourquoi une photo existe",
+            "body": "Une photo de numéro de série et une photo d'anniversaire n'ont rien à faire au même endroit. Donnez à chacune son intention : Technique (une preuve qu'on relira), Observation (un fait daté, une fissure, une fuite) ou Souvenir. La galerie se filtre alors sur l'une d'elles. Une photo que personne n'a triée reste dans « À trier » — c'est un état, pas un souvenir par défaut."
+          },
           "add": {
             "title": "Ajouter des photos",
             "body": "Sélectionnez toute une série d'un coup : le champ accepte plusieurs photos, envoyées l'une après l'autre. Depuis un projet, un équipement ou une zone, l'onglet Photos les classe en Avant / Pendant / Après et sait les comparer."
@@ -1918,6 +1922,34 @@
       "seeGallery": "Voir la galerie",
       "empty": "Rien à envoyer",
       "empty_hint": "Partagez des photos depuis votre galerie pour les retrouver ici."
+    },
+    "purpose": {
+      "label": "Intention",
+      "all": "Toutes",
+      "none": "Personne n'a encore trié cette photo.",
+      "untriaged": "À trier",
+      "technical": "Technique",
+      "technicalHint": "Une preuve : numéro de série, index de compteur, plan, plaque signalétique.",
+      "observation": "Observation",
+      "observationHint": "Un fait daté qu'on remarque : une fissure, une fuite, la pousse d'un semis.",
+      "memory": "Souvenir",
+      "memoryHint": "Un souvenir du foyer : un repas, un anniversaire, le jardin sous la neige.",
+      "saved": "{{count}} photo rangée.",
+      "saved_other": "{{count}} photos rangées.",
+      "savedWithSkipped": "{{count}} photo rangée ; {{skipped}} gardait son intention.",
+      "savedWithSkipped_other": "{{count}} photos rangées ; {{skipped}} gardaient leur intention.",
+      "savedOne": "Intention enregistrée."
+    },
+    "triage": {
+      "empty": "Tout est trié",
+      "empty_description": "Chaque photo dit pourquoi elle existe. Les nouvelles arriveront ici.",
+      "remaining": "{{count}} photo à trier.",
+      "remaining_other": "{{count}} photos à trier.",
+      "remainingPartial": "{{count}} photo à trier, dont {{shown}} affichée ici.",
+      "remainingPartial_other": "{{count}} photos à trier, dont {{shown}} affichées ici.",
+      "range": "Du {{from}} au {{to}}",
+      "count": "{{count}} photo",
+      "count_other": "{{count}} photos"
     }
   },
   "directory": {


### PR DESCRIPTION
Closes #528

## Quoi

Une photo portait trois axes — la zone dit *où*, le lien d'entité *sur quoi*,
`DocumentLink.phase` *quand dans le chantier*. Aucun ne disait **pourquoi elle existe**,
et c'est la question qui sépare une preuve d'un souvenir : le numéro de série d'une
chaudière, une fissure inquiétante et un anniversaire finissaient au même endroit, dans
le même ordre.

`Document.purpose` (`technical` / `observation` / `memory`, vide = non trié) ajoute cet
axe, avec sa file « À trier » **par grappes de session** — trente photos rapportées d'un
week-end sont une décision, pas trente.

**Deux invariants, chacun tenu par un test nommé :**

- **Le vide n'est pas `memory`.** Vide = personne n'a regardé (un écart) ; `memory` =
  quelqu'un a choisi. Même règle que `inflow_nature == ""` qui n'est pas `"other"`, et
  déclinaison du principe du parcours 26. D'où `?purpose=untriaged` en marqueur
  explicite, un **400** sur un paramètre vide ou inconnu, et **aucun backfill** —
  marquer `technical` ce qui est lié à un projet écrirait une devinette indistinguable
  d'un choix (`banking.rules`).
- **Un lot n'écrase jamais un choix déjà posé.** `set_purpose` renvoie
  `{updated, skipped}` ; écraser demande `overwrite: true`. Reposer la même intention
  n'est pas un conflit. Détrier reste un geste unitaire — en lot ce serait une
  destruction de masse déguisée en raccourci.

**Backend** : le champ + son index `(household, purpose)`, migration sans backfill,
`apps/documents/queries.py` (`untriaged`, `cluster_sessions`, `purpose_counts`), filtre
`?purpose=`, et trois endpoints — `triage/`, `purpose_counts/` (endpoint à part pour que
les pastilles restent un `COUNT(*)`), `set_purpose/`.

**Front** : pastilles d'intention avec compteurs en tête de galerie, `TriagePanel` par
grappes (un geste range la grappe), `PhotoPurposeEditor` dans la visionneuse (recliquer
détrie), et les trois intentions en lot depuis la barre de sélection. Une seule
définition des trois intentions (`purposes.ts`) — « À trier » n'y est délibérément pas,
ce n'est pas une quatrième intention.

## Critères de l'issue

- [x] 1. Une photo importée sans intention apparaît dans « À trier », avec son compte
- [ ] 2. La galerie s'ouvre sur une intention, jamais sur l'ensemble — **différé, voir
      « Hors scope »**
- [x] 3. Trier une grappe de 30 photos est **un** geste
- [x] 4. Une grappe contenant déjà des intentions le signale et ne les écrase pas —
      `test_photo_purpose.py::TestABatchNeverOverwritesAChoice`
- [x] 5. Vide et `memory` ne se confondent nulle part —
      `test_photo_purpose.py::TestEmptyIsNotAMemory`
- [x] 6. `keys.test.ts` vert

## Hors scope, et pourquoi

**Livré hors séquence, avant le lot 1 du parcours 29.** C'est le seul lot qui résout la
friction réelle de l'utilisateur ; les six autres sont de l'infrastructure pour un
volume qui n'existe pas encore. Trois contreparties, écrites dans le backlog pour que le
lot 1 sache ce qu'il vient lever :

- **La file est bornée côté serveur** (`TRIAGE_WINDOW = 500`, `TRIAGE_CLUSTERS = 20`) au
  lieu d'être paginée — `DocumentViewSet` n'a toujours pas de `pagination_class`, et
  sans backfill *toute* la photothèque est « à trier » au premier jour. Le panneau
  affiche `total` **et** ce qu'il montre, jamais l'un pour l'autre.
- **La galerie à plat ne se charge pas en mode tri** (`usePhotos(filters, !isTriage)`),
  pour la même raison.
- **Critère 2 différé** : sans backfill, aucune photo ne porte d'intention le premier
  matin — s'ouvrir sur `technical` afficherait un écran vide sur une photothèque pleine.
  Un défaut qui ment le premier jour coûte plus cher que le mélange qu'il corrige. La
  bascule se fera quand la file aura été vidée une fois.

**Choix de cadrage tranché ici** : la grappe se calcule sur `effective_date`
(`COALESCE(taken_at, created_at)`), **pas** sur la date d'ajout. Quinze photos envoyées
d'un coup depuis la feuille de partage contiennent la chaudière de mardi *et*
l'anniversaire de samedi : grouper par envoi reformerait exactement le mélange qu'on
défait. `SESSION_GAP = 2 h` est une constante, une ligne à changer.

## Docs

Backlog (lot 2 ✅ + section « Le lot 2 a été livré seul »), doc produit du parcours 29,
section entière dans `docs/MODULES/documents.md`, encadré de `NEXT_STEPS.md` avec
l'ordre réordonné, une règle dans `CLAUDE.md`, et l'étape « trier » du guide Photos dans
les 4 locales.

## Vérifications

- `pytest` : 4276 passed, 2 skipped
- `vitest` : 267 passed (dont `keys.test.ts` et `invalidate.test.ts`)
- `npm run lint` : 0 erreur (5 warnings préexistants, fichiers non touchés)
- `npx tsc -b ui/tsconfig.json` : propre
