### PR TITLE
fix(documents): le test e2e des photos cherchait un bouton renommé

### DIFF
--- a/e2e/photos.spec.ts
+++ b/e2e/photos.spec.ts
@@ -15,11 +15,13 @@ test('affiche la page des photos', async ({ page }) => {
 });
 
 test('téléverse une photo depuis la page Photos', async ({ page }) => {
-  await page.getByRole('button', { name: 'Téléverser des photos' }).first().click();
+  // « Ajouter des photos » (`photos.upload_title`) — le bouton et le titre du
+  // dialog partagent la clé, et le test cherchait encore l'ancien libellé.
+  await page.getByRole('button', { name: 'Ajouter des photos' }).first().click();
 
   const dialog = page.getByRole('dialog');
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByText('Téléverser des photos')).toBeVisible();
+  await expect(dialog.getByText('Ajouter des photos')).toBeVisible();
 
   // Le sélecteur de type ne doit pas apparaître en mode photo
   await expect(dialog.locator('#upload-type')).toHaveCount(0);


### PR DESCRIPTION
Six lignes, mais elles répondent à une question qui vaut plus qu'elles : **comment un test cassé depuis le 4 août a-t-il pu être déployé sans que rien ne bronche ?**

## Le défaut

`photos.upload_title` est passé à « Ajouter des photos » avec la refonte de la galerie. Le test cliquait toujours « Téléverser des photos » et mourait sur un timeout de 30 s.

```
1) [chromium] › e2e/photos.spec.ts:17 › téléverse une photo depuis la page Photos
   Test timeout of 30000ms exceeded.
   waiting for getByRole('button', { name: 'Téléverser des photos' })
```

Le troisième libellé du fichier — le bouton de soumission `« Téléverser », exact: true` **dans** le dialog — est resté juste ; il n'est pas touché.

## Pourquoi personne ne l'a vu

**Aucun job de `.github/workflows/` ne lance Playwright.** Les quatre jobs sont `backend` (pytest), `frontend` (ESLint + vitest + build), `proxy` (`nginx -t`) et `backup` ; le déploiement est conditionné à `needs: [backend, frontend, proxy]`. Le répertoire `e2e/` n'est lu par aucun d'eux — il n'y a pas eu d'échec ignoré, il n'y a jamais eu d'exécution.

Le produit, lui, allait bien : le bouton a été renommé volontairement. Ce qui était cassé, c'est le filet.

## Ce que ça laisse ouvert

Une suite que personne n'exécute ne dérive pas *si* le produit bouge — elle dérive **parce qu'**il bouge, et en silence. Le jour où on voudra s'en servir, elle sera rouge pour dix raisons dont neuf sans rapport, et elle aura perdu son crédit. Deux issues possibles, et les deux sont défendables : faire entrer Playwright en CI (coût : Postgres pgvector, `npm run build`, navigateurs, quelques minutes par PR), ou déclarer la suite explicitement manuelle. Ce qui ne tient pas, c'est la situation actuelle — le second choix, subi plutôt que décidé.

## Vérifications

`npx playwright test e2e/photos.spec.ts` : **3 reproductions de l'échec** avant (fichier seul, puis à la suite de `photos-lightbox.spec.ts`), **5 passed** après.