### PR TITLE
L'image arm64 est démarrée, pas seulement construite (lot 2, #488)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,14 +84,29 @@ jobs:
       # espoir publié. Le test est minuscule et il attrape ce qui casse vraiment
       # : une dépendance native absente de l'architecture, un `collectstatic`
       # raté au build, un module qui ne s'importe pas.
-      - name: L'image démarre et se connaît
+      #
+      # ⚠️ **Les deux architectures, et `--platform` explicitement.** Sans lui,
+      # `docker run` prend la variante du runner — amd64 — et le manifeste arm64
+      # part sans que personne ne l'ait jamais démarré. C'est la moitié du public
+      # de l'auto-hébergement (Raspberry Pi, NAS) qui découvrirait le problème à
+      # notre place, et la phrase du dessus vaut aussi pour elle. La construction
+      # arm64 réussit d'ailleurs sans rien prouver du démarrage : une roue
+      # native compilée pour la mauvaise architecture ne se voit qu'à l'import.
+      - name: L'image démarre et se connaît (les deux architectures)
         run: |
-          docker run --rm \
-            -e DJANGO_SETTINGS_MODULE=config.settings.selfhost \
-            -e MAISONNEE_STATE_DIR=/tmp/state \
-            -e DATABASE_URL=postgres://u:p@127.0.0.1:5432/none \
-            ghcr.io/${{ github.repository_owner }}/maisonnee:${{ steps.meta.outputs.version }} \
-            python manage.py check --deploy --fail-level ERROR
+          set -euo pipefail
+          for platform in linux/amd64 linux/arm64; do
+            echo "── $platform ───────────────────────────────────────────────"
+            # arm64 tourne ici sous QEMU (installé plus haut pour le build) :
+            # c'est lent, et c'est le prix d'une vérification qui vaut quelque
+            # chose sans avoir de Raspberry Pi dans la CI.
+            docker run --rm --platform "$platform" \
+              -e DJANGO_SETTINGS_MODULE=config.settings.selfhost \
+              -e MAISONNEE_STATE_DIR=/tmp/state \
+              -e DATABASE_URL=postgres://u:p@127.0.0.1:5432/none \
+              ghcr.io/${{ github.repository_owner }}/maisonnee:${{ steps.meta.outputs.version }} \
+              python manage.py check --deploy --fail-level ERROR
+          done
 
   # Les notes de release, écrites depuis l'historique.
   #


### PR DESCRIPTION
Trouvé en vérifiant la première release (`v0.1.0`).

Le workflow porte depuis le lot 2 la phrase *« une image qu'on n'a pas démarrée n'est pas une image publiée, c'est un espoir publié »* — et il ne démarrait que l'amd64. Sans `--platform`, `docker run` prend la variante du runner.

Le manifeste `v0.1.0` **contient** bien l'arm64 (le log montre `#10 [linux/arm64 stage-1]`), mais personne ne l'a jamais lancé. Construire réussit sans rien prouver du démarrage : une roue native compilée pour la mauvaise architecture ne se voit qu'à l'import — et c'est la moitié du public de l'auto-hébergement (Pi, NAS) qui l'aurait découvert à notre place.

Les deux architectures sont désormais démarrées, l'arm64 sous QEMU (déjà installé pour le build).

**Lève le critère 4 du lot 2** (#488), en attente depuis juillet. Une fois mergé, je relance `release.yml` en `workflow_dispatch` sur `v0.1.0` pour que la première release soit couverte elle aussi.